### PR TITLE
Misc fixes

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -130,6 +130,8 @@ func InitializeAKC() {
 	waitGroupMap["ingestion"] = wgIngestion
 	wgFastRetry := &sync.WaitGroup{}
 	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
 	go c.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/avinetworks/ako v0.0.0-20200818183048-9235bc726579 // indirect
 	github.com/avinetworks/container-lib v0.0.0-20200805113307-80c6b5ecc46e // indirect
-	github.com/avinetworks/sdk v0.0.0-20200908155649-48d0ac51ea58
+	github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/avinetworks/sdk v0.0.0-20200812060914-ba100c75801c h1:GsvjuI/E65E35vc
 github.com/avinetworks/sdk v0.0.0-20200812060914-ba100c75801c/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
 github.com/avinetworks/sdk v0.0.0-20200908155649-48d0ac51ea58 h1:CDN7TnSB1h6GIql/jiJeYhBjTEuHt+FcNetsxSpaFP0=
 github.com/avinetworks/sdk v0.0.0-20200908155649-48d0ac51ea58/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
+github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241 h1:dolIx15h9Ioz87HAdFRFzz4aUavgt5vWKsrJrPwYg2g=
+github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -5,31 +5,31 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   controllerIP: {{ .Values.configs.controllerIP | quote }}
-  controllerVersion: {{ .Values.configs.controllerVersion | quote }}
-  cniPlugin: {{ .Values.configs.cniPlugin | quote }}
-  shardVSSize: {{ .Values.configs.shardVSSize | quote }}
-  passthroughShardSize: {{ .Values.configs.passthroughShardSize | quote }}
-  fullSyncFrequency: {{ .Values.configs.fullSyncFrequency | quote }}
-  cloudName: {{ .Values.configs.cloudName | quote }}
-  clusterName: {{ .Values.configs.clusterName | quote }}
-  defaultDomain: {{ .Values.configs.defaultDomain | quote }}
-  disableStaticRouteSync: {{ .Values.configs.disableStaticRouteSync | quote }}
-  ingressApi: {{ .Values.configs.ingressApi | quote }}
-  defaultIngController: {{ .Values.configs.defaultIngController | quote }}
-  subnetIP: {{ .Values.configs.subnetIP | quote }}
-  subnetPrefix: {{ .Values.configs.subnetPrefix | quote }}
-  networkName: {{ .Values.configs.networkName | quote }}
-  l7ShardingScheme: {{ .Values.configs.l7ShardingScheme | quote }}
-  logLevel: {{ .Values.configs.logLevel | quote }}
-  deleteConfig: {{ .Values.configs.deleteConfig | quote }}
+  controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
+  cniPlugin: {{ .Values.AKOSettings.cniPlugin | quote }}
+  shardVSSize: {{ .Values.L7Settings.shardVSSize | quote }}
+  passthroughShardSize: {{ .Values.L7Settings.passthroughShardSize | quote }}
+  fullSyncFrequency: {{ .Values.AKOSettings.fullSyncFrequency | quote }}
+  cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
+  clusterName: {{ .Values.AKOSettings.clusterName | quote }}
+  defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}
+  disableStaticRouteSync: {{ .Values.AKOSettings.disableStaticRouteSync | quote }}
+  defaultIngController: {{ .Values.L7Settings.defaultIngController | quote }}
+  subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
+  subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
+  networkName: {{ .Values.NetworkSettings.networkName | quote }}
+  l7ShardingScheme: {{ .Values.L7Settings.l7ShardingScheme | quote }}
+  logLevel: {{ .Values.AKOSettings.logLevel | quote }}
+  deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   {{ if .Values.configs.syncNamespace  }}
   syncNamespace: {{ .Values.configs.syncNamespace | quote }}
   {{ end }}
