### PR TITLE
IngressClass/Ingress UTs, namespace shard and cache mapping fixes

### DIFF
--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -29,7 +29,7 @@ func AviGetCollectionRaw(client *clients.AviClient, uri string, retryNum ...int)
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			err := errors.New("msg: AviGetCollectionRaw retried 3 times, aborting")
 			return session.AviCollectionResult{}, err
 		}
@@ -51,7 +51,7 @@ func AviGet(client *clients.AviClient, uri string, response interface{}, retryNu
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			err := errors.New("msg: AviGet retried 3 times, aborting")
 			return err
 		}
@@ -72,7 +72,7 @@ func AviPut(client *clients.AviClient, uri string, payload interface{}, response
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			err := errors.New("msg: AviPut retried 3 times, aborting")
 			return err
 		}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -258,14 +258,14 @@ func handleIngress(key string, fullsync bool, ingressNames []string) {
 	objType, namespace, _ := extractTypeNameNamespace(key)
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 	if lib.GetShardScheme() == lib.NAMESPACE_SHARD_SCHEME {
-		shardVsName := DeriveNamespacedShardVS(namespace, key)
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			return
-		}
-		model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
 		for _, ingress := range ingressNames {
 			nsing, nameing := getIngressNSNameForIngestion(objType, namespace, ingress)
+			shardVsName := DeriveNamespacedShardVS(nsing, key)
+			if shardVsName == "" {
+				// If we aren't able to derive the ShardVS name, we should return
+				return
+			}
+			model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
 			// The assumption is that the ingress names are from the same namespace as the service/ep updates. Kubernetes
 			// does not allow cross tenant ingress references.
 			utils.AviLog.Debugf("key: %s, msg: evaluating ingress: %s", key, ingress)

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	svcapiv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
@@ -281,7 +282,7 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 			// Remove all the Ingress to Services mapping.
 			// Remove the references of this ingress from the Services
 			objects.SharedSvcLister().IngressMappings(namespace).RemoveIngressMappings(ingName)
-			objects.SharedSvcLister().IngressMappings("").RemoveIngressClassMappings(ingName)
+			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
 		}
 	} else {
 		// simple validator check for duplicate hostpaths, logs Warning if duplicates found
@@ -291,9 +292,9 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 		}
 
 		if ingObj.Spec.IngressClassName != nil {
-			objects.SharedSvcLister().IngressMappings("").UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
+			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
 		} else {
-			objects.SharedSvcLister().IngressMappings("").RemoveIngressClassMappings(ingName)
+			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
 		}
 
 		services := parseServicesForIngress(ingObj.Spec, key)
@@ -313,7 +314,7 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 }
 
 func IngClassToIng(ingClassName string, namespace string, key string) ([]string, bool) {
-	found, ingresses := objects.SharedSvcLister().IngressMappings("").GetClassToIng(ingClassName)
+	found, ingresses := objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).GetClassToIng(ingClassName)
 	return ingresses, found
 }
 

