### PR TITLE
Changes to use ipamdnsproviderprofiledomainlist which will make fetching the subdomain generic wrt dns provider type.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ multicloudtests:
 
 .PHONY: int_test
 int_test:
-	make -j 1 integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests
+	make -j 5 integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests
 
 .PHONY: scale_test
 scale_test:

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -73,7 +73,6 @@ type AviDSCache struct {
 type AviCloudPropertyCache struct {
 	Name      string
 	VType     string
-	NSIpam    string
 	NSIpamDNS []string
 }
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2359,24 +2359,15 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 
 	vtype := *cloud.Vtype
 	cloud_obj := &AviCloudPropertyCache{Name: cloudName, VType: vtype}
-	if cloud.DNSProviderRef == nil {
-		utils.AviLog.Warnf("Cloud does not have a dns_provider_ref configured %v", cloudName)
+
+	subdomains := c.AviDNSPropertyPopulate(client, *cloud.UUID)
+	if len(subdomains) == 0 {
+		utils.AviLog.Warnf("Cloud: %v does not have a dns provider configured", cloudName)
 		return nil
-	}
-	dns_uuid := ExtractPattern(*cloud.DNSProviderRef, "ipamdnsproviderprofile-.*")
-	subdomains := c.AviDNSPropertyPopulate(client, dns_uuid)
-	if subdomains != nil {
-		cloud_obj.NSIpamDNS = subdomains
 	}
 
-	if cloud.IPAMProviderRef == nil {
-		utils.AviLog.Warnf("Cloud does not have a ipam_provider_ref configured %v", cloudName)
-		return nil
-	}
-	ipam_uuid := ExtractPattern(*cloud.IPAMProviderRef, "ipamdnsproviderprofile-.*")
-	ipam := c.AviIPAMPropertyPopulate(client, ipam_uuid)
-	if ipam != "" {
-		cloud_obj.NSIpam = ipam
+	if subdomains != nil {
+		cloud_obj.NSIpamDNS = subdomains
 	}
 
 	c.CloudKeyCache.AviCacheAdd(cloudName, cloud_obj)
@@ -2384,38 +2375,25 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	return nil
 }
 
-func (c *AviObjCache) AviIPAMPropertyPopulate(client *clients.AviClient, ipamUUID string) string {
-	var ipamProvider models.IPAMDNSProviderProfile
-	uri := "/api/ipamdnsproviderprofile/" + ipamUUID
+func (c *AviObjCache) AviDNSPropertyPopulate(client *clients.AviClient, cloudUUID string) []string {
+	type IPAMDNSProviderProfileDomainList struct {
 
-	err := AviGet(client, uri, &ipamProvider)
-	if err != nil {
-		utils.AviLog.Warnf("IPAMProperty Get uri %v returned err %v", uri, err)
-		return ""
+		// List of service domains.
+		Domains []*string `json:"domains,omitempty"`
 	}
-
-	ipamName := *ipamProvider.Name
-	return ipamName
-}
-
-func (c *AviObjCache) AviDNSPropertyPopulate(client *clients.AviClient, dnsUUID string) []string {
-	var dnsProvider models.IPAMDNSProviderProfile
 	var dnsSubDomains []string
-	uri := "/api/ipamdnsproviderprofile/" + dnsUUID
+	domainList := IPAMDNSProviderProfileDomainList{}
+	uri := "/api/ipamdnsproviderprofiledomainlist?cloud_uuid=" + cloudUUID
 
-	err := AviGet(client, uri, &dnsProvider)
+	err := AviGet(client, uri, &domainList)
 	if err != nil {
 		utils.AviLog.Warnf("DNSProperty Get uri %v returned err %v", uri, err)
 		return nil
 	}
 
-	utils.AviLog.Debugf("DNSProperty Get uri %v returned %v ", uri, dnsProvider.Name)
-
-	dnsProfile := dnsProvider.InternalProfile
-	// Support multiple dns profiles.
-	for _, dnsProf := range dnsProfile.DNSServiceDomain {
-		utils.AviLog.Debugf("Found DNS Domain name: %v", *dnsProf.DomainName)
-		dnsSubDomains = append(dnsSubDomains, *dnsProf.DomainName)
+	for _, subdomain := range domainList.Domains {
+		utils.AviLog.Debugf("Found DNS Domain name: %v", *subdomain)
+		dnsSubDomains = append(dnsSubDomains, *subdomain)
 	}
 
 	return dnsSubDomains
@@ -2704,13 +2682,16 @@ func CheckAndSetVRFFromNetwork(client *clients.AviClient) bool {
 	return true
 }
 
-func ExtractPattern(word string, pattern string) string {
-	r, _ := regexp.Compile(pattern)
+func ExtractPattern(word string, pattern string) (string, error) {
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
 	result := r.FindAllString(word, -1)
 	if len(result) == 1 {
-		return result[0][:len(result[0])]
+		return result[0][:len(result[0])], nil
 	}
-	return ""
+	return "", nil
 }
 
 func ExtractUuid(word, pattern string) string {

--- a/tests/avimockobjects/ipamdnsproviderprofiledomainlist_mock.json
+++ b/tests/avimockobjects/ipamdnsproviderprofiledomainlist_mock.json
@@ -1,0 +1,6 @@
+{
+	"domains": [
+		"avi.internal",
+		".com"
+	]
+}

--- a/tests/bootuptests/bootupmock/ipamdnsproviderprofiledomainlist_mock.json
+++ b/tests/bootuptests/bootupmock/ipamdnsproviderprofiledomainlist_mock.json
@@ -1,0 +1,6 @@
+{
+	"domains": [
+		"avi.internal",
+		".com"
+	]
+}

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -681,6 +681,7 @@ var FakeServerMiddleware InjectFault
 var FakeAviObjects = []string{
 	"cloud",
 	"ipamdnsproviderprofile",
+	"ipamdnsproviderprofiledomainlist",
 	"network",
 	"pool",
 	"poolgroup",


### PR DESCRIPTION
- This is done to support route53 dns in any cloud.