### PR TITLE
Shutdown API Server if Avi Controller password is changed

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -165,7 +165,10 @@ func (rest *RestOperations) CheckAndPublishForRetry(err error, publishKey, key s
 	if webSyncErr, ok := err.(*utils.WebSyncError); ok {
 		aviError, ok := webSyncErr.GetWebAPIError().(session.AviError)
 		if ok && aviError.HttpStatusCode == 401 {
-			if avimodel != nil && avimodel.GetRetryCounter() != 0 {
+			if strings.Contains(*aviError.Message, "Invalid credentials") {
+				utils.AviLog.Errorf("key: %s, msg: Invalid credentials error, Shutting down API Server", key)
+				lib.ShutdownApi()
+			} else if avimodel != nil && avimodel.GetRetryCounter() != 0 {
 				utils.AviLog.Warnf("key: %s, msg: got 401 error while executing rest request, adding to fast retry queue", key)
 				rest.PublishKeyToRetryLayer(publishKey, key)
 			} else {


### PR DESCRIPTION
If controller pasword is changed while AKO is running, we can check
the error msg of the HTTP response. We would get this after session gets timed out
with HTTP Response code 401. The error msg would contain the string - Invalid credentials.

Then we would shutdown API server and AKO pod would get rebooted.

(cherry picked from commit d78a9fb229324a15aa2e86efd2debcea3c9d2089)