-  serviceType:  {{ .Values.configs.serviceType | quote }}
-  {{ if eq .Values.configs.serviceType "NodePort" }}
+  serviceType:  {{ .Values.L7Settings.serviceType | quote }}
+  {{ if eq .Values.L7Settings.serviceType "NodePort" }}
   nodeKey: {{ .Values.nodePortSelector.key | quote }}
   nodeValue: {{ .Values.nodePortSelector.value | quote }}
   {{ end }}
-  serviceEngineGroupName:  {{ .Values.configs.serviceEngineGroupName | quote }}
+  serviceEngineGroupName:  {{ .Values.ControllerSettings.serviceEngineGroupName | quote }}
   nodeNetworkList: |-
-    {{ .Values.configs.nodeNetworkList | mustToJson }}
+    {{ .Values.NetworkSettings.nodeNetworkList | mustToJson }}
+  apiServerPort: {{ default "8080" .Values.AKOSettings.apiServerPort | quote }}

--- a/helm/ako/templates/deployment.yaml
+++ b/helm/ako/templates/deployment.yaml
@@ -100,11 +100,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: disableStaticRouteSync
-          - name: INGRESS_API
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: ingressApi
            {{ if .Values.configs.syncNamespace  }}
           - name: SYNC_NAMESPACE
             valueFrom:
@@ -147,7 +142,7 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: serviceType
-          {{ if eq .Values.configs.serviceType "NodePort" }}
+          {{ if eq .Values.L7Settings.serviceType "NodePort" }}
           - name: NODE_KEY
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -10,7 +10,7 @@ image:
 
 ### This section outlines the generic AKO settings
 AKOSettings:
-  logLevel: "WARN" #enum: INFO|DEBUG|WARN|ERROR
+  logLevel: "INFO" #enum: INFO|DEBUG|WARN|ERROR
   fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.
   apiServerPort: 8080 # Specify the port for the API server, default is set as 8080 // EmptyAllowed: false
   deleteConfig: "false" # Has to be set to true in configmap if user wants to delete AKO created objects from AVI 

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -8,26 +8,18 @@ image:
   repository: 10.79.172.11:5000/avi-buildops/ako
   pullPolicy: IfNotPresent
 
-configs:
-  controllerVersion: "18.2.8"
-  shardVSSize: "LARGE"
-  passthroughShardSize: "SMALL"
-  fullSyncFrequency: "300"
-  cloudName: "Default-Cloud"
-  clusterName: ""
-  defaultDomain: ""
-  disableStaticRouteSync: "false"
-  ingressApi: "corev1" #enum: extensionv1 and corev1 - if not set default to corev1
-  defaultIngController: "true"
-  subnetIP: "" # Subnet IP of the data network
-  subnetPrefix: "" # Subnet Prefix of the data network
-  networkName: "" # Network Name of the data network
-  l7ShardingScheme: "hostname"
-  cniPlugin: "" #enum: calico|canal|flannel|openshift
-  logLevel: "INFO" #enum: INFO|DEBUG|WARN|ERROR
-  deleteConfig: "false" # Has to be set to true in configmap if user wants to delete AKO created objects from AVI
-  serviceType: ClusterIP #enum NodePort|ClusterIP
-  serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
+### This section outlines the generic AKO settings
+AKOSettings:
+  logLevel: "WARN" #enum: INFO|DEBUG|WARN|ERROR
+  fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.
+  apiServerPort: 8080 # Specify the port for the API server, default is set as 8080 // EmptyAllowed: false
+  deleteConfig: "false" # Has to be set to true in configmap if user wants to delete AKO created objects from AVI 
+  disableStaticRouteSync: "false" # If the POD networks are reachable from the Avi SE, set this knob to true.
+  clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
+  cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift 
+
+### This section outlines the network settings for virtualservices. 
+NetworkSettings:
   ## This list of network and cidrs are used in pool placement network for vcenter cloud.
   ## Node Network details are not needed when in nodeport mode / static routes are disabled / non vcenter clouds.
   nodeNetworkList: []
