### PR TITLE
populate pool from all PGs in vs cache during boot up

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1959,7 +1959,8 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 									// For each PG, formulate the key and then populate the pg collection cache
 									pgKey := NamespaceName{Namespace: lib.GetTenant(), Name: pgName}
 									poolgroupKeys = append(poolgroupKeys, pgKey)
-									poolKeys = c.AviPGPoolCachePopulate(client, cloud, pgName)
+									pgpoolKeys := c.AviPGPoolCachePopulate(client, cloud, pgName)
+									poolKeys = append(poolKeys, pgpoolKeys...)
 								}
 								dsKeys = append(dsKeys, dsKey)
 								sharedVsOrL4 = true
@@ -2203,7 +2204,8 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 									// For each PG, formulate the key and then populate the pg collection cache
 									pgKey := NamespaceName{Namespace: utils.ADMIN_NS, Name: pgName}
 									poolgroupKeys = append(poolgroupKeys, pgKey)
-									poolKeys = c.AviPGPoolCachePopulate(client, cloud, pgName)
+									pgpoolKeys := c.AviPGPoolCachePopulate(client, cloud, pgName)
+									poolKeys = append(poolKeys, pgpoolKeys...)
 								}
 								dsKeys = append(dsKeys, dsKey)
 							}


### PR DESCRIPTION
Passthrough VS can have multiple PGs, so we need to consider all of them.