### PR TITLE
Stop the slow retry queue on sigterm

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -290,6 +290,7 @@ LABEL:
 	ingestionQueue.StopWorkers(stopCh)
 	graphQueue.StopWorkers(stopCh)
 	fastRetryQueue.StopWorkers(stopCh)
+	slowRetryQueue.StopWorkers(stopCh)
 }
 
 func (c *AviController) FullSync() {


### PR DESCRIPTION
We were missing stopping the slow retry queue on sigterm.
This commit takes care of that.