### PR TITLE
Allow System-TCP-Fast-Path only as the network profile for adv l4

### DIFF
--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -92,7 +92,7 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		if !isTCP {
 			avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 		} else {
-			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
 		}
 
 		vsVipNode := &AviVSVIPNode{

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -51,6 +51,7 @@ const (
 	SYSTEM_UDP_FAST_PATH          = "System-UDP-Fast-Path"
 	DEFAULT_TCP_NW_PROFILE        = "System-TCP-Proxy"
 	DEFAULT_L4_APP_PROFILE        = "System-L4-Application"
+	TCP_NW_FAST_PATH              = "System-TCP-Fast-Path"
 	DEFAULT_L7_APP_PROFILE        = "System-HTTP"
 	DEFAULT_L7_SECURE_APP_PROFILE = "System-Secure-HTTP"
 	DEFAULT_SHARD_VS_PREFIX       = "Shard-VS-"


### PR DESCRIPTION
Since advancedl4 is meant to run with the ESSENTIALS Avi license,
changing the network profile to always use System-TCP-Fast-Path
instead of proxy.