### PR TITLE
Add port in AviPoolMetaServer to support service with multiple ports

### DIFF
--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -262,7 +262,14 @@ func PopulateServers(poolNode *AviPoolNode, ns string, serviceName string, ingre
 				if addr.NodeName != nil {
 					server.ServerNode = *addr.NodeName
 				}
-				pool_meta = append(pool_meta, server)
+				if allPort {
+					for _, port := range ss.Ports {
+						server.Port = port.Port
+						pool_meta = append(pool_meta, server)
+					}
+				} else {
+					pool_meta = append(pool_meta, server)
+				}
 			}
 		}
 	}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -996,6 +996,7 @@ func (o *AviObjectGraph) GetAviPoolNodeByName(poolname string) *AviPoolNode {
 type AviPoolMetaServer struct {
 	Ip         avimodels.IPAddr
 	ServerNode string
+	Port       int32
 }
 
 type IngressHostPathSvc struct {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -114,6 +114,9 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 	for _, server := range pool_meta.Servers {
 		sip := server.Ip
 		port := pool_meta.Port
+		if server.Port != 0 {
+			port = server.Port
+		}
 		s := avimodels.Server{IP: &sip, Port: &port}
 		if server.ServerNode != "" {
 			sn := server.ServerNode


### PR DESCRIPTION
If we have service with multiple ports and no port is specified in route,
then the common port in poolmeta would be empty. In this case we should add
servers with all ports as per the service. Introducing a new field Port in
AviPoolMetaServer to support this.