### PR TITLE
adding support for golangci linting and formatting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Go-CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  golangci-lint:
+    name: Golangci-lint
+    strategy:
+      matrix:
+        platform: [ ubuntu-18.04 ]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+    - name: Check-out code
+      uses: actions/checkout@v2
+    - name: Run golangci-lint
+      run: make golangci

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/ako
 bin/avi.log
+.golangci-bin/
 
 # IDE
 .idea

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - misspell
     - gofmt
     - deadcode
+    - unused
     - staticcheck
     - goimports
     - vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+# golangci-lint configuration used for CI
+run:
+  tests: true
+  timeout: 10m
+  skip-dirs:
+    - webhook
+  skip-dirs-use-default: true
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/vmware/load-balancer-and-ingress-services-for-kubernetes
+
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - gofmt
+    - deadcode
+    - staticcheck
+    - goimports
+    - vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@
 run:
   tests: true
   timeout: 10m
-  skip-dirs:
-    - webhook
   skip-dirs-use-default: true
 
 linters-settings:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,9 @@ and *merged* sorts of commits.
 
 To make it easier for reviewers to review your PR, consider the following:
 1. Follow the golang [coding conventions](https://github.com/golang/go/wiki/CodeReviewComments)
-2. Follow [git commit](https://chris.beams.io/posts/git-commit/) guidelines.
-3. Follow [logging](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) guidelines.
+2. Format your code with `make golangci-fix`. The [configured linters](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/blob/master/.golangci.yml) will throw an error in case the issue cannot be fixed automatically.
+3. Follow [git commit](https://chris.beams.io/posts/git-commit/) guidelines.
+4. Follow [logging](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) guidelines.
 
 ### Building and testing your change
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ int_test:
 .PHONY: scale_test
 scale_test:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
-	$(GOTEST) -v -mod=vendor ./tests/scaletest -failfast $(Timeout) $(TestbedFilePath) $(NumGoRoutines) $(NumOfIng) 
+	$(GOTEST) -v -mod=vendor ./tests/scaletest -failfast $(Timeout) $(TestbedFilePath) $(NumGoRoutines) $(NumOfLBSvc) $(NumOfIng)
 
 # linting and formatting
 GO_FILES := $(shell find . -type d -path ./vendor -prune -o -type f -name '*.go' -print)

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ else
 	$(eval BUILD_ARG_UBI=)
 endif
 
-
 .PHONY: all
 all: build docker
 
+# builds
 .PHONY: build
 build: glob-vars
 		sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
@@ -66,6 +66,7 @@ clean:
 deps:
 	dep ensure -v
 
+# docker images
 .PHONY: docker
 docker: glob-vars
 	sudo docker build -t $(BINARY_NAME_AKO):latest --label "BUILD_TAG=$(BUILD_TAG)" --label "BUILD_TIME=$(BUILD_TIME)" $(BUILD_ARG_GOLANG) $(BUILD_ARG_PHOTON) -f Dockerfile.ako .
@@ -74,6 +75,7 @@ docker: glob-vars
 ako-operator-docker: glob-vars
 	sudo docker build -t $(AKO_OPERATOR_IMAGE):latest --label "BUILD_TAG=$(BUILD_TAG)" --label "BUILD_TIME=$(BUILD_TIME)" $(BUILD_ARG_GOLANG) $(BUILD_ARG_UBI)  -f Dockerfile.ako-operator .
 
+# tests
 .PHONY: k8stest
 k8stest:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
@@ -121,4 +123,27 @@ int_test:
 .PHONY: scale_test
 scale_test:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
-	$(GOTEST) -v -mod=vendor ./tests/scaletest -failfast $(Timeout) $(TestbedFilePath) $(NumGoRoutines) $(NumOfLBSvc) $(NumOfIng)
+	$(GOTEST) -v -mod=vendor ./tests/scaletest -failfast $(Timeout) $(TestbedFilePath) $(NumGoRoutines) $(NumOfIng) 
+
+# linting and formatting
+GO_FILES := $(shell find . -type d -path ./vendor -prune -o -type f -name '*.go' -print)
+.PHONY: fmt
+fmt:
+	@echo
+	@echo "Formatting Go files"
+	@gofmt -s -l -w $(GO_FILES)
+
+.golangci-bin:
+	@echo "Installing Golangci-lint"
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $@ v1.32.1
+
+.PHONY: golangci
+golangci: .golangci-bin
+	@echo "Running golangci"
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml
+
+.PHONY: golangci-fix
+golangci-fix: .golangci-bin
+	@echo "Running golangci-fix"
+	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix
+

--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -37,7 +37,7 @@ type NamespaceSelector struct {
 	LabelValue string `json:"labelValue,omitempty"`
 }
 
-// AKOSettings defines the settings requried for the AKO controller
+// AKOSettings defines the settings required for the AKO controller
 type AKOSettings struct {
 	// LogLevel defines the log level to be used by the AKO controller
 	LogLevel LogLevelType `json:"logLevel,omitempty"`
@@ -59,7 +59,7 @@ type AKOSettings struct {
 
 type NodeNetwork struct {
 	NetworkName string   `json:"networkName,omitempty"`
-	Cidrs       []string `json:"cidrs,omiempty"`
+	Cidrs       []string `json:"cidrs,omitempty"`
 }
 
 // NetworkSettings defines the network details required for the AKO controller
@@ -71,7 +71,7 @@ type NetworkSettings struct {
 	// 3. non vcenter clouds
 	NodeNetworkList []NodeNetwork `json:"nodeNetworkList,omitempty"`
 	// SubnetIP is the Network IP for the subnet to be used
-	SubnetIP string `json:"subnetIP,omitemmpty"`
+	SubnetIP string `json:"subnetIP,omitempty"`
 	// SubnetPrefix is the netmask for the subnet
 	SubnetPrefix string `json:"subnetPrefix,omitempty"`
 	// NetworkName is the name of the network as specified in Avi

--- a/ako-operator/controllers/configmap.go
+++ b/ako-operator/controllers/configmap.go
@@ -23,12 +23,13 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
 func SetIfRebootRequired(oldCm corev1.ConfigMap, newCm corev1.ConfigMap) {

--- a/ako-operator/controllers/configmap_test.go
+++ b/ako-operator/controllers/configmap_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 var cmJson = `

--- a/ako-operator/controllers/crb.go
+++ b/ako-operator/controllers/crb.go
@@ -22,11 +22,12 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func createOrUpdateClusterroleBinding(ctx context.Context, ako akov1alpha1.AKOConfig, log logr.Logger, r *AKOConfigReconciler) error {

--- a/ako-operator/controllers/psp.go
+++ b/ako-operator/controllers/psp.go
@@ -21,10 +21,11 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func createOrUpdatePodSecurityPolicy(ctx context.Context, ako akov1alpha1.AKOConfig, log logr.Logger, r *AKOConfigReconciler) error {

--- a/ako-operator/controllers/role.go
+++ b/ako-operator/controllers/role.go
@@ -21,10 +21,11 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func createOrUpdateClusterRole(ctx context.Context, ako akov1alpha1.AKOConfig, log logr.Logger, r *AKOConfigReconciler) error {

--- a/ako-operator/controllers/sa.go
+++ b/ako-operator/controllers/sa.go
@@ -21,11 +21,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func createOrUpdateServiceAccount(ctx context.Context, ako akov1alpha1.AKOConfig, log logr.Logger, r *AKOConfigReconciler) error {

--- a/ako-operator/controllers/statefulset.go
+++ b/ako-operator/controllers/statefulset.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func createOrUpdateStatefulSet(ctx context.Context, ako akov1alpha1.AKOConfig, log logr.Logger, r *AKOConfigReconciler,

--- a/ako-operator/controllers/statefulset_test.go
+++ b/ako-operator/controllers/statefulset_test.go
@@ -22,10 +22,11 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 var sfJson = `

--- a/ako-operator/controllers/suite_test.go
+++ b/ako-operator/controllers/suite_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
 )
 
 func TestMain(m *testing.M) {

--- a/ako-operator/controllers/utils.go
+++ b/ako-operator/controllers/utils.go
@@ -4,11 +4,12 @@ import (
 	"reflect"
 	"sort"
 
-	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
 // properties used for naming the dependent artifacts

--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -17,9 +17,9 @@ package cache
 import (
 	"errors"
 	"os"
-	"sync"
 
 	"github.com/avinetworks/sdk/go/session"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
@@ -27,7 +27,6 @@ import (
 )
 
 var AviClientInstance *utils.AviRestClientPool
-var clientonce sync.Once
 
 // This class is in control of AKC. It uses utils from the common project.
 func SharedAVIClients() *utils.AviRestClientPool {

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -440,7 +440,7 @@ func (c *AviCache) AviGetAllKeys() []NamespaceName {
 	c.cache_lock.RLock()
 	defer c.cache_lock.RUnlock()
 	var keys []NamespaceName
-	for key, _ := range c.cache {
+	for key := range c.cache {
 		keys = append(keys, key.(NamespaceName))
 	}
 	return keys

--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -28,10 +28,11 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
-	advl4crd "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/clientset/versioned"
-	advl4informer "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/informers/externalversions"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
+
+	advl4crd "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/clientset/versioned"
+	advl4informer "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/informers/externalversions"
 )
 
 func NewAdvL4Informers(cs advl4crd.Interface) {

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -232,7 +232,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 		ingestionQueueParams := utils.WorkerQueue{NumWorkers: numWorkers, WorkqueueName: utils.ObjectIngestionLayer}
 		numGraphWorkers := lib.GetshardSize()
 		graphQueueParams := utils.WorkerQueue{NumWorkers: numGraphWorkers, WorkqueueName: utils.GraphLayer}
-		graphQueue = utils.SharedWorkQueue(ingestionQueueParams, graphQueueParams, slowRetryQParams, fastRetryQParams).GetQueueByName(utils.GraphLayer)
+		graphQueue = utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams, &slowRetryQParams, &fastRetryQParams).GetQueueByName(utils.GraphLayer)
 
 	} else {
 		// Namespace sharding.
@@ -245,7 +245,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 		}
 		ingestionQueueParams := utils.WorkerQueue{NumWorkers: numWorkers, WorkqueueName: utils.ObjectIngestionLayer}
 		graphQueueParams := utils.WorkerQueue{NumWorkers: utils.NumWorkersGraph, WorkqueueName: utils.GraphLayer}
-		graphQueue = utils.SharedWorkQueue(ingestionQueueParams, graphQueueParams, slowRetryQParams, fastRetryQParams).GetQueueByName(utils.GraphLayer)
+		graphQueue = utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams, &slowRetryQParams, &fastRetryQParams).GetQueueByName(utils.GraphLayer)
 	}
 
 	graphQueue.SyncFunc = SyncFromNodesLayer
@@ -325,7 +325,7 @@ func (c *AviController) FullSync() {
 		}
 		allModelsMap := objects.SharedAviGraphLister().GetAll()
 		var allModels []string
-		for modelName, _ := range allModelsMap.(map[string]interface{}) {
+		for modelName := range allModelsMap.(map[string]interface{}) {
 			allModels = append(allModels, modelName)
 		}
 		for _, modelName := range allModels {
@@ -486,7 +486,7 @@ func (c *AviController) FullSyncK8s() error {
 	utils.AviLog.Debugf("Got the VS keys: %s", vsKeys)
 	allModelsMap := objects.SharedAviGraphLister().GetAll()
 	var allModels []string
-	for modelName, _ := range allModelsMap.(map[string]interface{}) {
+	for modelName := range allModelsMap.(map[string]interface{}) {
 		// ignore vrf model, as it has been published already
 		if modelName != vrfModelName {
 			allModels = append(allModels, modelName)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -167,7 +167,7 @@ func isNamespaceUpdated(oldNS, newNS *corev1.Namespace) bool {
 func AddIngressFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
 	ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses(namespace).List(labels.Set(nil).AsSelector())
 	if err != nil {
-		utils.AviLog.Errorf("NS to ingress queue add: Error occured while retrieving ingresss for namespace: %s", namespace)
+		utils.AviLog.Errorf("NS to ingress queue add: Error occurred while retrieving ingresss for namespace: %s", namespace)
 		return
 	}
 	for _, ingObj := range ingObjs {
@@ -181,7 +181,7 @@ func AddIngressFromNSToIngestionQueue(numWorkers uint32, c *AviController, names
 func AddRoutesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
 	routeObjs, err := utils.GetInformers().RouteInformer.Lister().Routes(namespace).List(labels.Set(nil).AsSelector())
 	if err != nil {
-		utils.AviLog.Errorf("NS to route queue add: Error occured while retrieving routes for namespace: %s", namespace)
+		utils.AviLog.Errorf("NS to route queue add: Error occurred while retrieving routes for namespace: %s", namespace)
 		return
 	}
 	for _, routeObj := range routeObjs {
@@ -219,7 +219,7 @@ func AddNamespaceEventHandler(numWorkers uint32, c *AviController) cache.Resourc
 				utils.AddNamespaceToFilter(ns.GetName(), nsFilterObj)
 				utils.AviLog.Debugf("NS Add event: Namespace passed filter: %s", ns.GetName())
 			} else {
-				//Case: previoulsy deleted valid NS, added back with no labels or invalid labels but nsList contain that ns
+				//Case: previously deleted valid NS, added back with no labels or invalid labels but nsList contain that ns
 				utils.AviLog.Debugf("NS Add event: Namespace did not pass filter: %s", ns.GetName())
 				if utils.CheckIfNamespaceAccepted(ns.GetName(), nsFilterObj, nil, true) {
 					utils.AviLog.Debugf("Ns Add event: Deleting previous valid namespace: %s from valid NS List", ns.GetName())

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -52,8 +52,7 @@ var ctrlonce sync.Once
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 type AviController struct {
-	worker_id       uint32
-	worker_id_mutex sync.Mutex
+	worker_id uint32
 	//recorder        record.EventRecorder
 	informers        *utils.Informers
 	dynamicInformers *lib.DynamicInformers

--- a/internal/lib/advl4.go
+++ b/internal/lib/advl4.go
@@ -19,11 +19,12 @@ import (
 	"encoding/json"
 
 	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	advl4crd "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/clientset/versioned"
 	advl4informer "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/informers/externalversions/apis/v1alpha1pre1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var AdvL4Clientset advl4crd.Interface

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -178,4 +178,3 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 	vsNode.L4PolicyRefs = l4Policies
 	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
 }
-

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -29,15 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func contains(s []int32, e int32) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string) *AviVsNode {
 	var avi_vs_meta *AviVsNode
 	var fqdns []string

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -71,7 +71,7 @@ func (o *AviObjectGraph) BuildL7VSGraph(vsName string, namespace string, ingName
 			var storedHosts []string
 			// Mash the list of secure and insecure hosts.
 			for mtype, hostsbytype := range hostMap {
-				for host, _ := range hostsbytype {
+				for host := range hostsbytype {
 					if mtype == "secure" {
 						RemoveRedirectHTTPPolicyInModel(vsNode[0], host, key)
 					}
@@ -230,7 +230,7 @@ func (o *AviObjectGraph) DeletePoolForIngress(namespace, ingName, key string, vs
 	var hosts []string
 	// Mash the list of secure and insecure hosts.
 	for mtype, hostsbytype := range hostMap {
-		for host, _ := range hostsbytype {
+		for host := range hostsbytype {
 			if mtype == "secure" {
 				RemoveRedirectHTTPPolicyInModel(vsNode[0], host, key)
 			}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -935,7 +935,7 @@ func (v *AviPoolNode) CalculateCheckSum() {
 	nodeNetworkMap, _ := lib.GetNodeNetworkMap()
 
 	// A sum of fields for this Pool.
-	chksumStr := fmt.Sprintf(strings.Join([]string{
+	chksumStr := fmt.Sprint(strings.Join([]string{
 		v.Protocol,
 		strconv.Itoa(int(v.Port)),
 		v.PortName,
@@ -1085,7 +1085,7 @@ func (h *SecureHostNameMapProp) GetPathsForHostName(hostname string) []string {
 
 func (h *SecureHostNameMapProp) GetIngressesForHostName(hostname string) []string {
 	var ingresses []string
-	for k, _ := range h.HostNameMap {
+	for k := range h.HostNameMap {
 		ingresses = append(ingresses, k)
 	}
 	return ingresses

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -175,7 +175,7 @@ func (m *K8sIngressModel) GetDiffPathSvc(storedPathSvc map[string][]string, curr
 	for _, val := range currentPathSvc {
 		currPathSvcMap[val.Path] = append(currPathSvcMap[val.Path], val.ServiceName)
 	}
-	for path, _ := range currPathSvcMap {
+	for path := range currPathSvcMap {
 		_, ok := pathSvcCopy[path]
 		if ok {
 			delete(pathSvcCopy, path)
@@ -263,14 +263,6 @@ func getPathSvc(currentPathSvc []IngressHostPathSvc) map[string][]string {
 	return pathSvcMap
 }
 
-func pathsToEmptySvcMap(paths []string) map[string][]string {
-	pathSvcMap := make(map[string][]string)
-	for _, path := range paths {
-		pathSvcMap[path] = []string{}
-	}
-	return pathSvcMap
-}
-
 func ProcessInsecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng IngressConfig, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost, hostsMap map[string]*objects.RouteIngrhost) {
 	for host, pathsvcmap := range parsedIng.IngressHostMap {
 		// Remove this entry from storedHosts. First check if the host exists in the stored map or not.
@@ -327,10 +319,6 @@ func ProcessSecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng Ing
 			if found && hostData.SecurePolicy == lib.PolicyEdgeTerm {
 				// TODO: StoredPaths might be empty if the host was not specified with any paths.
 				// Verify the paths and take out the paths that are not need.
-				pathkeys := []string{}
-				for k := range hostData.PathSvc {
-					pathkeys = append(pathkeys, k)
-				}
 				pathSvcDiff := routeIgrObj.GetDiffPathSvc(hostData.PathSvc, newPathSvc)
 
 				// For transtion from insecureEdgeTermination policy Allow -> None in a route
@@ -498,7 +486,7 @@ func updateHostPathCacheV2(ns, ingress string, oldHostMap, newHostMap map[string
 
 	// remove from oldHostMap
 	for host, oldMap := range oldHostMap {
-		for path, _ := range oldMap.PathSvc {
+		for path := range oldMap.PathSvc {
 			SharedHostNameLister().RemoveHostPathStore(host, path, mmapval)
 		}
 	}
@@ -506,7 +494,7 @@ func updateHostPathCacheV2(ns, ingress string, oldHostMap, newHostMap map[string
 	// add from newHostMap
 	if newHostMap != nil {
 		for host, newMap := range newHostMap {
-			for path, _ := range newMap.PathSvc {
+			for path := range newMap.PathSvc {
 				SharedHostNameLister().SaveHostPathStore(host, path, mmapval)
 			}
 		}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -122,7 +122,7 @@ func DequeueIngestion(key string, fullsync bool) {
 	// handle the services APIs
 	if lib.GetAdvancedL4() {
 		if !valid && objType == utils.L4LBService {
-			schema, valid = ConfigDescriptor().GetByType(utils.Service)
+			schema, _ = ConfigDescriptor().GetByType(utils.Service)
 		}
 		gateways, gatewayFound := schema.GetParentGateways(name, namespace, key)
 		// For each gateway first verify if it has a valid subscription to the GatewayClass or not.

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -497,7 +497,7 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 	if !ok {
 		utils.AviLog.Debugf("key %s, msg: Couldn't find hostpath info for host: %s in cache", key, fqdn)
 	} else {
-		for pathPrefix, _ := range pathRules {
+		for pathPrefix := range pathRules {
 			re := regexp.MustCompile(fmt.Sprintf(`^%s.*`, strings.ReplaceAll(pathPrefix, `/`, `\/`)))
 			for path, ingresses := range pathIngs {
 				if !re.MatchString(path) {
@@ -517,7 +517,7 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 	if !ok {
 		utils.AviLog.Debugf("key %s, msg: Couldn't find hostpath info for host: %s in cache", key, oldFqdn)
 	} else {
-		for oldPathPrefix, _ := range oldPathRules {
+		for oldPathPrefix := range oldPathRules {
 			re := regexp.MustCompile(fmt.Sprintf(`^%s.*`, strings.ReplaceAll(oldPathPrefix, `/`, `\/`)))
 			for oldPath, oldIngresses := range oldPathIngs {
 				if !re.MatchString(oldPath) {

--- a/internal/objects/nodes.go
+++ b/internal/objects/nodes.go
@@ -25,7 +25,7 @@ import (
 )
 
 type K8sNodeStore struct {
-	ObjectMapStore
+	*ObjectMapStore
 }
 
 var nodeonce sync.Once
@@ -35,7 +35,7 @@ func SharedNodeLister() *K8sNodeStore {
 	nodeonce.Do(func() {
 		nodesStoreInstance = NewObjectMapStore()
 	})
-	return &K8sNodeStore{*nodesStoreInstance}
+	return &K8sNodeStore{nodesStoreInstance}
 }
 
 func (o *K8sNodeStore) PopulateAllNodes(cs *kubernetes.Clientset) {

--- a/internal/objects/store.go
+++ b/internal/objects/store.go
@@ -68,7 +68,7 @@ func (store *ObjectStore) GetAllNamespaces() []string {
 	store.NSLock.RLock()
 	defer store.NSLock.RUnlock()
 	var allNamespaces []string
-	for ns, _ := range store.NSObjectMap {
+	for ns := range store.NSObjectMap {
 		allNamespaces = append(allNamespaces, ns)
 	}
 	return allNamespaces

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -83,7 +83,7 @@ func (rest *RestOperations) AviDSDel(uuid string, tenant string, key string) *ut
 
 func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for datascriptset err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for datascriptset err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -95,10 +95,10 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 		var j int32
 		j = idx
 		rule := avimodels.HTTPRequestRule{
-			Index: &j,
-			Enable: &enable, 
-			Name: &name, 
-			Match: &match_target, 
+			Index:           &j,
+			Enable:          &enable,
+			Name:            &name,
+			Match:           &match_target,
 			SwitchingAction: &sw_action,
 		}
 		http_req_pol.Rules = append(http_req_pol.Rules, &rule)
@@ -170,7 +170,7 @@ func (rest *RestOperations) AviHttpPolicyDel(uuid string, tenant string, key str
 
 func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for httppolicyset, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for httppolicyset, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -123,7 +123,7 @@ func (rest *RestOperations) AviL4PolicyDel(uuid string, tenant string, key strin
 
 func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for l4policyset, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for l4policyset, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -175,7 +175,7 @@ func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *
 
 func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for POOL, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for POOL, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -115,7 +115,7 @@ func (rest *RestOperations) getVrfCacheObj(vrfName string) *avicache.AviVrfCache
 
 func (rest *RestOperations) AviVrfCacheAdd(restOp *utils.RestOp, vrfKey avicache.NamespaceName, key string) error {
 	if (restOp.Err != nil) || (restOp.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for vrfcontext, err: %s, response: %s", key, restOp.Err, restOp.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for vrfcontext, err: %s, response: %s", key, restOp.Err, restOp.Response)
 		return errors.New("Errored rest_op")
 	}
 	respElems, ok := RestRespArrToObjByType(restOp, "vrfcontext", key)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -493,8 +493,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				}}, false)
 			}
 			rest.cache.VsCacheMeta.AviCacheAdd(k, &vs_cache_obj)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key %v val %v\n", key, k,
-				vs_cache_obj))
+			utils.AviLog.Infof("key: %s, msg: added VS cache key %v val %v\n", key, k, utils.Stringify(&vs_cache_obj))
 		}
 
 	}
@@ -854,7 +853,7 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
 		if rest_op.Message == "" {
-			utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for vsvip err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+			utils.AviLog.Warnf("key: %s, rest_op has err or no response for vsvip err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 			return errors.New("Errored vsvip rest_op")
 		}
 

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -33,8 +33,7 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	cksum := pg_meta.CloudConfigCksum
 	cksumString := strconv.Itoa(int(cksum))
 	tenant := fmt.Sprintf("/api/tenant/?name=%s", pg_meta.Tenant)
-	members := pg_meta.Members
-	members = rest.SanitizePGMembers(pg_meta.Members, key)
+	members := rest.SanitizePGMembers(pg_meta.Members, key)
 	cr := lib.AKOUser
 	cloudRef := "/api/cloud?name=" + utils.CloudName
 
@@ -97,7 +96,7 @@ func (rest *RestOperations) AviPGDel(uuid string, tenant string, key string) *ut
 
 func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for PG err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for PG err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -367,9 +367,10 @@ func (rest *RestOperations) getVsCacheObj(vsKey avicache.NamespaceName, key stri
 
 func (rest *RestOperations) deleteVSOper(vsKey avicache.NamespaceName, vs_cache_obj *avicache.AviVsCache, namespace string, key string, skipVS, skipVSVip bool) bool {
 	var rest_ops []*utils.RestOp
-	sni_vs_keys := make([]string, len(vs_cache_obj.SNIChildCollection))
-	copy(sni_vs_keys, vs_cache_obj.SNIChildCollection)
 	if vs_cache_obj != nil {
+		sni_vs_keys := make([]string, len(vs_cache_obj.SNIChildCollection))
+		copy(sni_vs_keys, vs_cache_obj.SNIChildCollection)
+
 		// VS delete should delete everything together.
 		passthroughChild := vs_cache_obj.ServiceMetadataObj.PassthroughChildRef
 		if passthroughChild != "" {
@@ -1543,15 +1544,6 @@ func (rest *RestOperations) PkiProfileDelete(pkiProfileDelete []avicache.Namespa
 }
 
 func Remove(s []avicache.NamespaceName, r avicache.NamespaceName) []avicache.NamespaceName {
-	for i, v := range s {
-		if v == r {
-			return append(s[:i], s[i+1:]...)
-		}
-	}
-	return s
-}
-
-func filterKeyFromStringSlice(s []string, r string) []string {
 	for i, v := range s {
 		if v == r {
 			return append(s[:i], s[i+1:]...)

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -43,12 +43,10 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 	if ssl_node.CACert != "" {
 		cacertRef := "/api/sslkeyandcertificate/?name=" + ssl_node.CACert
 		caName := ssl_node.CACert
-		sslkeycert.CaCerts = []*avimodels.CertificateAuthority{
-			&avimodels.CertificateAuthority{
-				CaRef: &cacertRef,
-				Name:  &caName,
-			},
-		}
+		sslkeycert.CaCerts = []*avimodels.CertificateAuthority{{
+			CaRef: &cacertRef,
+			Name:  &caName,
+		}}
 	}
 
 	// TODO other fields like cloud_ref and lb algo
@@ -80,7 +78,7 @@ func (rest *RestOperations) AviSSLKeyCertDel(uuid string, tenant string) *utils.
 
 func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no reponse for sslkeycert, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for sslkeycert, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 
@@ -215,7 +213,7 @@ func (rest *RestOperations) AviPkiProfileDel(uuid string, tenant string) *utils.
 
 func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("rest_op has err or no reponse for PkiProfileObj")
+		utils.AviLog.Warnf("rest_op has err or no response for PkiProfileObj")
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
+
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -128,7 +129,7 @@ func UpdateGatewayStatusGWCondition(gwStatus *advl4v1alpha1pre1.GatewayStatus, u
 	utils.AviLog.Debugf("Updating Gateway status gateway condition %v", utils.Stringify(updateStatus))
 	InitializeGatewayConditions(gwStatus, nil, false)
 
-	for i, _ := range gwStatus.Conditions {
+	for i := range gwStatus.Conditions {
 		if string(gwStatus.Conditions[i].Type) == updateStatus.Type {
 			gwStatus.Conditions[i].Status = updateStatus.Status
 			gwStatus.Conditions[i].Message = updateStatus.Message
@@ -360,19 +361,19 @@ func getGateways(gwNSNames []string, bulk bool, retryNum ...int) map[string]*adv
 func compareGatewayStatuses(old, new *advl4v1alpha1pre1.GatewayStatus) bool {
 	oldStatus, newStatus := old.DeepCopy(), new.DeepCopy()
 	currentTime := metav1.Now()
-	for i, _ := range oldStatus.Conditions {
+	for i := range oldStatus.Conditions {
 		oldStatus.Conditions[i].LastTransitionTime = currentTime
 	}
 	for _, listener := range oldStatus.Listeners {
-		for i, _ := range listener.Conditions {
+		for i := range listener.Conditions {
 			listener.Conditions[i].LastTransitionTime = currentTime
 		}
 	}
-	for i, _ := range newStatus.Conditions {
+	for i := range newStatus.Conditions {
 		newStatus.Conditions[i].LastTransitionTime = currentTime
 	}
 	for _, listener := range newStatus.Listeners {
-		for i, _ := range listener.Conditions {
+		for i := range listener.Conditions {
 			listener.Conditions[i].LastTransitionTime = currentTime
 		}
 	}

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -179,7 +179,7 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 		for _, host := range svc_mdata_obj.HostNames {
 			if status.Hostname == host {
 				// Check if this host is still present in the spec, if so - don't delete it
-				//NS migration case: if false -> ns invalid event happend so remove status
+				//NS migration case: if false -> ns invalid event happened so remove status
 				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace, utils.GetGlobalNSFilter(), nil, true)
 				if !utils.HasElem(hostListIng, host) || isVSDelete || !nsMigrationFilterFlag {
 					mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -398,7 +398,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 		for _, host := range svc_mdata_obj.HostNames {
 			if mRoute.Status.Ingress[i].Host == host {
 				// Check if this host is still present in the spec, if so - don't delete it
-				//NS migration case: if false -> ns invalid event happend so remove status
+				//NS migration case: if false -> ns invalid event happened so remove status
 				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace, utils.GetGlobalNSFilter(), nil, true)
 				if !utils.HasElem(hostListIng, host) || isVSDelete || !nsMigrationFilterFlag {
 					mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -17,11 +17,12 @@ package status
 import (
 	"context"
 
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
 var msgForReason = map[string]string{

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -60,7 +60,7 @@ func UpdateL4LBStatus(options []UpdateStatusOptions, bulk bool) {
 			}
 			service.Status = corev1.ServiceStatus{
 				LoadBalancer: corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{corev1.LoadBalancerIngress{
+					Ingress: []corev1.LoadBalancerIngress{{
 						IP:       option.Vip,
 						Hostname: svcHostname,
 					}}}}

--- a/pkg/api/api_fake.go
+++ b/pkg/api/api_fake.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"github.com/gorilla/mux"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -43,6 +43,9 @@ func TestApiServerStatusModel(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fail()
+	}
 
 	var status models.StatusModel
 	if err = json.Unmarshal(body, &status); err != nil {

--- a/pkg/utils/queue.go
+++ b/pkg/utils/queue.go
@@ -25,7 +25,7 @@ import (
 
 var queuewrapper sync.Once
 var queueInstance *WorkQueueWrapper
-var fixedQueues = [...]WorkerQueue{WorkerQueue{NumWorkers: NumWorkersIngestion, WorkqueueName: ObjectIngestionLayer}, WorkerQueue{NumWorkers: NumWorkersGraph, WorkqueueName: GraphLayer}}
+var fixedQueues = [...]*WorkerQueue{{NumWorkers: NumWorkersIngestion, WorkqueueName: ObjectIngestionLayer}, {NumWorkers: NumWorkersGraph, WorkqueueName: GraphLayer}}
 
 type WorkQueueWrapper struct {
 	// This struct should manage a set of WorkerQueues for the various layers
@@ -37,7 +37,7 @@ func (w *WorkQueueWrapper) GetQueueByName(queueName string) *WorkerQueue {
 	return workqueue
 }
 
-func SharedWorkQueue(queueParams ...WorkerQueue) *WorkQueueWrapper {
+func SharedWorkQueue(queueParams ...*WorkerQueue) *WorkQueueWrapper {
 	queuewrapper.Do(func() {
 		queueInstance = &WorkQueueWrapper{}
 		queueInstance.queueCollection = make(map[string]*WorkerQueue)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -379,13 +379,6 @@ func CheckIfNamespaceAccepted(namespace string, obj *K8ValidNamespaces, nsLabels
 	}
 	return false
 }
-func retrieveNSList(nsList map[string]bool) []string {
-	var namespaces []string
-	for k := range nsList {
-		namespaces = append(namespaces, k)
-	}
-	return namespaces
-}
 
 // This utility returns a true/false depending on whether
 // the user requires advanced L4 functionality

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		utils.NSInformer,
 		utils.ConfigMapInformer,
 	}
-	utils.NewInformers(utils.KubeClientIntf{KubeClient}, registeredInformers)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers)
 	informers := k8s.K8sinformers{Cs: KubeClient}
 	// k8s.NewCRDInformers(CRDClient)
 	k8s.NewAdvL4Informers(AdvL4Client)

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -28,19 +28,6 @@ var uuidMap map[string]bool
 const mockFilePath = "bootupmock"
 const invalidFilePath = "invalidmock1"
 
-var FakeAviObjects = []string{
-	"cloud",
-	"ipamdnsproviderprofile",
-	"network",
-	"pool",
-	"poolgroup",
-	"virtualservice",
-	"vrfcontext",
-	"vsdatascriptset",
-	"serviceenginegroup",
-	"vsvip",
-}
-
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
 	os.Setenv("NETWORK_NAME", "net123")

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
@@ -14,15 +13,15 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 
-	crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/client/v1alpha1/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/client/v1alpha1/clientset/versioned/fake"
 )
 
 var KubeClient *k8sfake.Clientset
 var CRDClient *crdfake.Clientset
-var ctrl *k8s.AviController
 var restChan chan bool
 var uuidMap map[string]bool
 
@@ -67,7 +66,7 @@ func TestMain(m *testing.M) {
 		utils.NodeInformer,
 		utils.ConfigMapInformer,
 	}
-	utils.NewInformers(utils.KubeClientIntf{KubeClient}, registeredInformers)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers)
 	k8s.NewCRDInformers(CRDClient)
 
 	mcache := cache.SharedAviObjCache()
@@ -145,26 +144,6 @@ func injectMWForCloud() {
 			w.Write([]byte(`{"success": "true"}`))
 		}
 	})
-}
-
-// Wait for true or false on rest channel to confirm object deletion
-func waitAndverify(t *testing.T) {
-	waitChan := make(chan int)
-	go func() {
-		time.Sleep(50 * time.Second)
-		waitChan <- 1
-	}()
-
-	select {
-	case data := <-restChan:
-		if data == false {
-			t.Fatalf("error in stale object deletion")
-		}
-		t.Logf("xxx here")
-	case _ = <-waitChan:
-		t.Fatalf("timed out waiting for object deletion")
-
-	}
 }
 
 // PopulateCache populates cache and triggers deletion of unused objects.

--- a/tests/hostnameshardtests/crd_hostname_test.go
+++ b/tests/hostnameshardtests/crd_hostname_test.go
@@ -455,7 +455,7 @@ func TestHostnameHTTPRuleCreateDelete(t *testing.T) {
 		Paths:       []string{"/foo", "/bar"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}
 

--- a/tests/hostnameshardtests/l7_hostname_rest_test.go
+++ b/tests/hostnameshardtests/l7_hostname_rest_test.go
@@ -60,7 +60,7 @@ func SetUpIngressForCacheSyncCheck(t *testing.T, modelName string, tlsIngress, w
 	}
 	if tlsIngress {
 		ingressObject.TlsSecretDNS = map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		}
 	}
 	ingrFake := ingressObject.Ingress()
@@ -409,7 +409,7 @@ func TestHostnameUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/bar-updated"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
@@ -463,8 +463,8 @@ func TestHostnameMultiHostMultiSecretSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo.com"},
-			"my-secret-v2": []string{"bar.com"},
+			"my-secret":    {"foo.com"},
+			"my-secret-v2": {"bar.com"},
 		},
 	}
 	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -508,7 +508,7 @@ func TestHostnameMultiHostMultiSecretSNICacheSync(t *testing.T) {
 		Paths:       []string{"/doo"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}
 	integrationtest.AddSecret("my-secret", "red", "tlsCert", "tlsKey")
@@ -545,8 +545,8 @@ func TestHostnameMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo.com"},
-			"my-secret-v2": []string{"bar.com"},
+			"my-secret":    {"foo.com"},
+			"my-secret-v2": {"bar.com"},
 		},
 	}
 	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -620,7 +620,7 @@ func TestHostnameMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}
 
@@ -809,8 +809,8 @@ func TestHostnameMultiHostIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo.com"},
-			"my-secret-v2": []string{"bar.com"},
+			"my-secret":    {"foo.com"},
+			"my-secret-v2": {"bar.com"},
 		},
 	}
 	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -822,7 +822,7 @@ func TestHostnameMultiHostIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/doo"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}
 	ingrFake := ingressObject.Ingress()
@@ -889,7 +889,7 @@ func TestHostnameMultiHostUpdateIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/foo", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo" + pathSuffix},
+			"my-secret": {"foo" + pathSuffix},
 		},
 	}
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
@@ -922,7 +922,7 @@ func TestHostnameMultiHostUpdateIngressStatusCheck(t *testing.T) {
 		HostNames:   ingressStatusNames,
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo" + pathSuffix},
+			"my-secret": {"foo" + pathSuffix},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"

--- a/tests/hostnameshardtests/l7_hostname_shard_nodeport_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_nodeport_test.go
@@ -946,7 +946,7 @@ func TestUpdateNodeInNodePort(t *testing.T) {
 		t.Fatalf("error in adding Node: %v", err)
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
-	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	found, _ = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		// model should not be sent for this update as only the resource ver is changed.
 		t.Fatalf("Model found for node add %v", modelName)
@@ -1129,7 +1129,7 @@ func TestFullSyncCacheNoOpInNodePort(t *testing.T) {
 		Paths:     []string{"/foo", "/bar"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 		ServiceName: "avisvc",
 	}).IngressMultiPath()
@@ -1195,7 +1195,7 @@ func TestL7ModelMultiSNIInNodePort(t *testing.T) {
 		HostNames:   []string{"v1"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com", "bar.com"},
+			"my-secret": {"foo.com", "bar.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 		utils.NodeInformer,
 		utils.ConfigMapInformer,
 	}
-	utils.NewInformers(utils.KubeClientIntf{KubeClient}, registeredInformers)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers)
 	informers := k8s.K8sinformers{Cs: KubeClient}
 	k8s.NewCRDInformers(CRDClient)
 

--- a/tests/integrationtest/l7_ingress_rest_test.go
+++ b/tests/integrationtest/l7_ingress_rest_test.go
@@ -35,11 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	INGRESS    = "my-ingress"
-	TLSINGRESS = "tls-ingress"
-)
-
 func SetupDomain() {
 	mcache := cache.SharedAviObjCache()
 	cloud, _ := mcache.CloudKeyCache.AviCacheGet("Default-Cloud")

--- a/tests/integrationtest/l7_ingress_rest_test.go
+++ b/tests/integrationtest/l7_ingress_rest_test.go
@@ -64,7 +64,7 @@ func SetUpIngressForCacheSyncCheck(t *testing.T, modelName string, tlsIngress, w
 	}
 	if tlsIngress {
 		ingressObject.TlsSecretDNS = map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		}
 	}
 	ingrFake := ingressObject.Ingress()
@@ -354,7 +354,7 @@ func TestUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/bar-updated"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
@@ -408,8 +408,8 @@ func TestMultiHostMultiSecretSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo.com"},
-			"my-secret-v2": []string{"bar.com"},
+			"my-secret":    {"foo.com"},
+			"my-secret-v2": {"bar.com"},
 		},
 	}
 	AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -462,8 +462,8 @@ func TestMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo.com"},
-			"my-secret-v2": []string{"bar.com"},
+			"my-secret":    {"foo.com"},
+			"my-secret-v2": {"bar.com"},
 		},
 	}
 	AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -529,7 +529,7 @@ func TestMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		},
 	}
 
@@ -708,8 +708,8 @@ func TestMultiHostIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    []string{"foo2.com"},
-			"my-secret-v2": []string{"xyz2.com"},
+			"my-secret":    {"foo2.com"},
+			"my-secret-v2": {"xyz2.com"},
 		},
 	}
 	AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
@@ -755,7 +755,7 @@ func TestMultiHostUpdateIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/foo", "/bar", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo3.com", "bar3.com"},
+			"my-secret": {"foo3.com", "bar3.com"},
 		},
 	}
 	AddSecret("my-secret", "default", "tlsCert", "tlsKey")
@@ -786,7 +786,7 @@ func TestMultiHostUpdateIngressStatusCheck(t *testing.T) {
 		Paths:       []string{"/foo", "/xyz"},
 		ServiceName: "avisvc",
 		TlsSecretDNS: map[string][]string{
-			"my-secret": []string{"foo3.com"},
+			"my-secret": {"foo3.com"},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -115,7 +115,7 @@ func AddNamespace(nsName string, labels map[string]string) error {
 	if err != nil {
 		_, err = KubeClient.CoreV1().Namespaces().Create(context.TODO(), nsMetaOptions, metav1.CreateOptions{})
 		if err != nil {
-			utils.AviLog.Errorf("Error occured while Adding namespace : %v", err)
+			utils.AviLog.Errorf("Error occurred while Adding namespace : %v", err)
 		}
 	}
 	return err
@@ -206,7 +206,7 @@ func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
 				Host: dnsName,
 				IngressRuleValue: networking.IngressRuleValue{
 					HTTP: &networking.HTTPIngressRuleValue{
-						Paths: []networking.HTTPIngressPath{networking.HTTPIngressPath{
+						Paths: []networking.HTTPIngressPath{{
 							Path: "/foo",
 							Backend: networking.IngressBackend{ServiceName: ing.ServiceName, ServicePort: intstr.IntOrString{
 								Type:   intstr.String,
@@ -220,7 +220,7 @@ func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
 				Host: dnsName,
 				IngressRuleValue: networking.IngressRuleValue{
 					HTTP: &networking.HTTPIngressRuleValue{
-						Paths: []networking.HTTPIngressPath{networking.HTTPIngressPath{
+						Paths: []networking.HTTPIngressPath{{
 							Path: "/bar",
 							Backend: networking.IngressBackend{ServiceName: ing.ServiceName, ServicePort: intstr.IntOrString{
 								Type:   intstr.String,
@@ -235,7 +235,7 @@ func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
 				Host: dnsName,
 				IngressRuleValue: networking.IngressRuleValue{
 					HTTP: &networking.HTTPIngressRuleValue{
-						Paths: []networking.HTTPIngressPath{networking.HTTPIngressPath{
+						Paths: []networking.HTTPIngressPath{{
 							Path: path,
 							Backend: networking.IngressBackend{ServiceName: ing.ServiceName, ServicePort: intstr.IntOrString{
 								Type:   intstr.Int,
@@ -253,7 +253,7 @@ func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
 			SecretName: secret,
 		})
 	}
-	for i, _ := range ing.Ips {
+	for i := range ing.Ips {
 		hostname := ""
 		if len(ing.HostNames) >= i+1 {
 			hostname = ing.HostNames[i]
@@ -291,7 +291,7 @@ func (ing FakeIngress) SecureIngress() *networking.Ingress {
 			Host: dnsName,
 			IngressRuleValue: networking.IngressRuleValue{
 				HTTP: &networking.HTTPIngressRuleValue{
-					Paths: []networking.HTTPIngressPath{networking.HTTPIngressPath{
+					Paths: []networking.HTTPIngressPath{{
 						Path: path,
 						Backend: networking.IngressBackend{ServiceName: ing.ServiceName, ServicePort: intstr.IntOrString{
 							Type:   intstr.Int,
@@ -336,7 +336,7 @@ func (ing FakeIngress) IngressNoHost() *networking.Ingress {
 		ingress.Spec.Rules = append(ingress.Spec.Rules, networking.IngressRule{
 			IngressRuleValue: networking.IngressRuleValue{
 				HTTP: &networking.HTTPIngressRuleValue{
-					Paths: []networking.HTTPIngressPath{networking.HTTPIngressPath{
+					Paths: []networking.HTTPIngressPath{{
 						Path: path,
 						Backend: networking.IngressBackend{ServiceName: ing.ServiceName, ServicePort: intstr.IntOrString{
 							Type:   intstr.Int,

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -492,7 +492,6 @@ type FakeService struct {
 	Labels         map[string]string
 	Type           corev1.ServiceType
 	LoadBalancerIP string
-	annotations    map[string]string
 	ServicePorts   []Serviceport
 }
 

--- a/tests/integrationtest/static_route_test.go
+++ b/tests/integrationtest/static_route_test.go
@@ -17,7 +17,6 @@ package integrationtest
 import (
 	"context"
 	"testing"
-	"time"
 
 	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
@@ -170,7 +169,6 @@ func TestMultiNodeAdd(t *testing.T) {
 		t.Fatalf("error in adding Node: %v", err)
 	}
 
-	time.Sleep(5)
 	PollForCompletion(t, modelName, 5)
 	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	if !found {

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -110,7 +110,7 @@ func TestMain(m *testing.M) {
 		utils.NodeInformer,
 		utils.ConfigMapInformer,
 	}
-	utils.NewInformers(utils.KubeClientIntf{kubeClient}, registeredInformers)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers)
 	k8s.NewCRDInformers(crdClient)
 	integrationtest.InitializeFakeAKOAPIServer()
 

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -242,7 +242,7 @@ func TestMain(m *testing.M) {
 	dynamicClient = dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	crdClient = crdfake.NewSimpleClientset()
 	lib.SetCRDClientset(crdClient)
-	utils.NewInformers(utils.KubeClientIntf{kubeClient}, RegisteredInformers)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, RegisteredInformers)
 	k8s.NewCRDInformers(crdClient)
 
 	integrationtest.InitializeFakeAKOAPIServer()

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -26,15 +26,16 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/client/v1alpha1/clientset/versioned/fake"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
 var KubeClient *k8sfake.Clientset
@@ -160,7 +161,7 @@ func SetupIngress(t *testing.T, modelName, namespace string, withSecret, tlsIngr
 	}
 	if tlsIngress {
 		ingressObject.TlsSecretDNS = map[string][]string{
-			"my-secret": []string{"foo.com"},
+			"my-secret": {"foo.com"},
 		}
 	}
 
@@ -302,7 +303,7 @@ func checkNSTransition(t *testing.T, oldLabels, newLabels map[string]string, old
 	err = integrationtest.UpdateNamespace(namespace, newLabels)
 	integrationtest.PollForCompletion(t, modelName, 5)
 	if err != nil {
-		t.Fatal("Error occured while updating namespace")
+		t.Fatal("Error occurred while updating namespace")
 	}
 
 	g.Eventually(func() bool {

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -50,7 +50,7 @@ var defaultRouteName, defaultNamespace, defaultHostname, defaultService string
 var defaultModelName string
 var defaultKey, defaultValue string
 
-// Candiate to move to lib
+// Candidate to move to lib
 type FakeRoute struct {
 	Name        string
 	Namespace   string
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 		utils.NodeInformer,
 		utils.ConfigMapInformer,
 	}
-	utils.NewInformers(utils.KubeClientIntf{KubeClient}, registeredInformers, informersArg)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers, informersArg)
 	informers := k8s.K8sinformers{Cs: KubeClient}
 	k8s.NewCRDInformers(CRDClient)
 

--- a/tests/oshiftroutetests/oshift_route_namespace_sync_test.go
+++ b/tests/oshiftroutetests/oshift_route_namespace_sync_test.go
@@ -22,13 +22,14 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func SetupRouteNamespaceSync(key, value, shardScheme string) {
@@ -197,7 +198,7 @@ func checkNSTransition(t *testing.T, oldLabels, newLabels map[string]string, old
 	err = integrationtest.UpdateNamespace(namespace, newLabels)
 	integrationtest.PollForCompletion(t, modelName, 5)
 	if err != nil {
-		t.Fatal("Error occured while updating namespace")
+		t.Fatal("Error occurred while updating namespace")
 	}
 
 	g.Eventually(func() bool {

--- a/tests/oshiftroutetests/oshift_route_rest_test.go
+++ b/tests/oshiftroutetests/oshift_route_rest_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
@@ -15,14 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func SetupDomain() {
-	mcache := cache.SharedAviObjCache()
-	cloudObj := &cache.AviCloudPropertyCache{Name: "Default-Cloud", VType: "mock"}
-	subdomains := []string{"avi.internal", ".com"}
-	cloudObj.NSIpamDNS = subdomains
-	mcache.CloudKeyCache.AviCacheAdd("Default-Cloud", cloudObj)
-}
 
 func TearDownRouteForRestCheck(t *testing.T, modelName string) {
 	err := OshiftClient.RouteV1().Routes(defaultNamespace).Delete(context.TODO(), defaultRouteName, metav1.DeleteOptions{})

--- a/tests/scaletest/lib/parser.go
+++ b/tests/scaletest/lib/parser.go
@@ -17,7 +17,7 @@ package lib
 type VCenterConfiguration struct {
 	UserName   string `json:"user"`
 	Password   string `json:"password"`
-	VCenterURL string `json:"vcenter_url`
+	VCenterURL string `json:"vcenter_url"`
 }
 
 type Platform struct {

--- a/tests/scaletest/scale_test.go
+++ b/tests/scaletest/scale_test.go
@@ -212,7 +212,7 @@ func RebootAko(t *testing.T, wg *sync.WaitGroup) {
 }
 
 /* Reboots Controller/Node/Ako if Reboot is set to true */
-func (t *testing.T, wg *sync.WaitGroup) {
+func CheckReboot(t *testing.T, wg *sync.WaitGroup) {
 	if REBOOTAKO == true {
 		wg.Add(1)
 		go RebootAko(t, wg)

--- a/tests/scaletest/scale_test.go
+++ b/tests/scaletest/scale_test.go
@@ -12,6 +12,7 @@
 * limitations under the License.
 */
 
+// nolint:unused
 package scaletest
 
 import (


### PR DESCRIPTION
This PR adds github actions for pointing out linting issues in PRs pushed for master or release- branches
As part of adding the action, this PR addresses all the existing issues pointed out by the linter.
The action should get active once the PR is merged, for future PRs.

An exhaustive list of supported linters can be found here: https://golangci-lint.run/usage/linters/ 
The proposed configuration (see .golangci.yml) only attaches basic linters without changing too much in upstream.

The PR fixes multiple misspells, lock copying, deadcode, unused vars etc.