### PR TITLE
Granular RBAC support with AKO

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -63,11 +63,12 @@ func SharedAVIClients() *utils.AviRestClientPool {
 					SetTenant(client.AviSession)
 
 					controllerVersion := utils.CtrlVersion
-					if lib.GetAdvancedL4() && lib.CheckControllerVersionCompatibility(controllerVersion, lib.Advl4ControllerVersion) {
+					if lib.GetAdvancedL4() && lib.CheckControllerVersionCompatibility(controllerVersion, lib.Advl4ControllerVersion, ">") {
 						// for advancedL4 make sure the controller api version is set to a max version value of 20.1.2
 						controllerVersion = lib.Advl4ControllerVersion
 					}
-
+					//Set GRBAC Flag
+					lib.SetEnableGRBAC(controllerVersion)
 					utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
 					SetVersion := session.SetVersion(controllerVersion)
 					SetVersion(client.AviSession)

--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -63,7 +63,7 @@ func SharedAVIClients() *utils.AviRestClientPool {
 					SetTenant(client.AviSession)
 
 					controllerVersion := utils.CtrlVersion
-					if lib.GetAdvancedL4() && lib.CheckControllerVersionCompatibility(controllerVersion, lib.Advl4ControllerVersion, ">") {
+					if lib.GetAdvancedL4() && lib.CheckControllerVersionCompatibility(controllerVersion, ">", lib.Advl4ControllerVersion) {
 						// for advancedL4 make sure the controller api version is set to a max version value of 20.1.2
 						controllerVersion = lib.Advl4ControllerVersion
 					}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1425,19 +1425,6 @@ func (c *AviObjCache) PopulateSSLKeyToCache(client *clients.AviClient, cloud str
 				utils.AviLog.Warnf("Wrong data type for ssl key: %s in cache", k)
 			}
 		}
-		var cacert string
-		// Find CA Cert name from the cache for checksum calculation.
-		if SslKeyData[i].HasCARef {
-			ca, found := c.SSLKeyCache.AviCacheGetNameByUuid(SslKeyCacheObj.CACertUUID)
-			if !found {
-				utils.AviLog.Warnf("cacertUUID %s for keycert %s not found in cache", SslKeyCacheObj.CACertUUID, SslKeyCacheObj.Name)
-			} else {
-				cacert = ca.(string)
-			}
-		}
-		//TODO: Check with team : What is reason of recomputing checksum here again.
-		SslKeyData[i].CloudConfigCksum = lib.SSLKeyCertChecksum(SslKeyCacheObj.Name, SslKeyCacheObj.Cert, cacert)
-		SslKeyData[i].CloudConfigCksum += lib.GetClusterLabelChecksum()
 		utils.AviLog.Debugf("Adding key to sslkey cache :%s", k)
 		c.SSLKeyCache.AviCacheAdd(k, &SslKeyData[i])
 		delete(sslCacheData, k)

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -461,12 +461,15 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 			utils.AviLog.Warnf("Incomplete pki data unmarshalled, %s", utils.Stringify(pki))
 			continue
 		}
-
+		checksum := lib.SSLKeyCertChecksum(*pki.Name, string(*pki.CaCerts[0].Certificate), "")
+		if lib.GetEnableGRBAC() && pki.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(pki.Labels)
+		}
 		pkiCacheObj := AviPkiProfileCache{
 			Name:             *pki.Name,
 			Uuid:             *pki.UUID,
 			Tenant:           lib.GetTenant(),
-			CloudConfigCksum: lib.SSLKeyCertChecksum(*pki.Name, string(*pki.CaCerts[0].Certificate), ""),
+			CloudConfigCksum: checksum,
 		}
 		*pkiData = append(*pkiData, pkiCacheObj)
 
@@ -655,6 +658,7 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 		}
 
 		var fqdns []string
+		var checksum string
 		for _, dnsinfo := range vsvip.DNSInfo {
 			fqdns = append(fqdns, *dnsinfo.Fqdn)
 		}
