### PR TITLE
Added fixes for l4policy checksum, cache deletion logic, gw fixes

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -70,6 +70,10 @@ func GetAKOUser() string {
 }
 
 func GetshardSize() uint32 {
+	if GetAdvancedL4() {
+		// shard to 8 go routines in the REST layer
+		return shardSizeMap["LARGE"]
+	}
 	shardVsSize := os.Getenv("SHARD_VS_SIZE")
 	shardSize, ok := shardSizeMap[shardVsSize]
 	if ok {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -33,7 +33,6 @@ func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace string, gatewayName stri
 	defer o.Lock.Unlock()
 	if VsNode := o.ConstructAdvL4VsNode(gatewayName, namespace, key); VsNode != nil {
 		o.ConstructAdvL4PolPoolNodes(VsNode, gatewayName, namespace, key)
-		utils.AviLog.Debugf("key: %s, msg: Created VSNode with gateway %v", key, utils.Stringify(VsNode))
 		o.AddModelNode(VsNode)
 		VsNode.CalculateCheckSum()
 		o.GraphChecksum = o.GraphChecksum + VsNode.GetCheckSum()
@@ -57,10 +56,6 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 					serviceNSNames = append(serviceNSNames, service)
 				}
 			}
-		}
-		if len(serviceNSNames) == 0 {
-			// do not create the VS altogether in case services are not present
-			return nil
 		}
 
 		avi_vs_meta := &AviVsNode{
@@ -108,7 +103,6 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		utils.AviLog.Infof("key: %s, msg: created vs object: %s", key, utils.Stringify(avi_vs_meta))
 		return avi_vs_meta
 	}
-
 	return nil
 }
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -55,7 +55,7 @@ func (rest *RestOperations) CleanupVS(key string, skipVS bool) {
 }
 
 func (rest *RestOperations) DeQueueNodes(key string) {
-	utils.AviLog.Debugf("key: %s, msg: start rest layer sync.", key)
+	utils.AviLog.Infof("key: %s, msg: start rest layer sync.", key)
 	namespace, name := utils.ExtractNamespaceObjectName(key)
 	// Got the key from the Graph Layer - let's fetch the model
 	ok, avimodelIntf := objects.SharedAviGraphLister().Get(key)


### PR DESCRIPTION
This commit introduces the following fixes:

 - the has reference check had a copy paste problem.
 - The l4 policy checksum had issues with the protocol string

Additionally following scenarios were verified fixed:
 - Service deletion deletes the pools of the VS.
 - Service creation, adds the pools back.
 - GatewayClass deletion, deletes the Gateway associated VSes.
 - GatewayClass creation, re-creates the VSes associated with the Gateways