### PR TITLE
Added governance/maintainers list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,56 @@
+# AKO Governance
+
+The name AKO is used as a shorthand project name for load-balancer-and-ingress-services-for-kubernetes.
+
+This document defines the project governance for AKO.
+
+This is a Work in Progress, documenting approximately how we plan to operate the
+project.
+
+## Overview
+
+**AKO** is committed to building an open, inclusive, productive and
+self-governing open source community focused on building a high-quality Ingress controller based on [Avi](https://avinetworks.com/software-load-balancer/)
+
+## Code of Conduct
+
+The AKO community abides by this [code of conduct](CODE_OF_CONDUCT.md).
+
+## Community Roles
+
+* **Users:** Members that engage with the AKO community via any medium
+  (Slack, GitHub, mailing lists, etc.).
+* **Contributors:** Do regular contributions to the AKO project
+  (documentation, code reviews, responding to issues, participating in proposal
+  discussions, contributing code, etc.).
+* **Maintainers**: Responsible for the overall health and direction of the
+  project. They are the final reviewers of PRs and responsible for AKO
+  releases.
+
+### Contributors
+
+Anyone can contribute to the project (e.g. open a PR) as long as they follow the
+guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Maintainers
+
+The list of current maintainers can be found in
+[MAINTAINERS.md](MAINTAINERS.md).
+
+Maintainers have write access to the repository. While anyone can review a PR -
+and is welcome to do so -, only maintainers can leave an approving review, which
+will allow the PR to be merged.
+
+New maintainers must be nominated from contributors by an existing maintainer
+and must be elected by a [supermajority](#supermajority) of the current
+maintainers. Likewise, maintainers can be removed by a supermajority of the
+maintainers or can resign by notifying the maintainers.
+
+### Supermajority
+
+A supermajority is defined as two-thirds of members in the group.
+
+## Updating Governance
+
+All substantive changes in Governance require a supermajority vote of the
+maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# AKO Maintainers
+
+This is the current list of maintainers for the AKO project. The maintainer
+role is described in [GOVERNANCE.md](GOVERNANCE.md).
+
+| Maintainer | GitHub ID | Affiliation |
+| ---------- | --------- | ----------- |
+| Sudipto Biswas |  sudswasavi | VMware |
+| Monotosh Das | monotosh-avi | VMware |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ you get started:
 [Code of Conduct](CODE_OF_CONDUCT.md).
 * Check out our [Contributor Guide](CONTRIBUTING.md) for information
 about setting up your development environment and our contribution workflow.
+* Check out [Open Issues](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/issues).
+* [ako-dev](https://groups.google.com/g/ako-dev) to participate in discussions on AKO's development.
+
 
 ## License
 


### PR DESCRIPTION
This commit introduces the governance model and the maintainers
list for AKO. Addtional updates include the google group
information for AKO development related activities.