### PR TITLE
Introducing NodePortLocal in AKO

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -348,10 +348,6 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			if c.DisableSync {
 				return
 			}
-			if lib.IsNodePortMode() {
-				utils.AviLog.Debugf("skipping Pod for nodeport mode")
-				return
-			}
 			pod := obj.(*corev1.Pod)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
@@ -361,10 +357,6 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 		},
 		DeleteFunc: func(obj interface{}) {
 			if c.DisableSync {
-				return
-			}
-			if lib.IsNodePortMode() {
-				utils.AviLog.Debugf("skipping Pod for nodeport mode")
 				return
 			}
 			pod, ok := obj.(*corev1.Pod)
@@ -393,10 +385,6 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			oldPod := old.(*corev1.Pod)
 			newPod := cur.(*corev1.Pod)
 			if !reflect.DeepEqual(newPod, oldPod) {
-				if lib.IsNodePortMode() {
-					utils.AviLog.Debugf("skipping Pod for nodeport mode")
-					return
-				}
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newPod))
 				key := utils.Pod + "/" + utils.ObjKey(oldPod)
 				bkt := utils.Bkt(namespace, numWorkers)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -68,6 +68,7 @@ const (
 	PolicyPass                                 = "PASSTHROUGH"
 	DeleteConfig                               = "deleteConfig"
 	NodePort                                   = "NodePort"
+	NodePortLocal                              = "NodePortLocal"
 	RouteSecretsPrefix                         = "-route-secret"
 	CertTypeVS                                 = "SSL_CERTIFICATE_TYPE_VIRTUALSERVICE"
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
@@ -108,6 +109,7 @@ const (
 	ObjectDeletionTimeoutStatus                = "Timeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
 	DefaultRouteCert                           = "router-certs-default"
+	NPLPodAnnotation                           = "nodeportlocal.antrea.io"
 
 	//Specifies command used in namespace event handler
 	NsFilterAdd    = "ADD"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -490,6 +490,11 @@ func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Cl
 		utils.ConfigMapInformer,
 		utils.PodInformer,
 	}
+
+	if GetServiceType() == NodePortLocal {
+		allInformers = append(allInformers, utils.PodInformer)
+	}
+
 	if !GetAdvancedL4() {
 		allInformers = append(allInformers, utils.NSInformer)
 		allInformers = append(allInformers, utils.NodeInformer)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -488,6 +488,7 @@ func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Cl
 		utils.EndpointInformer,
 		utils.SecretInformer,
 		utils.ConfigMapInformer,
+		utils.PodInformer,
 	}
 	if !GetAdvancedL4() {
 		allInformers = append(allInformers, utils.NSInformer)
@@ -526,6 +527,10 @@ func IsNodePortMode() bool {
 		return true
 	}
 	return false
+}
+
+func GetServiceType() string {
+	return os.Getenv(SERVICE_TYPE)
 }
 
 func GetNodePortsSelector() map[string]string {

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -15,14 +15,24 @@
 package lib
 
 import (
+	"context"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+type NPLAnnotation struct {
+	PodPort  int    `json:"podPort"`
+	NodeIP   string `json:"nodeIP"`
+	NodePort int    `json:"nodePort"`
+}
 
 func ExtractTypeNameNamespace(key string) (string, string, string) {
 	segments := strings.Split(key, "/")
@@ -78,4 +88,69 @@ func GetSvcKeysForNodeCRUD() (svcl4Keys []string, svcl7Keys []string) {
 	}
 	return svcl4Keys, svcl7Keys
 
+}
+
+func GetPodsFromService(namespace, serviceName string) []utils.NamespaceName {
+	var pods []utils.NamespaceName
+	svcKey := namespace + "/" + serviceName
+	svc, err := utils.GetInformers().ClientSet.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return pods
+		}
+		if found, podsIntf := objects.SharedSvcToPodLister().Get(svcKey); found {
+			savedPods, ok := podsIntf.([]utils.NamespaceName)
+			if ok {
+				return savedPods
+			}
+		}
+		return pods
+	}
+
+	if len(svc.Spec.Selector) == 0 {
+		return pods
+	}
+
+	podList, err := utils.GetInformers().PodInformer.Lister().Pods(namespace).List(labels.SelectorFromSet(labels.Set(svc.Spec.Selector)))
+	if err != nil {
+		utils.AviLog.Warnf("Got error while listing Pods with selector %v: %v", svc.Spec.Selector, err)
+		return pods
+	}
+	for _, pod := range podList {
+		pods = append(pods, utils.NamespaceName{Namespace: pod.Namespace, Name: pod.Name})
+	}
+
+	objects.SharedSvcToPodLister().Save(svcKey, pods)
+	return pods
+}
+
+func GetServicesForPod(pod *corev1.Pod) []string {
+	var svcList []string
+	services, err := utils.GetInformers().ServiceInformer.Lister().List(labels.Everything())
+	if err != nil {
+		utils.AviLog.Warnf("Got error while listing Services with NPL annotation: %v", err)
+		return svcList
+	}
+
+	for _, svc := range services {
+		if svc.Spec.Type != corev1.ServiceTypeNodePort {
+			if matchSvcSelectorPodLabels(svc.Spec.Selector, pod.GetLabels()) {
+				svcList = append(svcList, svc.Namespace+"/"+svc.Name)
+			}
+		}
+	}
+	return svcList
+}
+
+func matchSvcSelectorPodLabels(svcSelector, podLabel map[string]string) bool {
+	if len(svcSelector) == 0 {
+		return false
+	}
+
+	for selectorKey, selectorVal := range svcSelector {
+		if labelVal, ok := podLabel[selectorKey]; !ok || selectorVal != labelVal {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -15,7 +15,6 @@
 package lib
 
 import (
-	"context"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +23,6 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -93,7 +91,7 @@ func GetSvcKeysForNodeCRUD() (svcl4Keys []string, svcl7Keys []string) {
 func GetPodsFromService(namespace, serviceName string) []utils.NamespaceName {
 	var pods []utils.NamespaceName
 	svcKey := namespace + "/" + serviceName
-	svc, err := utils.GetInformers().ClientSet.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	svc, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(serviceName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return pods

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
+	"github.com/avinetworks/sdk/go/models"
 	avimodels "github.com/avinetworks/sdk/go/models"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -114,12 +115,17 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 		poolNode := &AviPoolNode{Name: lib.GetL4PoolName(vsNode.Name, filterPort), Tenant: lib.GetTenant(), Protocol: portProto.Protocol, PortName: portProto.Name}
 		poolNode.VrfContext = lib.GetVrf()
 
-		if !lib.IsNodePortMode() {
-			if servers := PopulateServers(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+		serviceType := lib.GetServiceType()
+		if serviceType == lib.NodePortLocal {
+			if servers := PopulateServersForNPL(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+				poolNode.Servers = servers
+			}
+		} else if serviceType == lib.NodePort {
+			if servers := PopulateServersForNodePort(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
 				poolNode.Servers = servers
 			}
 		} else {
-			if servers := PopulateServersForNodePort(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+			if servers := PopulateServers(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
 				poolNode.Servers = servers
 			}
 		}
@@ -142,6 +148,59 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 	vsNode.L4PolicyRefs = l4Policies
 	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
 
+}
+
+func PopulateServersForNPL(poolNode *AviPoolNode, ns string, serviceName string, ingress bool, key string) []AviPoolMetaServer {
+	if ingress {
+		found, _ := objects.SharedClusterIpLister().Get(ns + "/" + serviceName)
+		if !found {
+			utils.AviLog.Warnf("key: %s, msg: service pointed by the ingress object is not found in ClusterIP store", key)
+			return nil
+		}
+	}
+	pods := lib.GetPodsFromService(ns, serviceName)
+
+	var poolMeta []AviPoolMetaServer
+	svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(ns).Get(serviceName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: error in obtaining the object for service: %s", key, serviceName)
+		return poolMeta
+	}
+
+	targetPorts := make(map[int]bool)
+	for _, port := range svcObj.Spec.Ports {
+		if port.Name != poolNode.PortName && len(svcObj.Spec.Ports) != 1 {
+			// continue only if port name does not match and it is multiport svcobj
+			continue
+		}
+		targetPorts[port.TargetPort.IntValue()] = true
+	}
+
+	for _, pod := range pods {
+		var annotations []lib.NPLAnnotation
+		found, obj := objects.SharedNPLLister().Get(ns + "/" + pod.Name)
+		if !found {
+			continue
+		}
+		annotations = obj.([]lib.NPLAnnotation)
+		for _, a := range annotations {
+			var atype string
+			if utils.IsV4(a.NodeIP) {
+				atype = "V4"
+			} else {
+				atype = "V6"
+			}
+			server := AviPoolMetaServer{
+				Port: int32(a.NodePort),
+				Ip: models.IPAddr{
+					Addr: &a.NodeIP,
+					Type: &atype,
+				}}
+			poolMeta = append(poolMeta, server)
+		}
+	}
+	utils.AviLog.Infof("key: %s, msg: servers for port: %v, are: %v", key, poolNode.Port, utils.Stringify(poolMeta))
+	return poolMeta
 }
 
 func PopulateServersForNodePort(poolNode *AviPoolNode, ns string, serviceName string, ingress bool, key string) []AviPoolMetaServer {

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -96,12 +96,17 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 				},
 			}
 			poolNode.VrfContext = lib.GetVrf()
-			if !lib.IsNodePortMode() {
-				if servers := PopulateServers(poolNode, namespace, obj.ServiceName, true, key); servers != nil {
+			serviceType := lib.GetServiceType()
+			if serviceType == lib.NodePortLocal {
+				if servers := PopulateServersForNPL(poolNode, namespace, obj.ServiceName, true, key); servers != nil {
+					poolNode.Servers = servers
+				}
+			} else if serviceType == lib.NodePort {
+				if servers := PopulateServersForNodePort(poolNode, namespace, obj.ServiceName, true, key); servers != nil {
 					poolNode.Servers = servers
 				}
 			} else {
-				if servers := PopulateServersForNodePort(poolNode, namespace, obj.ServiceName, true, key); servers != nil {
+				if servers := PopulateServers(poolNode, namespace, obj.ServiceName, true, key); servers != nil {
 					poolNode.Servers = servers
 				}
 			}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1021,6 +1021,7 @@ func (o *AviObjectGraph) GetAviPoolNodeByName(poolname string) *AviPoolNode {
 type AviPoolMetaServer struct {
 	Ip         avimodels.IPAddr
 	ServerNode string
+	Port       int32
 }
 
 type IngressHostPathSvc struct {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -15,7 +15,6 @@
 package nodes
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -26,7 +25,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func DequeueIngestion(key string, fullsync bool) {
@@ -165,7 +163,7 @@ func DequeueIngestion(key string, fullsync bool) {
 // It also stores a mapping of Pod to Services for future use
 func handlePod(key, namespace, podName string) {
 	podKey := namespace + "/" + podName
-	pod, err := utils.GetInformers().ClientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := utils.GetInformers().PodInformer.Lister().Pods(namespace).Get(podName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			objects.SharedNPLLister().Delete(podKey)

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -59,7 +59,6 @@ var (
 	Pod = GraphSchema{
 		Type:               "Pod",
 		GetParentIngresses: PodToIng,
-		GetParentRoutes:    PodToRoute,
 	}
 	Node = GraphSchema{
 		Type:               "Node",
@@ -219,27 +218,6 @@ func SvcToGateway(svcName string, namespace string, key string) ([]string, bool)
 
 	utils.AviLog.Infof("key: %s, msg: Gateways retrieved %v", key, allGateways)
 	return allGateways, true
-}
-
-// PodToRoute fetches the list of impacted Routes from Pod update.
-// First fetch list of Services for the Pod.
-// Then get list of Routes for the services.
-func PodToRoute(podName string, namespace string, key string) ([]string, bool) {
-	var allRoutes []string
-	podKey := namespace + "/" + podName
-	ok, servicesIntf := objects.SharedPodToSvcLister().Get(podKey)
-	if !ok {
-		return allRoutes, false
-	}
-	services := servicesIntf.([]string)
-	utils.AviLog.Debugf("key: %s, msg: services retrieved:  %s", key, services)
-	for _, svc := range services {
-		_, svcName := utils.ExtractNamespaceObjectName(svc)
-		routes, _ := SvcToRoute(svcName, namespace, key)
-		allRoutes = append(allRoutes, routes...)
-	}
-	utils.AviLog.Debugf("key: %s, msg: Routes retrieved:  %s", key, allRoutes)
-	return allRoutes, true
 }
 
 func EPToRoute(epName string, namespace string, key string) ([]string, bool) {

--- a/internal/objects/npl.go
+++ b/internal/objects/npl.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package objects
+
+import (
+	"sync"
+)
+
+var nplInstance *NPLLister
+var nplOnce sync.Once
+
+func SharedNPLLister() *NPLLister {
+	nplOnce.Do(func() {
+		store := NewObjectMapStore()
+		nplInstance = &NPLLister{}
+		nplInstance.store = store
+	})
+	return nplInstance
+}
+
+// NPLLister stores a list of NPL annotations for a pod
+type NPLLister struct {
+	store *ObjectMapStore
+}
+
+func (a *NPLLister) Save(key string, val interface{}) {
+	a.store.AddOrUpdate(key, val)
+}
+
+func (a *NPLLister) Get(key string) (bool, interface{}) {
+	ok, obj := a.store.Get(key)
+	return ok, obj
+}
+
+func (a *NPLLister) GetAll() interface{} {
+	obj := a.store.GetAllObjectNames()
+	return obj
+}
+
+func (a *NPLLister) Delete(key string) {
+	a.store.Delete(key)
+
+}
+
+var podSvcInstance *PodSvcLister
+var podSvcOnce sync.Once
+
+func SharedPodToSvcLister() *PodSvcLister {
+	podSvcOnce.Do(func() {
+		store := NewObjectMapStore()
+		podSvcInstance = &PodSvcLister{}
+		podSvcInstance.store = store
+	})
+	return podSvcInstance
+}
+
+// PodSvcLister stores list of services for a pod.
+// For all these services, the Pod acts a backend through matching selector
+type PodSvcLister struct {
+	store *ObjectMapStore
+}
+
+func (a *PodSvcLister) Save(key string, val interface{}) {
+	a.store.AddOrUpdate(key, val)
+}
+
+func (a *PodSvcLister) Get(key string) (bool, interface{}) {
+	ok, obj := a.store.Get(key)
+	return ok, obj
+}
+
+func (a *PodSvcLister) GetAll() interface{} {
+	obj := a.store.GetAllObjectNames()
+	return obj
+}
+
+func (a *PodSvcLister) Delete(key string) {
+	a.store.Delete(key)
+}
+
+var svcPodInstance *SvcPodLister
+var svcPodOnce sync.Once
+
+func SharedSvcToPodLister() *SvcPodLister {
+	svcPodOnce.Do(func() {
+		store := NewObjectMapStore()
+		svcPodInstance = &SvcPodLister{}
+		svcPodInstance.store = store
+	})
+	return svcPodInstance
+}
+
+// SvcPodLister stores list of pods for a service with matching label selector
+type SvcPodLister struct {
+	store *ObjectMapStore
+}
+
+func (a *SvcPodLister) Save(key string, val interface{}) {
+	a.store.AddOrUpdate(key, val)
+}
+
+func (a *SvcPodLister) Get(key string) (bool, interface{}) {
+	ok, obj := a.store.Get(key)
+	return ok, obj
+}
+
+func (a *SvcPodLister) GetAll() interface{} {
+	obj := a.store.GetAllObjectNames()
+	return obj
+}
+
+func (a *SvcPodLister) Delete(key string) {
+	a.store.Delete(key)
+}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -110,9 +110,12 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		}
 	}
 
-	for _, server := range pool_meta.Servers {
-		sip := server.Ip
+	for i, server := range pool_meta.Servers {
 		port := pool_meta.Port
+		sip := server.Ip
+		if server.Port != 0 {
+			port = pool_meta.Servers[i].Port
+		}
 		s := avimodels.Server{IP: &sip, Port: &port}
 		if server.ServerNode != "" {
 			sn := server.ServerNode

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -35,6 +35,7 @@ const (
 	NSInformer                    = "NamespaceInformer"
 	L4LBService                   = "L4LBService"
 	LoadBalancer                  = "LoadBalancer"
+	Pod                           = "Pod"
 	Endpoints                     = "Endpoints"
 	Ingress                       = "Ingress"
 	IngressClass                  = "IngressClass"


### PR DESCRIPTION
In this first set of changes, addition of pool servers from NPL annotation
of Pod is handled.

- A new service type NodePortLocal is introduced. When this is set,
  servers would be populated from NPL annotation of POD.

- New PodInformers would be started only when this flag is set.

- New store objects are created to store NPL annotation per pod, and
  mapping between Pods and Services.

Not handled in this set of changes:
- Automatic annotation of services from ingresses for NPL
- Mapping between gateway and POD
- CNI verification