### PR TITLE
Be tolerant to ingresses without backends

### DIFF
--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -258,7 +258,10 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 		}
 
 		// simple validator check for duplicate hostpaths, logs Warning if duplicates found
-		validateSpecFromHostnameCache(key, ingObj.Namespace, ingObj.Name, ingObj.Spec)
+		success := validateSpecFromHostnameCache(key, ingObj.Namespace, ingObj.Name, ingObj.Spec)
+		if !success {
+			return ingresses, false
+		}
 
 		services := parseServicesForIngress(ingObj.Spec, key)
 		for _, svc := range services {
@@ -505,8 +508,10 @@ func parseServicesForIngress(ingSpec v1beta1.IngressSpec, key string) []string {
 	// Figure out the service names that are part of this ingress
 	var services []string
 	for _, rule := range ingSpec.Rules {
-		for _, path := range rule.IngressRuleValue.HTTP.Paths {
-			services = append(services, path.Backend.ServiceName)
+		if rule.IngressRuleValue.HTTP != nil {
+			for _, path := range rule.IngressRuleValue.HTTP.Paths {
+				services = append(services, path.Backend.ServiceName)
+			}
 		}
 	}
 	utils.AviLog.Debugf("key: %s, msg: total services retrieved  from corev1:  %s", key, services)

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -56,18 +56,23 @@ func (v *Validator) IsValiddHostName(hostname string) bool {
 	return false
 }
 
-func validateSpecFromHostnameCache(key, ns, ingName string, ingSpec v1beta1.IngressSpec) {
+func validateSpecFromHostnameCache(key, ns, ingName string, ingSpec v1beta1.IngressSpec) bool {
 	nsIngress := ns + "/" + ingName
 	for _, rule := range ingSpec.Rules {
-		for _, svcPath := range rule.IngressRuleValue.HTTP.Paths {
-			found, val := SharedHostNameLister().GetHostPathStoreIngresses(rule.Host, svcPath.Path)
-			if found && len(val) > 0 && utils.HasElem(val, nsIngress) && len(val) > 1 {
-				// TODO: push in ako apiserver
-				utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s%s: %s in ingresses: %+v", key, nsIngress, rule.Host, svcPath.Path, utils.Stringify(val))
+		if rule.IngressRuleValue.HTTP != nil {
+			for _, svcPath := range rule.IngressRuleValue.HTTP.Paths {
+				found, val := SharedHostNameLister().GetHostPathStoreIngresses(rule.Host, svcPath.Path)
+				if found && len(val) > 0 && utils.HasElem(val, nsIngress) && len(val) > 1 {
+					// TODO: push in ako apiserver
+					utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s%s: %s in ingresses: %+v", key, nsIngress, rule.Host, svcPath.Path, utils.Stringify(val))
+				}
 			}
+		} else {
+			utils.AviLog.Warnf("key: %s, msg: Found Ingress: %s without service backends. Not going to process.", key, ingName)
+			return false
 		}
 	}
-	return
+	return true
 }
 
 func validateRouteSpecFromHostnameCache(key, ns, routeName string, routeSpec routev1.RouteSpec) {
@@ -157,21 +162,22 @@ func (v *Validator) ParseHostPathForIngress(ns string, ingName string, ingSpec v
 		} else {
 			secretHostsMap[secretName] = append(secretHostsMap[secretName], hostName)
 		}
-
-		for _, path := range rule.IngressRuleValue.HTTP.Paths {
-			hostPathMapSvc := IngressHostPathSvc{
-				Path:        path.Path,
-				ServiceName: path.Backend.ServiceName,
-				Port:        path.Backend.ServicePort.IntVal,
-				PortName:    path.Backend.ServicePort.StrVal,
+		if rule.IngressRuleValue.HTTP != nil {
+			for _, path := range rule.IngressRuleValue.HTTP.Paths {
+				hostPathMapSvc := IngressHostPathSvc{
+					Path:        path.Path,
+					ServiceName: path.Backend.ServiceName,
+					Port:        path.Backend.ServicePort.IntVal,
+					PortName:    path.Backend.ServicePort.StrVal,
+				}
+				if hostPathMapSvc.Port == 0 {
+					// Default to port 80 if not set in the ingress object
+					hostPathMapSvc.Port = 80
+				}
+				// for ingress use 100 as default weight
+				hostPathMapSvc.weight = 100
+				hostPathMapSvcList = append(hostPathMapSvcList, hostPathMapSvc)
 			}
-			if hostPathMapSvc.Port == 0 {
-				// Default to port 80 if not set in the ingress object
-				hostPathMapSvc.Port = 80
-			}
-			// for ingress use 100 as default weight
-			hostPathMapSvc.weight = 100
-			hostPathMapSvcList = append(hostPathMapSvcList, hostPathMapSvc)
 		}
 
 		if useHostRuleSSL {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -303,6 +303,27 @@ func (ing FakeIngress) IngressNoHost() *extensionv1beta1.Ingress {
 	return ingress
 }
 
+func (ing FakeIngress) IngressOnlyHostNoBackend() *extensionv1beta1.Ingress {
+	ingress := &extensionv1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   ing.Namespace,
+			Name:        ing.Name,
+			Annotations: ing.annotations,
+		},
+		Spec: extensionv1beta1.IngressSpec{
+			Rules: nil,
+		},
+
+	}
+	ingress.Spec.Rules = append(ingress.Spec.Rules, extensionv1beta1.IngressRule{
+		IngressRuleValue: extensionv1beta1.IngressRuleValue{
+			HTTP: nil,
+		},
+	})
+
+	return ingress
+}
+
 func (ing FakeIngress) IngressMultiPath() *extensionv1beta1.Ingress {
 	ingress := &extensionv1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This commit makes AKO tolerant to ingresses without backends.
We simply return and not process.

Added a test to verify this.