### PR TITLE
Fix nsxalbsetting CRD

### DIFF
--- a/helm/ako/crds/nsxalbinfrasettings.yaml
+++ b/helm/ako/crds/nsxalbinfrasettings.yaml
@@ -27,7 +27,6 @@ spec:
                 properties:
                   name:
                     type: string
-                properties:
                   rhi:
                     type: boolean
                 type: object
@@ -60,8 +59,6 @@ spec:
               status:
                 type: string
             type: object
-        required:
-        - network
         type: object
     additionalPrinterColumns:
     - description: status of the nas object

--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -33,7 +33,7 @@ rules:
     resources: ["routes", "routes/status"]
     verbs: ["get", "watch", "list", "patch", "update"]
   - apiGroups: ["ako.vmware.com"]
-    resources: ["hostrules", "hostrules/status", "httprules", "httprules/status"]
+    resources: ["hostrules", "hostrules/status", "httprules", "httprules/status", "nsxalbinfrasettings", "nsxalbinfrasettings/status"]
     verbs: ["get","watch","list","patch", "update"]
   - apiGroups: ["networking.x-k8s.io"]
     resources: ["gateways", "gateways/status", "gatewayclasses", "gatewayclasses/status"]

--- a/tests/oshiftroutetests/oshift_crd_test.go
+++ b/tests/oshiftroutetests/oshift_crd_test.go
@@ -241,7 +241,7 @@ func TestOshiftMultiRouteToSecureHostRule(t *testing.T) {
 			}
 		}
 		return false
-	}, 30*time.Second).Should(gomega.Equal(true))
+	}, 60*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisahostruleref-sslkey"))


### PR DESCRIPTION
This makes two fixes:
 - Removes `network` being mandatory field.
 - Corrects the schema for the `network` section of the CRD