### PR TITLE
Fix typo in sample AKOConfig

### DIFF
--- a/ako-operator/config/samples/ako_v1alpha1_akoconfig.yaml
+++ b/ako-operator/config/samples/ako_v1alpha1_akoconfig.yaml
@@ -33,7 +33,7 @@ spec:
     advancedL4: false
     defaultDomain: ""
 
-  ControllerSettings:
+  controllerSettings:
     serviceEngineGroupName: "Default-Group"
     controllerVersion: "20.1.1"
     cloudName: "Default-Cloud"


### PR DESCRIPTION
The typo causes the controller settings to be set to empty, which in turn makes the ako pod fail to detect the controller.