@@ -36,24 +28,33 @@ configs:
   #     cidrs:
   #       - 10.0.0.1/24
   #       - 11.0.0.1/24
+  subnetIP: "" # Subnet IP of the vip network
+  subnetPrefix: "" # Subnet Prefix of the vip network
+  networkName: "" # Network Name of the vip network
 
+### This section outlines all the knobs  used to control Layer 7 loadbalancing settings in AKO.
+L7Settings:
+  defaultIngController: "true"
+  l7ShardingScheme: "hostname"
+  serviceType: ClusterIP #enum NodePort|ClusterIP
+  shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL
+  passthroughShardSize: "SMALL" # Control the passthrough virtualservice numbers using this ENUM. ENUMs: LARGE, MEDIUM, SMALL
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+### This section outlines all the knobs  used to control Layer 4 loadbalancing settings in AKO.
+L4Settings:
+  defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
+
+### This section outlines settings on the Avi controller that affects AKO's functionality.
+ControllerSettings:
+  serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
+  controllerVersion: "18.2.10" # The controller API version
+  cloudName: "Default-Cloud" # The configured cloud name on the Avi controller.
+
 
 nodePortSelector: # Only applicable if serviceType is NodePort
   key: ""
   value: ""
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -198,11 +198,13 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	var ingestionwg *sync.WaitGroup
 	var graphwg *sync.WaitGroup
 	var fastretrywg *sync.WaitGroup
