### PR TITLE
Enable RHI as a AKO wide setting

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   disableStaticRouteSync: {{ .Values.AKOSettings.disableStaticRouteSync | quote }}
   defaultIngController: {{ .Values.L7Settings.defaultIngController | quote }}
   subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
+  enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
   networkName: {{ .Values.NetworkSettings.networkName | quote }}
   l7ShardingScheme: {{ .Values.L7Settings.l7ShardingScheme | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -102,6 +102,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: clusterName
+          - name: ENABLE_RHI
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: enableRHI
           - name: DEFAULT_DOMAIN
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -31,6 +31,7 @@ NetworkSettings:
   subnetIP: "" # Subnet IP of the vip network
   subnetPrefix: "" # Subnet Prefix of the vip network
   networkName: "" # Network Name of the vip network
+  enableRHI: false # This is a cluster wide setting for BGP peering.
 
 ### This section outlines all the knobs  used to control Layer 7 loadbalancing settings in AKO.
 L7Settings:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -16,6 +16,7 @@ package lib
 
 const (
 	DISABLE_STATIC_ROUTE_SYNC = "DISABLE_STATIC_ROUTE_SYNC"
+	ENABLE_RHI                = "ENABLE_RHI"
 	CNI_PLUGIN                = "CNI_PLUGIN"
 	CALICO_CNI                = "calico"
 	OPENSHIFT_CNI             = "openshift"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -258,6 +258,15 @@ func GetNamespaceToSync() string {
 	return ""
 }
 
+func GetEnableRHI() bool {
+	if ok, _ := strconv.ParseBool(os.Getenv(ENABLE_RHI)); ok {
+		utils.AviLog.Debugf("Enable RHI set to true")
+		return true
+	}
+	utils.AviLog.Debugf("Enable RHI set to false")
+	return false
+}
+
 // The port to run the AKO API server on
 func GetAkoApiServerPort() string {
 	port := os.Getenv("AKO_API_PORT")

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -60,6 +60,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		svc_mdata := string(svc_mdata_json)
 		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
 		seGroupRef := "/api/serviceenginegroup?name=" + lib.GetSEGName()
+		enableRHI := lib.GetEnableRHI() // We don't impact the checksum of the VS since it's a global setting in AKO.
 		vs := avimodels.VirtualService{
 			Name:                  &name,
 			NetworkProfileRef:     &network_prof,
@@ -70,6 +71,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			ServiceMetadata:       &svc_mdata,
 			SeGroupRef:            &seGroupRef,
 			VrfContextRef:         &vrfContextRef,
+			EnableRhi:             &enableRHI,
 		}
 		if lib.GetAdvancedL4() {
 			ignPool := true

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 	defer AviFakeClientInstance.Close()
 
 	ctrl = k8s.SharedAviController()
-        AddConfigMap()
+	AddConfigMap()
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})


### PR DESCRIPTION
This commit introduces a `enableRHI` flag that allows the operator
to setup BGP peering for the virtual services created by AKO as a
cluster wide setting.