### PR TITLE
Supporting multiple usable networks as a part of the IPAM by skipping validation for network_name.

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2654,7 +2654,8 @@ func checkPublicCloud(client *clients.AviClient) bool {
 	if lib.IsPublicCloud() {
 		// Handle all public cloud validations here
 		networkName := lib.GetNetworkName()
-		if networkName == "" {
+		if networkName == "" && lib.GetCloudType() != lib.CLOUD_GCP {
+			// networkName is required param for AWS and Azure Clouds
 			utils.AviLog.Errorf("Required param networkName not specified, syncing will be disabled.")
 			return false
 		}
@@ -2725,8 +2726,8 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 
 	networkName := lib.GetNetworkName()
 	if networkName == "" {
-		utils.AviLog.Error("Required param networkName not specified, syncing will be disabled.")
-		return false
+		utils.AviLog.Warnf("Param networkName not specified, skipping fetching of the VRF setting from network")
+		return true
 	}
 
 	uri := "/api/network/?include_name&name=" + networkName + "&cloud_ref.name=" + utils.CloudName

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -305,8 +305,8 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 
 func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for VS, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
-		return errors.New("Errored rest_op")
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for VS, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		return errors.New("Error rest_op")
 	}
 
 	resp_elems, ok := RestRespArrToObjByType(rest_op, "virtualservice", key)
@@ -630,7 +630,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		vsvip.DNSInfo = dns_info_arr
 
 		// handling static IP updates, this would throw an error
-		// for advl4 the error is propogated to the gateway status
+		// for advl4 the error is propagated to the gateway status
 		if vsvip_meta.IPAddress != "" {
 			auto_alloc := true
 			var vips []*avimodels.Vip


### PR DESCRIPTION
- AKO will auto-allocate the ip from the list of usable networks.