### PR TITLE
enable ingress class workflow onlly for networking/v1 IngressClass enabled cluster k8s-1.19+

### DIFF
--- a/pkg/utils/ingress.go
+++ b/pkg/utils/ingress.go
@@ -36,10 +36,10 @@ func SetIngressClassEnabled(kc kubernetes.Interface) {
 		AviLog.Infof("networking.k8s.io/v1/IngressClass not found/enabled on cluster: %v", ingClassError)
 		isPresent = false
 	} else {
+		AviLog.Infof("networking.k8s.io/v1/IngressClass enabled on cluster")
 		isPresent = true
 	}
 
-	AviLog.Infof("networking.k8s.io/v1/IngressClass enabled on cluster")
 	ingressClassEnabled = &isPresent
 }
 

--- a/pkg/utils/ingress.go
+++ b/pkg/utils/ingress.go
@@ -30,7 +30,8 @@ func SetIngressClassEnabled(kc kubernetes.Interface) {
 
 	var isPresent bool
 	timeout := int64(120)
-	_, ingClassError := kc.NetworkingV1beta1().IngressClasses().List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeout})
+	// should only work for k8s 1.19+ clusters
+	_, ingClassError := kc.NetworkingV1().IngressClasses().List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeout})
 	if ingClassError != nil {
 		AviLog.Infof("networking.k8s.io/v1/IngressClass not found/enabled on cluster: %v", ingClassError)
 		isPresent = false


### PR DESCRIPTION
networking v1beta1 IngressClasss is enabled in clusters prior to k8s-1.19 as well.
This PR enables ingress class functionality in AKO only when networking/v1 IngressClass is present and can be listed via the client api call.

This was already taken care in helm where we specifically check for networking/v1 IngressClass capability.