@@ -671,13 +675,18 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 			}
 		}
 
+		if vsvip.VsvipCloudConfigCksum != nil {
+			checksum = *vsvip.VsvipCloudConfigCksum
+		}
+
 		vsVipCacheObj := AviVSVIPCache{
-			Name:         *vsvip.Name,
-			Uuid:         *vsvip.UUID,
-			FQDNs:        fqdns,
-			NetworkName:  networkName,
-			LastModified: *vsvip.LastModified,
-			Vips:         vips,
+			Name:             *vsvip.Name,
+			Uuid:             *vsvip.UUID,
+			FQDNs:            fqdns,
+			NetworkName:      networkName,
+			LastModified:     *vsvip.LastModified,
+			Vips:             vips,
+			CloudConfigCksum: checksum,
 		}
 		*vsVipData = append(*vsVipData, vsVipCacheObj)
 	}
@@ -775,7 +784,11 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 			Uuid:       *ds.UUID,
 			PoolGroups: pgs,
 		}
-		dsCacheObj.CloudConfigCksum = lib.DSChecksum(dsCacheObj.PoolGroups)
+		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
+		if lib.GetEnableGRBAC() && ds.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		}
+		dsCacheObj.CloudConfigCksum = checksum
 		*DsData = append(*DsData, dsCacheObj)
 	}
 	if result.Next != "" {
@@ -870,6 +883,9 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
+		if lib.GetEnableGRBAC() && sslkey.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
+		}
 		sslCacheObj := AviSSLCache{
 			Name:             *sslkey.Name,
 			Uuid:             *sslkey.UUID,
@@ -941,6 +957,9 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
+		if lib.GetEnableGRBAC() && sslkey.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
+		}
 		sslCacheObj := AviSSLCache{
 			Name:             *sslkey.Name,
 			Uuid:             *sslkey.UUID,
@@ -988,6 +1007,9 @@ func (c *AviObjCache) AviPopulateOnePKICache(client *clients.AviClient,
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pkikey.Name, *pkikey.CaCerts[0].Certificate, "")
+		if lib.GetEnableGRBAC() && pkikey.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(pkikey.Labels)
+		}
 		sslCacheObj := AviSSLCache{
 			Name:             *pkikey.Name,
 			Uuid:             *pkikey.UUID,
@@ -1114,7 +1136,11 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 			Uuid:       *ds.UUID,
 			PoolGroups: pgs,
 		}
-		dsCacheObj.CloudConfigCksum = lib.DSChecksum(dsCacheObj.PoolGroups)
+		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
+		if lib.GetEnableGRBAC() && ds.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		}
+		dsCacheObj.CloudConfigCksum = checksum
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *ds.Name}
 		c.DSCache.AviCacheAdd(k, &dsCacheObj)
 		utils.AviLog.Debugf("Adding ds to Cache during refresh %s\n", k)
@@ -1214,6 +1240,7 @@ func (c *AviObjCache) AviPopulateOneVsVipCache(client *clients.AviClient,
 			continue
 		}
 		var fqdns []string
+		var checksum string
 		for _, dnsinfo := range vsvip.DNSInfo {
 			fqdns = append(fqdns, *dnsinfo.Fqdn)
 		}
@@ -1231,13 +1258,17 @@ func (c *AviObjCache) AviPopulateOneVsVipCache(client *clients.AviClient,
 			}
 		}
 
+		if vsvip.VsvipCloudConfigCksum != nil {
+			checksum = *vsvip.VsvipCloudConfigCksum
+		}
 		vsVipCacheObj := AviVSVIPCache{
-			Name:         *vsvip.Name,
-			Uuid:         *vsvip.UUID,
-			FQDNs:        fqdns,
-			Vips:         vips,
-			NetworkName:  networkName,
-			LastModified: *vsvip.LastModified,
+			Name:             *vsvip.Name,
+			Uuid:             *vsvip.UUID,
+			FQDNs:            fqdns,
+			LastModified:     *vsvip.LastModified,
+			Vips:             vips,
+			NetworkName:      networkName,
+			CloudConfigCksum: checksum,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *vsvip.Name}
 		c.VSVIPCache.AviCacheAdd(k, &vsVipCacheObj)