--- a/internal/objects/ingress_to_service.go
+++ b/internal/objects/ingress_to_service.go
@@ -184,11 +184,11 @@ func (v *SvcNSCache) UpdateSecretToIngMapping(secretName string, ingressList []s
 //=====All ingress class to ingress mapping methods are here.
 
 func (v *SvcNSCache) GetClassToIng(className string) (bool, []string) {
-	found, ingNames := v.classIngObject.Get(className)
+	found, ingNSNames := v.classIngObject.Get(className)
 	if !found {
 		return false, make([]string, 0)
 	}
-	return true, ingNames.([]string)
+	return true, ingNSNames.([]string)
 }
 
 func (v *SvcNSCache) DeleteClassToIngMapping(className string) bool {
@@ -415,36 +415,36 @@ func (v *SvcNSCache) RemoveIngressMappings(ingName string) {
 	v.DeleteIngToSvcMapping(ingName)
 }
 
-func (v *SvcNSCache) RemoveIngressSecretMappings(ingName string) {
+func (v *SvcNSCache) RemoveIngressSecretMappings(ingNSName string) {
 	v.IngressLock.Lock()
 	defer v.IngressLock.Unlock()
 	// Get all the secrets for the ingress
-	ok, secrets := v.GetIngToSecret(ingName)
+	ok, secrets := v.GetIngToSecret(ingNSName)
 	// Iterate and remove this ingress from the secret mappings
 	if ok {
 		for _, secret := range secrets {
 			found, ingresses := v.GetSecretToIng(secret)
 			if found {
-				ingresses = utils.Remove(ingresses, ingName)
+				ingresses = utils.Remove(ingresses, ingNSName)
 				// Update the secret mapping
 				v.UpdateSecretToIngMapping(secret, ingresses)
 			}
 		}
 	}
 	// Remove the ingress from the ingress --> secret map
-	v.DeleteIngToSecretMapping(ingName)
+	v.DeleteIngToSecretMapping(ingNSName)
 }
 
-func (v *SvcNSCache) RemoveIngressClassMappings(ingName string) {
+func (v *SvcNSCache) RemoveIngressClassMappings(ingNSName string) {
 	v.IngressLock.Lock()
 	defer v.IngressLock.Unlock()
-	ok, class := v.GetIngToClass(ingName)
+	ok, class := v.GetIngToClass(ingNSName)
 	if ok {
 		found, ingresses := v.GetClassToIng(class)
 		if found {
-			ingresses = utils.Remove(ingresses, ingName)
+			ingresses = utils.Remove(ingresses, ingNSName)
 			v.UpdateClassToIngMapping(class, ingresses)
 		}
 	}
-	v.DeleteIngToClassMapping(ingName)
+	v.DeleteIngToClassMapping(ingNSName)
 }

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -219,7 +219,7 @@ func UpdateGatewayStatusObject(gw *advl4v1alpha1pre1.Gateway, updateStatus *advl
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 4 {
+		if retry >= 5 {
 			return errors.New("msg: UpdateGatewayStatus retried 5 times, aborting")
 		}
 	}
@@ -318,7 +318,7 @@ func getGateways(gwNSNames []string, bulk bool, retryNum ...int) map[string]*adv
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("msg: Retrying to get the gateway for status update")
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			utils.AviLog.Errorf("msg: getGateways for status update retried 3 times, aborting")
 			return gwMap
 		}

--- a/internal/status/crd_status.go
+++ b/internal/status/crd_status.go
@@ -37,7 +37,7 @@ func UpdateHostRuleStatus(hr *akov1alpha1.HostRule, updateStatus UpdateCRDStatus
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("msg: UpdateHostRuleStatus retried 3 times, aborting")
 		}
 	}
@@ -68,7 +68,7 @@ func UpdateHTTPRuleStatus(rr *akov1alpha1.HTTPRule, updateStatus UpdateCRDStatus
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("msg: UpdateHTTPRuleStatus retried 3 times, aborting")
 		}
 	}

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -65,7 +65,7 @@ func updateObject(mIngress *networkingv1beta1.Ingress, updateOption UpdateStatus
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("key: %s, msg: UpdateIngressStatus retried 3 times, aborting")
 		}
 	}
@@ -157,7 +157,7 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("key: %s, msg: Retrying to update the ingress status", key)
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("key: %s, msg: DeleteIngressStatus retried 3 times, aborting")
 		}
 	}
@@ -243,7 +243,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("msg: Retrying to get the ingress for status update")
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			utils.AviLog.Errorf("msg: getIngresses for status update retried 3 times, aborting")
 			return ingressMap
 		}

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -111,7 +111,7 @@ func getRoutes(routeNSNames []string, bulk bool, retryNum ...int) map[string]*ro
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("msg: Retrying to get the routes for status update")
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			utils.AviLog.Errorf("msg: getRoutes for status update retried 3 times, aborting")
 			return routeMap
 		}
@@ -159,7 +159,7 @@ func UpdateRouteStatusWithErrMsg(routeName, namespace, msg string, retryNum ...i
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("msg: UpdateRouteStatus retried 3 times, aborting")
 		}
 	}
