### PR TITLE
Do not delete vsvip cache for insecure passthrough VS deletion

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -481,4 +482,15 @@ func HasValidBackends(routeSpec routev1.RouteSpec, routeName, namespace, key str
 		svcList[altBackend.Name] = true
 	}
 	return true
+}
+
+func VSVipDelRequired() bool {
+	c, err := semver.NewConstraint(">= " + VSVIPDELCTRLVER)
+	if err == nil {
+		currVersion, verErr := semver.NewVersion(utils.CtrlVersion)
+		if verErr == nil && c.Check(currVersion) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -488,15 +488,20 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					hostFoundInParentPool = rest.isHostPresentInSharedPool(hostname, parent_vs_cache_obj, key)
 				}
 			}
-			if len(vs_cache_obj.VSVipKeyCollection) > 0 {
-				vsvip := vs_cache_obj.VSVipKeyCollection[0].Name
-				vsvipKey := avicache.NamespaceName{Namespace: vsKey.Namespace, Name: vsvip}
-				utils.AviLog.Debugf("key: %s, msg: deleting vsvip cache for key: %s", key, vsvipKey)
-				// Reset the LB status field as well.
-				if vs_cache_obj.ServiceMetadataObj.ServiceName != "" && vs_cache_obj.ServiceMetadataObj.Namespace != "" {
-					status.DeleteL4LBStatus(vs_cache_obj.ServiceMetadataObj, key)
+
+			// try to delete the vsvip from cache only if the vs is not of type insecure passthrough
+			// and if controller version is >= 20.1.1
+			if vs_cache_obj.ServiceMetadataObj.PassthroughParentRef == "" {
+				if lib.VSVipDelRequired() && len(vs_cache_obj.VSVipKeyCollection) > 0 {
+					vsvip := vs_cache_obj.VSVipKeyCollection[0].Name
+					vsvipKey := avicache.NamespaceName{Namespace: vsKey.Namespace, Name: vsvip}
+					utils.AviLog.Infof("key: %s, msg: deleting vsvip cache for key: %s", key, vsvipKey)
+					// Reset the LB status field as well.
+					if vs_cache_obj.ServiceMetadataObj.ServiceName != "" && vs_cache_obj.ServiceMetadataObj.Namespace != "" {
+						status.DeleteL4LBStatus(vs_cache_obj.ServiceMetadataObj, key)
+					}
+					rest.cache.VSVIPCache.AviCacheDelete(vsvipKey)
 				}
-				rest.cache.VSVIPCache.AviCacheDelete(vsvipKey)
 			}
 
 			if (vs_cache_obj.ServiceMetadataObj.IngressName != "" || len(vs_cache_obj.ServiceMetadataObj.NamespaceIngressName) > 0) && vs_cache_obj.ServiceMetadataObj.Namespace != "" {

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -26,9 +26,6 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
-
-	"github.com/Masterminds/semver"
-
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -333,12 +330,8 @@ func (rest *RestOperations) deleteVSOper(vsKey avicache.NamespaceName, vs_cache_
 		}
 		if !skipVSVip {
 			// Delete the vsvip explicitly if controller version is >= 20.1.1
-			c, err := semver.NewConstraint(">= " + lib.VSVIPDELCTRLVER)
-			if err == nil {
-				currVersion, verErr := semver.NewVersion(utils.CtrlVersion)
-				if verErr == nil && c.Check(currVersion) {
-					rest_ops = rest.VSVipDelete(vs_cache_obj.VSVipKeyCollection, namespace, rest_ops, key)
-				}
+			if lib.VSVipDelRequired() {
+				rest_ops = rest.VSVipDelete(vs_cache_obj.VSVipKeyCollection, namespace, rest_ops, key)
 			}
 		}
 		rest_ops = rest.DataScriptDelete(vs_cache_obj.DSKeyCollection, namespace, rest_ops, key)

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -370,9 +370,16 @@ func TestRouteServiceAdd(t *testing.T) {
 
 	aviModel := ValidateModelCommon(t, g)
 	g.Eventually(func() int {
-		pool := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(1))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(1))
 
 	poolgroups := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolGroupRefs
 	pgmember := poolgroups[0].Members[0]
@@ -400,9 +407,16 @@ func TestRouteScaleEndpoint(t *testing.T) {
 
 	integrationtest.ScaleCreateEP(t, "default", "avisvc")
 	g.Eventually(func() int {
-		pool = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(2))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(2))
 
 	g.Expect(pool.Name).To(gomega.Equal("cluster--foo.com_foo-default-foo-avisvc"))
 	g.Expect(pool.PriorityLabel).To(gomega.Equal("foo.com/foo"))
@@ -486,9 +500,16 @@ func TestRouteUpdatePath(t *testing.T) {
 	pool := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
 
 	g.Eventually(func() int {
-		pool = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs[0]
-		return len(pool.Servers)
-	}, 10*time.Second).Should(gomega.Equal(1))
+		vslist := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(vslist) == 0 {
+			return 0
+		}
+		pools := vslist[0].PoolRefs
+		if len(pools) == 0 {
+			return 0
+		}
+		return len(pools[0].Servers)
+	}, 60*time.Second).Should(gomega.Equal(1))
 
 	g.Expect(pool.Name).To(gomega.Equal("cluster--foo.com_bar-default-foo-avisvc"))
 


### PR DESCRIPTION
- vsvip objects should be deleted from cache only if controoler version
is >= 20.1.1 and the VS is not of type insecure passthrough. Else while
deleting the secure passthrough VS, vsvip won;t be pressent in the cache
and vsvip deletion would be skipped

(cherry picked from commit 674aa4aaf24fff847389d26c2e617a29862189d2)