### PR TITLE
Avoid unnecessary PUT calls to the Avi controller for Vsvip updates

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -108,8 +108,8 @@ func GetL4PoolName(vsName string, port int32) string {
 	return vsName + "--" + strconv.Itoa(int(port))
 }
 
-func GetAdvL4PoolName(svcName, namespace string, port int32) string {
-	return NamePrefix + namespace + "-" + svcName + "--" + strconv.Itoa(int(port))
+func GetAdvL4PoolName(svcName, namespace, gwName string, port int32) string {
+	return NamePrefix + namespace + "-" + svcName + "-" + gwName + "--" + strconv.Itoa(int(port))
 }
 
 func GetL4PGName(vsName string, port int32) string {
@@ -514,6 +514,18 @@ func GetPassthroughShardVSName(s string, key string) string {
 	vsName := shardVsPrefix + fmt.Sprint(vsNum)
 	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
 	return vsName
+}
+
+func VSVipChecksum(FQDNs []string, IPAddress string) uint32 {
+	sort.Strings(FQDNs)
+	var checksum uint32
+	if len(FQDNs) != 0 {
+		checksum = utils.Hash(utils.Stringify(FQDNs))
+	}
+	if IPAddress != "" {
+		checksum = checksum + utils.Hash(IPAddress)
+	}
+	return checksum
 }
 
 // GetLabels returns the key value pair used for tagging the segroups and routes in vrfcontext

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -131,7 +131,7 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		port, _ := strconv.Atoi(portProto[1])
 
 		poolNode := &AviPoolNode{
-			Name:       lib.GetAdvL4PoolName(svcNSName[1], namespace, int32(port)),
+			Name:       lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port)),
 			Tenant:     lib.GetTenant(),
 			Protocol:   portProto[0],
 			PortName:   "",

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -735,10 +735,7 @@ func (v *AviVSVIPNode) GetCheckSum() uint32 {
 }
 
 func (v *AviVSVIPNode) CalculateCheckSum() {
-	// A sum of fields for this VS.
-	sort.Strings(v.FQDNs)
-	checksum := utils.Hash(utils.Stringify(v.FQDNs)) + utils.Hash(v.IPAddress)
-	v.CloudConfigCksum = checksum
+	v.CloudConfigCksum = lib.VSVipChecksum(v.FQDNs, v.IPAddress)
 }
 
 func (v *AviVSVIPNode) GetNodeType() string {

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -188,11 +188,11 @@ func SvcToGateway(svcName string, namespace string, key string) ([]string, bool)
 					if !utils.HasElem(svcPortProtocols, portProto) {
 						svcs = utils.Remove(svcs, svcNSName)
 					}
-					} else {
-						svcs = append(svcs, svcNSName)
-						newSvcListeners[portProto] = svcs
-					}
+				} else {
+					svcs = append(svcs, svcNSName)
+					newSvcListeners[portProto] = svcs
 				}
+			}
 
 			objects.ServiceGWLister().UpdateGatewayMappings(gateway, newSvcListeners, svcNSName)
 			if !utils.HasElem(allGateways, gateway) {
@@ -201,7 +201,7 @@ func SvcToGateway(svcName string, namespace string, key string) ([]string, bool)
 		}
 	}
 
-	utils.AviLog.Debugf("key: %s, msg: Gateways retrieved %v", key, allGateways)
+	utils.AviLog.Infof("key: %s, msg: Gateways retrieved %v", key, allGateways)
 	return allGateways, true
 }
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -116,7 +116,7 @@ func (rest *RestOperations) AviL4PolicyDel(uuid string, tenant string, key strin
 	path := "/api/l4policyset/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
-	utils.AviLog.Debug(spew.Sprintf("L4 Policy Set DELETE Restop %v \n",
+	utils.AviLog.Infof(spew.Sprintf("L4 Policy Set DELETE Restop %v \n",
 		utils.Stringify(rest_op)))
 	return &rest_op
 }


### PR DESCRIPTION
This commit addresses the issue of unnecessary PUT calls for VS
vip updates during AKO reboot.

Modified the logic of calculating checksum. Thing to note is,
an empty string when done a hash on, results in a non-zero
checksum. This is fixed as a part of the PR.