@@ -236,7 +236,7 @@ func updateRouteObject(mRoute *routev1.Route, updateOption UpdateStatusOptions, 
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("key: %s, msg: UpdateRouteStatus retried 3 times, aborting")
 		}
 	}
@@ -372,7 +372,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("key: %s, msg: Retrying to update the route status", key)
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			return errors.New("key: %s, msg: DeleteRouteStatus retried 3 times, aborting")
 		}
 	}

--- a/internal/status/services_api_status.go
+++ b/internal/status/services_api_status.go
@@ -275,7 +275,7 @@ func UpdateSvcApiGatewayStatusObject(gw *svcapiv1alpha1.Gateway, updateStatus *s
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
-		if retry >= 4 {
+		if retry >= 5 {
 			return errors.New("msg: UpdateGatewayStatus retried 5 times, aborting")
 		}
 	}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -115,7 +115,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("msg: Retrying to get the services for status update")
 		retry = retryNum[0]
-		if retry >= 2 {
+		if retry >= 3 {
 			utils.AviLog.Errorf("msg: getServices for status update retried 3 times, aborting")
 			return serviceMap
 		}

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package hostnameshardtests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+)
+
+type FakeIngressClass struct {
+	Name       string
+	Controller string
+}
+
+func (gwclass FakeIngressClass) IngressClass() *networkingv1beta1.IngressClass {
+	ingressclass := &networkingv1beta1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gwclass.Name,
+		},
+		Spec: networkingv1beta1.IngressClassSpec{
+			Controller: gwclass.Controller,
+		},
+	}
+
+	return ingressclass
+}
+
+func SetupIngressClass(t *testing.T, gwclassName, controller string) {
+	ingclass := FakeIngressClass{
+		Name:       gwclassName,
+		Controller: controller,
+	}
+
+	ingClassCreate := ingclass.IngressClass()
+	if _, err := KubeClient.NetworkingV1beta1().IngressClasses().Create(context.TODO(), ingClassCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding IngressClass: %v", err)
+	}
+}
+
+func TeardownIngressClass(t *testing.T, ingClassName string) {
+	if err := KubeClient.NetworkingV1beta1().IngressClasses().Delete(context.TODO(), ingClassName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("error in deleting IngressClass: %v", err)
+	}
+}
+
+func VerifyVSNodeDeletion(g *gomega.WithT, modelName string) {
+	g.Eventually(func() interface{} {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		return aviModel
+	}, 30*time.Second).Should(gomega.BeNil())
+}
+
+// Ingress - IngressClass mapping tests
+
+func TestHostnameAdvL4WrongClassMappingInIngress(t *testing.T) {
+	// create ingclass, ingress
+	// update wrong mapping of class in ingress, VS deleted
+	// fix class in ingress, VS created
+	g := gomega.NewGomegaWithT(t)
+
+	integrationtest.RemoveDefaultIngressClass()
+
+	ingClassName, ingressName, ns := "avi-lb", "foo-with-class", "default"
+	modelName := "admin/cluster--Shared-L7-1"
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController)
+	SetUpTestForIngress(t, modelName)
+	ingressCreate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 20*time.Second).Should(gomega.Equal(1))
+
+	ingressUpdate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   "xyz",
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingressUpdate.ResourceVersion = "2"
+	if _, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs)
+	}, 60*time.Second).Should(gomega.Equal(0))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 20*time.Second).Should(gomega.Equal(0))
+
+	ingressUpdate2 := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingressUpdate.ResourceVersion = "3"
+	if _, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingressUpdate2, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	// vsNode must come back up
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs)
+	}, 60*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownTestForIngress(t, modelName)
+	TeardownIngressClass(t, ingClassName)
+	VerifyVSNodeDeletion(g, modelName)
+	integrationtest.AddDefaultIngressClass()
+}

