### PR TITLE
Process service type ClusterIP in full sync if AKO is not running in Adv L4 mode

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -387,7 +387,7 @@ func (c *AviController) FullSyncK8s() error {
 			if isSvcLb {
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
 			} else {
-				if !lib.GetAdvancedL4() {
+				if lib.GetAdvancedL4() {
 					continue
 				}
 				key = utils.Service + "/" + utils.ObjKey(svcObj)

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -233,7 +233,7 @@ func PopulateServers(poolNode *AviPoolNode, ns string, serviceName string, ingre
 		// If it's an ingress case, check if the service of type clusterIP or not.
 		found, _ := objects.SharedClusterIpLister().Get(ns + "/" + serviceName)
 		if !found {
-			utils.AviLog.Warnf("key: %s, msg: service pointed by the ingress object is not of type ClusterIP", key)
+			utils.AviLog.Warnf("key: %s, msg: service pointed by the ingress object is not found in ClusterIP store", key)
 			return nil
 		}
 	}

--- a/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
+++ b/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
@@ -379,7 +379,7 @@ func TestNoHostIngressInNodePortWithMultiTenantEnabled(t *testing.T) {
 		ServiceName: "avisvc",
 	}).IngressNoHost()
 
-	_, err := KubeClient.ExtensionsV1beta1().Ingresses("default").Create(ingrFake)
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestNoHostIngressInNodePortWithMultiTenantEnabled(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	err = KubeClient.ExtensionsV1beta1().Ingresses("default").Delete("ingress-nohost", nil)
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-nohost", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}

--- a/tests/integrationtest/l7_ingress_node_test.go
+++ b/tests/integrationtest/l7_ingress_node_test.go
@@ -167,7 +167,7 @@ func TestL7ModelWithMultiTenant(t *testing.T) {
 		ServiceName: "avisvc",
 	}).Ingress()
 
-	_, err := KubeClient.ExtensionsV1beta1().Ingresses("default").Create(ingrFake)
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestL7ModelWithMultiTenant(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %v", err)
 	}
-	err = KubeClient.ExtensionsV1beta1().Ingresses("default").Delete("foo-with-targets", nil)
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}


### PR DESCRIPTION

Without this change - we may derive a Pool with no server after restart, then add the server again
after processing service from informer update.