### PR TITLE
Allow AKO to work in psp enabled environments

### DIFF
--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -24,3 +24,14 @@ rules:
   - apiGroups: ["ako.vmware.com"]
     resources: ["hostrules", "hostrules/status", "httprules", "httprules/status"]
     verbs: ["get","watch","list","patch", "update"]
+{{- if .Values.rbac.pspEnable }}
+  - apiGroups:
+    - policy
+    - extensions
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+    resourceNames:
+    - {{ template "ako.name" . }}
+{{- end }}

--- a/helm/ako/templates/psppolicy.yaml
+++ b/helm/ako/templates/psppolicy.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.rbac.pspEnable }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "ako.name" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "AKO"
+    {{- else }}
+    app.kubernetes.io/name: {{ template "ako.name" . }}
+    {{- end }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -61,10 +61,13 @@ resources:
     memory: 300Mi
   requests:
     cpu: 100m
-    memory: 75Mi
+    memory: 200Mi
 
 podSecurityContext: {}
-  # fsGroup: 2000
+
+rbac:
+  # Creates the pod security policy if set to true
+  pspEnable: false
 
 
 avicredentials:

--- a/tests/oshiftroutetests/oshift_l4_l7_nodeport_test.go
+++ b/tests/oshiftroutetests/oshift_l4_l7_nodeport_test.go
@@ -344,8 +344,11 @@ func TestAlternateBackendNoPathInNodePort(t *testing.T) {
 
 	aviModel := ValidateModelCommon(t, g)
 
+	g.Eventually(func() int {
+		pools := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs
+		return len(pools)
+	}, 60*time.Second).Should(gomega.Equal(2))
 	pools := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].PoolRefs
-	g.Expect(pools).To(gomega.HaveLen(2))
 	for _, pool := range pools {
 		if pool.Name == "cluster--foo.com-default-foo-avisvc" || pool.Name == "cluster--foo.com-default-foo-absvc2" {
 			g.Expect(len(pool.Servers)).To(gomega.Equal(1))


### PR DESCRIPTION
This includes a psp template needed by AKO and a corresponding
flag in the values.yaml that allows the policy to be used.

The clusterrole is modified as per.