--- a/tests/integrationtest/ingressclass_test.go
+++ b/tests/integrationtest/ingressclass_test.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package integrationtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+)
+
+type FakeIngressClass struct {
+	Name       string
+	Controller string
+}
+
+func (gwclass FakeIngressClass) IngressClass() *networkingv1beta1.IngressClass {
+	ingressclass := &networkingv1beta1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gwclass.Name,
+		},
+		Spec: networkingv1beta1.IngressClassSpec{
+			Controller: gwclass.Controller,
+		},
+	}
+
+	return ingressclass
+}
+
+func SetupIngressClass(t *testing.T, gwclassName, controller string) {
+	ingclass := FakeIngressClass{
+		Name:       gwclassName,
+		Controller: controller,
+	}
+
+	ingClassCreate := ingclass.IngressClass()
+	if _, err := KubeClient.NetworkingV1beta1().IngressClasses().Create(context.TODO(), ingClassCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding IngressClass: %v", err)
+	}
+}
+
+func TeardownIngressClass(t *testing.T, ingClassName string) {
+	if err := KubeClient.NetworkingV1beta1().IngressClasses().Delete(context.TODO(), ingClassName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("error in deleting IngressClass: %v", err)
+	}
+}
+
+func VerifyVSNodeDeletion(g *gomega.WithT, modelName string) {
+	g.Eventually(func() interface{} {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		return aviModel
+	}, 30*time.Second).Should(gomega.BeNil())
+}
+
+// Ingresss - IngressClass mapping tests
+
+func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
+	// create ingclass, ingress
+	// update wrong mapping of class in ingress, VS deleted
+	// fix class in ingress, VS created
+	g := gomega.NewGomegaWithT(t)
+
+	RemoveDefaultIngressClass()
+
+	ingClassName, ingressName, ns := "avi-lb", "foo-with-class", "default"
+	modelName := "admin/cluster--Shared-L7-6"
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController)
+	SetUpTestForIngress(t, modelName)
+	ingressCreate := (FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 5*time.Second).Should(gomega.Equal(1))
+
+	wrongIngressClassName := "xyz"
+	ingressCreate.Spec.IngressClassName = &wrongIngressClassName
+	ingressCreate.ResourceVersion = "2"
+	if _, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingressCreate, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs)
+	}, 60*time.Second).Should(gomega.Equal(0))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 25*time.Second).Should(gomega.Equal(0))
+
+	ingressCreate.Spec.IngressClassName = &ingClassName
+	ingressCreate.ResourceVersion = "3"
+	if _, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingressCreate, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	// vsNode must come back up
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs)
+	}, 60*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
+		return len(ingress.Status.LoadBalancer.Ingress)
+	}, 40*time.Second).Should(gomega.Equal(1))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownTestForIngress(t, modelName)
+	TeardownIngressClass(t, ingClassName)
+	VerifyVSNodeDeletion(g, modelName)
+	AddDefaultIngressClass()
+}