+	var slowretrywg *sync.WaitGroup
 	if len(waitGroupMap) > 0 {
 		// Fetch all the waitgroups
 		ingestionwg, _ = waitGroupMap[0]["ingestion"]
 		graphwg, _ = waitGroupMap[0]["graph"]
 		fastretrywg, _ = waitGroupMap[0]["fastretry"]
+		slowretrywg, _ = waitGroupMap[0]["slowretry"]
 	}
 	c.Start(stopCh)
 	/** Sequence:
@@ -268,6 +270,10 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	fastRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.FAST_RETRY_LAYER)
 	fastRetryQueue.SyncFunc = SyncFromFastRetryLayer
 	fastRetryQueue.Run(stopCh, fastretrywg)
+
+	slowRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.SLOW_RETRY_LAYER)
+	slowRetryQueue.SyncFunc = SyncFromSlowRetryLayer
+	slowRetryQueue.Run(stopCh, slowretrywg)
 LABEL:
 	for {
 		select {
@@ -502,6 +508,11 @@ func SyncFromIngestionLayer(key string, wg *sync.WaitGroup) error {
 
 func SyncFromFastRetryLayer(key string, wg *sync.WaitGroup) error {
 	retry.DequeueFastRetry(key)
+	return nil
+}
+
+func SyncFromSlowRetryLayer(key string, wg *sync.WaitGroup) error {
+	retry.DequeueSlowRetry(key)
 	return nil
 }
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -14,11 +14,13 @@
 package rest
 
 import (
+	"errors"
 	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -373,17 +375,22 @@ func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_o
 func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, sslKey ...utils.NamespaceName) {
 	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
 	shardSize := lib.GetshardSize()
-	var fastRetry, retry bool
+	var retry, fastRetry bool
 	if shardSize != 0 {
 		bkt := utils.Bkt(key, shardSize)
 		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v", key, bkt)
 		if len(rest.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
 			aviclient := rest.aviRestPoolClient.AviClient[bkt]
-			err := rest.aviRestPoolClient.AviRestOperate(aviclient, rest_ops)
+			err := rest.AviRestOperateWrapper(aviclient, rest_ops)
 			if err != nil {
 				var publishKey string
 				if avimodel != nil && len(avimodel.GetAviVS()) > 0 {
 					publishKey = avimodel.GetAviVS()[0].Name
+				}
+				if strings.Contains(err.Error(), "Rest request error") || strings.Contains(err.Error(), "timed out waiting for rest response") {
+					// This is a candidate for slow retry
+					rest.PublishKeyToSlowRetryLayer(publishKey, aviclient, key)
+					return
 				}
 				utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
 				models.RestStatus.UpdateAviApiRestStatus("", err)
@@ -407,13 +414,14 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 							}
 						} else {
 							utils.AviLog.Warnf("key: %s, msg: Avi model not set", key)
+							retry = true
 						}
 					} else {
 						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
 					}
 				}
 				if retry {
-					rest.PublishKeyToRetryLayer(publishKey, aviclient, key, fastRetry)
+					rest.PublishKeyToRetryLayer(publishKey, aviclient, key)
 				}
 			} else {
 				models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
@@ -491,12 +499,35 @@ func (rest *RestOperations) DataScriptDelete(dsToDelete []avicache.NamespaceName
 	return restOps
 }
 
-func (rest *RestOperations) PublishKeyToRetryLayer(parentVsKey string, c *clients.AviClient, key string, fastRetry bool) {
+func (rest *RestOperations) PublishKeyToRetryLayer(parentVsKey string, c *clients.AviClient, key string) {
 	var bkt uint32
 	bkt = 0
 	fastRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.FAST_RETRY_LAYER)
 	fastRetryQueue.Workqueue[bkt].AddRateLimited(parentVsKey)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to fast path retry queue: %s", key, parentVsKey)
+}
+
+func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, c *clients.AviClient, key string) {
+	var bkt uint32
+	bkt = 0
+	slowRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.SLOW_RETRY_LAYER)
+	slowRetryQueue.Workqueue[bkt].AddRateLimited(parentVsKey)
+	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to slow path retry queue: %s", key, parentVsKey)
+}
+
+func (rest *RestOperations) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp) error {
+	restTimeoutChan := make(chan error, 1)
+	go func() {
+		err := rest.aviRestPoolClient.AviRestOperate(aviClient, rest_ops)
+		restTimeoutChan <- err
+	}()
+	select {
+	case err := <-restTimeoutChan:
+		return err
+	case <-time.After(80 * time.Second):
+		utils.AviLog.Warnf("timed out waiting for rest response")
+		return errors.New("timed out waiting for rest response")
+	}
 }
 
 func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObjKey avicache.NamespaceName, rest_op *utils.RestOp, aviError session.AviError, c *clients.AviClient, avimodel *nodes.AviObjectGraph, key string) (bool, bool) {

--- a/internal/retry/dequeue_retry.go
+++ b/internal/retry/dequeue_retry.go
@@ -26,3 +26,11 @@ func DequeueFastRetry(vsKey string) {
 	nodes.PublishKeyToRestLayer(modelName, "retry", sharedQueue)
 
 }
+
+func DequeueSlowRetry(vsKey string) {
+	utils.AviLog.Infof("Retrieved the key for slow retry: %s", vsKey)
+	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
+	modelName := utils.ADMIN_NS + "/" + vsKey
+	nodes.PublishKeyToRestLayer(modelName, "retry", sharedQueue)
+
+}

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -55,6 +55,12 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 		// Retry 20 times with an interval of 10 seconds each.
 		aviClient, err := clients.NewAviClient(api_ep, username,
 			session.SetPassword(password), session.SetControllerStatusCheckLimits(20, 10), session.SetInsecure)
+		version, err := aviClient.AviSession.GetControllerVersion()
+		if err == nil && CtrlVersion == "" {
+			AviLog.Debugf("Setting the client version to %v", version)
+			session.SetVersion(version)
+			CtrlVersion = version
+		}
 		if err != nil {
 			AviLog.Warnf("NewAviClient returned err %v", err)
 			return &p, err
@@ -70,8 +76,6 @@ func (p *AviRestClientPool) AviRestOperate(c *clients.AviClient, rest_ops []*Res
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
-		SetVersion := session.SetVersion(op.Version)
-		SetVersion(c.AviSession)
 		switch op.Method {
 		case RestPost:
 			op.Err = c.AviSession.Post(op.Path, op.Obj, &op.Response)

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -54,7 +54,7 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 	for i := uint32(0); i < num; i++ {
 		// Retry 20 times with an interval of 10 seconds each.
 		aviClient, err := clients.NewAviClient(api_ep, username,
-			session.SetPassword(password), session.SetControllerStatusCheckLimits(20, 10), session.SetInsecure)
+			session.SetPassword(password), session.ControllerStatusCheckDisabled(), session.SetInsecure)
 		if err != nil {
 			AviLog.Warnf("NewAviClient returned err %v", err)
 			return &p, err

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -55,15 +55,15 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 		// Retry 20 times with an interval of 10 seconds each.
 		aviClient, err := clients.NewAviClient(api_ep, username,
 			session.SetPassword(password), session.SetControllerStatusCheckLimits(20, 10), session.SetInsecure)
+		if err != nil {
+			AviLog.Warnf("NewAviClient returned err %v", err)
+			return &p, err
+		}
 		version, err := aviClient.AviSession.GetControllerVersion()
 		if err == nil && CtrlVersion == "" {
 			AviLog.Debugf("Setting the client version to %v", version)
 			session.SetVersion(version)
 			CtrlVersion = version
-		}
-		if err != nil {
-			AviLog.Warnf("NewAviClient returned err %v", err)
-			return &p, err
 		}
 
 		p.AviClient = append(p.AviClient, aviClient)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,9 +42,6 @@ var runtimeScheme = k8sruntime.NewScheme()
 func init() {
 	//Setting the package-wide version
 	CtrlVersion = os.Getenv("CTRL_VERSION")
-	if CtrlVersion == "" {
-		CtrlVersion = "18.2.2"
-	}
 	extensions.AddToScheme(runtimeScheme)
 	networking.AddToScheme(runtimeScheme)
 }

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -115,10 +115,9 @@ func injectMWForObjDeletion() {
 			}
 		} else if r.Method == "GET" {
 			integrationtest.FeedMockCollectionData(w, r, mockFilePath)
-
-		} else if strings.Contains(url, "login") {
+		} else if strings.Contains(url, "initial-data") {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"success": "true"}`))
+			w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 		}
 	})
 }
@@ -128,7 +127,9 @@ func injectMWForCloud() {
 		url := r.URL.EscapedPath()
 		if r.Method == "GET" && strings.Contains(url, "/api/cloud/") {
 			integrationtest.FeedMockCollectionData(w, r, invalidFilePath)
-
+		} else if strings.Contains(url, "initial-data") {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 		} else if r.Method == "GET" {
 			integrationtest.FeedMockCollectionData(w, r, mockFilePath)
 

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -83,6 +83,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["ingestion"] = wgIngestion
 	wgFastRetry := &sync.WaitGroup{}
 	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -117,6 +117,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["ingestion"] = wgIngestion
 	wgFastRetry := &sync.WaitGroup{}
 	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -833,6 +833,9 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 		// This is used for /login --> first request to controller
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"success": "true"}`))
+	} else if strings.Contains(url, "initial-data") {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 	}
 }
 

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -159,6 +159,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["ingestion"] = wgIngestion
 	wgFastRetry := &sync.WaitGroup{}
 	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/Masterminds/semver v1.5.0
 github.com/Masterminds/semver
-# github.com/avinetworks/sdk v0.0.0-20200908155649-48d0ac51ea58
+# github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241
 github.com/avinetworks/sdk/go/clients
 github.com/avinetworks/sdk/go/models
 github.com/avinetworks/sdk/go/session


### PR DESCRIPTION
This PR, modifies the helm charts to become more readable.
Plus makes the controller version auto-discoverable.

It also implements a slow retry layer in AKO.
The slow retry layer is used only if there's a problem in contacting the Avi Controller. 
We now call AviRestOperate inside a go routine and timeout post 80 seconds.