### PR TITLE
Renaming controllerIP to ControllerHost in helm values.yaml

### DIFF
--- a/ako-operator/helm/ako-operator/templates/akoconfig.yaml
+++ b/ako-operator/helm/ako-operator/templates/akoconfig.yaml
@@ -44,7 +44,7 @@ spec:
     serviceEngineGroupName: {{ .Values.ControllerSettings.serviceEngineGroupName | quote }}
     controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
     cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
-    controllerIP: {{ .Values.ControllerSettings.controllerIP | quote }}
+    controllerIP: {{ .Values.ControllerSettings.controllerHost | quote }}
     tenantsPerCluster: {{ .Values.ControllerSettings.tenantsPerCluster }}
     tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
 

--- a/ako-operator/helm/ako-operator/values.yaml
+++ b/ako-operator/helm/ako-operator/values.yaml
@@ -62,7 +62,7 @@ ControllerSettings:
   serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
   controllerVersion: "18.2.10" # The controller API version
   cloudName: "Default-Cloud" # The configured cloud name on the Avi controller.
-  controllerIP: ""
+  controllerHost: "" # IP address or Hostname of Avi Controller
   tenantsPerCluster: "false" # If set to true, AKO will map each kubernetes cluster uniquely to a tenant in Avi
   tenantName: "admin" # Name of the tenant where all the AKO objects will be created in AVI. // Required only if tenantsPerCluster is set to True
 

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: avi-k8s-config
   namespace: {{ .Release.Namespace }}
 data:
-  controllerIP: {{ .Values.ControllerSettings.controllerIP | quote }}
+  controllerIP: {{ .Values.ControllerSettings.controllerHost | quote }}
   controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
   cniPlugin: {{ .Values.AKOSettings.cniPlugin | quote }}
   shardVSSize: {{ .Values.L7Settings.shardVSSize | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -56,7 +56,7 @@ ControllerSettings:
   serviceEngineGroupName: "Default-Group" # Name of the ServiceEngine Group.
   controllerVersion: "18.2.10" # The controller API version
   cloudName: "Default-Cloud" # The configured cloud name on the Avi controller.
-  controllerIP: ""
+  controllerHost: "" # IP address or Hostname of Avi Controller
   tenantsPerCluster: "false" # If set to true, AKO will map each kubernetes cluster uniquely to a tenant in Avi
   tenantName: "admin" # Name of the tenant where all the AKO objects will be created in AVI. // Required only if tenantsPerCluster is set to True
 


### PR DESCRIPTION
We can use both controller IP and hostname to connect to Avi Controller.
Renaming the field in values.yaml to reflect this.
Internal keynames are being kept unchanged.