### PR TITLE
Modifications to clusterID and ignore pool reachability

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -378,7 +378,7 @@ func GetClusterID() string {
 	if clusterID != "" {
 		clusterName := strings.Split(clusterID, ":")
 		if len(clusterName) > 1 {
-			return clusterName[1]
+			return clusterName[0]
 		}
 	}
 	return ""

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -74,7 +74,10 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			VrfContextRef:               &vrfContextRef,
 			RemoveListeningPortOnVsDown: &vsDownOnPoolDown,
 		}
-
+		if lib.GetAdvancedL4() {
+			ignPool := true
+			vs.IgnPoolNetReach = &ignPool
+		}
 		if vs_meta.DefaultPoolGroup != "" {
 			pool_ref := "/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup
 			vs.PoolGroupRef = &pool_ref

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -241,7 +241,7 @@ func TestAdvL4BestCase(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	gwClassName, gatewayName, ns := "avi-lb", "my-gateway", "default"
-	modelName := "admin/cluster--default-my-gateway"
+	modelName := "admin/abc--default-my-gateway"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
 	SetupGateway(t, gatewayName, ns, gwClassName)
@@ -254,7 +254,7 @@ func TestAdvL4BestCase(t *testing.T) {
 			return gw.Status.Addresses[0].Value
 		}
 		return ""
-	}, 10*time.Second).Should(gomega.Equal("10.250.250.250"))
+	}, 40*time.Second).Should(gomega.Equal("10.250.250.250"))
 	svc, _ := KubeClient.CoreV1().Services(ns).Get("svc", metav1.GetOptions{})
 	g.Expect(svc.Status.LoadBalancer.Ingress[0].IP).To(gomega.Equal("10.250.250.250"))
 
@@ -288,7 +288,7 @@ func TestAdvL4WrongControllerGWClass(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	gwClassName, gatewayName, ns := "avi-lb", "my-gateway", "default"
-	modelName := "admin/cluster--default-my-gateway"
+	modelName := "admin/abc--default-my-gateway"
 
 	SetupGateway(t, gatewayName, ns, gwClassName)
 	SetupAdvLBService(t, "svc", ns, gatewayName, ns)
@@ -332,7 +332,7 @@ func TestAdvL4WrongClassMappingInGateway(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	gwClassName, gatewayName, ns := "avi-lb", "my-gateway", "default"
-	modelName := "admin/cluster--default-my-gateway"
+	modelName := "admin/abc--default-my-gateway"
 
 	SetupGateway(t, gatewayName, ns, gwClassName)
 	SetupAdvLBService(t, "svc", ns, gatewayName, ns)


### PR DESCRIPTION
Couple of fixes:

 - Modified the logic of parsing the clusterID.
 - Added ignore pool reachability to true for advanced L4 to operated
in single arm mode.