### PR TITLE
Remove local path from go binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOCMD=/usr/local/go/bin/go
+GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOGET=$(GOCMD) get

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -38,7 +38,7 @@ func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace string, gatewayName stri
 
 	found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName)
 	if !found {
-		utils.AviLog.Debugf("key: %s, msg: No services mapped to gateway %s/%s", namespace, gatewayName)
+		utils.AviLog.Warnf("key: %s, msg: No services mapped to gateway %s/%s", key, namespace, gatewayName)
 		return
 	}
 	utils.AviLog.Infof("key: %s, msg: Found Services %v for Gateway %s/%s", key, services, gateway.Namespace, gateway.Name)

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -135,7 +135,7 @@ func DequeueIngestion(key string, fullsync bool) {
 					}
 				} else {
 					aviModelGraph := NewAviObjectGraph()
-					aviModelGraph.BuildAdvancedL4Graph(namespace, name, key)
+					aviModelGraph.BuildAdvancedL4Graph(namespace, gwName, key)
 					ok := saveAviModel(modelName, aviModelGraph, key)
 					if ok && len(aviModelGraph.GetOrderedNodes()) != 0 && !fullsync {
 						PublishKeyToRestLayer(modelName, key, sharedQueue)


### PR DESCRIPTION
This commit gets rid of hardcoded path from the go binary
instead relies on the user to have a exported path for the go
binary.

Plus minor fixes to the gateway code.