### PR TITLE
static IP support for service LB using spec.loadbalancerIP

### DIFF
--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -96,9 +96,20 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	} else {
 		avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
 	}
+
 	vsVipName := lib.GetL4VSVipName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace)
-	vsVipNode := &AviVSVIPNode{Name: vsVipName, Tenant: lib.GetTenant(),
-		FQDNs: fqdns, EastWest: false, VrfContext: vrfcontext}
+	vsVipNode := &AviVSVIPNode{
+		Name:       vsVipName,
+		Tenant:     lib.GetTenant(),
+		FQDNs:      fqdns,
+		EastWest:   false,
+		VrfContext: vrfcontext,
+	}
+
+	if svcObj.Spec.LoadBalancerIP != "" {
+		vsVipNode.IPAddress = svcObj.Spec.LoadBalancerIP
+	}
+
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
 	utils.AviLog.Infof("key: %s, msg: created vs object: %s", key, utils.Stringify(avi_vs_meta))
 	return avi_vs_meta

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -614,8 +614,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		}
 		vsvip.DNSInfo = dns_info_arr
 
-		// handling static IP updates in case of advl4 workflows
-		if lib.GetAdvancedL4() && vsvip_meta.IPAddress != "" {
+		// handling static IP updates, this would throw an error
+		// for advl4 the error is propogated to the gateway status
+		if vsvip_meta.IPAddress != "" {
 			auto_alloc := true
 			var vips []*avimodels.Vip
 			vips = append(vips, &avimodels.Vip{
@@ -635,33 +636,21 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 	} else {
 		auto_alloc := true
 		var vips []*avimodels.Vip
-		var vip avimodels.Vip
+
+		// all vsvip models would have auto_alloc set to true even in case of static IP programming
+		vip := avimodels.Vip{AutoAllocateIP: &auto_alloc}
 		networkRef := lib.GetNetworkName()
 		if lib.IsPublicCloud() && lib.GetNetworkName() != "" {
-			vip = avimodels.Vip{
-				AutoAllocateIP: &auto_alloc,
-				SubnetUUID:     &networkRef,
-			}
-		} else if lib.GetAdvancedL4() {
-			if vsvip_meta.IPAddress != "" {
-				auto_alloc = true
-				vip = avimodels.Vip{
-					VipID:          &vipId,
-					AutoAllocateIP: &auto_alloc,
-					IPAddress: &avimodels.IPAddr{
-						Type: &ipType,
-						Addr: &vsvip_meta.IPAddress,
-					},
-				}
-			} else {
-				vip = avimodels.Vip{
-					AutoAllocateIP: &auto_alloc,
-				}
+			vip.SubnetUUID = &networkRef
+		} else if vsvip_meta.IPAddress != "" {
+			vip.VipID = &vipId
+			vip.IPAddress = &avimodels.IPAddr{
+				Type: &ipType,
+				Addr: &vsvip_meta.IPAddress,
 			}
 		} else if lib.GetSubnetPrefix() == "" || lib.GetSubnetIP() == "" || lib.GetNetworkName() == "" {
 			utils.AviLog.Warnf("Incomplete values provided for subnet/cidr/network, will not use network ref in vsvip")
-			vip = avimodels.Vip{AutoAllocateIP: &auto_alloc}
-		} else {
+		} else if !lib.GetAdvancedL4() {
 			intCidr, err := strconv.ParseInt(lib.GetSubnetPrefix(), 10, 32)
 			if err != nil {
 				utils.AviLog.Warnf("The value of CIDR couldn't be converted to int32. Defaulting to /24")
@@ -673,12 +662,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			subnet_ip_obj := avimodels.IPAddr{Type: &subnet_atype, Addr: &subnet_addr}
 			subnet_obj := avimodels.IPAddrPrefix{IPAddr: &subnet_ip_obj, Mask: &subnet_mask}
 			networkRef = "/api/network/?name=" + lib.GetNetworkName()
-			vip = avimodels.Vip{
-				AutoAllocateIP: &auto_alloc,
-				IPAMNetworkSubnet: &avimodels.IPNetworkSubnet{
-					Subnet:     &subnet_obj,
-					NetworkRef: &networkRef,
-				},
+			vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
+				Subnet:     &subnet_obj,
+				NetworkRef: &networkRef,
 			}
 		}
 

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -312,7 +312,6 @@ func (ing FakeIngress) IngressOnlyHostNoBackend() *extensionv1beta1.Ingress {
 		Spec: extensionv1beta1.IngressSpec{
 			Rules: nil,
 		},
-
 	}
 	ingress.Spec.Rules = append(ingress.Spec.Rules, extensionv1beta1.IngressRule{
 		IngressRuleValue: extensionv1beta1.IngressRuleValue{
@@ -430,12 +429,13 @@ func PollForSyncStart(ctrl *k8s.AviController, counter int) bool {
 }
 
 type FakeService struct {
-	Namespace    string
-	Name         string
-	Labels       map[string]string
-	Type         corev1.ServiceType
-	annotations  map[string]string
-	ServicePorts []Serviceport
+	Namespace      string
+	Name           string
+	Labels         map[string]string
+	Type           corev1.ServiceType
+	LoadBalancerIP string
+	annotations    map[string]string
+	ServicePorts   []Serviceport
 }
 
 type Serviceport struct {
@@ -459,8 +459,9 @@ func (svc FakeService) Service() *corev1.Service {
 	}
 	svcExample := &corev1.Service{
 		Spec: corev1.ServiceSpec{
-			Type:  svc.Type,
-			Ports: ports,
+			Type:           svc.Type,
+			Ports:          ports,
+			LoadBalancerIP: svc.LoadBalancerIP,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: svc.Namespace,


### PR DESCRIPTION
This introduces staticIP support for k8s services objects using the `spec.loadBalancerIP` field
The functionality is similar to how AKO handles static IPs in gateways, wherein updates on the corresponding vsvip objects is not allowed. In order to update the static IP, the Service/Gateway object must be re-created using the new preferred IP.
Errors associated to preferred IP updates are reported to the gateway status conditions, but is not currently possible in case of service objects, although AKO logs the Avi controller API response error. 