### PR TITLE
Stop saving model from layer2 if disable sync is set to true

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -58,6 +58,13 @@ func GetNamePrefix() string {
 	return NamePrefix
 }
 
+var DisableSync bool
+
+func SetDisableSync(state bool) {
+	DisableSync = state
+	utils.AviLog.Infof("Setting Disable Sync to: %v", state)
+}
+
 var AKOUser string
 
 func SetAKOUser() {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -267,6 +267,11 @@ func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, st
 
 func saveAviModel(model_name string, aviGraph *AviObjectGraph, key string) bool {
 	utils.AviLog.Debugf("key: %s, msg: Evaluating model :%s", key, model_name)
+	if lib.DisableSync == true {
+		// Note: This is not thread safe, however locking is expensive and the condition for locking should happen rarely
+		utils.AviLog.Infof("key: %s, msg: Disable Sync is True, model %s can not be saved", key, model_name)
+		return false
+	}
 	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
 	if found && aviModel != nil {
 		prevChecksum := aviModel.(*AviObjectGraph).GraphChecksum


### PR DESCRIPTION
In case of repeated enable and disable sync in a cluster with large number of objects,
layer2 may be processing an object after sync has been disabled from layer1.
In this case layer1 would set the model to nil, but layer2 can save and overrite the value.

Later when layer3 picks up the key to process, it won't find nil model and won't delete
all avi objects.

Checking if disableSync is set to before saving model from layer2 to handle this.