### PR TITLE
Change in AKO statefulset status condition message

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -101,9 +101,9 @@ const (
 	AviObjDeletionTime                         = 30 // Minutes
 	AKOConditionType                           = "ako.vmware.com/ObjectDeletionInProgress"
 	AKOStatefulSet                             = "ako"
-	ObjectDeletionStartStatus                  = "ObjectDeletionStarted"
-	ObjectDeletionDoneStatus                   = "ObjectDeletionDone"
-	ObjectDeletionTimeoutStatus                = "ObjectDeletionTimeout"
+	ObjectDeletionStartStatus                  = "Started"
+	ObjectDeletionDoneStatus                   = "Done"
+	ObjectDeletionTimeoutStatus                = "Timeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
 	DefaultRouteCert                           = "router-certs-default"
 

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -99,11 +99,11 @@ const (
 	GatewayFinalizer                           = "gateway.ako.vmware.com"
 	ClusterStatusCacheKey                      = "cluster-runtime"
 	AviObjDeletionTime                         = 30 // Minutes
-	AKOConditionType                           = "akoStatus"
+	AKOConditionType                           = "ako.vmware.com/ObjectDeletionInProgress"
 	AKOStatefulSet                             = "ako"
-	ObjectDeletionStartStatus                  = "objDeletionStarted"
-	ObjectDeletionDoneStatus                   = "objDeletionDone"
-	ObjectDeletionTimeoutStatus                = "objDeletionTimeout"
+	ObjectDeletionStartStatus                  = "ObjectDeletionStarted"
+	ObjectDeletionDoneStatus                   = "ObjectDeletionDone"
+	ObjectDeletionTimeoutStatus                = "ObjectDeletionTimeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
 	DefaultRouteCert                           = "router-certs-default"
 

--- a/tests/oshiftroutetests/oshift_crd_test.go
+++ b/tests/oshiftroutetests/oshift_crd_test.go
@@ -228,7 +228,6 @@ func TestOshiftMultiRouteToSecureHostRule(t *testing.T) {
 
 	g.Eventually(func() bool {
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
-		t.Logf("model found: %v, %v", found, aviModel)
 		if found {
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 			if len(nodes[0].SniNodes) > 0 &&


### PR DESCRIPTION
The type of the condition is now ako.vmware.com/ObjectDeletionInProgress, which signifies if AKO is deleting all Avi Objects. The value of status would be True only when the delete operation is in progress, else it would be set False. In case of an error like timeout, it would be set to unknown. 

- The status of this condition would be set to true after setting deleteConfig to true, before starting all object deletion.
- The reason would be set to ObjectDeletionStarted.
- The status would be set to false when all objects gets deleted.
- The reason would be set to ObjectDeletionDone.

For example:
Status condition before deletion:
  - lastTransitionTime: "2020-12-15T10:10:45Z"
    message: Started deleting objects
    reason: ObjectDeletionStarted
    status: "True"
    type: ako.vmware.com/ObjectDeletionInProgress

Status condition after deletion:
  - lastTransitionTime: "2020-12-15T10:10:48Z"
    message: Successfully deleted all objects
    reason: ObjectDeletionDone
    status: "False"
    type: ako.vmware.com/ObjectDeletionInProgress