### PR TITLE
avi_obj_vs AviVsVipBuild cleanup, fix AviVsVipBuild static IP usecases in public clouds

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -303,7 +303,7 @@ func GetSubnetPrefixInt() int32 {
 	defaultCidr := int32(24)
 	intCidr, err := strconv.ParseInt(GetSubnetPrefix(), 10, 32)
 	if err != nil {
-		utils.AviLog.Errorf("The value of subnetPrefix couldn't be converted to int32, %v", err)
+		utils.AviLog.Warnf("The value of subnetPrefix couldn't be converted to int32, defaulting to /24, %v", err)
 		return defaultCidr
 	}
 	return int32(intCidr)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -298,6 +298,17 @@ func GetSubnetPrefix() string {
 	return ""
 }
 
+func GetSubnetPrefixInt() int32 {
+	// check if subnetPrefix value is a valid integer value
+	defaultCidr := int32(24)
+	intCidr, err := strconv.ParseInt(GetSubnetPrefix(), 10, 32)
+	if err != nil {
+		utils.AviLog.Errorf("The value of subnetPrefix couldn't be converted to int32, %v", err)
+		return defaultCidr
+	}
+	return int32(intCidr)
+}
+
 func GetNetworkName() string {
 	networkName := os.Getenv(NETWORK_NAME)
 	if networkName != "" {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -607,7 +607,17 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 	var dns_info_arr []*avimodels.DNSInfo
 	var path string
 	var rest_op utils.RestOp
+	var networkRef string
 	vipId, ipType := "0", "V4"
+
+	networkName := lib.GetNetworkName()
+	if networkName != "" {
+		networkRef = "/api/network/?name=" + networkName
+	}
+	subnetMask := lib.GetSubnetPrefixInt()
+	subnetAddress := lib.GetSubnetIP()
+
+	autoAllocate := true // all vsvip models would have auto_alloc set to true even in case of static IP programming
 
 	if cache_obj != nil {
 		vsvip, err := rest.AviVsVipGet(key, cache_obj.Uuid, name)
@@ -632,88 +642,78 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		// handling static IP updates, this would throw an error
 		// for advl4 the error is propagated to the gateway status
 		if vsvip_meta.IPAddress != "" {
-			auto_alloc := true
-			var vips []*avimodels.Vip
-			vips = append(vips, &avimodels.Vip{
+			vip := &avimodels.Vip{
 				VipID:          &vipId,
-				AutoAllocateIP: &auto_alloc,
+				AutoAllocateIP: &autoAllocate,
 				IPAddress: &avimodels.IPAddr{
 					Type: &ipType,
 					Addr: &vsvip_meta.IPAddress,
 				},
-			})
-			vsvip.Vip = vips
-		}
-
-		path = "/api/vsvip/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsvip,
-			Tenant: vsvip_meta.Tenant, Model: "VsVip", Version: utils.CtrlVersion}
-	} else {
-		auto_alloc := true
-		var vips []*avimodels.Vip
-
-		// all vsvip models would have auto_alloc set to true even in case of static IP programming
-		vip := avimodels.Vip{AutoAllocateIP: &auto_alloc}
-		networkRef := lib.GetNetworkName()
-		if lib.IsPublicCloud() && lib.GetNetworkName() != "" {
-
-			if lib.GetCloudType() == lib.CLOUD_GCP {
-				// add the IPAMNetworkSubnet
-				intCidr, err := strconv.ParseInt(lib.GetSubnetPrefix(), 10, 32)
-				if err != nil {
-					utils.AviLog.Warnf("The value of CIDR couldn't be converted to int32. Defaulting to /24")
-					intCidr = 24
-				}
-				subnetMask := int32(intCidr)
-				subnetAddr := lib.GetSubnetIP()
-				subnetAtype := "V4"
-				subnetIPObj := avimodels.IPAddr{Type: &subnetAtype, Addr: &subnetAddr}
-				subnetObj := avimodels.IPAddrPrefix{IPAddr: &subnetIPObj, Mask: &subnetMask}
-				networkRef = "/api/network/?name=" + lib.GetNetworkName()
+			}
+			if networkName != "" {
 				vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
-					Subnet:     &subnetObj,
 					NetworkRef: &networkRef,
 				}
+			}
+			vsvip.Vip = []*avimodels.Vip{vip}
+		}
+
+		rest_op = utils.RestOp{
+			Path:    "/api/vsvip/" + cache_obj.Uuid,
+			Method:  utils.RestPut,
+			Obj:     vsvip,
+			Tenant:  vsvip_meta.Tenant,
+			Model:   "VsVip",
+			Version: utils.CtrlVersion,
+		}
+	} else {
+		// all vsvip models would have AutoAllocateIP set to true even in case of static IP programming
+		vip := avimodels.Vip{
+			VipID:          &vipId,
+			AutoAllocateIP: &autoAllocate,
+		}
+
+		if lib.IsPublicCloud() && networkName != "" {
+			if lib.GetCloudType() == lib.CLOUD_GCP {
+				// add the IPAMNetworkSubnet
+				vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
+					NetworkRef: &networkRef,
+					Subnet: &avimodels.IPAddrPrefix{
+						IPAddr: &avimodels.IPAddr{Type: &ipType, Addr: &subnetAddress},
+						Mask:   &subnetMask,
+					},
+				}
 			} else {
-				vip.SubnetUUID = &networkRef
+				vip.SubnetUUID = &networkName
 			}
 		} else if vsvip_meta.IPAddress != "" {
-			vip.VipID = &vipId
 			vip.IPAddress = &avimodels.IPAddr{
 				Type: &ipType,
 				Addr: &vsvip_meta.IPAddress,
 			}
-			if lib.GetNetworkName() != "" {
-				networkRef = "/api/network/?name=" + lib.GetNetworkName()
+			if networkName != "" {
 				vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
 					NetworkRef: &networkRef,
 				}
 			}
-		} else if lib.GetSubnetPrefix() == "" || lib.GetSubnetIP() == "" || lib.GetNetworkName() == "" {
+		} else if lib.GetSubnetPrefix() == "" || lib.GetSubnetIP() == "" || networkName == "" {
 			utils.AviLog.Warnf("Incomplete values provided for subnet/cidr/network, will not use network ref in vsvip")
 		} else if !lib.GetAdvancedL4() {
-			intCidr, err := strconv.ParseInt(lib.GetSubnetPrefix(), 10, 32)
-			if err != nil {
-				utils.AviLog.Warnf("The value of CIDR couldn't be converted to int32. Defaulting to /24")
-				intCidr = 24
-			}
-			subnet_mask := int32(intCidr)
-			subnet_addr := lib.GetSubnetIP()
-			subnet_atype := "V4"
-			subnet_ip_obj := avimodels.IPAddr{Type: &subnet_atype, Addr: &subnet_addr}
-			subnet_obj := avimodels.IPAddrPrefix{IPAddr: &subnet_ip_obj, Mask: &subnet_mask}
-			networkRef = "/api/network/?name=" + lib.GetNetworkName()
 			vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
-				Subnet:     &subnet_obj,
 				NetworkRef: &networkRef,
+				Subnet: &avimodels.IPAddrPrefix{
+					IPAddr: &avimodels.IPAddr{Type: &ipType, Addr: &subnetAddress},
+					Mask:   &subnetMask,
+				},
 			}
 		}
 
-		mask := int32(24)
 		addr := "172.18.0.0"
-		atype := "V4"
-		sip := avimodels.IPAddr{Type: &atype, Addr: &addr}
-		ew_subnet := avimodels.IPAddrPrefix{IPAddr: &sip, Mask: &mask}
+		ew_subnet := avimodels.IPAddrPrefix{
+			IPAddr: &avimodels.IPAddr{Type: &ipType, Addr: &addr},
+			Mask:   &subnetMask,
+		}
+
 		var east_west bool
 		if vsvip_meta.EastWest == true {
 			vip.Subnet = &ew_subnet
@@ -735,12 +735,18 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 				dns_info_arr = append(dns_info_arr, &dns_info)
 			}
 		}
