### PR TITLE
Use default-group for SEG if not specified.

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -90,6 +90,7 @@ const (
 	PassthroughInsecure                        = "-insecure"
 	AviControllerVSVipIDChangeError            = "Changing an existing VIP's vip_id is not supported"
 	AviControllerRecreateVIPError              = "If a new preferred IP is needed, please recreate the VIP"
+	DefaultSEGroup                             = "Default-Group"
 )
 
 const (

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -296,6 +296,9 @@ func GetSEGName() string {
 	if segName != "" {
 		return segName
 	}
+	if GetAdvancedL4() {
+		return DefaultSEGroup
+	}
 	return ""
 }
 


### PR DESCRIPTION
If the SE Group is not supplied as a parameter as in the case
with wcp, default the SE group name to "Default-Group"