### PR TITLE
Increase informer re-sync value and reduction of configmap informer cache

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -113,8 +113,8 @@ func InitializeAKC() {
 
 	if lib.GetNamespaceToSync() != "" {
 		informersArg[utils.INFORMERS_NAMESPACE] = lib.GetNamespaceToSync()
-		utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
 	}
+	informersArg[utils.INFORMERS_ADVANCED_L4] = lib.GetAdvancedL4()
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
 	lib.NewDynamicInformers(dynamicClient)
 	if lib.GetAdvancedL4() {

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -187,7 +187,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	if lib.GetNamespaceToSync() != "" {
 		informersArg[utils.INFORMERS_NAMESPACE] = lib.GetNamespaceToSync()
 	}
-
+	informersArg[utils.INFORMERS_ADVANCED_L4] = lib.GetAdvancedL4()
 	c.informers = utils.NewInformers(utils.KubeClientIntf{ClientSet: informers.Cs}, registeredInformers, informersArg)
 	c.dynamicInformers = lib.NewDynamicInformers(informers.DynamicClient)
 	var ingestionwg *sync.WaitGroup

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -16,6 +16,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"time"
 
 	avimodels "github.com/avinetworks/sdk/go/models"
 	oshiftclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -26,6 +27,8 @@ import (
 )
 
 type EvType string
+
+var InformerDefaultResync = 12 * time.Hour
 
 const (
 	CreateEv            EvType = "CREATE"
@@ -54,6 +57,9 @@ const (
 	INFORMERS_INSTANTIATE_ONCE string = "instantiateOnce"
 	INFORMERS_OPENSHIFT_CLIENT string = "oshiftClient"
 	INFORMERS_NAMESPACE        string = "namespace"
+	INFORMERS_ADVANCED_L4      string = "informersAdvL4"
+	VMWARE_SYSTEM_AKO          string = "vmware-system-ako"
+	AKO_DEFAULT_NS             string = "avi-system"
 )
 
 type KubeClientIntf struct {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -147,17 +147,27 @@ func RandomSeq(n int) string {
 var informer sync.Once
 var informerInstance *Informers
 
-const informerDefaultResync = 12 * time.Hour
-
-func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []string, ocs oshiftclientset.Interface, namespace string) *Informers {
+func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []string, ocs oshiftclientset.Interface, namespace string, adv_l4 bool) *Informers {
 	cs := kubeClient.ClientSet
-	var kubeInformerFactory kubeinformers.SharedInformerFactory
+	var kubeInformerFactory, configMapInformerFactory kubeinformers.SharedInformerFactory
 	if namespace == "" {
-		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, informerDefaultResync)
+		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, InformerDefaultResync)
 	} else {
 		// The informer factory only allows to initialize 1 namespace filter. Not a set of namespaces.
-		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, informerDefaultResync, kubeinformers.WithNamespace(namespace))
+		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, InformerDefaultResync, kubeinformers.WithNamespace(namespace))
 		AviLog.Infof("Initialized informer factory for namespace :%s", namespace)
+	}
+	// We listen to configmaps only in `avi-system or vmware-system-ako`
+	if adv_l4 {
+		// Advanced L4 is for vmware-system-ako
+		configmapns := VMWARE_SYSTEM_AKO
+		configMapInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, InformerDefaultResync, kubeinformers.WithNamespace(configmapns))
+		AviLog.Infof("Initializing configmap informer in %v", configmapns)
+	} else {
+		// Regular AKO
+		configmapns := AKO_DEFAULT_NS
+		configMapInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, InformerDefaultResync, kubeinformers.WithNamespace(configmapns))
+		AviLog.Infof("Initializing configmap informer in %v", configmapns)
 	}
 	informers := &Informers{}
 	informers.KubeClientIntf = kubeClient
@@ -176,7 +186,7 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 		case NodeInformer:
 			informers.NodeInformer = kubeInformerFactory.Core().V1().Nodes()
 		case ConfigMapInformer:
-			informers.ConfigMapInformer = kubeInformerFactory.Core().V1().ConfigMaps()
+			informers.ConfigMapInformer = configMapInformerFactory.Core().V1().ConfigMaps()
 		case IngressInformer:
 			ingressAPI := GetIngressApi(cs)
 			if ingressAPI == ExtV1IngressInformer {
@@ -208,7 +218,7 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 
 func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args ...map[string]interface{}) *Informers {
 	var oshiftclient oshiftclientset.Interface
-	var instantiateOnce, ok bool = true, true
+	var instantiateOnce, ok, adv_l4 bool = true, true, false
 	var namespace string
 	if len(args) > 0 {
 		for k, v := range args[0] {
@@ -217,6 +227,11 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 				instantiateOnce, ok = v.(bool)
 				if !ok {
 					AviLog.Warnf("arg instantiateOnce is not of type bool")
+				}
+			case INFORMERS_ADVANCED_L4:
+				adv_l4, ok = v.(bool)
+				if !ok {
+					AviLog.Infof("Running AKO in avi-system namespace")
 				}
 			case INFORMERS_OPENSHIFT_CLIENT:
 				oshiftclient, ok = v.(oshiftclientset.Interface)
@@ -234,10 +249,10 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 		}
 	}
 	if !instantiateOnce {
-		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace)
+		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace, adv_l4)
 	}
 	informer.Do(func() {
-		informerInstance = instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace)
+		informerInstance = instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace, adv_l4)
 	})
 	return informerInstance
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -147,14 +147,16 @@ func RandomSeq(n int) string {
 var informer sync.Once
 var informerInstance *Informers
 
+const informerDefaultResync = 12 * time.Hour
+
 func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []string, ocs oshiftclientset.Interface, namespace string) *Informers {
 	cs := kubeClient.ClientSet
 	var kubeInformerFactory kubeinformers.SharedInformerFactory
 	if namespace == "" {
-		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, time.Second*30)
+		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, informerDefaultResync)
 	} else {
 		// The informer factory only allows to initialize 1 namespace filter. Not a set of namespaces.
-		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, time.Second*30, kubeinformers.WithNamespace(namespace))
+		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(cs, informerDefaultResync, kubeinformers.WithNamespace(namespace))
 		AviLog.Infof("Initialized informer factory for namespace :%s", namespace)
 	}
 	informers := &Informers{}


### PR DESCRIPTION
This commit increases the value of informer re-sync period to 12 hours
This value was currently set to 30 seconds, which would mean that the
kubernetes API server would be polled too frequently for full sync.

This commit sets the value as used in the kube api server defaults:
https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/controller/apis/config/v1alpha1/defaults.go#L120

In addition to this, we also restrict the configmap informers to listen on specific namespaces for both advancedL4 and non-advancedL4. This brings down the indexer cache consumption significantly for systems that have huge number of configmaps.