### PR TITLE
Squash L4 policysets for a VS into 1 object

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,10 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/avinetworks/container-lib v0.0.0-20200805113307-80c6b5ecc46e/go.mod h1:wlslasV754w0HIvZMVzXn76U77IT2cH/QuEuutJ0ASE=
 github.com/avinetworks/sdk v0.0.0-20200812060914-ba100c75801c h1:GsvjuI/E65E35vcS69wUTMgLalYbP4T4vfCWR2NhKVI=
 github.com/avinetworks/sdk v0.0.0-20200812060914-ba100c75801c/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
+github.com/avinetworks/sdk v0.0.0-20200828204623-98f121776595 h1:NJXlwvanjb3cn+jGiy/Ikj96A/gKxAdbywXj7SpHRhU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -100,10 +100,6 @@ func GetAdvL4PoolName(svcName, namespace string, port int32) string {
 	return NamePrefix + namespace + "-" + svcName + "--" + strconv.Itoa(int(port))
 }
 
-func GetL4PolicyName(vsName string, port int32) string {
-	return GetL4PoolName(vsName, port)
-}
-
 func GetL4PGName(vsName string, port int32) string {
 	return vsName + "-" + strconv.Itoa(int(port))
 }

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -106,6 +106,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 
 func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNode *AviVsNode, key string) {
 	var l4Policies []*AviL4PolicyNode
+	var portPoolSet []AviHostPathPortPoolPG
 	for _, portProto := range vsNode.PortProto {
 		filterPort := portProto.Port
 		poolNode := &AviPoolNode{Name: lib.GetL4PoolName(vsNode.Name, filterPort), Tenant: lib.GetTenant(), Protocol: portProto.Protocol, PortName: portProto.Name}
@@ -122,21 +123,20 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 		}
 
 		pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
-		var portPoolSet []AviHostPathPortPoolPG
 		portPool := AviHostPathPortPoolPG{Port: uint32(filterPort), Pool: pool_ref, Protocol: portProto.Protocol}
 		portPoolSet = append(portPoolSet, portPool)
-		l4policyNode := &AviL4PolicyNode{Name: lib.GetL4PolicyName(vsNode.Name, filterPort), Tenant: lib.GetTenant(), PortPool: portPoolSet}
 
 		vsNode.PoolRefs = append(vsNode.PoolRefs, poolNode)
 		utils.AviLog.Infof("key: %s, msg: evaluated L4 pool values :%v", key, utils.Stringify(poolNode))
 
-		l4Policies = append(l4Policies, l4policyNode)
 		poolNode.CalculateCheckSum()
-		l4policyNode.CalculateCheckSum()
 		o.AddModelNode(poolNode)
-		o.GraphChecksum = o.GraphChecksum + l4policyNode.GetCheckSum()
 		o.GraphChecksum = o.GraphChecksum + poolNode.GetCheckSum()
 	}
+	l4policyNode := &AviL4PolicyNode{Name: vsNode.Name, Tenant: lib.GetTenant(), PortPool: portPoolSet}
+	l4Policies = append(l4Policies, l4policyNode)
+	l4policyNode.CalculateCheckSum()
+	o.GraphChecksum = o.GraphChecksum + l4policyNode.GetCheckSum()
 	vsNode.L4PolicyRefs = l4Policies
 	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -51,7 +51,8 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 			ports = append(ports, int64(hppmap.Port))
 			l4action := &avimodels.L4RuleAction{}
 			actionSelect := &avimodels.L4RuleActionSelectPool{}
-			actionSelect.PoolRef = &hppmap.Pool
+			poolName := hppmap.Pool
+			actionSelect.PoolRef = &poolName
 			poolSelect := "L4_RULE_ACTION_SELECT_POOL"
 			actionSelect.ActionType = &poolSelect
 			l4action.SelectPool = actionSelect

--- a/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
+++ b/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
@@ -204,7 +204,7 @@ func TestMultiPortL4SvcNodePort(t *testing.T) {
 		}
 		g.Expect(nodes[0].ApplicationProfile).To(gomega.Equal(utils.DEFAULT_L4_APP_PROFILE))
 		g.Expect(nodes[0].NetworkProfile).To(gomega.Equal(utils.DEFAULT_TCP_NW_PROFILE))
-		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(3))
+		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(1))
 	}
 
 	TearDownTestForSvcLBMultiport(t, g)

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -217,7 +217,7 @@ func TestAviNodeCreationMultiPort(t *testing.T) {
 				g.Expect(node.Servers[0].Ip.Addr).To(gomega.Equal(&address))
 			}
 		}
-		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(3))
+		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(1))
 		g.Expect(nodes[0].ApplicationProfile).To(gomega.Equal(utils.DEFAULT_L4_APP_PROFILE))
 		g.Expect(nodes[0].NetworkProfile).To(gomega.Equal(utils.DEFAULT_TCP_NW_PROFILE))
 	}
@@ -259,7 +259,7 @@ func TestAviNodeMultiPortApplicationProf(t *testing.T) {
 				g.Expect(node.Servers[0].Ip.Addr).To(gomega.Equal(&address))
 			}
 		}
-		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(3))
+		g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(1))
 		g.Expect(nodes[0].SharedVS).To(gomega.Equal(false))
 		g.Expect(nodes[0].ApplicationProfile).To(gomega.Equal(utils.DEFAULT_L4_APP_PROFILE))
 		g.Expect(nodes[0].NetworkProfile).To(gomega.Equal(utils.DEFAULT_TCP_NW_PROFILE))
@@ -334,7 +334,7 @@ func TestCreateServiceLBCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
 
 	TearDownTestForSvcLB(t, g)
@@ -401,7 +401,7 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
 
 	TearDownTestForSvcLB(t, g)
@@ -427,8 +427,8 @@ func TestCreateMultiportServiceLBCacheSync(t *testing.T) {
 	g.Expect(vsCacheObj.Tenant).To(gomega.Equal(AVINAMESPACE))
 	g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(3))
 	g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp(`^(cluster--[a-zA-Z0-9-]+-808(0|1|2))$`))
-	g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(3))
-	g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp(`^(cluster--[a-zA-Z0-9-]+-808(0|1|2))$`))
+	g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
+	g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp(`^(cluster--[a-zA-Z0-9-]+)$`))
 
 	TearDownTestForSvcLBMultiport(t, g)
 }


### PR DESCRIPTION
We were creating an L4 policy per port, but this commit will instead
create 1 L4 policyset object for all the ports and index them.