### PR TITLE
redirect httppolicy for parentVS via secure hostrule fix

### DIFF
--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -211,6 +211,9 @@ func (v *Validator) ParseHostPathForIngress(ns string, ingName string, ingSpec v
 	for aviSecret, securedHostNames := range secretHostsMap {
 		additionalTLS := TlsSettings{}
 		additionalTLS.SecretName = aviSecret
+		// Always add http -> https redirect rule for secure ingress
+		// for sni VS created using hostrule
+		additionalTLS.redirect = true
 		additionalTLSHostSvcMap := make(IngressHostMap)
 		for _, host := range securedHostNames {
 			if hostSvcMap, ok := additionalSecureHostMap[host]; ok {

--- a/tests/hostnameshardtests/crd_hostname_test.go
+++ b/tests/hostnameshardtests/crd_hostname_test.go
@@ -132,6 +132,7 @@ func TestHostnameInsecureToSecureHostRule(t *testing.T) {
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisahostruleref-sslkey"))
 	g.Expect(nodes[0].SniNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisahostruleref-waf"))
+	g.Expect(nodes[0].HttpPolicyRefs[0].RedirectPorts[0].StatusCode).To(gomega.Equal("HTTP_REDIRECT_STATUS_CODE_302"))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
 	TearDownIngressForCacheSyncCheck(t, modelName)
@@ -176,6 +177,7 @@ func TestHostnameMultiIngressToSecureHostRule(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].PoolRefs).To(gomega.HaveLen(2))
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisahostruleref-sslkey"))
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertRefs).To(gomega.HaveLen(0))
+	g.Expect(nodes[0].HttpPolicyRefs[0].RedirectPorts[0].StatusCode).To(gomega.Equal("HTTP_REDIRECT_STATUS_CODE_302"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
 	integrationtest.VerifyMetadataHostRule(g, sniVSKey, "default/samplehr-foo", true)
@@ -393,7 +395,7 @@ func TestHostnameValidToInvalidHostSwitch(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-// httprule with HostRules
+// HttpRule tests
 
 func TestHostnameHTTPRuleCreateDelete(t *testing.T) {
 	// ingress secure foo.com/foo /bar


### PR DESCRIPTION
added UTs for the same
to be cherry-picked in release-1.2.1
