### PR TITLE
remove lint action on push to master branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,14 +1,7 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Go-CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches:
-      - master
-      - release-*
+  # Triggers the workflow on pull request events for the master  and release-* branches
   pull_request:
     branches:
       - master
@@ -17,9 +10,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   golangci-lint:
     name: Golangci-lint
     strategy:


### PR DESCRIPTION
This limits the action to run on pull requests only, action on push is not required.