### PR TITLE
Fixing the helm charts + Controller version discovery

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -5,33 +5,32 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   controllerIP: {{ .Values.configs.controllerIP | quote }}
-  controllerVersion: {{ .Values.configs.controllerVersion | quote }}
-  cniPlugin: {{ .Values.configs.cniPlugin | quote }}
-  shardVSSize: {{ .Values.configs.shardVSSize | quote }}
-  passthroughShardSize: {{ .Values.configs.passthroughShardSize | quote }}
-  fullSyncFrequency: {{ .Values.configs.fullSyncFrequency | quote }}
-  cloudName: {{ .Values.configs.cloudName | quote }}
-  clusterName: {{ .Values.configs.clusterName | quote }}
-  defaultDomain: {{ .Values.configs.defaultDomain | quote }}
-  disableStaticRouteSync: {{ .Values.configs.disableStaticRouteSync | quote }}
-  ingressApi: {{ .Values.configs.ingressApi | quote }}
-  defaultIngController: {{ .Values.configs.defaultIngController | quote }}
-  subnetIP: {{ .Values.configs.subnetIP | quote }}
-  subnetPrefix: {{ .Values.configs.subnetPrefix | quote }}
-  networkName: {{ .Values.configs.networkName | quote }}
-  l7ShardingScheme: {{ .Values.configs.l7ShardingScheme | quote }}
-  logLevel: {{ .Values.configs.logLevel | quote }}
-  deleteConfig: {{ .Values.configs.deleteConfig | quote }}
-  advancedL4: {{ .Values.configs.advancedL4 | quote }}
+  controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
+  cniPlugin: {{ .Values.AKOSettings.cniPlugin | quote }}
+  shardVSSize: {{ .Values.L7Settings.shardVSSize | quote }}
+  passthroughShardSize: {{ .Values.L7Settings.passthroughShardSize | quote }}
+  fullSyncFrequency: {{ .Values.AKOSettings.fullSyncFrequency | quote }}
+  cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
+  clusterName: {{ .Values.AKOSettings.clusterName | quote }}
+  defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}
+  disableStaticRouteSync: {{ .Values.AKOSettings.disableStaticRouteSync | quote }}
+  defaultIngController: {{ .Values.L7Settings.defaultIngController | quote }}
+  subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
+  subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
+  networkName: {{ .Values.NetworkSettings.networkName | quote }}
+  l7ShardingScheme: {{ .Values.L7Settings.l7ShardingScheme | quote }}
+  logLevel: {{ .Values.AKOSettings.logLevel | quote }}
+  deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
+  advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}
   {{ if .Values.configs.syncNamespace  }}
   syncNamespace: {{ .Values.configs.syncNamespace | quote }}
   {{ end }}
-  serviceType:  {{ .Values.configs.serviceType | quote }}
-  {{ if eq .Values.configs.serviceType "NodePort" }}
+  serviceType:  {{ .Values.L7Settings.serviceType | quote }}
+  {{ if eq .Values.L7Settings.serviceType "NodePort" }}
   nodeKey: {{ .Values.nodePortSelector.key | quote }}
   nodeValue: {{ .Values.nodePortSelector.value | quote }}
   {{ end }}
-  serviceEngineGroupName:  {{ .Values.configs.serviceEngineGroupName | quote }}
+  serviceEngineGroupName:  {{ .Values.ControllerSettings.serviceEngineGroupName | quote }}
   nodeNetworkList: |-
-    {{ .Values.configs.nodeNetworkList | mustToJson }}
-  apiServerPort: {{ default "8080" .Values.configs.apiServerPort | quote }}
+    {{ .Values.NetworkSettings.nodeNetworkList | mustToJson }}
+  apiServerPort: {{ default "8080" .Values.AKOSettings.apiServerPort | quote }}

--- a/helm/ako/templates/deployment.yaml
+++ b/helm/ako/templates/deployment.yaml
@@ -100,11 +100,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: disableStaticRouteSync
-          - name: INGRESS_API
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: ingressApi
            {{ if .Values.configs.syncNamespace  }}
           - name: SYNC_NAMESPACE
             valueFrom:
@@ -152,7 +147,7 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: serviceType
-          {{ if eq .Values.configs.serviceType "NodePort" }}
+          {{ if eq .Values.L7Settings.serviceType "NodePort" }}
           - name: NODE_KEY
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -8,26 +8,18 @@ image:
   repository: 10.79.172.11:5000/avi-buildops/ako
   pullPolicy: IfNotPresent
 
