### PR TITLE
Make the API server port configurable.

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -47,7 +47,7 @@ func main() {
 }
 
 func InitializeAKOApi() {
-	akoApi := api.NewServer("8080", []models.ApiModel{})
+	akoApi := api.NewServer(lib.GetAkoApiServerPort(), []models.ApiModel{})
 	akoApi.InitApi()
 	lib.SetApiServerInstance(akoApi)
 }

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -36,3 +36,4 @@ data:
     {{- range $.Values.configs.nodeNetworkCIDRs }}
     - {{ . }}
     {{- end }}
+  apiServerPort: {{ default "8080" .Values.configs.apiServerPort | quote }}

--- a/helm/ako/templates/deployment.yaml
+++ b/helm/ako/templates/deployment.yaml
@@ -142,6 +142,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: nodeNetworkName
+          - name: AKO_API_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: apiServerPort
           - name: NODE_NETWORK_CIDRS
             valueFrom:
               configMapKeyRef:
@@ -190,7 +195,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /api/status
-              port: 8080
+              port:  {{ default "8080" .Values.configs.apiServerPort }}
             initialDelaySeconds: 5
             periodSeconds: 10
         

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -30,6 +30,7 @@ configs:
   serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
   nodeNetworkName: "" # Network name of the node network
   nodeNetworkCIDRs: [] # List of CIDR of node network where the nodes are created.
+  apiServerPort: 8080 # Specify the port for the API server, default is set as 8080
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -243,6 +243,16 @@ func GetNamespaceToSync() string {
 	return ""
 }
 
+// The port to run the AKO API server on
+func GetAkoApiServerPort() string {
+	port := os.Getenv("AKO_API_PORT")
+	if port != "" {
+		return port
+	}
+	// Default case, if not specified.
+	return "8080"
+}
+
 func GetSubnetIP() string {
 	subnetIP := os.Getenv(SUBNET_IP)
 	if subnetIP != "" {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -101,7 +101,7 @@ func NewServer(port string, models []models.ApiModel) *ApiServer {
 
 func (a *ApiServer) InitApi() {
 	go func() {
-		utils.AviLog.Infof("Starting API server")
+		utils.AviLog.Infof("Starting API server at %s", a.Server.Addr)
 		err := a.ListenAndServe()
 		if err != nil {
 			utils.AviLog.Infof("API server shutdown: %v", err)


### PR DESCRIPTION
AKO runs an API server on port 8080 by default. This commit allows
this port to be configurable via a helm option.