### PR TITLE
Remove objects from avi for routes with duplicate backends

### DIFF
--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -72,7 +72,7 @@ func GetOshiftRouteModel(name, namespace, key string) (*OshiftRouteModel, error,
 	o := NewNodesValidator()
 	if !o.HasValidBackends(routeObj.Spec, name, key) {
 		err := errors.New("validation failed for alternate backends for route: " + name)
-		return &routeModel, err, processObj
+		return &routeModel, err, false
 	}
 
 	return &routeModel, nil, processObj


### PR DESCRIPTION
If a route has two backends with same service name, then don't sync the
route and delete objects from AVi if already syned. This change is
required to keep the behavior consistent with ako reboot, when this
route doesn't get syned and stale objects gets deleted.