### PR TITLE
Remove dependence on hostname for l4

### DIFF
--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -34,8 +34,7 @@ func UpdateL4LBStatus(options []UpdateStatusOptions, bulk bool) {
 
 	for _, option := range options {
 		if len(option.ServiceMetadata.HostNames) != 1 && !lib.GetAdvancedL4() {
-			utils.AviLog.Error("Service hostname not found for service %v status update", option.ServiceMetadata.NamespaceServiceName)
-			continue
+			utils.AviLog.Warnf("Service hostname not found for service %v status update", option.ServiceMetadata.NamespaceServiceName)
 		}
 
 		for _, svc := range option.ServiceMetadata.NamespaceServiceName {


### PR DESCRIPTION
This commit removes the need for a hostname to be present for the
service of type LBs status update.

This allows AKO to update the service object's status even if the
IPAM DNS profile is not configured in the Avi controller.