### PR TITLE
Fix PATCH payload for staticroutes.

### DIFF
--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -77,18 +77,19 @@ func (rest *RestOperations) AviVrfBuild(key string, vrfNode *nodes.AviVrfNode, u
 	}
 
 	patchOp := utils.PatchReplaceOp
+	patchPayload := make(map[string]interface{})
 	if len(nodeStaticRoutes) == 0 {
 		// this is the case of deleting all the static routes for the cluster
 		patchOp = utils.PatchDeleteOp
-		vrf.StaticRoutes = clusterStaticRoutes
+		patchPayload["static_routes"] = clusterStaticRoutes
 
 	} else {
 		patchOp = utils.PatchReplaceOp
 		mergedStaticRoutes = append(mergedStaticRoutes, nodeStaticRoutes...)
-		vrf.StaticRoutes = mergedStaticRoutes
+		patchPayload["static_routes"] = mergedStaticRoutes
 	}
 
-	restOp := utils.RestOp{Path: path, Method: utils.RestPatch, PatchOp: patchOp, Obj: vrf,
+	restOp := utils.RestOp{Path: path, Method: utils.RestPatch, PatchOp: patchOp, Obj: patchPayload,
 		Tenant: lib.GetTenant(), Model: "VrfContext", Version: utils.CtrlVersion}
 	return &restOp
 }


### PR DESCRIPTION
- The whole vrf context payload used to work in earlier builds. Adhering to https://avinetworks.com/docs/20.1/api-http-patch-support/ now.