### PR TITLE
Changes related to advanced L4

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2455,7 +2455,7 @@ func checkRequiredValuesYaml() bool {
 	if clusterName == "" {
 		utils.AviLog.Error("Required param clusterName not specified, syncing will be disabled")
 		return false
-	} else if len(clusterName) > 32 || !re.MatchString(clusterName) {
+	} else if !re.MatchString(clusterName) {
 		utils.AviLog.Error("clusterName must consist of alphanumeric characters or '-'/'_' (max 32 chars), syncing will be disabled")
 		return false
 	}
@@ -2473,12 +2473,15 @@ func checkRequiredValuesYaml() bool {
 	// check if config map exists
 	k8sClient := utils.GetInformers().ClientSet
 	aviCMNamespace := lib.AviNS
+	if lib.GetAdvancedL4() {
+		aviCMNamespace = lib.VMwareNS
+	}
 	if lib.GetNamespaceToSync() != "" {
 		aviCMNamespace = lib.GetNamespaceToSync()
 	}
 	_, err := k8sClient.CoreV1().ConfigMaps(aviCMNamespace).Get(lib.AviConfigMap, metav1.GetOptions{})
 	if err != nil {
-		utils.AviLog.Errorf("Configmap %s/%s not found, error: %v, syncing will be disabled", lib.AviNS, lib.AviConfigMap, err)
+		utils.AviLog.Errorf("Configmap %s/%s not found, error: %v, syncing will be disabled", aviCMNamespace, lib.AviConfigMap, err)
 		return false
 	}
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -85,7 +85,11 @@ func delConfigFromData(data map[string]string) bool {
 }
 
 func deleteConfigFromConfigmap(cs kubernetes.Interface) bool {
-	cm, err := cs.CoreV1().ConfigMaps(lib.AviNS).Get(lib.AviConfigMap, metav1.GetOptions{})
+	cmNS := lib.AviNS
+	if lib.GetAdvancedL4() {
+		cmNS = lib.VMwareNS
+	}
+	cm, err := cs.CoreV1().ConfigMaps(cmNS).Get(lib.AviConfigMap, metav1.GetOptions{})
 	if err == nil {
 		return delConfigFromData(cm.Data)
 	}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -47,7 +47,7 @@ var ctrlonce sync.Once
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=services;services/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=configmap,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;
 
 type AviController struct {
 	worker_id       uint32
@@ -637,6 +637,8 @@ func validateAviConfigMap(obj interface{}) (*corev1.ConfigMap, bool) {
 			return configMap, true
 		}
 	} else if ok && configMap.Namespace == lib.AviNS && configMap.Name == lib.AviConfigMap {
+		return configMap, true
+	} else if ok && lib.GetAdvancedL4() && configMap.Namespace == lib.VMwareNS && configMap.Name == lib.AviConfigMap {
 		return configMap, true
 	}
 	return nil, false

--- a/internal/lib/cni.go
+++ b/internal/lib/cni.go
@@ -56,7 +56,7 @@ func NewDynamicClientSet(config *rest.Config) (dynamic.Interface, error) {
 
 	ds, err := dynamic.NewForConfig(config)
 	if err != nil {
-		utils.AviLog.Warnf("Error while creating dynamic client %v", err)
+		utils.AviLog.Infof("Error while creating dynamic client %v", err)
 		return nil, err
 	}
 	if dynamicClientSet == nil {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -15,13 +15,15 @@
 package lib
 
 const (
-	DISABLE_STATIC_ROUTE_SYNC                  = "DISABLE_STATIC_ROUTE_SYNC"
-	CNI_PLUGIN                                 = "CNI_PLUGIN"
-	CALICO_CNI                                 = "calico"
-	OPENSHIFT_CNI                              = "openshift"
-	INGRESS_API                                = "INGRESS_API"
-	AviConfigMap                               = "avi-k8s-config"
-	AviNS                                      = "avi-system"
+	DISABLE_STATIC_ROUTE_SYNC = "DISABLE_STATIC_ROUTE_SYNC"
+	CNI_PLUGIN                = "CNI_PLUGIN"
+	CALICO_CNI                = "calico"
+	OPENSHIFT_CNI             = "openshift"
+	INGRESS_API               = "INGRESS_API"
+	AviConfigMap              = "avi-k8s-config"
+	AviNS                     = "avi-system"
+	VMwareNS                  = "vmware-system-ako"
+
 	INGRESS_CLASS_ANNOT                        = "kubernetes.io/ingress.class"
 	AVI_INGRESS_CLASS                          = "avi"
 	SUBNET_IP                                  = "SUBNET_IP"
@@ -35,6 +37,7 @@ const (
 	DEFAULT_DOMAIN                             = "DEFAULT_DOMAIN"
 	ADVANCED_L4                                = "ADVANCED_L4"
 	CLUSTER_NAME                               = "CLUSTER_NAME"
+	CLUSTER_ID                                 = "CLUSTER_ID"
 	CLOUD_VCENTER                              = "CLOUD_VCENTER"
 	CLOUD_AZURE                                = "CLOUD_AZURE"
 	CLOUD_AWS                                  = "CLOUD_AWS"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -348,8 +348,10 @@ func GetAdvancedL4() bool {
 }
 
 func GetDisableStaticRoute() bool {
-	disableStaticRoute := os.Getenv(DISABLE_STATIC_ROUTE_SYNC)
-	if disableStaticRoute == "true" && !GetAdvancedL4() {
+	if GetAdvancedL4() {
+		return true
+	}
+	if ok, _ := strconv.ParseBool(os.Getenv(DISABLE_STATIC_ROUTE_SYNC)); ok {
 		return true
 	}
 	if IsNodePortMode() {
@@ -359,9 +361,25 @@ func GetDisableStaticRoute() bool {
 }
 
 func GetClusterName() string {
+	if GetAdvancedL4() {
+		return GetClusterID()
+	}
 	clusterName := os.Getenv(CLUSTER_NAME)
 	if clusterName != "" {
 		return clusterName
+	}
+	return ""
+}
+
+func GetClusterID() string {
+	clusterID := os.Getenv(CLUSTER_ID)
+	// The clusterID is an internal field only in the advanced L4 mode and we expect the format to be: domain-c8:3fb16b38-55f0-49fb-997d-c117487cd98d
+	// We want to truncate this string to just have the uuid.
+	if clusterID != "" {
+		clusterName := strings.Split(clusterID, ":")
+		if len(clusterName) > 1 {
+			return clusterName[1]
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
Following are the summary of changes for advanced L4 as a part of this
commit:

- Disable VRF related changes  automatically for advanced L4.
- Reduce severity of the dynamic informer initialization problem and
convert to INFO.
- Advanced L4's expectation is to have AKO installed in a namespace
called "vmware-system-ako". We will hardcode it for now.
- CLUSTER_ID honoring.