### PR TITLE
gateway ipaddr status update, cache mapping changes

### DIFF
--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -46,11 +46,12 @@ type ServiceMetadataObj struct {
 	IngressName          string      `json:"ingress_name"`
 	Namespace            string      `json:"namespace"`
 	HostNames            []string    `json:"hostnames"`
-	ServiceName          string      `json:"svc_name"`
+	NamespaceServiceName []string    `json:"namespace_svc_name"` // []string{ns/name}
 	CRDStatus            CRDMetadata `json:"crd_status"`
 	PoolRatio            int32       `json:"pool_ratio"`
 	PassthroughParentRef string      `json:"passthrough_parent_ref"`
 	PassthroughChildRef  string      `json:"passthrough_child_ref"`
+	Gateway              string      `json:"gateway"` // ns/name
 }
 
 type CRDMetadata struct {

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -63,8 +63,15 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		}
 		fqdns = append(fqdns, fqdn)
 	}
-	avi_vs_meta = &AviVsNode{Name: vsName, Tenant: lib.GetTenant(),
-		EastWest: false, ServiceMetadata: avicache.ServiceMetadataObj{ServiceName: svcObj.ObjectMeta.Name, Namespace: svcObj.ObjectMeta.Namespace, HostNames: fqdns}}
+	avi_vs_meta = &AviVsNode{
+		Name:     vsName,
+		Tenant:   lib.GetTenant(),
+		EastWest: false,
+		ServiceMetadata: avicache.ServiceMetadataObj{
+			NamespaceServiceName: []string{svcObj.ObjectMeta.Namespace + "/" + svcObj.ObjectMeta.Name},
+			HostNames:            fqdns,
+		},
+	}
 
 	if lib.GetSEGName() != lib.DEFAULT_GROUP {
 		avi_vs_meta.ServiceEngineGroup = lib.GetSEGName()

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -486,7 +486,7 @@ func RouteIngrDeletePoolsByHostname(routeIgrObj RouteIngressModel, namespace, ob
 	}
 	// Now remove the secret relationship
 	routeIgrObj.GetSvcLister().IngressMappings(namespace).RemoveIngressSecretMappings(objname)
-	utils.AviLog.Infof("key: %s, removed ingess mapping for: %s", key, objname)
+	utils.AviLog.Infof("key: %s, removed ingress mapping for: %s", key, objname)
 
 	// Remove the hosts mapping for this ingress
 	routeIgrObj.GetSvcLister().IngressMappings(namespace).DeleteIngToHostMapping(objname)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -387,7 +387,12 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 
 				utils.AviLog.Debug(spew.Sprintf("key: %s, msg: updated VS cache key %v val %v\n", key, k,
 					utils.Stringify(vs_cache_obj)))
-				if svc_mdata_obj.ServiceName != "" && svc_mdata_obj.Namespace != "" {
+				if svc_mdata_obj.Gateway != "" {
+					status.UpdateGatewayStatusAddress([]status.UpdateStatusOptions{{
+						Vip:             vs_cache_obj.Vip,
+						ServiceMetadata: svc_mdata_obj,
+					}}, false)
+				} else if len(svc_mdata_obj.NamespaceServiceName) > 0 {
 					// This service needs an update of the status
 					status.UpdateL4LBStatus([]status.UpdateStatusOptions{{
 						Vip:             vs_cache_obj.Vip,
@@ -448,7 +453,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				}
 			}
 
-			if svc_mdata_obj.ServiceName != "" && svc_mdata_obj.Namespace != "" {
+			if len(svc_mdata_obj.NamespaceServiceName) > 0 {
 				// This service needs an update of the status
 				status.UpdateL4LBStatus([]status.UpdateStatusOptions{{
 					Vip:             vs_cache_obj.Vip,
@@ -491,7 +496,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				vsvipKey := avicache.NamespaceName{Namespace: vsKey.Namespace, Name: vsvip}
 				utils.AviLog.Debugf("key: %s, msg: deleting vsvip cache for key: %s", key, vsvipKey)
 				// Reset the LB status field as well.
-				if vs_cache_obj.ServiceMetadataObj.ServiceName != "" && vs_cache_obj.ServiceMetadataObj.Namespace != "" {
+				if len(vs_cache_obj.ServiceMetadataObj.NamespaceServiceName) > 0 {
 					status.DeleteL4LBStatus(vs_cache_obj.ServiceMetadataObj, key)
 				}
 				rest.cache.VSVIPCache.AviCacheDelete(vsvipKey)

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -55,7 +55,7 @@ func (rest *RestOperations) SyncIngressStatus() {
 				option := status.UpdateStatusOptions{Vip: parentVsObj.Vip, ServiceMetadata: vsSvcMetadataObj, Key: "syncstatus"}
 				allIngressUpdateOptions = append(allIngressUpdateOptions, option)
 			}
-		} else if vsSvcMetadataObj.ServiceName != "" && vsSvcMetadataObj.Namespace != "" {
+		} else if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
 			// serviceLB
 			option := status.UpdateStatusOptions{Vip: vsCacheObj.Vip, ServiceMetadata: vsSvcMetadataObj, Key: "syncstatus"}
 			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions, option)

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"errors"
+	"strings"
+
+	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Type: specific condition enums must be part of independent update functions
+type UpdateGatewayStatusOptions struct {
+	Status             core.ConditionStatus // defaults to True
+	Message            string               // extended condition message
+	Reason             string               // reason for transition
+	LastTransitionTime metav1.Time          // send in time of function call
+}
+
+// TODO: handle bulk during bootup
+func UpdateGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) {
+	for _, option := range options {
+		gatewayNSName := strings.Split(option.ServiceMetadata.Gateway, "/")
+		gw, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().Gateways(gatewayNSName[0]).Get(gatewayNSName[1], metav1.GetOptions{})
+		if err != nil {
+			utils.AviLog.Infof("key: %s, msg: unable to find gateway object %s", option.Key, option.ServiceMetadata.Gateway)
+		}
+
+		// assuming 1 IP per gateway
+		gwStatus := gw.Status
+		gwStatus.Addresses = []advl4v1alpha1pre1.GatewayAddress{{
+			Value: option.Vip,
+			Type:  advl4v1alpha1pre1.IPAddressType,
+		}}
+		updateGatewayStatusObject(gw, &gwStatus)
+	}
+
+	return
+}
+
+// supported GatewayConditionTypes
+// InvalidListeners, InvalidAddress, *Serviceable
+func UpdateGatewayStatusGWCondition(gw *advl4v1alpha1pre1.Gateway, gwConditionType advl4v1alpha1pre1.GatewayConditionType, updateStatus *UpdateGatewayStatusOptions) {
+	gwStatus := gw.Status
+	for _, condition := range gwStatus.Conditions {
+		if condition.Type == gwConditionType {
+			condition.Status = updateStatus.Status
+			condition.Message = updateStatus.Message
+			condition.Reason = updateStatus.Reason
+			break
+		}
+	}
+
+	updateGatewayStatusObject(gw, &gwStatus)
+}
+
+// supported ListenerConditionType
+// PortConflict, UnsupportedProtocol, InvalidRoutes, UnsupportedProtocol, *Serviceable
+func UpdateGatewayStatusListenerConditions(gw *advl4v1alpha1pre1.Gateway, port string, listenerConditionType advl4v1alpha1pre1.ListenerConditionType, updateStatus *UpdateGatewayStatusOptions) {
+	gwStatus := gw.Status
+	for _, condition := range gwStatus.Listeners {
+		if condition.Port == port {
+			for _, portCondition := range condition.Conditions {
+				if portCondition.Type == listenerConditionType {
+					portCondition.Status = updateStatus.Status
+					portCondition.Message = updateStatus.Message
+					portCondition.Reason = updateStatus.Reason
+					break
+				}
+			}
+			break
+		}
+	}
+
+	updateGatewayStatusObject(gw, &gwStatus)
+}
+
+func updateGatewayStatusObject(gw *advl4v1alpha1pre1.Gateway, updateStatus *advl4v1alpha1pre1.GatewayStatus, retryNum ...int) error {
+	retry := 0
+	if len(retryNum) > 0 {
+		retry = retryNum[0]
+		if retry >= 4 {
+			return errors.New("msg: UpdateGatewayStatus retried 5 times, aborting")
+		}
+	}
+
+	gw.Status = *updateStatus
+	_, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().Gateways(gw.Namespace).UpdateStatus(gw)
+	if err != nil {
+		utils.AviLog.Errorf("msg: %d there was an error in updating the gateway status: %+v", retry, err)
+		updatedGW, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().Gateways(gw.Namespace).Get(gw.Name, metav1.GetOptions{})
+		if err != nil {
+			utils.AviLog.Warnf("gateway not found %v", err)
+			return err
+		}
+		return updateGatewayStatusObject(updatedGW, updateStatus, retry+1)
+	}
+
+	utils.AviLog.Infof("msg: Successfully updated the gateway %s/%s status %+v", gw.Namespace, gw.Name, utils.Stringify(updateStatus))
+	return nil
+}


### PR DESCRIPTION
This PR fixes a few cache mappings maintained for gateway<->services, and corresponding graph layer changes in building the VSNode.

Also included are serviceMetadata changes in the virtualservice objects to accommodate gateway objects and mappings from gateway to multiple services. The updated serviceMetadata is now being used for populating IPAddress in the gateway object.

This also introduces basic Gateway condition status update interfaces, around which validations will follow subsequently.