### PR TITLE
Don't brick Avi VSes if kube API server is flakey

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -128,7 +128,11 @@ func InitializeAKC() {
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
-	c.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
+	err = c.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
+	if err != nil {
+		utils.AviLog.Errorf("Handleconfigmap error during reboot, shutting down AKO")
+		return
+	}
 	err = k8s.PopulateCache()
 	if err != nil {
 		c.DisableSync = true

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -15,6 +15,7 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -101,7 +102,7 @@ func deleteConfigFromConfigmap(cs kubernetes.Interface) bool {
 
 // HandleConfigMap : initialise the controller, start informer for configmap and wait for the akc configmap to be created.
 // When the configmap is created, enable sync for other k8s objects. When the configmap is disabled, disable sync.
-func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct{}, stopCh <-chan struct{}, quickSyncCh chan struct{}) {
+func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct{}, stopCh <-chan struct{}, quickSyncCh chan struct{}) error {
 	cs := k8sinfo.Cs
 	aviClientPool := avicache.SharedAVIClients()
 	if aviClientPool == nil || len(aviClientPool.AviClient) < 1 {
@@ -109,10 +110,13 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 		lib.SetDisableSync(true)
 		utils.AviLog.Errorf("could not get client to connect to Avi Controller, disabling sync")
 		lib.ShutdownApi()
-		return
+		return errors.New("Unable to contact the avi controller on bootup")
 	}
 	aviclient := aviClientPool.AviClient[0]
 	c.DisableSync = !avicache.ValidateUserInput(aviclient) || deleteConfigFromConfigmap(cs)
+	if c.DisableSync {
+		return errors.New("Sync is disabled because of configmap unavailability during bootup")
+	}
 	lib.SetDisableSync(c.DisableSync)
 
 	utils.AviLog.Infof("Creating event broadcaster for handling configmap")
@@ -177,6 +181,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 	} else {
 		utils.AviLog.Info("Caches synced")
 	}
+	return nil
 }
 
 func (c *AviController) InitController(informers K8sinformers, registeredInformers []string, ctrlCh <-chan struct{}, stopCh <-chan struct{}, quickSyncCh chan struct{}, waitGroupMap ...map[string]*sync.WaitGroup) {
@@ -251,7 +256,13 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 		utils.AviLog.Errorf("Cannot convert full sync interval value to integer, pls correct the value and restart AKO. Error: %s", err)
 	} else {
 		// First boot sync
-		c.FullSyncK8s()
+		err = c.FullSyncK8s()
+		if err != nil {
+			// Something bad sync. We need to return and shutdown the API server
+			utils.AviLog.Errorf("Couldn't run full sync successfully on bootup, going to shutdown AKO: %s", err)
+			lib.ShutdownApi()
+			return
+		}
 		if interval != 0 {
 			worker = utils.NewFullSyncThread(time.Duration(interval) * time.Second)
 			worker.SyncFunction = c.FullSync
@@ -325,10 +336,10 @@ func (c *AviController) FullSync() {
 	}
 }
 
-func (c *AviController) FullSyncK8s() {
+func (c *AviController) FullSyncK8s() error {
 	if c.DisableSync {
 		utils.AviLog.Infof("Sync disabled, skipping full sync")
-		return
+		return nil
 	}
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 	var vrfModelName string
@@ -361,6 +372,7 @@ func (c *AviController) FullSyncK8s() {
 	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services("").List(labels.Set(nil).AsSelector())
 	if err != nil {
 		utils.AviLog.Errorf("Unable to retrieve the services during full sync: %s", err)
+		return err
 	} else {
 		for _, svcObj := range svcObjs {
 			isSvcLb := isServiceLBType(svcObj)
@@ -425,6 +437,7 @@ func (c *AviController) FullSyncK8s() {
 		gatewayObjs, err := lib.GetAdvL4Informers().GatewayInformer.Lister().Gateways("").List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the gateways during full sync: %s", err)
+			return err
 		} else {
 			for _, gatewayObj := range gatewayObjs {
 				key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
@@ -436,6 +449,7 @@ func (c *AviController) FullSyncK8s() {
 		gwClassObjs, err := lib.GetAdvL4Informers().GatewayClassInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the gatewayclasses during full sync: %s", err)
+			return err
 		} else {
 			for _, gwClassObj := range gwClassObjs {
 				key := lib.GatewayClass + "/" + utils.ObjKey(gwClassObj)
@@ -497,7 +511,7 @@ func (c *AviController) FullSyncK8s() {
 			nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
 		}
 	}
-	return
+	return nil
 }
 
 // DeleteModels : Delete models and add the model name in the queue.

--- a/pkg/utils/full_sync_worker.go
+++ b/pkg/utils/full_sync_worker.go
@@ -24,7 +24,7 @@ type FullSyncThread struct {
 	QuickSyncChan     chan string
 	Interval          time.Duration
 	SyncFunction      func()
-	QuickSyncFunction func()
+	QuickSyncFunction func() error
 }
 
 func NewFullSyncThread(interval time.Duration) *FullSyncThread {

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -87,9 +87,9 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+        AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
-	AddConfigMap()
 	integrationtest.KubeClient = KubeClient
 	os.Exit(m.Run())
 }

--- a/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
+++ b/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
@@ -35,6 +35,7 @@ func SetUpTestForIngressInNodePortMode(t *testing.T, model_Name string) {
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("L7_SHARD_SCHEME", "namespace")
 	objects.SharedAviGraphLister().Delete(model_Name)
+        AddConfigMap()
 	CreateSVC(t, "default", "avisvc", corev1.ServiceTypeNodePort, false)
 }
 

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -109,6 +109,7 @@ func TestMain(m *testing.M) {
 	defer AviFakeClientInstance.Close()
 
 	ctrl = k8s.SharedAviController()
+        AddConfigMap()
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -78,17 +78,14 @@ func setupQueue(stopCh <-chan struct{}) {
 	ingestionQueue.Run(stopCh, wgIngestion)
 }
 
-func addConfigMap(t *testing.T) {
+func addConfigMap() {
 	aviCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "avi-system",
 			Name:      "avi-k8s-config",
 		},
 	}
-	_, err := kubeClient.CoreV1().ConfigMaps("avi-system").Create(aviCM)
-	if err != nil {
-		t.Fatalf("error in adding configmap: %v", err)
-	}
+	kubeClient.CoreV1().ConfigMaps("avi-system").Create(aviCM)
 }
 
 func TestMain(m *testing.M) {
@@ -102,6 +99,7 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	crdClient = crdfake.NewSimpleClientset()
 	lib.SetCRDClientset(crdClient)
+        addConfigMap()
 
 	registeredInformers := []string{
 		utils.ServiceInformer,
@@ -131,22 +129,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestAviConfigMap(t *testing.T) {
-	aviCM := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "avi-system",
-			Name:      "avi-k8s-config",
-		},
-	}
-	_, err := kubeClient.CoreV1().ConfigMaps("avi-system").Create(aviCM)
-	if err != nil {
-		t.Fatalf("error in adding configmap: %v", err)
-	}
-	time.Sleep(30 * time.Second)
-	if ctrl.DisableSync {
-		t.Fatalf("sync not enabled after adding configmap")
-	}
-}
 
 func TestSvc(t *testing.T) {
 	svcExample := &corev1.Service{

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -106,6 +106,16 @@ func AddConfigMap(t *testing.T) {
 	time.Sleep(10 * time.Second)
 }
 
+func AddCMap() {
+    aviCM := &corev1.ConfigMap{
+        ObjectMeta: metav1.ObjectMeta{
+            Namespace: "avi-system",
+            Name:      "avi-k8s-config",
+        },
+    }
+    kubeClient.CoreV1().ConfigMaps("avi-system").Create(aviCM)
+}
+
 func DeleteConfigMap(t *testing.T) {
 	options := metav1.DeleteOptions{}
 	err := kubeClient.CoreV1().ConfigMaps("avi-system").Delete("avi-k8s-config", &options)
@@ -244,6 +254,7 @@ func TestMain(m *testing.M) {
 	keyChan = make(chan string)
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
+        AddCMap()
 	ctrl.HandleConfigMap(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}, ctrlCh, stopCh, quickSyncCh)
 	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient})
 	setupQueue(stopCh)
@@ -252,7 +263,7 @@ func TestMain(m *testing.M) {
 
 // Cloud does not have a ipam_provider_ref configured, sync should be disabled
 func TestVcenterCloudNoIpamDuringBootup(t *testing.T) {
-
+        DeleteConfigMap(t)
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	utils.SetCloudName("CLOUD_VCENTER")
 	os.Setenv("SERVICE_TYPE", "ClusterIP")

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -163,9 +163,9 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
-	AddConfigMap()
 	integrationtest.KubeClient = KubeClient
 
 	DefaultRouteName = "foo"


### PR DESCRIPTION
This commit handles a couple of things:

- It will ensure that the Avi VSes aren't bricked if due to some
reason AKO was rebooted and during the first full sync, it couldn't
retrieve either a gateway or a service in advanced L4. These errors
before this commit would lead to a partial object model build up in
layer 2 which could process unintended updates.

- If during bootup of AKO, we are not able to retrieve the configmap
we will return immediately instead of just shutting down the API server
This is required because, the API server shutting down allows the pod
some more time to run till the liveness probe fails. This fix allows
us to shutdown the API server and return to main.