### PR TITLE
Allow session version to be set during rest operate calls to Avi

### DIFF
--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -78,6 +78,8 @@ func (p *AviRestClientPool) AviRestOperate(c *clients.AviClient, rest_ops []*Res
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
+		SetVersion := session.SetVersion(op.Version)
+		SetVersion(c.AviSession)
 		switch op.Method {
 		case RestPost:
 			op.Err = c.AviSession.Post(op.Path, op.Obj, &op.Response)


### PR DESCRIPTION
Add back the SetVersion call in AviRestOperate() in the utils package. This
allows individual operations to set Avi version.