### PR TITLE
Optimising the processing of services during node CUD for NodePort mode.

### DIFF
--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -55,11 +55,20 @@ func DequeueIngestion(key string, fullsync bool) {
 				handleL4Service(svcl4Key, fullsync)
 			}
 			for _, svcl7Key := range svcl7Keys {
+				_, namespace, svcName := extractTypeNameNamespace(svcl7Key)
 				if ingressFound {
-					handleIngress(svcl7Key, fullsync, ingressNames)
+					filteredIngressFound, filteredIngressNames := objects.SharedSvcLister().IngressMappings(namespace).GetSvcToIng(svcName)
+					if !filteredIngressFound {
+						continue
+					}
+					handleIngress(svcl7Key, fullsync, filteredIngressNames)
 				}
 				if routeFound {
-					handleRoute(svcl7Key, fullsync, routeNames)
+					filteredRouteFound, filteredRouteNames := objects.OshiftRouteSvcLister().IngressMappings(namespace).GetSvcToIng(svcName)
+					if !filteredRouteFound {
+						continue
+					}
+					handleRoute(svcl7Key, fullsync, filteredRouteNames)
 				}
 			}
 		}


### PR DESCRIPTION
- Instead of passing all the routes of the system to each service, this change filters the routes/ingresses for each l7 service and handles it.
- It also means that the all ingress and routes need not be fetched for each node update. ( node-> ingress ) mapping.