### PR TITLE
RemoveListeningPortOnVsDown only for L4 VSes

### DIFF
--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -61,18 +61,16 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		svc_mdata := string(svc_mdata_json)
 		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
 		seGroupRef := "/api/serviceenginegroup?name=" + lib.GetSEGName()
-		vsDownOnPoolDown := true
 		vs := avimodels.VirtualService{
-			Name:                        &name,
-			NetworkProfileRef:           &network_prof,
-			ApplicationProfileRef:       &app_prof,
-			CloudConfigCksum:            &checksumstr,
-			CreatedBy:                   &cr,
-			CloudRef:                    &cloudRef,
-			ServiceMetadata:             &svc_mdata,
-			SeGroupRef:                  &seGroupRef,
-			VrfContextRef:               &vrfContextRef,
-			RemoveListeningPortOnVsDown: &vsDownOnPoolDown,
+			Name:                  &name,
+			NetworkProfileRef:     &network_prof,
+			ApplicationProfileRef: &app_prof,
+			CloudConfigCksum:      &checksumstr,
+			CreatedBy:             &cr,
+			CloudRef:              &cloudRef,
+			ServiceMetadata:       &svc_mdata,
+			SeGroupRef:            &seGroupRef,
+			VrfContextRef:         &vrfContextRef,
 		}
 		if lib.GetAdvancedL4() {
 			ignPool := true
@@ -137,6 +135,8 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		}
 
 		if len(vs_meta.L4PolicyRefs) > 0 {
+			vsDownOnPoolDown := true
+			vs.RemoveListeningPortOnVsDown = &vsDownOnPoolDown
 			var i int32
 			i = 0
 			var l4Policies []*avimodels.L4Policies

--- a/tests/hostnameshardtests/l7_hostname_rest_test.go
+++ b/tests/hostnameshardtests/l7_hostname_rest_test.go
@@ -901,7 +901,7 @@ func TestHostnameMultiHostUpdateIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get(ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 10*time.Second).Should(gomega.Equal(2))
+	}, 60*time.Second).Should(gomega.Equal(2))
 	ingress, _ := KubeClient.ExtensionsV1beta1().Ingresses("default").Get(ingressName, metav1.GetOptions{})
 
 	// donot update status


### PR DESCRIPTION
RemoveListeningPortOnVsDown was applicable for the shared VSes as well.
Due to the current behavior of the avi controller this flag would bring
down the shared VS with insecure pools going down, despite of having
functional SNIs.

Hence this commit restricts the changes to L4 VSes only.