### PR TITLE
additional fixes for status update

### DIFF
--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -502,11 +502,17 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 			} else {
 				poolName = lib.GetSniPoolName(ingName, namespace, host, path.Path, path.ServiceName)
 			}
+			hostSlice := []string{host}
 			poolNode := &AviPoolNode{
 				Name:       poolName,
 				PortName:   path.PortName,
 				Tenant:     lib.GetTenant(),
 				VrfContext: lib.GetVrf(),
+				ServiceMetadata: avicache.ServiceMetadataObj{
+					IngressName: ingName,
+					Namespace:   namespace,
+					HostNames:   hostSlice,
+				},
 			}
 
 			if hostpath.reencrypt == true {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -409,19 +409,21 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				}
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
 				// But before this a pool may have got created as a part of the macro operation, so update the ingress status here.
-				for _, poolkey := range vs_cache_obj.PoolKeyCollection {
-					// Fetch the pool object from cache and check the service metadata
-					pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)
-					if ok {
-						utils.AviLog.Infof("key: %s, msg: found pool: %s, will update status", key, poolkey.Name)
-						pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
-						if found {
-							if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
-								status.UpdateRouteIngressStatus([]status.UpdateStatusOptions{{
-									Vip:             vs_cache_obj.Vip,
-									ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
-									Key:             key,
-								}}, false)
+				if rest_op.Method == utils.RestPost {
+					for _, poolkey := range vs_cache_obj.PoolKeyCollection {
+						// Fetch the pool object from cache and check the service metadata
+						pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)
+						if ok {
+							utils.AviLog.Infof("key: %s, msg: found pool: %s, will update status", key, poolkey.Name)
+							pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
+							if found {
+								if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
+									status.UpdateRouteIngressStatus([]status.UpdateStatusOptions{{
+										Vip:             vs_cache_obj.Vip,
+										ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
+										Key:             key,
+									}}, false)
+								}
 							}
 						}
 					}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -409,7 +409,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				}
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
 				// But before this a pool may have got created as a part of the macro operation, so update the ingress status here.
-				if rest_op.Method == utils.RestPost {
+				if rest_op.Method == utils.RestPost || rest_op.Method == utils.RestDelete {
 					for _, poolkey := range vs_cache_obj.PoolKeyCollection {
 						// Fetch the pool object from cache and check the service metadata
 						pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -33,6 +33,9 @@ func (rest *RestOperations) SyncIngressStatus() {
 	var allServiceLBUpdateOptions []status.UpdateStatusOptions
 	var allGatewayUpdateOptions []status.UpdateStatusOptions
 	for _, vsKey := range vsKeys {
+		if vsKey.Name == lib.DummyVSForStaleData {
+			continue
+		}
 		vsCache, ok := rest.cache.VsCacheMeta.AviCacheGet(vsKey)
 		if !ok {
 			continue

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -56,6 +56,10 @@ func UpdateIngressStatus(options []UpdateStatusOptions, bulk bool) {
 }
 
 func updateObject(mIngress *networking.Ingress, updateOption UpdateStatusOptions, retryNum ...int) error {
+	if updateOption.Vip == "" {
+		return nil
+	}
+
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -377,12 +377,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 	for i := len(mRoute.Status.Ingress) - 1; i >= 0; i-- {
 		for _, host := range svc_mdata_obj.HostNames {
 			if mRoute.Status.Ingress[i].Host == host {
-				// Check if this host is still present in the spec, if so - don't delete it
-				if !utils.HasElem(hostListIng, host) || isVSDelete {
-					mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)
-				} else {
-					utils.AviLog.Debugf("key: %s, msg: skipping status update since host is present in the route: %v", key, host)
-				}
+				mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)
 			}
 		}
 	}

--- a/tests/integrationtest/l7_ingress_rest_test.go
+++ b/tests/integrationtest/l7_ingress_rest_test.go
@@ -170,7 +170,7 @@ func TestCreateIngressWithFaultCacheSync(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs)
-	}, 5*time.Second).Should(gomega.Equal(1))
+	}, 60*time.Second).Should(gomega.Equal(1))
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-6"}
@@ -212,7 +212,7 @@ func TestUpdatePoolCacheSync(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.PoolCache.AviCacheGet(poolKey)
 		return found
-	}, 5*time.Second).Should(gomega.Equal(true))
+	}, 60*time.Second).Should(gomega.Equal(true))
 	poolCacheBefore, _ := mcache.PoolCache.AviCacheGet(poolKey)
 	poolCacheBeforeObj, _ := poolCacheBefore.(*cache.AviPoolCache)
 	oldPoolCksum := poolCacheBeforeObj.CloudConfigCksum
