### PR TITLE
Bring the VS passthrough secure VS down on pool down

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -81,6 +81,7 @@ const (
 	AviGatewayController                       = "lbapi.run.tanzu.vmware.com/avi-lb"
 	DummyVSForStaleData                        = "DummyVSForStaleData"
 	ControllerReqWaitTime                      = 300
+	PassthroughInsecure                        = "-insecure"
 )
 
 const (

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -166,7 +166,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 
 	if passChildVS == nil {
 		passChildVS = &AviVsNode{
-			Name: secureSharedVS.Name + "-insecure", Tenant: lib.GetTenant(), EastWest: false, VrfContext: lib.GetVrf(),
+			Name: secureSharedVS.Name + lib.PassthroughInsecure, Tenant: lib.GetTenant(), EastWest: false, VrfContext: lib.GetVrf(),
 		}
 		if lib.GetSEGName() != lib.DEFAULT_GROUP {
 			passChildVS.ServiceEngineGroup = lib.GetSEGName()

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -129,7 +129,11 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			}
 			vs.HTTPPolicies = httpPolicyCollection
 		}
-
+		if strings.HasPrefix(*vs.Name, lib.PassthroughPrefix) && !strings.HasSuffix(*vs.Name, lib.PassthroughInsecure) {
+			// This is a passthrough secure VS, we want the VS to be down if all the pools are down.
+			vsDownOnPoolDown := true
+			vs.RemoveListeningPortOnVsDown = &vsDownOnPoolDown
+		}
 		if len(vs_meta.L4PolicyRefs) > 0 {
 			vsDownOnPoolDown := true
 			vs.RemoveListeningPortOnVsDown = &vsDownOnPoolDown


### PR DESCRIPTION
This commit ensures that the passthrough secure VS is brought
down if all the pools on it are unreachable and down.