### PR TITLE
AKO Stability Fix for invalid clustername

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,13 +149,14 @@ AKO can be tested from your laptop. Please follow the instructions:
         export CTRL_PASSWORD=<password>
         export CTRL_IPADDRESS=<controller-ip>
         export CTRL_VERSION=<controller-api-version>
-        export SHARD_VS_SIZE=<LARGE.MEDIUM,SMALL>
+        export SHARD_VS_SIZE=<LARGE,MEDIUM,SMALL>
         export FULL_SYNC_INTERVAL=1800
         export CLOUD_NAME=<Avi-cloud-name>
         export CLUSTER_NAME=<your-unique-cluster-name>
         export NODE_NETWORK_LIST='[{"networkName":"Nw1","cidrs":["10.79.168.0/22"]}]'
-        export SEG_NAME="Default-Group"
+        export SEG_NAME=<se-group-name>
         
+     NODE_NETWORK_LIST is a managment network name and a CIDR of that network. SEG_NAME can be empty for advance L4 deployment.
      You can control additional settings by exporting respective variables from inside the deployment [file](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/blob/master/helm/ako/templates/statefulset.yaml).
 
   4. Run: ./bin/ako

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ AKO can be tested from your laptop. Please follow the instructions:
         export CLOUD_NAME=<Avi-cloud-name>
         export CLUSTER_NAME=<your-unique-cluster-name>
         export NODE_NETWORK_LIST='[{"networkName":"Nw1","cidrs":["10.79.168.0/22"]}]'
+        export SEG_NAME="Default-Group"
         
      You can control additional settings by exporting respective variables from inside the deployment [file](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/blob/master/helm/ako/templates/statefulset.yaml).
 

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,7 @@ github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241/go.mod h1:BcllDeAF
 github.com/avinetworks/sdk v0.0.0-20200910070359-d9ffda19a7dd h1:W+4xqQczmklVpG+JQlY9nBQaSbhbv3MvGaFLX6UvNrY=
 github.com/avinetworks/sdk v0.0.0-20200910070359-d9ffda19a7dd/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
 github.com/avinetworks/sdk v0.0.0-20200910092938-580bed7585cb h1:i6jbYz4bcAN6ropnUUmfG0RCQv+w/SC/MkCXCIUUaAs=
+github.com/avinetworks/sdk v0.0.0-20200921035123-787ceaed92c5 h1:yTqiP3xkjLNhfC7NOkWYz7YxaFhWpGLlSxBJbluJofg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/go.sum
+++ b/go.sum
@@ -35,7 +35,6 @@ github.com/avinetworks/sdk v0.0.0-20200910040148-2ed48a016241/go.mod h1:BcllDeAF
 github.com/avinetworks/sdk v0.0.0-20200910070359-d9ffda19a7dd h1:W+4xqQczmklVpG+JQlY9nBQaSbhbv3MvGaFLX6UvNrY=
 github.com/avinetworks/sdk v0.0.0-20200910070359-d9ffda19a7dd/go.mod h1:BcllDeAFx8PtaMrPxvvuCUo7NRS2x6w+3W17WFDu0sk=
 github.com/avinetworks/sdk v0.0.0-20200910092938-580bed7585cb h1:i6jbYz4bcAN6ropnUUmfG0RCQv+w/SC/MkCXCIUUaAs=
-github.com/avinetworks/sdk v0.0.0-20200921035123-787ceaed92c5 h1:yTqiP3xkjLNhfC7NOkWYz7YxaFhWpGLlSxBJbluJofg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2430,8 +2430,8 @@ func ValidateUserInput(client *clients.AviClient) bool {
 		return true
 	}
 
-	isSegroupValid := checkSegroupLabels(client)
-	isNodeNetworkValid := checkNodeNetwork(client)
+	isSegroupValid := isCloudValid && checkSegroupLabels(client)
+	isNodeNetworkValid := isCloudValid && checkNodeNetwork(client)
 	isValid := isCloudValid &&
 		isSegroupValid &&
 		isNodeNetworkValid &&
@@ -2450,13 +2450,7 @@ func ValidateUserInput(client *clients.AviClient) bool {
 }
 
 func checkRequiredValuesYaml() bool {
-	clusterName := lib.GetClusterName()
-	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
-	if clusterName == "" {
-		utils.AviLog.Error("Required param clusterName not specified, syncing will be disabled")
-		return false
-	} else if !re.MatchString(clusterName) {
-		utils.AviLog.Error("clusterName must consist of alphanumeric characters or '-'/'_' (max 32 chars), syncing will be disabled")
+	if !lib.IsClusterNameValid() {
 		return false
 	}
 	lib.SetNamePrefix()

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -59,8 +59,8 @@ func PopulateCache() error {
 	aviclient := avicache.SharedAVIClients()
 	restlayer := rest.NewRestOperations(avi_obj_cache, aviclient)
 	staleVSKey := utils.ADMIN_NS + "/" + lib.DummyVSForStaleData
-	utils.AviLog.Infof("Starting clean up of stale objects")
-	if aviclient != nil && len(aviclient.AviClient) > 0 {
+	if lib.IsClusterNameValid() && aviclient != nil && len(aviclient.AviClient) > 0 {
+		utils.AviLog.Infof("Starting clean up of stale objects")
 		restlayer.CleanupVS(staleVSKey, true)
 		staleCacheKey := avicache.NamespaceName{
 			Name:      lib.DummyVSForStaleData,
@@ -149,9 +149,10 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 				return
 			}
 			// if DeleteConfig value has changed, then check if we need to enable/disable sync
-			c.DisableSync = !avicache.ValidateUserInput(aviclient) || delConfigFromData(cm.Data)
+			isValidUserInput := avicache.ValidateUserInput(aviclient)
+			c.DisableSync = !isValidUserInput || delConfigFromData(cm.Data)
 			lib.SetDisableSync(c.DisableSync)
-			if avicache.ValidateUserInput(aviclient) {
+			if isValidUserInput {
 				if delConfigFromData(cm.Data) {
 					c.DeleteModels()
 				} else {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -386,6 +387,18 @@ func GetClusterID() string {
 		}
 	}
 	return ""
+}
+func IsClusterNameValid() bool {
+	clusterName := GetClusterName()
+	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
+	if clusterName == "" {
+		utils.AviLog.Error("Required param clusterName not specified, syncing will be disabled")
+		return false
+	} else if !re.MatchString(clusterName) {
+		utils.AviLog.Error("clusterName must consist of alphanumeric characters or '-'/'_' (max 32 chars), syncing will be disabled")
+		return false
+	}
+	return true
 }
 
 var StaticRouteSyncChan chan struct{}

--- a/scripts/pre_stop_hook.sh
+++ b/scripts/pre_stop_hook.sh
@@ -1,3 +1,16 @@
+# Copyright 2019-2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #!/bin/sh
 set -e
 function zip_old_files() {


### PR DESCRIPTION
This Commit addresses: 
1. IF clustername is invalid, do not delete stale VS and objects.
2. Adding header to pre_stop_hook
3. Adding env variable for running ako locally