-configs:
-  controllerVersion: "18.2.8"
-  shardVSSize: "LARGE"
-  passthroughShardSize: "SMALL"
-  fullSyncFrequency: "300"
-  cloudName: "Default-Cloud"
-  clusterName: ""
-  defaultDomain: ""
-  disableStaticRouteSync: "false"
-  ingressApi: "corev1" #enum: extensionv1 and corev1 - if not set default to corev1
-  defaultIngController: "true"
-  subnetIP: "" # Subnet IP of the data network
-  subnetPrefix: "" # Subnet Prefix of the data network
-  networkName: "" # Network Name of the data network
-  l7ShardingScheme: "hostname"
-  cniPlugin: "" #enum: calico|canal|flannel|openshift
-  logLevel: "INFO" #enum: INFO|DEBUG|WARN|ERROR
-  deleteConfig: "false" # Has to be set to true in configmap if user wants to delete AKO created objects from AVI
-  serviceType: ClusterIP #enum NodePort|ClusterIP
-  serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
+### This section outlines the generic AKO settings
+AKOSettings:
+  logLevel: "WARN" #enum: INFO|DEBUG|WARN|ERROR
+  fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.
+  apiServerPort: 8080 # Specify the port for the API server, default is set as 8080 // EmptyAllowed: false
+  deleteConfig: "false" # Has to be set to true in configmap if user wants to delete AKO created objects from AVI 
+  disableStaticRouteSync: "false" # If the POD networks are reachable from the Avi SE, set this knob to true.
+  clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
+  cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift 
+
+### This section outlines the network settings for virtualservices. 
+NetworkSettings:
   ## This list of network and cidrs are used in pool placement network for vcenter cloud.
   ## Node Network details are not needed when in nodeport mode / static routes are disabled / non vcenter clouds.
   nodeNetworkList: []
@@ -36,27 +28,34 @@ configs:
   #     cidrs:
   #       - 10.0.0.1/24
   #       - 11.0.0.1/24