@@ -283,7 +283,7 @@ func TestDeletePoolCacheSync(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.PoolCache.AviCacheGet(newPoolKey)
 		return found
-	}, 5*time.Second).Should(gomega.Equal(true))
+	}, 60*time.Second).Should(gomega.Equal(true))
 	newPoolCache, _ := mcache.PoolCache.AviCacheGet(newPoolKey)
 	newPoolCacheObj, _ := newPoolCache.(*cache.AviPoolCache)
 	g.Expect(newPoolCacheObj.Name).To(gomega.Not(gomega.ContainSubstring("foo.com")))
@@ -564,7 +564,7 @@ func TestMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey1)
 		return found
-	}, 15*time.Second).Should(gomega.Equal(false))
+	}, 60*time.Second).Should(gomega.Equal(false))
 	TearDownTestForIngress(t, modelName)
 }
 
@@ -662,7 +662,7 @@ func TestCUDSecretCacheSync(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.SSLKeyCache.AviCacheGet(sslKey)
 		return found
-	}, 5*time.Second).Should(gomega.Equal(false))
+	}, 60*time.Second).Should(gomega.Equal(false))
 	_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 	g.Expect(found).To(gomega.Equal(false))
 
@@ -685,7 +685,7 @@ func TestIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get("foo-with-targets", metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 5*time.Second).Should(gomega.Equal(1))
+	}, 60*time.Second).Should(gomega.Equal(1))
 	ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get("foo-with-targets", metav1.GetOptions{})
 	g.Expect(ingress.Status.LoadBalancer.Ingress[0].IP).To(gomega.Equal("10.250.250.16"))
 	g.Expect(ingress.Status.LoadBalancer.Ingress[0].Hostname).To(gomega.ContainSubstring("foo.com"))
@@ -724,7 +724,7 @@ func TestMultiHostIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get(ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 15*time.Second).Should(gomega.Equal(3))
+	}, 60*time.Second).Should(gomega.Equal(3))
 	ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get(ingressName, metav1.GetOptions{})
 
 	// fake avi controller server returns IP in the form: 10.250.250.1<Shard-VS-NUM>
@@ -799,7 +799,7 @@ func TestMultiHostUpdateIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get(ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 15*time.Second).Should(gomega.Equal(2))
+	}, 60*time.Second).Should(gomega.Equal(2))
 
 	KubeClient.ExtensionsV1beta1().Ingresses("default").Delete(ingressName, nil)
 	TearDownTestForIngress(t, modelName)
@@ -821,7 +821,7 @@ func TestDeleteSecretSecureIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get("foo-with-targets", metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 15*time.Second).Should(gomega.Equal(0))
+	}, 60*time.Second).Should(gomega.Equal(0))
 
 	TearDownIngressForCacheSyncCheck(t, modelName, g)
 }

--- a/tests/oshiftroutetests/oshift_route_rest_test.go
+++ b/tests/oshiftroutetests/oshift_route_rest_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+
 	"github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -160,4 +163,105 @@ func TestMultiRouteStatusSameHost(t *testing.T) {
 
 	TearDownRouteForRestCheck(t, DefaultModelName)
 	objects.SharedAviGraphLister().Delete("admin/cluster--Shared-L7-1")
