### PR TITLE
wrap avi client inits in goroutines for faster bootup

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -56,6 +56,7 @@ func SharedAVIClients() *utils.AviRestClientPool {
 				if err != nil {
 					connectionStatus = utils.AVIAPI_DISCONNECTED
 					utils.AviLog.Error("AVI controller initilization failed")
+					return nil
 				}
 				// set the tenant and controller version in avisession obj
 				for _, client := range AviClientInstance.AviClient {


### PR DESCRIPTION
avi controller clients, earlier were being initialised sequentially, wrapped the initialisation sequence with goroutines.
Please feel free to merge this after the release/review extra carefully :). This affects both AKO/AMKO.