### PR TITLE
Introduce L4 DNS formats etc

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}
+  autoFQDN: {{ .Values.L4Settings.autoFQDN | quote }}
   {{ if .Values.AKOSettings.syncNamespace  }}
   syncNamespace: {{ .Values.AKOSettings.syncNamespace | quote }}
   {{ end }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -201,6 +201,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: advancedL4
+          - name: AUTO_L4_FQDN
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: autoFQDN
           {{ if .Values.persistentVolumeClaim }}
           - name: USE_PVC
             value: "true"

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -50,6 +50,7 @@ L7Settings:
 L4Settings:
   advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
   defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
+  autoFQDN: "<svc>.<ns>.<subdomain>" # ENUM: <svc>-<ns>.<subdomain>, <svc>.<ns>.<subdomain>, "false" If the value is false then the FQDN generation is disabled.
 
 ### This section outlines settings on the Avi controller that affects AKO's functionality.
 ControllerSettings:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -50,7 +50,7 @@ L7Settings:
 L4Settings:
   advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
   defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
-  autoFQDN: "<svc>.<ns>.<subdomain>" # ENUM: <svc>-<ns>.<subdomain>, <svc>.<ns>.<subdomain>, "false" If the value is false then the FQDN generation is disabled.
+  autoFQDN: "default" # ENUM: default(<svc>.<ns>.<subdomain>), flat (<svc>-<ns>.<subdomain>), "disabled" If the value is disabled then the FQDN generation is disabled.
 
 ### This section outlines settings on the Avi controller that affects AKO's functionality.
 ControllerSettings:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -105,6 +105,7 @@ const (
 	ObjectDeletionDoneStatus                   = "Done"
 	ObjectDeletionTimeoutStatus                = "Timeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
+	ExternalDNSAnnotation                      = "external-dns.alpha.kubernetes.io/hostname"
 	DefaultRouteCert                           = "router-certs-default"
 
 	//Specifies command used in namespace event handler

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -47,9 +47,8 @@ var shardSizeMap = map[string]uint32{
 }
 
 var fqdnEnum = map[string]int32{
-	"<svc>.<ns>.<subdomain>": 1,
-	"<svc>-<ns>.<subdomain>": 2,
-	"false":                  3,
+	"default": 1,
+	"flat":    2,
 }
 
 var NamePrefix string

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -46,6 +46,12 @@ var shardSizeMap = map[string]uint32{
 	"SMALL":  1,
 }
 
+var fqdnEnum = map[string]int32{
+	"<svc>.<ns>.<subdomain>": 1,
+	"<svc>-<ns>.<subdomain>": 2,
+	"false":                  3,
+}
+
 var NamePrefix string
 
 func SetNamePrefix() {
@@ -85,6 +91,17 @@ func GetshardSize() uint32 {
 		return shardSize
 	} else {
 		return 1
+	}
+}
+
+func GetL4FqdnFormat() int32 {
+	fqdnFormat := os.Getenv("AUTO_L4_FQDN")
+	enumVal, ok := fqdnEnum[fqdnFormat]
+	if ok {
+		return enumVal
+	} else {
+		// If no match then disable FQDNs for L4.
+		return 3
 	}
 }
 

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -63,23 +63,18 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 
 		// subDomains[0] would either have the defaultSubDomain value
 		// or would default to the first dns subdomain it gets from the dns profile
+		subdomain := subDomains[0]
 		if strings.HasPrefix(subDomains[0], ".") {
-			if lib.GetL4FqdnFormat() == 1 {
-				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + subDomains[0]
-			} else if lib.GetL4FqdnFormat() == 2 {
-				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + subDomains[0]
-			}
-		} else {
-			if lib.GetL4FqdnFormat() == 1 {
-				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
-			} else if lib.GetL4FqdnFormat() == 2 {
-				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
-			}
+			subdomain = strings.Replace(subDomains[0], ".", "", -1)
 		}
+		if lib.GetL4FqdnFormat() == 1 {
+			// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+			fqdn = svcObj.Name + "." + svcObj.ObjectMeta.Namespace + "." + subdomain
+		} else if lib.GetL4FqdnFormat() == 2 {
+			// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+			fqdn = svcObj.Name + "-" + svcObj.ObjectMeta.Namespace + "." + subdomain
+		}
+
 		fqdns = append(fqdns, fqdn)
 	}
 	avi_vs_meta = &AviVsNode{

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -41,12 +41,19 @@ func contains(s []int32, e int32) bool {
 func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string) *AviVsNode {
 	var avi_vs_meta *AviVsNode
 	var fqdns []string
-	// FQDN should come from the cloud. Modify
+	autoFQDN := true
+	if lib.GetL4FqdnFormat() == 3 {
+		autoFQDN = false
+	}
+	annotations := svcObj.GetAnnotations()
+	extDNS, ok := annotations[lib.ExternalDNSAnnotation]
+	if ok {
+		autoFQDN = false
+		fqdns = append(fqdns, extDNS)
+	}
 	vsName := lib.GetL4VSName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace)
-	// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
 	subDomains := GetDefaultSubDomain()
-
-	if subDomains != nil {
+	if subDomains != nil && autoFQDN {
 		var fqdn string
 		// honour defaultSubDomain from values.yaml if specified
 		defaultSubDomain := lib.GetDomain()
@@ -57,9 +64,21 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		// subDomains[0] would either have the defaultSubDomain value
 		// or would default to the first dns subdomain it gets from the dns profile
 		if strings.HasPrefix(subDomains[0], ".") {
-			fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + subDomains[0]
+			if lib.GetL4FqdnFormat() == 1 {
+				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + subDomains[0]
+			} else if lib.GetL4FqdnFormat() == 2 {
+				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + subDomains[0]
+			}
 		} else {
-			fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
+			if lib.GetL4FqdnFormat() == 1 {
+				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
+			} else if lib.GetL4FqdnFormat() == 2 {
+				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
+			}
 		}
 		fqdns = append(fqdns, fqdn)
 	}

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -324,18 +324,6 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string) *AviVsN
 	o.ConstructHTTPDataScript(vsName, key, avi_vs_meta)
 	var fqdns []string
 
-	subDomains := GetDefaultSubDomain()
-	if subDomains != nil {
-		var fqdn string
-		if strings.HasPrefix(subDomains[0], ".") {
-			fqdn = vsName + "." + lib.GetTenant() + subDomains[0]
-		} else {
-			fqdn = vsName + "." + lib.GetTenant() + "." + subDomains[0]
-		}
-		fqdns = append(fqdns, fqdn)
-	} else {
-		utils.AviLog.Warnf("key: %s, msg: there is no nsipamdns configured in the cloud, not configuring the default fqdn", key)
-	}
 	vsVipNode := &AviVSVIPNode{Name: lib.GetVsVipName(vsName), Tenant: lib.GetTenant(), FQDNs: fqdns,
 		EastWest: false, VrfContext: vrfcontext}
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)


### PR DESCRIPTION
This commit intorduces the following changes:

- Allows an option to disable FQDN generation for L4 VSes.
- Allows specification of formats for FQDNs for L4.
- Allows specification of an annoation to generate custom FQDNs for L4 VSes.

Also removes the code that auto-generated the default FQDN for Shared VS for L4.