### PR TITLE
passing cache layer keys to status update calls for logging

### DIFF
--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -148,12 +148,12 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 
 func InformerStatusUpdatesForGateway(key string, gateway *advl4v1alpha1pre1.Gateway) {
 	gwStatus := gateway.Status.DeepCopy()
-	defer status.UpdateGatewayStatusObject(gateway, gwStatus)
+	defer status.UpdateGatewayStatusObject(key, gateway, gwStatus)
 
 	status.InitializeGatewayConditions(gwStatus, &gateway.Spec, false)
 	gwClassObj, err := lib.GetAdvL4Informers().GatewayClassInformer.Lister().Get(gateway.Spec.Class)
 	if err != nil {
-		status.UpdateGatewayStatusGWCondition(gwStatus, &status.UpdateGWStatusConditionOptions{
+		status.UpdateGatewayStatusGWCondition(key, gwStatus, &status.UpdateGWStatusConditionOptions{
 			Type:    "Pending",
 			Status:  corev1.ConditionTrue,
 			Message: fmt.Sprintf("Corresponding networking.x-k8s.io/gatewayclass not found %s", gateway.Spec.Class),
@@ -170,7 +170,7 @@ func InformerStatusUpdatesForGateway(key string, gateway *advl4v1alpha1pre1.Gate
 		if !nameOk || !nsOk ||
 			(nameOk && gwName != gateway.Name) ||
 			(nsOk && gwNamespace != gateway.Namespace) {
-			status.UpdateGatewayStatusGWCondition(gwStatus, &status.UpdateGWStatusConditionOptions{
+			status.UpdateGatewayStatusGWCondition(key, gwStatus, &status.UpdateGWStatusConditionOptions{
 				Type:    "Pending",
 				Status:  corev1.ConditionTrue,
 				Message: "Incorrect gateway matchLabels configuration",
@@ -183,7 +183,7 @@ func InformerStatusUpdatesForGateway(key string, gateway *advl4v1alpha1pre1.Gate
 	// Additional check to see if the gatewayclass is a valid avi gateway class or not.
 	if gwClassObj.Spec.Controller != lib.AviGatewayController {
 		// Return an error since this is not our object.
-		status.UpdateGatewayStatusGWCondition(gwStatus, &status.UpdateGWStatusConditionOptions{
+		status.UpdateGatewayStatusGWCondition(key, gwStatus, &status.UpdateGWStatusConditionOptions{
 			Type:    "Pending",
 			Status:  corev1.ConditionTrue,
 			Message: fmt.Sprintf("Unable to identify controller %s", gwClassObj.Spec.Controller),
@@ -220,12 +220,12 @@ func checkSvcForGatewayPortConflict(svc *corev1.Service, key string) {
 			if len(val) > 1 {
 				portProtocolArr := strings.Split(portProtocol, "/")
 				gwStatus := gw.Status.DeepCopy()
-				status.UpdateGatewayStatusListenerConditions(gwStatus, portProtocolArr[1], &status.UpdateGWStatusConditionOptions{
+				status.UpdateGatewayStatusListenerConditions(key, gwStatus, portProtocolArr[1], &status.UpdateGWStatusConditionOptions{
 					Type:   "PortConflict",
 					Status: corev1.ConditionTrue,
 					Reason: fmt.Sprintf("conflicting port configuration provided in service %s and %s/%s", val, svc.Namespace, svc.Name),
 				})
-				status.UpdateGatewayStatusObject(gw, gwStatus)
+				status.UpdateGatewayStatusObject(key, gw, gwStatus)
 				return
 			}
 		}
@@ -253,12 +253,12 @@ func checkGWForGatewayPortConflict(key string, gw *advl4v1alpha1pre1.Gateway) {
 
 		if val, ok := gwSvcListeners[portProtoGW]; ok && len(val) > 1 {
 			gwStatus := gw.Status.DeepCopy()
-			status.UpdateGatewayStatusListenerConditions(gwStatus, strconv.Itoa(int(listener.Port)), &status.UpdateGWStatusConditionOptions{
+			status.UpdateGatewayStatusListenerConditions(key, gwStatus, strconv.Itoa(int(listener.Port)), &status.UpdateGWStatusConditionOptions{
 				Type:   "PortConflict",
 				Status: corev1.ConditionTrue,
 				Reason: fmt.Sprintf("conflicting port configuration provided in service %s and %v", val, gwSvcListeners[portProtoGW]),
 			})
-			status.UpdateGatewayStatusObject(gw, gwStatus)
+			status.UpdateGatewayStatusObject(key, gw, gwStatus)
 			return
 		}
 	}
@@ -268,12 +268,12 @@ func checkGWForGatewayPortConflict(key string, gw *advl4v1alpha1pre1.Gateway) {
 		svcProtocol := strings.Split(portProto, "/")[0]
 		if !utils.HasElem(gwProtocols, svcProtocol) {
 			gwStatus := gw.Status.DeepCopy()
-			status.UpdateGatewayStatusListenerConditions(gwStatus, strings.Split(portProto, "/")[1], &status.UpdateGWStatusConditionOptions{
+			status.UpdateGatewayStatusListenerConditions(key, gwStatus, strings.Split(portProto, "/")[1], &status.UpdateGWStatusConditionOptions{
 				Type:   "UnsupportedProtocol",
 				Status: corev1.ConditionTrue,
 				Reason: fmt.Sprintf("Unsupported protocol found in services %v", svcs),
 			})
-			status.UpdateGatewayStatusObject(gw, gwStatus)
+			status.UpdateGatewayStatusObject(key, gw, gwStatus)
 			return
 		}
 	}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -283,7 +283,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
 			bkt := utils.Bkt(namespace, numWorkers)
 			if !lib.HasValidBackends(route.Spec, route.Name, namespace, key) {
-				status.UpdateRouteStatusWithErrMsg(route.Name, namespace, lib.DuplicateBackends)
+				status.UpdateRouteStatusWithErrMsg(key, route.Name, namespace, lib.DuplicateBackends)
 			}
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -332,7 +332,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 				key := utils.OshiftRoute + "/" + utils.ObjKey(newRoute)
 				bkt := utils.Bkt(namespace, numWorkers)
 				if !lib.HasValidBackends(newRoute.Spec, newRoute.Name, namespace, key) {
-					status.UpdateRouteStatusWithErrMsg(newRoute.Name, namespace, lib.DuplicateBackends)
+					status.UpdateRouteStatusWithErrMsg(key, newRoute.Name, namespace, lib.DuplicateBackends)
 				}
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -130,7 +130,7 @@ func BuildL7HostRule(host, namespace, ingName, key string, vsNode *AviVsNode) {
 	vsNode.Enabled = vsEnabled
 	vsNode.ServiceMetadata.CRDStatus = crdStatus
 
-	utils.AviLog.Infof("key: %s, Attached hostrule %s on vsNode %s", key, host, vsNode.Name)
+	utils.AviLog.Infof("key: %s, Attached hostrule %s on vsNode %s", key, hrNamespaceName, vsNode.Name)
 }
 
 // BuildPoolHTTPRule notes
@@ -263,7 +263,7 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 	foundHost, foundHR := objects.SharedCRDLister().GetFQDNToHostruleMapping(fqdn)
 	if foundHost && foundHR != hostrule.Namespace+"/"+hostrule.Name {
 		err = fmt.Errorf("duplicate fqdn %s found in %s", fqdn, foundHR)
-		status.UpdateHostRuleStatus(hostrule, status.UpdateCRDStatusOptions{
+		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{
 			Status: lib.StatusRejected,
 			Error:  err.Error(),
 		})
@@ -294,14 +294,14 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 		}
 
 		if errStatus := checkRefOnController(key, value, k); errStatus != nil {
-			status.UpdateHostRuleStatus(hostrule, status.UpdateCRDStatusOptions{
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{
 				Status: lib.StatusRejected,
 				Error:  errStatus.Error(),
 			})
 			return errStatus
 		}
 	}
-	status.UpdateHostRuleStatus(hostrule, status.UpdateCRDStatusOptions{
+	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{
 		Status: lib.StatusAccepted,
 		Error:  "",
 	})
@@ -326,7 +326,7 @@ func validateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
 		}
 
 		if errStatus := checkRefOnController(key, value, k); errStatus != nil {
-			status.UpdateHTTPRuleStatus(httprule, status.UpdateCRDStatusOptions{
+			status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
 				Status: lib.StatusRejected,
 				Error:  errStatus.Error(),
 			})
@@ -334,7 +334,7 @@ func validateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
 		}
 	}
 
-	status.UpdateHTTPRuleStatus(httprule, status.UpdateCRDStatusOptions{
+	status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
 		Status: lib.StatusAccepted,
 		Error:  "",
 	})

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -879,13 +879,13 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 					}
 
 					gwStatus := gw.Status.DeepCopy()
-					status.UpdateGatewayStatusGWCondition(gwStatus, &status.UpdateGWStatusConditionOptions{
+					status.UpdateGatewayStatusGWCondition(key, gwStatus, &status.UpdateGWStatusConditionOptions{
 						Type:    "Pending",
 						Status:  corev1.ConditionTrue,
 						Reason:  "InvalidAddress",
 						Message: rest_op.Message,
 					})
-					status.UpdateGatewayStatusObject(gw, gwStatus)
+					status.UpdateGatewayStatusObject(key, gw, gwStatus)
 
 				} else if lib.UseServicesAPI() {
 					gw, err := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways(gwNSName[0]).Get(gwNSName[1])
@@ -895,13 +895,13 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 					}
 
 					gwStatus := gw.Status.DeepCopy()
-					status.UpdateSvcApiGatewayStatusGWCondition(gwStatus, &status.UpdateSvcApiGWStatusConditionOptions{
+					status.UpdateSvcApiGatewayStatusGWCondition(key, gwStatus, &status.UpdateSvcApiGWStatusConditionOptions{
 						Type:    "Pending",
 						Status:  metav1.ConditionTrue,
 						Reason:  "InvalidAddress",
 						Message: rest_op.Message,
 					})
-					status.UpdateSvcApiGatewayStatusObject(gw, gwStatus)
+					status.UpdateSvcApiGatewayStatusObject(key, gw, gwStatus)
 				}
 				utils.AviLog.Warnf("key: %s, msg: IPAddress Updates on gateway not supported, Please recreate gateway object with the new preferred IPAddress", key)
 				return errors.New(rest_op.Message)

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -34,7 +34,7 @@ func UpdateL4LBStatus(options []UpdateStatusOptions, bulk bool) {
 
 	for _, option := range options {
 		if len(option.ServiceMetadata.HostNames) != 1 && !lib.GetAdvancedL4() {
-			utils.AviLog.Warnf("Service hostname not found for service %v status update", option.ServiceMetadata.NamespaceServiceName)
+			utils.AviLog.Warnf("key: %s, msg: Service hostname not found for service %v status update", option.Key, option.ServiceMetadata.NamespaceServiceName)
 		}
 
 		for _, svc := range option.ServiceMetadata.NamespaceServiceName {
@@ -113,10 +113,10 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 	mClient := utils.GetInformers().ClientSet
 	serviceMap := make(map[string]*corev1.Service)
 	if len(retryNum) > 0 {
-		utils.AviLog.Infof("msg: Retrying to get the services for status update")
+		utils.AviLog.Infof("Retrying to get the services for status update")
 		retry = retryNum[0]
 		if retry >= 3 {
-			utils.AviLog.Errorf("msg: getServices for status update retried 3 times, aborting")
+			utils.AviLog.Errorf("getServices for status update retried 3 times, aborting")
 			return serviceMap
 		}
 	}
@@ -142,7 +142,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 		nsNameSplit := strings.Split(namespaceName, "/")
 		serviceLB, err := mClient.CoreV1().Services(nsNameSplit[0]).Get(context.TODO(), nsNameSplit[1], metav1.GetOptions{})
 		if err != nil {
-			utils.AviLog.Warnf("msg: Could not get the service object for UpdateStatus: %s", err)
+			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
 			// retry get if request timeout
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
 				return getServices(serviceNSNames, bulk, retry+1)


### PR DESCRIPTION
This commit sanitises some of the status package logs and makes sure that we pass and log the REST layer keys to the logs.