@@ -1358,16 +1389,20 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 				}
 			}
 		}
+		checksum := lib.L4PolicyChecksum(ports, protocol)
+		if lib.GetEnableGRBAC() && l4pol.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
+		}
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,
 			Uuid:             *l4pol.UUID,
 			Pools:            pools,
 			LastModified:     *l4pol.LastModified,
-			CloudConfigCksum: lib.L4PolicyChecksum(ports, protocol),
+			CloudConfigCksum: checksum,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *l4pol.Name}
 		c.L4PolicyCache.AviCacheAdd(k, &l4PolCacheObj)
-		utils.AviLog.Infof("Adding l4pol to Cache during refresh %s\n", lib.L4PolicyChecksum(ports, protocol))
+		utils.AviLog.Infof("Adding l4pol to Cache during refresh %s\n", utils.Stringify(l4PolCacheObj))
 	}
 	return nil
 }
@@ -1400,7 +1435,9 @@ func (c *AviObjCache) PopulateSSLKeyToCache(client *clients.AviClient, cloud str
 				cacert = ca.(string)
 			}
 		}
+		//TODO: Check with team : What is reason of recomputing checksum here again.
 		SslKeyData[i].CloudConfigCksum = lib.SSLKeyCertChecksum(SslKeyCacheObj.Name, SslKeyCacheObj.Cert, cacert)
+		SslKeyData[i].CloudConfigCksum += lib.GetClusterLabelChecksum()
 		utils.AviLog.Debugf("Adding key to sslkey cache :%s", k)
 		c.SSLKeyCache.AviCacheAdd(k, &SslKeyData[i])
 		delete(sslCacheData, k)
@@ -1573,12 +1610,16 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 		} else {
 			protocol = utils.UDP
 		}
+		checksum := lib.L4PolicyChecksum(ports, protocol)
+		if lib.GetEnableGRBAC() && l4pol.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
+		}
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,
 			Uuid:             *l4pol.UUID,
 			Pools:            pools,
 			LastModified:     *l4pol.LastModified,
-			CloudConfigCksum: lib.L4PolicyChecksum(ports, protocol),
+			CloudConfigCksum: checksum,
 		}
 
 		*l4PolicyData = append(*l4PolicyData, l4PolCacheObj)
