### PR TITLE
Use ldflags to print AKO version

### DIFF
--- a/Dockerfile.ako
+++ b/Dockerfile.ako
@@ -1,11 +1,12 @@
 FROM golang:latest AS build
 ENV BUILD_PATH="github.com/vmware/load-balancer-and-ingress-services-for-kubernetes"
+ENV AKO_VERSION="v1.3.2"
 RUN mkdir -p $GOPATH/src/$BUILD_PATH
 
 COPY . $GOPATH/src/$BUILD_PATH
 WORKDIR $GOPATH/src/$BUILD_PATH
 
-RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/akc -mod=vendor $BUILD_PATH/cmd/ako-main
+RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/akc -ldflags="-X 'main.version=$AKO_VERSION'" -mod=vendor $BUILD_PATH/cmd/ako-main
 
 FROM photon:latest
 RUN yum install -y tar.x86_64

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GOCLEAN=$(GOCMD) clean
 GOGET=$(GOCMD) get
 GOTEST=$(GOCMD) test
 BINARY_NAME_AKO=ako
+AKO_VERSION=v1.3.2
 REL_PATH_AKO=github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/cmd/ako-main
 
 
@@ -12,7 +13,7 @@ all: build docker
 
 .PHONY: build
 build: 
-		$(GOBUILD) -o bin/$(BINARY_NAME_AKO)  -mod=vendor $(REL_PATH_AKO)
+		$(GOBUILD) -o bin/$(BINARY_NAME_AKO) -ldflags="-X 'main.version=$(AKO_VERSION)'"  -mod=vendor $(REL_PATH_AKO)
 
 .PHONY: clean
 clean: 

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -38,6 +38,7 @@ import (
 var (
 	masterURL  string
 	kubeconfig string
+	version    = "dev"
 )
 
 func main() {
@@ -56,6 +57,7 @@ func InitializeAKOApi() {
 func InitializeAKC() {
 	var err error
 	kubeCluster := false
+	utils.AviLog.Info("AKO is running with version: ", version)
 	// Check if we are running inside kubernetes. Hence try authenticating with service token
 	cfg, err := rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
This commit introduces a way by which one should be able to pass
a ldflag argument to AKO and AKO on bootup would print the version.

This will help us recognize the running AKO version.