### PR TITLE
changed log file permission to enable edit by other users

### DIFF
--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -140,7 +140,7 @@ func init() {
 	encoderCfg.EncodeLevel = zapcore.CapitalLevelEncoder
 	logpath = getFileName()
 	file, err = os.OpenFile(logpath,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Otherwise we get an error saying persmission denied if user ID of the pod changes
in oepnshift after reboot

(cherry picked from commit 599b7d178c16711d05628d7ca5b08f7f12b35965)