### PR TITLE
Stop saving model from layer2 if disable sync is set to true

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -100,12 +100,14 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 	aviClientPool := avicache.SharedAVIClients()
 	if len(aviClientPool.AviClient) < 1 {
 		c.DisableSync = true
+		lib.SetDisableSync(true)
 		utils.AviLog.Errorf("could not get client to connect to Avi Controller, disabling sync")
 		lib.ShutdownApi()
 		return
 	}
 	aviclient := aviClientPool.AviClient[0]
 	c.DisableSync = !avicache.ValidateUserInput(aviclient) || deleteConfigFromConfigmap(cs)
+	lib.SetDisableSync(c.DisableSync)
 
 	utils.AviLog.Infof("Creating event broadcaster for handling configmap")
 	eventBroadcaster := record.NewBroadcaster()
@@ -122,6 +124,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			utils.AviLog.Infof("avi k8s configmap created")
 			utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
 			c.DisableSync = !avicache.ValidateUserInput(aviclient) || delConfigFromData(cm.Data)
+			lib.SetDisableSync(c.DisableSync)
 			if !firstboot && avicache.ValidateUserInput(aviclient) {
 				if delConfigFromData(cm.Data) {
 					c.DeleteModels()
@@ -149,6 +152,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			}
 			// if DeleteConfig value has changed, then check if we need to enable/disable sync
 			c.DisableSync = !avicache.ValidateUserInput(aviclient) || delConfigFromData(cm.Data)
+			lib.SetDisableSync(c.DisableSync)
 			if avicache.ValidateUserInput(aviclient) {
 				if delConfigFromData(cm.Data) {
 					c.DeleteModels()
@@ -162,6 +166,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			if _, ok := validateAviConfigMap(obj); ok {
 				utils.AviLog.Warnf("avi k8s configmap deleted, disabling sync")
 				c.DisableSync = true
+				lib.SetDisableSync(true)
 				firstboot = false
 			}
 		},

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -58,6 +58,13 @@ func GetNamePrefix() string {
 	return NamePrefix
 }
 
+var DisableSync bool
+
+func SetDisableSync(state bool) {
+	DisableSync = state
+	utils.AviLog.Infof("Setting Disable Sync to: %v", state)
+}
+
 var AKOUser string
 
 func SetAKOUser() {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -218,6 +218,11 @@ func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, st
 
 func saveAviModel(model_name string, aviGraph *AviObjectGraph, key string) bool {
 	utils.AviLog.Debugf("key: %s, msg: Evaluating model :%s", key, model_name)
+	if lib.DisableSync == true {
+		// Note: This is not thread safe, however locking is expensive and the condition for locking should happen rarely
+		utils.AviLog.Infof("key: %s, msg: Disable Sync is True, model %s can not be saved", key, model_name)
+		return false
+	}
 	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
 	if found && aviModel != nil {
 		prevChecksum := aviModel.(*AviObjectGraph).GraphChecksum


### PR DESCRIPTION
In case of repeated enable and disable sync in a cluster with large number of objects,
layer2 may be processing an object after sync has been disabled from layer1.
In this case layer1 would set the model to nil, but layer2 can save and overrite the value.

Later when layer3 picks up the key to process, it won't find nil model and won't delete
all avi objects.

Checking if disableSync is set to before saving model from layer2 to handle this.

(cherry picked from commit 80d1762c7be2dd91fc534b7560d61340accb5503)