--- a/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
+++ b/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
@@ -240,28 +240,34 @@ func TestMultiVSIngressInNodePort(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 	PollForCompletion(t, model_Name, 5)
-	found, aviModel := objects.SharedAviGraphLister().Get(model_Name)
-	if found {
-		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-		g.Expect(len(nodes)).To(gomega.Equal(1))
-		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
-		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
-		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
-		g.Expect(len(dsNodes)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(1))
-		for _, pool := range nodes[0].PoolRefs {
-			// We should get two pools.
-			if strings.Contains(pool.Name, "foo.com.avi.internal_foo") {
-				g.Expect(pool.PriorityLabel).To(gomega.Equal("foo.com.avi.internal/foo"))
-				g.Expect(len(pool.Servers)).To(gomega.Equal(1))
-				// check if the port is set to nodeport and backed serverIP is pointing to nodeIP
-				g.Expect(pool.Port).To(gomega.Equal(nodePort))
-				g.Expect(pool.Servers[0].Ip.Addr).To(gomega.Equal(&nodeIP))
+
+	g.Eventually(func() int {
+		if found, aviModel := objects.SharedAviGraphLister().Get(model_Name); found && aviModel != nil {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+			if len(nodes) > 0 {
+				return len(nodes[0].PoolRefs)
 			}
 		}
-	} else {
-		t.Fatalf("Could not find model: %v", err)
+		return -1
+	}, 30*time.Second).Should(gomega.Equal(1))
+	_, aviModel := objects.SharedAviGraphLister().Get(model_Name)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+	dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+	g.Expect(len(dsNodes)).To(gomega.Equal(1))
+	for _, pool := range nodes[0].PoolRefs {
+		// We should get two pools.
+		if strings.Contains(pool.Name, "foo.com.avi.internal_foo") {
+			g.Expect(pool.PriorityLabel).To(gomega.Equal("foo.com.avi.internal/foo"))
+			g.Expect(len(pool.Servers)).To(gomega.Equal(1))
+			// check if the port is set to nodeport and backed serverIP is pointing to nodeIP
+			g.Expect(pool.Port).To(gomega.Equal(nodePort))
+			g.Expect(pool.Servers[0].Ip.Addr).To(gomega.Equal(&nodeIP))
+		}
 	}
+
 	randoming := (FakeIngress{
 		Name:        "foo-with-targets",
 		Namespace:   "randomNamespacethatyeildsdiff",
@@ -271,24 +277,34 @@ func TestMultiVSIngressInNodePort(t *testing.T) {
 		ServiceName: "avisvc",
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1beta1().Ingresses("randomNamespacethatyeildsdiff").Create(context.TODO(), randoming, metav1.CreateOptions{})
-	model_Name = "admin/cluster--Shared-L7-5"
-	PollForCompletion(t, model_Name, 5)
-	found, aviModel = objects.SharedAviGraphLister().Get(model_Name)
-	if found {
-		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-		g.Expect(len(nodes)).To(gomega.Equal(1))
-		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
-		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
-		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
-		g.Expect(len(dsNodes)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].PoolRefs[0].Servers)).To(gomega.Equal(0))
-	} else {
-		t.Fatalf("Could not find model: %v", err)
-	}
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
+
+	model_Name = "admin/cluster--Shared-L7-5"
+	PollForCompletion(t, model_Name, 5)
+	// time.Sleep(15 * time.Second)
+	// _, aviModel = objects.SharedAviGraphLister().Get(model_Name)
+	// nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	// fmt.Printf("HEY MAN %v\n", utils.Stringify(nodes))
+	g.Eventually(func() int {
+		if found, aviModel := objects.SharedAviGraphLister().Get(model_Name); found && aviModel != nil {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+			if len(nodes) > 0 && len(nodes[0].PoolRefs) > 0 {
+				return len(nodes[0].PoolRefs[0].Servers)
+			}
+		}
+		return -1
+	}, 30*time.Second).Should(gomega.Equal(0))
+	_, aviModel = objects.SharedAviGraphLister().Get(model_Name)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+	dsNodes = aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+	g.Expect(len(dsNodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(1))
+
 	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)

--- a/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
+++ b/tests/integrationtest/l4_l7_namespace_shard_nodeport_test.go
@@ -283,10 +283,6 @@ func TestMultiVSIngressInNodePort(t *testing.T) {
 
 	model_Name = "admin/cluster--Shared-L7-5"
 	PollForCompletion(t, model_Name, 5)
-	// time.Sleep(15 * time.Second)
-	// _, aviModel = objects.SharedAviGraphLister().Get(model_Name)
-	// nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	// fmt.Printf("HEY MAN %v\n", utils.Stringify(nodes))
 	g.Eventually(func() int {
 		if found, aviModel := objects.SharedAviGraphLister().Get(model_Name); found && aviModel != nil {
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()


### PR DESCRIPTION
Changing the controller in an existing IngressClass has not been covered in the UTs (the way it was covered for GatewayClass), since the action is blocked by k8s.

This also fixes two issues in IngressClass/Ingress with 
1) relating to removing cache mappings: ingress removal was not happening properly in ingressClass/ingress cache mappings
2) namespace shard VS naming: shard VS name was getting calculated based on IngressClass namespace ("")