### PR TITLE
Only set RHI flag if it's set to true

### DIFF
--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -71,7 +71,10 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			ServiceMetadata:       &svc_mdata,
 			SeGroupRef:            &seGroupRef,
 			VrfContextRef:         &vrfContextRef,
-			EnableRhi:             &enableRHI,
+		}
+		if enableRHI {
+			// If the value is set to false, we would simply remove it from the payload, which should default it to false.
+			vs.EnableRhi = &enableRHI
 		}
 		if lib.GetAdvancedL4() {
 			ignPool := true


### PR DESCRIPTION
This commit will unblock usage of Avi essentials license where RHI
is not supported in the VS payload.

If RHI is set to true only then, we set it in the VS object,
for all other cases RHI is not set in the payload but defaulted
to false by the go sdk.