### PR TITLE
Do not delete vsvip cache for insecure passthrough VS deletion

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -535,4 +536,15 @@ func HasValidBackends(routeSpec routev1.RouteSpec, routeName, namespace, key str
 		svcList[altBackend.Name] = true
 	}
 	return true
+}
+
+func VSVipDelRequired() bool {
+	c, err := semver.NewConstraint(">= " + VSVIPDELCTRLVER)
+	if err == nil {
+		currVersion, verErr := semver.NewVersion(utils.CtrlVersion)
+		if verErr == nil && c.Check(currVersion) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -25,9 +25,6 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
-
-	"github.com/Masterminds/semver"
-
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -332,12 +329,8 @@ func (rest *RestOperations) deleteVSOper(vsKey avicache.NamespaceName, vs_cache_
 		}
 		if !skipVSVip {
 			// Delete the vsvip explicitly if controller version is >= 20.1.1
-			c, err := semver.NewConstraint(">= " + lib.VSVIPDELCTRLVER)
-			if err == nil {
-				currVersion, verErr := semver.NewVersion(utils.CtrlVersion)
-				if verErr == nil && c.Check(currVersion) {
-					rest_ops = rest.VSVipDelete(vs_cache_obj.VSVipKeyCollection, namespace, rest_ops, key)
-				}
+			if lib.VSVipDelRequired() {
+				rest_ops = rest.VSVipDelete(vs_cache_obj.VSVipKeyCollection, namespace, rest_ops, key)
 			}
 		}
 		rest_ops = rest.DataScriptDelete(vs_cache_obj.DSKeyCollection, namespace, rest_ops, key)

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -370,9 +370,16 @@ func TestRouteServiceAdd(t *testing.T) {
 
 	aviModel := ValidateModelCommon(t, g)
 	g.Eventually(func() int {
-		pool := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(1))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(1))
 
 	poolgroups := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolGroupRefs
 	pgmember := poolgroups[0].Members[0]
@@ -400,9 +407,16 @@ func TestRouteScaleEndpoint(t *testing.T) {
 
 	integrationtest.ScaleCreateEP(t, "default", "avisvc")
 	g.Eventually(func() int {
-		pool = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(2))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(2))
 
 	g.Expect(pool.Name).To(gomega.Equal("cluster--foo.com_foo-default-foo-avisvc"))
 	g.Expect(pool.PriorityLabel).To(gomega.Equal("foo.com/foo"))
@@ -486,9 +500,16 @@ func TestRouteUpdatePath(t *testing.T) {
 	pool := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
 
 	g.Eventually(func() int {
-		pool = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(1))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(1))
 
 	g.Expect(pool.Name).To(gomega.Equal("cluster--foo.com_bar-default-foo-avisvc"))
 


### PR DESCRIPTION
- vsvip objects should be deleted from cache only if controoler version
is >= 20.1.1 and the VS is not of type insecure passthrough. Else while
deleting the secure passthrough VS, vsvip won;t be pressent in the cache
and vsvip deletion would be skipped