### PR TITLE
freeze controller api version to 20.1.2 for advancedl4

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -62,7 +62,15 @@ func SharedAVIClients() *utils.AviRestClientPool {
 				for _, client := range AviClientInstance.AviClient {
 					SetTenant := session.SetTenant(lib.GetTenant())
 					SetTenant(client.AviSession)
-					SetVersion := session.SetVersion(utils.CtrlVersion)
+
+					controllerVersion := utils.CtrlVersion
+					if lib.GetAdvancedL4() && lib.CheckControllerVersionCompatibility(controllerVersion, lib.Advl4ControllerVersion) {
+						// for advancedL4 make sure the controller api version is set to a max version value of 20.1.2
+						controllerVersion = lib.Advl4ControllerVersion
+					}
+
+					utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
+					SetVersion := session.SetVersion(controllerVersion)
 					SetVersion(client.AviSession)
 				}
 			}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -69,6 +69,7 @@ const (
 	CertTypeVS                                 = "SSL_CERTIFICATE_TYPE_VIRTUALSERVICE"
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
 	VSVIPDELCTRLVER                            = "20.1.1"
+	Advl4ControllerVersion                     = "20.1.2"
 	HostRule                                   = "HostRule"
 	HTTPRule                                   = "HTTPRule"
 	DummySecret                                = "@avisslkeycertrefdummy"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -352,6 +352,15 @@ func GetAdvancedL4() bool {
 	return false
 }
 
+func CheckControllerVersionCompatibility(version, maxVersion string) bool {
+	if c, err := semver.NewConstraint(fmt.Sprintf("> %s", maxVersion)); err == nil {
+		if currentVersion, err := semver.NewVersion(version); err == nil && c.Check(currentVersion) {
+			return true
+		}
+	}
+	return false
+}
+
 func GetDisableStaticRoute() bool {
 	if GetAdvancedL4() {
 		return true

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -97,7 +97,7 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 			if err == nil && aviClient.AviSession != nil {
 				version, err := aviClient.AviSession.GetControllerVersion()
 				if err == nil && CtrlVersion == "" {
-					AviLog.Debugf("Setting the client version to %v", version)
+					AviLog.Infof("Setting the client version to the current controller version %v", version)
 					session.SetVersion(version)
 					CtrlVersion = version
 				}


### PR DESCRIPTION
In cases where the controller version is greater than 20.1.2, AKO would enforce 20.1.2 as the avi controller api version.