+}
+
+func TestRouteAlternateBackend(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForRoute(t, DefaultModelName)
+	integrationtest.CreateSVC(t, "default", "absvc2", corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "absvc2", false, false, "3.3.3")
+	routeExample := FakeRoute{}.ABRoute()
+	_, err := OshiftClient.RouteV1().Routes(DefaultNamespace).Create(routeExample)
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	var route *routev1.Route
+	g.Eventually(func() string {
+		route, _ = OshiftClient.RouteV1().Routes("default").Get(DefaultRouteName, metav1.GetOptions{})
+		if (len(route.Status.Ingress)) != 1 {
+			return ""
+		}
+		return route.Status.Ingress[0].Host
+	}, 60*time.Second).Should(gomega.Equal(DefaultHostname))
+	g.Expect(route.Status.Ingress[0].Conditions[0].Message).Should(gomega.Equal("10.250.250.10"))
+
+	TearDownRouteForRestCheck(t, DefaultModelName)
+	objects.SharedAviGraphLister().Delete("admin/cluster--Shared-L7-1")
+	integrationtest.DelSVC(t, "default", "absvc2")
+	integrationtest.DelEP(t, "default", "absvc2")
+}
+
+func TestRouteWrongAlternateBackend(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForRoute(t, DefaultModelName)
+	routeExample := FakeRoute{Backend2: "avisvc"}.ABRoute()
+	_, err := OshiftClient.RouteV1().Routes(DefaultNamespace).Create(routeExample)
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	var route *routev1.Route
+	g.Eventually(func() string {
+		route, _ = OshiftClient.RouteV1().Routes("default").Get(DefaultRouteName, metav1.GetOptions{})
+		if (len(route.Status.Ingress)) != 1 {
+			return ""
+		}
+		return route.Status.Ingress[0].Host
+	}, 60*time.Second).Should(gomega.Equal(DefaultHostname))
+
+	g.Expect(route.Status.Ingress[0].Conditions[0].Message).Should(gomega.Equal(""))
+
+	TearDownRouteForRestCheck(t, DefaultModelName)
+	objects.SharedAviGraphLister().Delete("admin/cluster--Shared-L7-1")
+}
+
+func TestPassthroughRouteAlternateBackend(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForRoute(t, DefaultPassthroughModel)
+	integrationtest.CreateSVC(t, "default", "absvc2", corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "absvc2", false, false, "3.3.3")
+	routeExample := FakeRoute{Path: "/foo"}.PassthroughABRoute()
+	_, err := OshiftClient.RouteV1().Routes(DefaultNamespace).Create(routeExample)
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	var route *routev1.Route
+	g.Eventually(func() string {
+		route, _ = OshiftClient.RouteV1().Routes("default").Get(DefaultRouteName, metav1.GetOptions{})
+		if (len(route.Status.Ingress)) != 1 {
+			return ""
+		}
+		return route.Status.Ingress[0].Host
+	}, 60*time.Second).Should(gomega.Equal(DefaultHostname))
+	g.Expect(route.Status.Ingress[0].Conditions[0].Message).Should(gomega.Equal("10.250.250.250"))
+
+	TearDownRouteForRestCheck(t, DefaultPassthroughModel)
+	integrationtest.DelSVC(t, "default", "absvc2")
+	integrationtest.DelEP(t, "default", "absvc2")
+}
+
+func TestPassthroughRouteWrongAlternateBackend(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForRoute(t, DefaultPassthroughModel)
+	routeExample := FakeRoute{Backend2: "avisvc"}.ABRoute()
+	_, err := OshiftClient.RouteV1().Routes(DefaultNamespace).Create(routeExample)
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	var route *routev1.Route
+	g.Eventually(func() string {
+		route, _ = OshiftClient.RouteV1().Routes("default").Get(DefaultRouteName, metav1.GetOptions{})
+		if (len(route.Status.Ingress)) != 1 {
+			return ""
+		}
+		return route.Status.Ingress[0].Host
+	}, 60*time.Second).Should(gomega.Equal(DefaultHostname))
+
+	g.Expect(route.Status.Ingress[0].Conditions[0].Message).Should(gomega.Equal(""))
+
+	TearDownRouteForRestCheck(t, DefaultPassthroughModel)
+	objects.SharedAviGraphLister().Delete(DefaultPassthroughModel)
 }


### PR DESCRIPTION

- don't sync status for dummy vs
- add service metadata in pool for namespace shard
- test cases for duplicate backend in route
- Update status from AviVsCacheAdd only for Post / Delete operation: If we update for put operation, then we may be adding updates which are not required. These should be handled during pool add operations