### PR TITLE
Support for using default secret for TLS route if cert is not specified on route

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2498,7 +2498,7 @@ func checkRequiredValuesYaml() bool {
 
 	// check if config map exists
 	k8sClient := utils.GetInformers().ClientSet
-	aviCMNamespace := lib.GetAKONamespace()
+	aviCMNamespace := utils.GetAKONamespace()
 	if lib.GetNamespaceToSync() != "" {
 		aviCMNamespace = lib.GetNamespaceToSync()
 	}

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -91,7 +91,7 @@ func delConfigFromData(data map[string]string) bool {
 }
 
 func deleteConfigFromConfigmap(cs kubernetes.Interface) bool {
-	cmNS := lib.GetAKONamespace()
+	cmNS := utils.GetAKONamespace()
 	cm, err := cs.CoreV1().ConfigMaps(cmNS).Get(context.TODO(), lib.AviConfigMap, metav1.GetOptions{})
 	if err == nil {
 		return delConfigFromData(cm.Data)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -822,7 +822,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 			},
 		}
-		
+
 		c.informers.IngressClassInformer.Informer().AddEventHandler(ingressClassEventHandler)
 	}
 
@@ -857,14 +857,14 @@ func validateAviConfigMap(obj interface{}) (*corev1.ConfigMap, bool) {
 		if configMap.Name == lib.AviConfigMap {
 			return configMap, true
 		}
-	} else if ok && configMap.Namespace == lib.GetAKONamespace() && configMap.Name == lib.AviConfigMap {
+	} else if ok && configMap.Namespace == utils.GetAKONamespace() && configMap.Name == lib.AviConfigMap {
 		return configMap, true
 	}
 	return nil, false
 }
 
 func validateAviSecret(secret *corev1.Secret) bool {
-	if secret.Namespace == lib.GetAKONamespace() && secret.Name == lib.AviSecret {
+	if secret.Namespace == utils.GetAKONamespace() && secret.Name == lib.AviSecret {
 		// if the secret is updated or deleted we shutdown API server
 		utils.AviLog.Warnf("Avi Secret object %s/%s updated/deleted, shutting down AKO", secret.Namespace, secret.Name)
 		lib.ShutdownApi()

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -105,6 +105,7 @@ const (
 	ObjectDeletionDoneStatus                   = "objDeletionDone"
 	ObjectDeletionTimeoutStatus                = "objDeletionTimeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
+	DefaultRouteCert                           = "router-certs-default"
 
 	//Specifies command used in namespace event handler
 	NsFilterAdd    = "ADD"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -628,12 +628,6 @@ func ContainsFinalizer(o metav1.Object, finalizer string) bool {
 	return false
 }
 
-// GetAKONamespace returns the namespace of AKO pod.
-// In Advance L4 Mode this is vmware-system-ako
-// In all other cases this is avi-system
-func GetAKONamespace() string {
-	if GetAdvancedL4() {
-		return VMwareNS
-	}
-	return AviNS
+func GetDefaultSecretForRoutes() string {
+	return DefaultRouteCert
 }

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -90,6 +90,10 @@ func (o *AviObjectGraph) BuildL7VSGraph(vsName string, namespace string, ingName
 			if found {
 				for _, namespacedSecret := range secrets {
 					_, secret := utils.ExtractNamespaceObjectName(namespacedSecret)
+					if secret == "" {
+						utils.AviLog.Warnf("key: %s, msg: got empty secret for ingress %s/%s", key, namespace, ingName)
+						continue
+					}
 					sniNodeName := lib.GetSniNodeName(ingName, namespace, secret)
 					RemoveSniInModel(sniNodeName, vsNode, key)
 				}
@@ -213,6 +217,10 @@ func (o *AviObjectGraph) DeletePoolForIngress(namespace, ingName, key string, vs
 	if found {
 		for _, namespacedSecret := range secrets {
 			_, secret := utils.ExtractNamespaceObjectName(namespacedSecret)
+			if secret == "" {
+				utils.AviLog.Warnf("key: %s, msg: got empty secret while deleting pool for Ingress %s/%s", key, namespace, ingName)
+				continue
+			}
 			sniNodeName := lib.GetSniNodeName(ingName, namespace, secret)
 			utils.AviLog.Infof("key: %s, msg: sni node to delete :%s", key, sniNodeName)
 			RemoveSniInModel(sniNodeName, vsNode, key)

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -88,7 +88,8 @@ func (o *AviObjectGraph) BuildL7VSGraph(vsName string, namespace string, ingName
 			found, secrets := objects.SharedSvcLister().IngressMappings(namespace).GetIngToSecret(ingName)
 			utils.AviLog.Infof("key: %s, msg: retrieved secrets for ingress: %s", key, secrets)
 			if found {
-				for _, secret := range secrets {
+				for _, namespacedSecret := range secrets {
+					_, secret := utils.ExtractNamespaceObjectName(namespacedSecret)
 					sniNodeName := lib.GetSniNodeName(ingName, namespace, secret)
 					RemoveSniInModel(sniNodeName, vsNode, key)
 				}
@@ -210,7 +211,8 @@ func (o *AviObjectGraph) DeletePoolForIngress(namespace, ingName, key string, vs
 	found, secrets := objects.SharedSvcLister().IngressMappings(namespace).GetIngToSecret(ingName)
 	utils.AviLog.Infof("key: %s, msg: retrieved secrets for ingress: %s", key, secrets)
 	if found {
-		for _, secret := range secrets {
+		for _, namespacedSecret := range secrets {
+			_, secret := utils.ExtractNamespaceObjectName(namespacedSecret)
 			sniNodeName := lib.GetSniNodeName(ingName, namespace, secret)
 			utils.AviLog.Infof("key: %s, msg: sni node to delete :%s", key, sniNodeName)
 			RemoveSniInModel(sniNodeName, vsNode, key)
@@ -377,6 +379,10 @@ func (o *AviObjectGraph) BuildCACertNode(tlsNode *AviVsNode, cacert, keycertname
 func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode *AviVsNode, namespace string, tlsData TlsSettings, key string, sniHost ...string) bool {
 	mClient := utils.GetInformers().ClientSet
 	secretName := tlsData.SecretName
+	secretNS := tlsData.SecretNS
+	if secretNS == "" {
+		secretNS = namespace
+	}
 
 	var certNode *AviTLSKeyCertNode
 	if len(sniHost) > 0 {
@@ -406,7 +412,7 @@ func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode 
 			return false
 		}
 	} else {
-		secretObj, err := mClient.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+		secretObj, err := mClient.CoreV1().Secrets(secretNS).Get(context.TODO(), secretName, metav1.GetOptions{})
 		if err != nil || secretObj == nil {
 			// This secret has been deleted.
 			ok, ingNames := svcLister.IngressMappings(namespace).GetSecretToIng(secretName)

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1001,7 +1001,7 @@ type AviPoolMetaServer struct {
 type IngressHostPathSvc struct {
 	ServiceName string
 	Path        string
-	PathType	networkingv1beta1.PathType
+	PathType    networkingv1beta1.PathType
 	Port        int32
 	weight      int32 //required for alternate backends in openshift route
 	PortName    string
@@ -1013,6 +1013,7 @@ type IngressHostMap map[string][]IngressHostPathSvc
 type TlsSettings struct {
 	Hosts      map[string][]IngressHostPathSvc
 	SecretName string
+	SecretNS   string
 	key        string
 	cert       string
 	cacert     string

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -274,7 +274,7 @@ func handleIngress(key string, fullsync bool, ingressNames []string) {
 }
 
 func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, string) {
-	if objType == lib.HostRule || objType == lib.HTTPRule {
+	if objType == lib.HostRule || objType == lib.HTTPRule || objType == utils.Secret {
 		arr := strings.Split(nsname, "/")
 		return arr[0], arr[1]
 	}

--- a/internal/objects/ingress_to_service.go
+++ b/internal/objects/ingress_to_service.go
@@ -361,20 +361,27 @@ func (v *SvcNSCache) UpdateIngressMappings(ingName string, svcName string) {
 	}
 }
 
-func (v *SvcNSCache) UpdateIngressSecretsMappings(ingName string, secret string) {
+func (v *SvcNSCache) AddIngressToSecretsMappings(ingressNS, ingName, secretName string) {
 	v.IngressLock.Lock()
-	defer v.IngressLock.Unlock()
-	_, ingresses := v.GetSecretToIng(secret)
-	if !utils.HasElem(ingresses, ingName) {
-		ingresses = append(ingresses, ingName)
-		v.UpdateSecretToIngMapping(secret, ingresses)
+	nsIngress := ingressNS + "/" + ingName
+	_, ingresses := v.GetSecretToIng(secretName)
+	if !utils.HasElem(ingresses, nsIngress) {
+		ingresses = append(ingresses, nsIngress)
+		v.UpdateSecretToIngMapping(secretName, ingresses)
 	}
+	v.IngressLock.Unlock()
+}
+
+func (v *SvcNSCache) AddSecretsToIngressMappings(secretNS, ingName, secretName string) {
+	v.IngressLock.Lock()
 	_, secrets := v.GetIngToSecret(ingName)
-	if !utils.HasElem(secrets, secret) {
-		secrets = append(secrets, secret)
+	nsSecret := secretNS + "/" + secretName
+	if !utils.HasElem(secrets, nsSecret) {
+		secrets = append(secrets, nsSecret)
 		utils.AviLog.Debugf("Updated the ingress: %s to secrets: %s", ingName, secrets)
 		v.UpdateIngToSecretMapping(ingName, secrets)
 	}
+	v.IngressLock.Unlock()
 }
 
 func (v *SvcNSCache) UpdateIngressClassMappings(ingName string, ingClass string) {

--- a/internal/objects/ingress_to_service.go
+++ b/internal/objects/ingress_to_service.go
@@ -361,19 +361,20 @@ func (v *SvcNSCache) UpdateIngressMappings(ingName string, svcName string) {
 	}
 }
 
-func (v *SvcNSCache) AddIngressToSecretsMappings(ingressNS, ingName, secretName string) {
+func (v *SvcNSCache) AddSecretsToIngressMappings(ingressNS, ingName, secretName string) {
 	v.IngressLock.Lock()
+	defer v.IngressLock.Unlock()
 	nsIngress := ingressNS + "/" + ingName
 	_, ingresses := v.GetSecretToIng(secretName)
 	if !utils.HasElem(ingresses, nsIngress) {
 		ingresses = append(ingresses, nsIngress)
 		v.UpdateSecretToIngMapping(secretName, ingresses)
 	}
-	v.IngressLock.Unlock()
 }
 
-func (v *SvcNSCache) AddSecretsToIngressMappings(secretNS, ingName, secretName string) {
+func (v *SvcNSCache) AddIngressToSecretsMappings(secretNS, ingName, secretName string) {
 	v.IngressLock.Lock()
+	defer v.IngressLock.Unlock()
 	_, secrets := v.GetIngToSecret(ingName)
 	nsSecret := secretNS + "/" + secretName
 	if !utils.HasElem(secrets, nsSecret) {
@@ -381,7 +382,6 @@ func (v *SvcNSCache) AddSecretsToIngressMappings(secretNS, ingName, secretName s
 		utils.AviLog.Debugf("Updated the ingress: %s to secrets: %s", ingName, secrets)
 		v.UpdateIngToSecretMapping(ingName, secrets)
 	}
-	v.IngressLock.Unlock()
 }
 
 func (v *SvcNSCache) UpdateIngressClassMappings(ingName string, ingClass string) {

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -35,7 +35,7 @@ func msgFoundInStatus(conditions []appsv1.StatefulSetCondition, msg string) bool
 
 // ResetStatefulSetStatus removes the condition set by AKO from AKO statefulset
 func ResetStatefulSetStatus() {
-	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(lib.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
+	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
 		return
@@ -53,7 +53,7 @@ func ResetStatefulSetStatus() {
 		return
 	}
 
-	u, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(lib.GetAKONamespace()).UpdateStatus(context.TODO(), ss, metav1.UpdateOptions{})
+	u, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).UpdateStatus(context.TODO(), ss, metav1.UpdateOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in updating ako statefulset: %v", err)
 		return
@@ -63,7 +63,7 @@ func ResetStatefulSetStatus() {
 
 // AddStatefulSetStatus sets a condition in status of AKO statefulset to the desired value
 func AddStatefulSetStatus(msg string) {
-	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(lib.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
+	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
 		return
@@ -91,7 +91,7 @@ func AddStatefulSetStatus(msg string) {
 		ss.Status.Conditions = append(ss.Status.Conditions, cond)
 	}
 
-	u, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(lib.GetAKONamespace()).UpdateStatus(context.TODO(), ss, metav1.UpdateOptions{})
+	u, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).UpdateStatus(context.TODO(), ss, metav1.UpdateOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in patching ako statefulset: %v", err)
 		return

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -69,6 +69,7 @@ const (
 	FULL_SYNC_INTERVAL            = "FULL_SYNC_INTERVAL"
 	DEFAULT_FILE_SUFFIX           = "avi.log"
 	K8S_ETIMEDOUT                 = "timed out"
+	ADVANCED_L4                   = "ADVANCED_L4"
 
 	// container-lib/api constants
 	AVIAPI_INITIATING   = "INITIATING"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -389,9 +390,7 @@ func retrieveNSList(nsList map[string]bool) []string {
 // This utility returns a true/false depending on whether
 // the user requires advanced L4 functionality
 func GetAdvancedL4() bool {
-	advanceL4 := os.Getenv(ADVANCED_L4)
-	if advanceL4 == "true" {
-
+	if ok, _ := strconv.ParseBool(os.Getenv(ADVANCED_L4)); ok {
 		return true
 	}
 	return false

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -157,12 +157,7 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 	}
 
 	// We listen to configmaps only in`avi-system or vmware-system-ako`
-	var akoNS string
-	if akoNSBoundInformer {
-		akoNS = VMWARE_SYSTEM_AKO // Advanced L4 is for vmware-system-ako
-	} else {
-		akoNS = AKO_DEFAULT_NS // Regular AKO
-	}
+	akoNS := GetAKONamespace()
 
 	SetIngressClassEnabled(cs)
 
@@ -233,8 +228,6 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 					AviLog.Infof("Running AKO in avi-system namespace")
 				}
 			case INFORMERS_OPENSHIFT_CLIENT:
-				// this would initialize secret/configmap informer for AKO namespace in openshift
-				akoNSBoundInformer = true
 				oshiftclient, ok = v.(oshiftclientset.Interface)
 				if !ok {
 					AviLog.Warnf("arg oshiftclient is not of type oshiftclientset.Interface")
@@ -248,6 +241,10 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 				AviLog.Warnf("Unknown Key %s in args", k)
 			}
 		}
+	}
+
+	if oshiftclient != nil {
+		akoNSBoundInformer = true
 	}
 	if !instantiateOnce {
 		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace, akoNSBoundInformer)
@@ -387,4 +384,25 @@ func retrieveNSList(nsList map[string]bool) []string {
 		namespaces = append(namespaces, k)
 	}
 	return namespaces
+}
+
+// This utility returns a true/false depending on whether
+// the user requires advanced L4 functionality
+func GetAdvancedL4() bool {
+	advanceL4 := os.Getenv(ADVANCED_L4)
+	if advanceL4 == "true" {
+
+		return true
+	}
+	return false
+}
+
+// GetAKONamespace returns the namespace of AKO pod.
+// In Advance L4 Mode this is vmware-system-ako
+// In all other cases this is avi-system
+func GetAKONamespace() string {
+	if GetAdvancedL4() {
+		return VMWARE_SYSTEM_AKO
+	}
+	return AKO_DEFAULT_NS
 }


### PR DESCRIPTION


- If key/cert is not specified on TLS route, then a secret named router-certs-default would be used.
- This secret should be presesnt in avi-system namesapce.
- So support this, routes are now stored as namespace/routename per secret.
- Similarly secret per route is being stored as namesapce/secretname.