### PR TITLE
gateway finalizers implementation

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -91,6 +91,7 @@ const (
 	AviControllerVSVipIDChangeError            = "Changing an existing VIP's vip_id is not supported"
 	AviControllerRecreateVIPError              = "If a new preferred IP is needed, please recreate the VIP"
 	DefaultSEGroup                             = "Default-Group"
+	GatewayFinalizer                           = "gateway.ako.vmware.com"
 )
 
 const (

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -388,6 +388,7 @@ func GetClusterID() string {
 	}
 	return ""
 }
+
 func IsClusterNameValid() bool {
 	clusterName := GetClusterName()
 	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
@@ -573,6 +574,16 @@ func VSVipDelRequired() bool {
 	if err == nil {
 		currVersion, verErr := semver.NewVersion(utils.CtrlVersion)
 		if verErr == nil && c.Check(currVersion) {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsFinalizer(o metav1.Object, finalizer string) bool {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
 			return true
 		}
 	}


### PR DESCRIPTION
if an IP address is present on the gateway object, it is fair to assume that the gateway corresponds to a VS in avi
in case the IP is not present, the gateway can be deleted freely since deleting that would be a NOOP for AKO
so we add finalizer when an IP is updated to the gateway, and remove it when we delete the IP address.
The finalizer we attach to the gateway object is `gateway.ako.vmware.com`

This approach takes care of reboot scenarios, updates from the gateway AND service event handler, and of-course layer3 workflows.