### PR TITLE
Changes to dockerfile and makefile

### DIFF
--- a/Dockerfile.ako
+++ b/Dockerfile.ako
@@ -1,4 +1,6 @@
-FROM golang:latest AS build
+ARG golang_src_repo=golang:latest
+ARG photon_src_repo=photon:latest
+FROM ${golang_src_repo} as build
 ENV BUILD_PATH="github.com/vmware/load-balancer-and-ingress-services-for-kubernetes"
 ENV AKO_VERSION="v1.3.1"
 RUN mkdir -p $GOPATH/src/$BUILD_PATH
@@ -8,7 +10,8 @@ WORKDIR $GOPATH/src/$BUILD_PATH
 
 RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/akc -ldflags="-X 'main.version=$AKO_VERSION'" -mod=vendor $BUILD_PATH/cmd/ako-main
 
-FROM photon:latest
+ARG photon_src_repo=photon:latest
+FROM ${photon_src_repo}
 RUN yum install -y tar.x86_64
 COPY --from=build /go/bin/akc .
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,19 @@ endif
 ifndef BUILD_TIME
 	$(eval BUILD_TIME=$(shell date +%Y-%m-%d_%H:%M:%S_%Z))
 endif
-	sudo docker build -t $(BINARY_NAME_AKO):latest --label "BUILD_TAG=$(BUILD_TAG)" --label "BUILD_TIME=$(BUILD_TIME)" -f Dockerfile.ako .
 
+ifdef GOLANG_SRC_REPO
+	$(eval BUILD_ARG_GOLANG=--build-arg golang_src_repo=$(GOLANG_SRC_REPO))
+else
+	$(eval BUILD_ARG_GOLANG=)
+endif
+
+ifdef PHOTON_SRC_REPO
+	$(eval BUILD_ARG_PHOTON=--build-arg photon_src_repo=$(PHOTON_SRC_REPO))
+else
+	$(eval BUILD_ARG_PHOTON=)
+endif
+	sudo docker build -t $(BINARY_NAME_AKO):latest --label "BUILD_TAG=$(BUILD_TAG)" --label "BUILD_TIME=$(BUILD_TIME)" $(BUILD_ARG_GOLANG) $(BUILD_ARG_PHOTON) -f Dockerfile.ako .
 
 .PHONY: test
 test:

--- a/tests/integrationtest/l7_ingress_node_test.go
+++ b/tests/integrationtest/l7_ingress_node_test.go
@@ -735,10 +735,10 @@ func TestEditPathIngress(t *testing.T) {
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 		g.Eventually(func() []*avinodes.AviPoolNode {
 			return nodes[0].PoolRefs
-		}, 5*time.Second).Should(gomega.HaveLen(1))
+		}, 40*time.Second).Should(gomega.HaveLen(1))
 		g.Eventually(func() string {
 			return nodes[0].PoolRefs[0].Name
-		}, 5*time.Second).Should(gomega.Equal("cluster--foo.com.avi.internal_bar-default-ingress-edit"))
+		}, 40*time.Second).Should(gomega.Equal("cluster--foo.com.avi.internal_bar-default-ingress-edit"))
 		g.Expect(nodes[0].PoolRefs[0].PriorityLabel).To(gomega.Equal("foo.com.avi.internal/bar"))
 		g.Expect(len(nodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 


### PR DESCRIPTION
These changes are being done due to the new docker rate limit
imposition on docker pulls. For internal CI frameworks, we would
like to use internal registry of base images for builds.