### PR TITLE
changes in retry logic

### DIFF
--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -88,7 +88,7 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 	}
 
 	resp_elems, ok := RestRespArrToObjByType(rest_op, "vsdatascriptset", key)
-	utils.AviLog.Warnf("The datascriptset object response %v", rest_op.Response)
+	utils.AviLog.Debugf("The datascriptset object response %v", rest_op.Response)
 	if ok != nil || resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find datascriptset obj in resp %v", key, rest_op.Response)
 		return errors.New("datascriptset not found")


### PR DESCRIPTION
- Do a fast retry on failure due to session expiry
- If any error occurs during execution of a rest call to avi,
then return false to the caller, so that no subsequent requests are made.

Without this change, we may land into a inconsient state. E.g. during clean up
of VSes for passthrough routes, if we get an error in deletion of insecure
passthrough VS, possibly due to session expiry, we would continute with the deletion
of the secure passthrough VS. But deletrion of the vsvip would fail.

On retry, insecure passthrough VS would be deleted, but we would get a 404 as secure
passthrough VS is already deleted, leading to stale pool objects.