### PR TITLE
moving ako from deployment to statefulset

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: ako
   namespace: {{ .Release.Namespace }}
@@ -7,6 +7,7 @@ metadata:
     {{- include "ako.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  serviceName: ako
   selector:
     matchLabels:
       {{- include "ako.selectorLabels" . | nindent 6 }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -55,6 +55,13 @@ nodePortSelector: # Only applicable if serviceType is NodePort
   key: ""
   value: ""
 
+resources:
+  limits:
+    cpu: 250m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 75Mi
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -80,6 +80,7 @@ const (
 	GatewayTypeLabelKey                        = "service.route.lbapi.run.tanzu.vmware.com/type"
 	AviGatewayController                       = "lbapi.run.tanzu.vmware.com/avi-lb"
 	DummyVSForStaleData                        = "DummyVSForStaleData"
+	ControllerReqWaitTime                      = 300
 )
 
 const (

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -531,8 +531,8 @@ func (rest *RestOperations) AviRestOperateWrapper(aviClient *clients.AviClient, 
 	select {
 	case err := <-restTimeoutChan:
 		return err
-	case <-time.After(80 * time.Second):
-		utils.AviLog.Warnf("timed out waiting for rest response")
+	case <-time.After(lib.ControllerReqWaitTime * time.Second):
+		utils.AviLog.Warnf("timed out waiting for rest response after %d seconds", lib.ControllerReqWaitTime)
 		return errors.New("timed out waiting for rest response")
 	}
 }
@@ -1400,7 +1400,7 @@ func (rest *RestOperations) PkiProfileCU(pki_node *nodes.AviPkiProfileNode, pool
 }
 
 func (rest *RestOperations) PkiProfileDelete(pkiProfileDelete []avicache.NamespaceName, namespace string, rest_ops []*utils.RestOp, key string) []*utils.RestOp {
-	utils.AviLog.Infof("key: %s, msg: about to delete pki profile %s", key, utils.Stringify(pkiProfileDelete))
+	utils.AviLog.Debugf("key: %s, msg: about to delete pki profile %s", key, utils.Stringify(pkiProfileDelete))
 	for _, delPki := range pkiProfileDelete {
 		pkiProfile := avicache.NamespaceName{Namespace: namespace, Name: delPki.Name}
 		pkiCache, ok := rest.cache.PKIProfileCache.AviCacheGet(pkiProfile)


### PR DESCRIPTION
- statefulset ensures that there is only one pod running at a time if replica count is set to one.
- this would resolve problems which we face because there are multiple pods of ako running at a time

- added default resource limit for ako
- Also increased wait time for controller response to 300 seconds

(cherry picked from commit 9f11e02e83a69f27ee0af2fe057c72760bdecc43)