+
 		vrfContextRef := "/api/vrfcontext?name=" + vsvip_meta.VrfContext
-		vsvip := avimodels.VsVip{Name: &name, TenantRef: &tenant, CloudRef: &cloudRef,
-			EastWestPlacement: &east_west, VrfContextRef: &vrfContextRef}
-		vsvip.DNSInfo = dns_info_arr
-		vips = append(vips, &vip)
-		vsvip.Vip = vips
+		vsvip := avimodels.VsVip{
+			Name:              &name,
+			TenantRef:         &tenant,
+			CloudRef:          &cloudRef,
+			EastWestPlacement: &east_west,
+			VrfContextRef:     &vrfContextRef,
+			DNSInfo:           dns_info_arr,
+			Vip:               []*avimodels.Vip{&vip},
+		}
+
 		macro := utils.AviRestObjMacro{ModelName: "VsVip", Data: vsvip}
 		path = "/api/macro"
 		// Patch an existing vsvip if it exists in the cache but not associated with this VS.
@@ -778,12 +784,23 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			}
 			vsvip_avi.DNSInfo = dns_info_arr
 			vsvip_avi.VrfContextRef = &vrfContextRef
+
 			path = "/api/vsvip/" + vsvip_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsvip_avi,
-				Tenant: vsvip_meta.Tenant, Model: "VsVip", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{Path: path,
+				Method:  utils.RestPut,
+				Obj:     vsvip_avi,
+				Tenant:  vsvip_meta.Tenant,
+				Model:   "VsVip",
+				Version: utils.CtrlVersion,
+			}
 		} else {
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
-				Tenant: vsvip_meta.Tenant, Model: "VsVip", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{Path: path,
+				Method:  utils.RestPost,
+				Obj:     macro,
+				Tenant:  vsvip_meta.Tenant,
+				Model:   "VsVip",
+				Version: utils.CtrlVersion,
+			}
 		}
 	}
 


### PR DESCRIPTION
This includes/extends static IP vsvip configuration to public cloud types. Prior to this public cloud and staticIP vsvip implementation was exclusive of each other.
This also involves a major cleanup in the AviVsVipBuild function, to make it more readable, trimmed it down a bit for easier logical workflow.
I have intentionally kept the two commits separated out, where the first one just focuses on providing better readability, and the second one fixes the bug reported AV-102214

Since there have been multiple authors for this block of code, lets merge it when all you guys approve it @parimanur @monotosh-avi @sudswasavi 
Please try checking for all the use cases, including the fix introduced in the second commit