@@ -2333,6 +2374,8 @@ func checkRequiredValuesYaml() bool {
 
 	// after clusterName validation, set AKO User to be used in created_by fields for Avi Objects
 	lib.SetAKOUser()
+	//Set clusterlabel checksum
+	lib.SetClusterLabelChecksum()
 
 	cloudName := os.Getenv("CLOUD_NAME")
 	if cloudName == "" {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -74,7 +74,7 @@ const (
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
 	VSVIPDELCTRLVER                            = "20.1.1"
 	Advl4ControllerVersion                     = "20.1.2"
-	GRBACControllerVersion                     = "20.1.2"
+	GRBACControllerVersion                     = "20.1.4"
 	HostRule                                   = "HostRule"
 	HTTPRule                                   = "HTTPRule"
 	NsxAlbInfraSetting                         = "NsxAlbInfraSetting"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -74,6 +74,7 @@ const (
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
 	VSVIPDELCTRLVER                            = "20.1.1"
 	Advl4ControllerVersion                     = "20.1.2"
+	GRBACControllerVersion                     = "20.1.2"
 	HostRule                                   = "HostRule"
 	HTTPRule                                   = "HTTPRule"
 	NsxAlbInfraSetting                         = "NsxAlbInfraSetting"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -533,8 +533,9 @@ var clusterValue string
 
 func SetClusterLabelChecksum() {
 	if GetEnableGRBAC() {
-		clusterKey = *GetLabels()[0].Key
-		clusterValue = *GetLabels()[0].Value
+		labels := GetLabels()
+		clusterKey = *labels[0].Key
+		clusterValue = *labels[0].Value
 		clusterLabelChecksum = utils.Hash(clusterKey + clusterValue)
 	}
 }

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -560,6 +560,7 @@ func (v *AviVsNode) CalculateCheckSum() {
 	if v.Enabled != nil {
 		checksum += utils.Hash(utils.Stringify(v.Enabled))
 	}
+	checksum += lib.GetClusterLabelChecksum()
 
 	if v.EnableRhi != nil {
 		checksum += utils.Hash(utils.Stringify(*v.EnableRhi))
@@ -604,6 +605,7 @@ func (v *AviL4PolicyNode) CalculateCheckSum() {
 	if len(v.PortPool) > 0 {
 		checksum = lib.L4PolicyChecksum(ports, v.PortPool[0].Protocol)
 	}
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 
@@ -650,6 +652,7 @@ func (v *AviHttpPolicySetNode) CalculateCheckSum() {
 		sort.Strings(redir.Hosts)
 		checksum = checksum + utils.Hash(utils.Stringify(redir.Hosts))
 	}
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 
@@ -702,6 +705,7 @@ type AviTLSKeyCertNode struct {
 func (v *AviTLSKeyCertNode) CalculateCheckSum() {
 	// A sum of fields for this SSL cert.
 	checksum := lib.SSLKeyCertChecksum(v.Name, string(v.Cert), v.CACert)
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 
@@ -760,12 +764,12 @@ func (v *AviVSVIPNode) GetCheckSum() uint32 {
 }
 
 func (v *AviVSVIPNode) CalculateCheckSum() {
-	var checksum uint32
+	var networkName string
 	if v.NetworkName != nil {
-		checksum = lib.VSVipChecksum(v.FQDNs, v.IPAddress, *v.NetworkName)
-	} else {
-		checksum = lib.VSVipChecksum(v.FQDNs, v.IPAddress, "")
+		networkName = *v.NetworkName
 	}
+	checksum := lib.VSVipChecksum(v.FQDNs, v.IPAddress, networkName)
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 
@@ -808,6 +812,7 @@ func (v *AviPoolGroupNode) CalculateCheckSum() {
 		return *pgMembers[i].PoolRef < *pgMembers[j].PoolRef
 	})
 	checksum := utils.Hash(utils.Stringify(pgMembers))
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 
@@ -858,7 +863,9 @@ func (v *AviHTTPDataScriptNode) GetCheckSum() uint32 {
 
 func (v *AviHTTPDataScriptNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
-	v.CloudConfigCksum = lib.DSChecksum(v.PoolGroupRefs)
+	checksum := lib.DSChecksum(v.PoolGroupRefs)
+	checksum += lib.GetClusterLabelChecksum()
+	v.CloudConfigCksum = checksum
 }
 
 func (v *AviHTTPDataScriptNode) GetNodeType() string {
@@ -908,7 +915,9 @@ func (v *AviPkiProfileNode) GetCheckSum() uint32 {
 }
 
 func (v *AviPkiProfileNode) CalculateCheckSum() {
-	v.CloudConfigCksum = lib.SSLKeyCertChecksum(v.Name, "", v.CACert)
+	checksum := lib.SSLKeyCertChecksum(v.Name, "", v.CACert)
+	checksum += lib.GetClusterLabelChecksum()
+	v.CloudConfigCksum = checksum
 }
 
 type AviPoolNode struct {
@@ -971,6 +980,7 @@ func (v *AviPoolNode) CalculateCheckSum() {
 	if v.PkiProfile != nil {
 		checksum += v.PkiProfile.GetCheckSum()
 	}
+	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
 

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -40,6 +40,9 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	tenant_ref := "/api/tenant/?name=" + ds_meta.Tenant
 	cr := lib.AKOUser
 	vsdatascriptset := avimodels.VSDataScriptSet{CreatedBy: &cr, Datascript: datascriptlist, Name: &ds_meta.Name, TenantRef: &tenant_ref, PoolGroupRefs: poolgroupref}
+	if lib.GetEnableGRBAC() {
+		vsdatascriptset.Labels = lib.GetLabels()
+	}
 	if len(ds_meta.ProtocolParsers) > 0 {
 		vsdatascriptset.ProtocolParserRefs = ds_meta.ProtocolParsers
 	}

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -125,7 +125,9 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		ds_cache_obj := avicache.AviDSCache{Name: name, Tenant: rest_op.Tenant,
 			Uuid: uuid, PoolGroups: poolgroups}
 
-		ds_cache_obj.CloudConfigCksum = lib.DSChecksum(ds_cache_obj.PoolGroups)
+		checksum := lib.DSChecksum(ds_cache_obj.PoolGroups)
+		checksum += lib.GetClusterLabelChecksum()
+		ds_cache_obj.CloudConfigCksum = checksum
 
 		k := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: name}
 		rest.cache.DSCache.AviCacheAdd(k, &ds_cache_obj)

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -41,6 +41,9 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 	hps := avimodels.HTTPPolicySet{Name: &name, CloudConfigCksum: &cksumString,
 		CreatedBy: &cr, TenantRef: &tenant, HTTPRequestPolicy: &http_req_pol}
 
+	if lib.GetEnableGRBAC() {
+		hps.Labels = lib.GetLabels()
+	}
 	var idx int32
 	idx = 0
 	for _, hppmap := range hps_meta.HppMap {

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -38,6 +38,9 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 
 	hps := avimodels.L4PolicySet{Name: &name,
 		CreatedBy: &cr, TenantRef: &tenant}
+	if lib.GetEnableGRBAC() {
+		hps.Labels = lib.GetLabels()
+	}
 	var idx int32
 	idx = 0
 	var l4Policy avimodels.L4ConnectionPolicy

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -177,12 +177,13 @@ func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avi
 			pool := strings.TrimPrefix(*rule.Action.SelectPool.PoolRef, "/api/pool?name=")
 			pools = append(pools, pool)
 		}
-
+		checksum := lib.L4PolicyChecksum(ports, protocol)
+		checksum += lib.GetClusterLabelChecksum()
 		l4_cache_obj := avicache.AviL4PolicyCache{Name: name, Tenant: rest_op.Tenant,
 			Uuid:             uuid,
 			LastModified:     lastModifiedStr,
 			Pools:            pools,
-			CloudConfigCksum: lib.L4PolicyChecksum(ports, protocol),
+			CloudConfigCksum: checksum,
 		}
 		k := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: name}
 		rest.cache.L4PolicyCache.AviCacheAdd(k, &l4_cache_obj)

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -93,7 +93,9 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		SslProfileRef:     &pool_meta.SslProfileRef,
 		PlacementNetworks: placementNetworks,
 	}
-
+	if lib.GetEnableGRBAC() {
+		pool.Labels = lib.GetLabels()
+	}
 	if pool_meta.PkiProfile != nil {
 		pkiProfileName := "/api/pkiprofile?name=" + pool_meta.PkiProfile.Name
 		pool.PkiProfileRef = &pkiProfileName

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -97,7 +97,9 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		}
 		tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
 		vs.TenantRef = &tenant
-
+		if lib.GetEnableGRBAC() {
+			vs.Labels = lib.GetLabels()
+		}
 		if vs_meta.SNIParent {
 			// This is a SNI parent
 			utils.AviLog.Debugf("key: %s, msg: vs %s is a SNI Parent", key, vs_meta.Name)
@@ -237,7 +239,9 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	sniChild.VhDomainName = vs_meta.VHDomainNames
 	ignPool := false
 	sniChild.IgnPoolNetReach = &ignPool
-
+	if lib.GetEnableGRBAC() {
+		sniChild.Labels = lib.GetLabels()
+	}
 	if vs_meta.DefaultPool != "" {
 		pool_ref := "/api/pool/?name=" + vs_meta.DefaultPool
 		sniChild.PoolRef = &pool_ref
@@ -684,6 +688,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		// Override the Vip in VsVip tto bring in updates, keeping everything else as is.
 		vsvip.Vip = []*avimodels.Vip{vip}
 
+		if lib.GetEnableGRBAC() {
+			vsvip.Labels = lib.GetLabels()
+		}
 		rest_op = utils.RestOp{
 			Path:    "/api/vsvip/" + cache_obj.Uuid,
 			Method:  utils.RestPut,
@@ -777,7 +784,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			DNSInfo:           dns_info_arr,
 			Vip:               []*avimodels.Vip{&vip},
 		}
-
+		if lib.GetEnableGRBAC() {
+			vsvip.Labels = lib.GetLabels()
+		}
 		macro := utils.AviRestObjMacro{ModelName: "VsVip", Data: vsvip}
 		path = "/api/macro"
 		// Patch an existing vsvip if it exists in the cache but not associated with this VS.
@@ -815,7 +824,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			}
 			vsvip_avi.DNSInfo = dns_info_arr
 			vsvip_avi.VrfContextRef = &vrfContextRef
-
+			if lib.GetEnableGRBAC() {
+				vsvip_avi.Labels = lib.GetLabels()
+			}
 			path = "/api/vsvip/" + vsvip_cache_obj.Uuid
 			rest_op = utils.RestOp{Path: path,
 				Method:  utils.RestPut,

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -40,6 +40,9 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	pg := avimodels.PoolGroup{Name: &name, CloudConfigCksum: &cksumString,
 		CreatedBy: &cr, TenantRef: &tenant, Members: members, CloudRef: &cloudRef, ImplicitPriorityLabels: &pg_meta.ImplicitPriorityLabel}
 
+	if lib.GetEnableGRBAC() {
+		pg.Labels = lib.GetLabels()
+	}
 	macro := utils.AviRestObjMacro{ModelName: "PoolGroup", Data: pg}
 
 	var path string

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -40,6 +40,9 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 		CreatedBy: &cr, TenantRef: &tenant, Certificate: &avimodels.SSLCertificate{Certificate: &certificate},
 		Key: &key, Type: &certType}
 
+	if lib.GetEnableGRBAC() {
+		sslkeycert.Labels = lib.GetLabels()
+	}
 	if ssl_node.CACert != "" {
 		cacertRef := "/api/sslkeyandcertificate/?name=" + ssl_node.CACert
 		caName := ssl_node.CACert
@@ -185,7 +188,9 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 			Certificate: &caCert,
 		}),
 	}
-
+	if lib.GetEnableGRBAC() {
+		pkiobject.Labels = lib.GetLabels()
+	}
 	macro := utils.AviRestObjMacro{ModelName: "PKIprofile", Data: pkiobject}
 
 	var path string

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -124,6 +124,7 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(name, cert, cacert)
+		checksum += lib.GetClusterLabelChecksum()
 		ssl_cache_obj := avicache.AviSSLCache{Name: name, Tenant: rest_op.Tenant,
 			Uuid: uuid, CloudConfigCksum: checksum, HasCARef: hasCA}
 
@@ -250,6 +251,7 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 		}
 
 		checksum := lib.SSLKeyCertChecksum(name, pkiCertificate, "")
+		checksum += lib.GetClusterLabelChecksum()
 		pki_cache_obj := avicache.AviPkiProfileCache{
 			Name:             name,
 			Tenant:           rest_op.Tenant,


### PR DESCRIPTION
Adding GRBAC support for AKO.  Enabling default support for controller version 20.1.2 and above. GRBAC will come into picture if user is associated with labelled role. 