### PR TITLE
Multiples Fixes:  log file name and sni vs deletion error handling

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -241,7 +241,7 @@ func (rest *RestOperations) RestOperation(vsName string, namespace string, avimo
 		utils.AviLog.Infof("key: %s, msg: SNI delete candidates are : %s", key, sni_to_delete)
 		var rest_ops []*utils.RestOp
 		for _, del_sni := range sni_to_delete {
-			rest.SNINodeDelete(del_sni, namespace, rest_ops, key)
+			rest.SNINodeDelete(del_sni, namespace, rest_ops, avimodel, key)
 			rest.ExecuteRestAndPopulateCache(rest_ops, vsKey, avimodel, key)
 		}
 	}
@@ -319,7 +319,7 @@ func (rest *RestOperations) deleteVSOper(vsKey avicache.NamespaceName, vs_cache_
 			sniVsKey, ok := rest.cache.VsCacheMeta.AviCacheGetKeyByUuid(sni_uuid)
 			if ok {
 				delSNI := sniVsKey.(avicache.NamespaceName)
-				rest.SNINodeDelete(delSNI, namespace, rest_ops, key)
+				rest.SNINodeDelete(delSNI, namespace, rest_ops, nil, key)
 			}
 		}
 		if !skipVS {
@@ -346,7 +346,7 @@ func (rest *RestOperations) deleteVSOper(vsKey avicache.NamespaceName, vs_cache_
 	return false
 }
 
-func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_obj *avicache.AviVsCache, namespace string, key string) bool {
+func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_obj *avicache.AviVsCache, avimodel *nodes.AviObjectGraph, namespace, key string) bool {
 	var rest_ops []*utils.RestOp
 
 	if vs_cache_obj != nil {
@@ -359,7 +359,7 @@ func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_o
 		rest_ops = rest.HTTPPolicyDelete(vs_cache_obj.HTTPKeyCollection, namespace, rest_ops, key)
 		rest_ops = rest.PoolGroupDelete(vs_cache_obj.PGKeyCollection, namespace, rest_ops, key)
 		rest_ops = rest.PoolDelete(vs_cache_obj.PoolKeyCollection, namespace, rest_ops, key)
-		rest.ExecuteRestAndPopulateCache(rest_ops, vsKey, nil, key)
+		rest.ExecuteRestAndPopulateCache(rest_ops, vsKey, avimodel, key)
 		return true
 	}
 	return false
@@ -918,7 +918,7 @@ func (rest *RestOperations) PoolCU(pool_nodes []*nodes.AviPoolNode, vs_cache_obj
 	return cache_pool_nodes, rest_ops
 }
 
-func (rest *RestOperations) SNINodeDelete(del_sni avicache.NamespaceName, namespace string, rest_ops []*utils.RestOp, key string) {
+func (rest *RestOperations) SNINodeDelete(del_sni avicache.NamespaceName, namespace string, rest_ops []*utils.RestOp, avimodel *nodes.AviObjectGraph, key string) {
 	utils.AviLog.Infof("key: %s, msg: about to delete the SNI child %s", key, del_sni)
 	sni_key := avicache.NamespaceName{Namespace: namespace, Name: del_sni.Name}
 	sni_cache_obj := rest.getVsCacheObj(sni_key, key)
@@ -950,7 +950,7 @@ func (rest *RestOperations) SNINodeDelete(del_sni avicache.NamespaceName, namesp
 				sni_cache_obj = rest.getVsCacheObj(sni_key, key)
 			}
 		}
-		rest.deleteSniVs(sni_key, sni_cache_obj, namespace, key)
+		rest.deleteSniVs(sni_key, sni_cache_obj, avimodel, namespace, key)
 	}
 
 }

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -423,8 +423,18 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 								utils.AviLog.Warnf("key: %s, msg: retry count exhausted, skipping", key)
 							}
 						} else {
-							utils.AviLog.Warnf("key: %s, msg: Avi model not set", key)
-							retry = true
+							utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
+							aviError, ok := rest_ops[i].Err.(session.AviError)
+							// If it's 404, don't retry
+							if ok {
+								statuscode := aviError.HttpStatusCode
+								if statuscode != 404 {
+									rest.PublishKeyToSlowRetryLayer(publishKey, aviclient, key)
+									return
+								} else {
+									rest.AviVsCacheDel(rest_ops[i], aviObjKey, key)
+								}
+							}
 						}
 					} else {
 						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -15,8 +15,10 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -95,7 +97,8 @@ func getFileName() string {
 	if input == "" {
 		input = DEFAULT_FILE_SUFFIX
 	}
-	return getFilePath() + getPodName() + input
+	fileName := fmt.Sprintf("%s%s%s.%d", getFilePath(), getPodName(), input, time.Now().Unix())
+	return fileName
 }
 
 func getFilePath() string {
@@ -140,7 +143,7 @@ func init() {
 	encoderCfg.EncodeLevel = zapcore.CapitalLevelEncoder
 	logpath = getFileName()
 	file, err = os.OpenFile(logpath,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adding timestamp to log file name, as changing file permission did not fix the issue as per system test report. 

Pass model to ExecuteRestAndPopulateCache for sni vs deletion  …
- If we encounter an error while deleting sni vs, if the model is nil, we would  not refresh the cache
and go on retrying forever, as we don't be able to get avimodel.GetRetryCounter().
- The same problem can also happen if we face error while bootup if avimodel is nil. Not making any change
for this now. We can potentially skip retry here or do a slow retry here.