### PR TITLE
static IP on vsvip rest layer changes and gw status updates

### DIFF
--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -278,36 +278,3 @@ func checkGWForGatewayPortConflict(key string, gw *advl4v1alpha1pre1.Gateway) {
 		}
 	}
 }
-
-func checkGWForIPUpdate(key string, gw, oldGw *advl4v1alpha1pre1.Gateway) bool {
-	var newIPAddress, oldIPAddress string
-	if len(gw.Spec.Addresses) > 0 {
-		newIPAddress = gw.Spec.Addresses[0].Value
-	}
-	if len(oldGw.Spec.Addresses) > 0 {
-		oldIPAddress = oldGw.Spec.Addresses[0].Value
-	}
-
-	// honor new IP coming in
-	// old: nil, new: X
-	if oldIPAddress == "" && newIPAddress != "" {
-		return false
-	}
-
-	// old: X, new: nil | old: X, new: Y
-	if newIPAddress != oldIPAddress {
-		errString := "IPAddress Updates on gateway not supported, Please recreate gateway object with the new preferred IPAddress"
-		status.UpdateGatewayStatusGWCondition(gw, &status.UpdateGWStatusConditionOptions{
-			Type:    "Pending",
-			Status:  corev1.ConditionTrue,
-			Reason:  "InvalidAddress",
-			Message: errString,
-		})
-		utils.AviLog.Errorf("key: %s, msg: %s Last IPAddress: %s, Current IPAddress: %s",
-			key, errString, oldIPAddress, newIPAddress)
-		status.UpdateGatewayStatusObject(gw, &gw.Status)
-		return true
-	}
-
-	return false
-}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -88,6 +88,8 @@ const (
 	DummyVSForStaleData                        = "DummyVSForStaleData"
 	ControllerReqWaitTime                      = 300
 	PassthroughInsecure                        = "-insecure"
+	AviControllerVSVipIDChangeError            = "Changing an existing VIP's vip_id is not supported"
+	AviControllerRecreateVIPError              = "If a new preferred IP is needed, please recreate the VIP"
 )
 
 const (

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -122,8 +122,8 @@ func UpdateGatewayStatusGWCondition(gw *advl4v1alpha1pre1.Gateway, updateStatus 
 			// if Ready true, mark Pending as false automatically
 			gw.Status.Conditions[i].Status = corev1.ConditionFalse
 			gw.Status.Conditions[i].LastTransitionTime = metav1.Now()
-			gw.Status.Conditions[i].Message = updateStatus.Message
-			gw.Status.Conditions[i].Reason = updateStatus.Reason
+			gw.Status.Conditions[i].Message = ""
+			gw.Status.Conditions[i].Reason = ""
 		}
 
 		if updateStatus.Type == "Ready" {

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -98,6 +98,7 @@ type RestOp struct {
 	PatchOp  string
 	Response interface{}
 	Err      error
+	Message  string // Optional field - can be used to carry forward err/msgs to k8s objects
 	Model    string
 	Version  string
 	ObjName  string // Optional field - right only to be used for delete.


### PR DESCRIPTION
With this we allow PUT requests to vsvip in case of ip address changes, but in case there are vsvip IPAddress change related errors from the controller, they are reported back in the gateway status with reason `InvalidAddress`.
The two strings we look out for as part of those errors are:
- "Changing an existing VIP's vip_id is not supported"
- "If a new preferred IP is needed, please recreate the VIP"