-  ## Advanced L4 allows users to control VS settings using the services-api. This disables all Ingress/Route features.
-  ## Forces the L4 syncing to use Gateway object.
-  advancedL4: "false"
-  apiServerPort: 8080 # Specify the port for the API server, default is set as 8080
+  subnetIP: "" # Subnet IP of the vip network
+  subnetPrefix: "" # Subnet Prefix of the vip network
+  networkName: "" # Network Name of the vip network
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+### This section outlines all the knobs  used to control Layer 7 loadbalancing settings in AKO.
+L7Settings:
+  defaultIngController: "true"
+  l7ShardingScheme: "hostname"
+  serviceType: ClusterIP #enum NodePort|ClusterIP
+  shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL
+  passthroughShardSize: "SMALL" # Control the passthrough virtualservice numbers using this ENUM. ENUMs: LARGE, MEDIUM, SMALL
+
+### This section outlines all the knobs  used to control Layer 4 loadbalancing settings in AKO.
+L4Settings:
+  advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
+  defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
+
+### This section outlines settings on the Avi controller that affects AKO's functionality.
+ControllerSettings:
+  serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
+  controllerVersion: "18.2.10" # The controller API version
+  cloudName: "Default-Cloud" # The configured cloud name on the Avi controller.
+
 
 nodePortSelector: # Only applicable if serviceType is NodePort
   key: ""
   value: ""
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1771,8 +1771,7 @@ func (c *AviObjCache) PopulateL4PolicySetToCache(client *clients.AviClient, clou
 }
 
 func (c *AviObjCache) AviObjVrfCachePopulate(client *clients.AviClient, cloud string) error {
-	disableStaticRoute := os.Getenv(lib.DISABLE_STATIC_ROUTE_SYNC)
-	if disableStaticRoute == "true" {
+	if lib.GetDisableStaticRoute() {
 		utils.AviLog.Debugf("Static route sync disabled, skipping vrf cache population")
 		return nil
 	}
@@ -2483,7 +2482,7 @@ func checkRequiredValuesYaml() bool {
 func checkSegroupLabels(client *clients.AviClient) bool {
 
 	// Not applicable for NodePort mode / disable route is set as True
-	if lib.IsNodePortMode() || os.Getenv(lib.DISABLE_STATIC_ROUTE_SYNC) == "true" {
+	if lib.GetDisableStaticRoute() {
 		utils.AviLog.Infof("Skipping the check for SE group labels ")
 		return true
 	}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2421,6 +2421,7 @@ func ValidateUserInput(client *clients.AviClient) bool {
 	isCloudValid := checkAndSetCloudType(client)
 	isRequiredValuesValid := checkRequiredValuesYaml()
 	if lib.GetAdvancedL4() && isCloudValid && isRequiredValuesValid {
+		utils.AviLog.Info("All values verified for advanced L4, proceeding with bootup")
 		return true
 	}
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -325,7 +325,7 @@ func (c *AviController) FullSyncK8s() {
 	}
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 	var vrfModelName string
-	if os.Getenv(lib.DISABLE_STATIC_ROUTE_SYNC) == "true" && !lib.IsNodePortMode() {
+	if lib.GetDisableStaticRoute() && !lib.IsNodePortMode() {
 		utils.AviLog.Infof("Static route sync disabled, skipping node informers")
 	} else {
 		lib.SetStaticRouteSyncHandler()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -16,7 +16,6 @@ package k8s
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"sync"
 
@@ -615,7 +614,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 		c.informers.SecretInformer.Informer().AddEventHandler(secretEventHandler)
 	}
 
-	if os.Getenv(lib.DISABLE_STATIC_ROUTE_SYNC) == "true" && !lib.IsNodePortMode() {
+	if lib.GetDisableStaticRoute() && !lib.IsNodePortMode() {
 		utils.AviLog.Infof("Static route sync disabled, skipping node informers")
 	} else {
 		c.informers.NodeInformer.Informer().AddEventHandler(nodeEventHandler)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -341,6 +341,18 @@ func GetDomain() string {
 func GetAdvancedL4() bool {
 	advanceL4 := os.Getenv(ADVANCED_L4)
 	if advanceL4 == "true" {
+
+		return true
+	}
+	return false
+}
+
+func GetDisableStaticRoute() bool {
+	disableStaticRoute := os.Getenv(DISABLE_STATIC_ROUTE_SYNC)
+	if disableStaticRoute == "true" && !GetAdvancedL4() {
+		return true
+	}
+	if IsNodePortMode() {
 		return true
 	}
 	return false

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -14,7 +14,6 @@
 package rest
 
 import (
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -101,7 +100,7 @@ func (rest *RestOperations) DeQueueNodes(key string) {
 }
 
 func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObjectGraph) {
-	if os.Getenv(lib.DISABLE_STATIC_ROUTE_SYNC) == "true" {
+	if lib.GetDisableStaticRoute() {
 		utils.AviLog.Debugf("key: %s, msg: static route sync disabled\n", key)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -55,6 +55,12 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 		// Retry 20 times with an interval of 10 seconds each.
 		aviClient, err := clients.NewAviClient(api_ep, username,
 			session.SetPassword(password), session.SetControllerStatusCheckLimits(20, 10), session.SetInsecure)
+		version, err := aviClient.AviSession.GetControllerVersion()
+		if err == nil && CtrlVersion == "" {
+			AviLog.Debugf("Setting the client version to %v", version)
+			session.SetVersion(version)
+			CtrlVersion = version
+		}
 		if err != nil {
 			AviLog.Warnf("NewAviClient returned err %v", err)
 			return &p, err
@@ -70,8 +76,6 @@ func (p *AviRestClientPool) AviRestOperate(c *clients.AviClient, rest_ops []*Res
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
-		SetVersion := session.SetVersion(op.Version)
-		SetVersion(c.AviSession)
 		switch op.Method {
 		case RestPost:
 			op.Err = c.AviSession.Post(op.Path, op.Obj, &op.Response)

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -55,15 +55,17 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 		// Retry 20 times with an interval of 10 seconds each.
 		aviClient, err := clients.NewAviClient(api_ep, username,
 			session.SetPassword(password), session.SetControllerStatusCheckLimits(20, 10), session.SetInsecure)
-		version, err := aviClient.AviSession.GetControllerVersion()
-		if err == nil && CtrlVersion == "" {
-			AviLog.Debugf("Setting the client version to %v", version)
-			session.SetVersion(version)
-			CtrlVersion = version
-		}
 		if err != nil {
 			AviLog.Warnf("NewAviClient returned err %v", err)
 			return &p, err
+		}
+		if err == nil && aviClient.AviSession != nil {
+			version, err := aviClient.AviSession.GetControllerVersion()
+			if err == nil && CtrlVersion == "" {
+				AviLog.Debugf("Setting the client version to %v", version)
+				session.SetVersion(version)
+				CtrlVersion = version
+			}
 		}
 
 		p.AviClient = append(p.AviClient, aviClient)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,9 +42,6 @@ var runtimeScheme = k8sruntime.NewScheme()
 func init() {
 	//Setting the package-wide version
 	CtrlVersion = os.Getenv("CTRL_VERSION")
-	if CtrlVersion == "" {
-		CtrlVersion = "18.2.2"
-	}
 	extensions.AddToScheme(runtimeScheme)
 	networking.AddToScheme(runtimeScheme)
 }

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -119,6 +119,9 @@ func injectMWForObjDeletion() {
 		} else if strings.Contains(url, "login") {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"success": "true"}`))
+		} else if strings.Contains(url, "initial-data") {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 		}
 	})
 }
@@ -129,6 +132,9 @@ func injectMWForCloud() {
 		if r.Method == "GET" && strings.Contains(url, "/api/cloud/") {
 			integrationtest.FeedMockCollectionData(w, r, invalidFilePath)
 
+		} else if strings.Contains(url, "initial-data") {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 		} else if r.Method == "GET" {
 			integrationtest.FeedMockCollectionData(w, r, mockFilePath)
 

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -833,6 +833,9 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 		// This is used for /login --> first request to controller
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"success": "true"}`))
+	} else if strings.Contains(url, "initial-data") {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 	}
 }
 


### PR DESCRIPTION
Simplified the helm chart and forced AKO to set the controller version by querying the SDK if it's not specified. 