### PR TITLE
 Introduce L4 DNS formats etc (Cherry-picked)

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}
+  autoFQDN: {{ .Values.L4Settings.autoFQDN | quote }}
   {{ if .Values.AKOSettings.syncNamespace  }}
   syncNamespace: {{ .Values.AKOSettings.syncNamespace | quote }}
   {{ end }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -206,6 +206,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: advancedL4
+          - name: AUTO_L4_FQDN
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: autoFQDN
           {{ if .Values.persistentVolumeClaim }}
           - name: USE_PVC
             value: "true"

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -52,6 +52,7 @@ L7Settings:
 L4Settings:
   advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
   defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
+  autoFQDN: "<svc>.<ns>.<subdomain>" # ENUM: <svc>-<ns>.<subdomain>, <svc>.<ns>.<subdomain>, "false" If the value is false then the FQDN generation is disabled.
 
 ### This section outlines settings on the Avi controller that affects AKO's functionality.
 ControllerSettings:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -52,7 +52,7 @@ L7Settings:
 L4Settings:
   advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
   defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
-  autoFQDN: "<svc>.<ns>.<subdomain>" # ENUM: <svc>-<ns>.<subdomain>, <svc>.<ns>.<subdomain>, "false" If the value is false then the FQDN generation is disabled.
+  autoFQDN: "default" # ENUM: default(<svc>.<ns>.<subdomain>), flat (<svc>-<ns>.<subdomain>), "disabled" If the value is disabled then the FQDN generation is disabled.
 
 ### This section outlines settings on the Avi controller that affects AKO's functionality.
 ControllerSettings:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -108,6 +108,7 @@ const (
 	ObjectDeletionDoneStatus                   = "Done"
 	ObjectDeletionTimeoutStatus                = "Timeout"
 	DefaultIngressClassAnnotation              = "ingressclass.kubernetes.io/is-default-class"
+	ExternalDNSAnnotation                      = "external-dns.alpha.kubernetes.io/hostname"
 	DefaultRouteCert                           = "router-certs-default"
 	NPLPodAnnotation                           = "nodeportlocal.antrea.io"
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -48,9 +48,8 @@ var shardSizeMap = map[string]uint32{
 }
 
 var fqdnEnum = map[string]int32{
-	"<svc>.<ns>.<subdomain>": 1,
-	"<svc>-<ns>.<subdomain>": 2,
-	"false":                  3,
+	"default": 1,
+	"flat":    2,
 }
 
 var NamePrefix string

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -47,6 +47,12 @@ var shardSizeMap = map[string]uint32{
 	"SMALL":  1,
 }
 
+var fqdnEnum = map[string]int32{
+	"<svc>.<ns>.<subdomain>": 1,
+	"<svc>-<ns>.<subdomain>": 2,
+	"false":                  3,
+}
+
 var NamePrefix string
 
 func SetNamePrefix() {
@@ -86,6 +92,17 @@ func GetshardSize() uint32 {
 		return shardSize
 	} else {
 		return 1
+	}
+}
+
+func GetL4FqdnFormat() int32 {
+	fqdnFormat := os.Getenv("AUTO_L4_FQDN")
+	enumVal, ok := fqdnEnum[fqdnFormat]
+	if ok {
+		return enumVal
+	} else {
+		// If no match then disable FQDNs for L4.
+		return 3
 	}
 }
 

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -55,23 +55,18 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 
 		// subDomains[0] would either have the defaultSubDomain value
 		// or would default to the first dns subdomain it gets from the dns profile
+		subdomain := subDomains[0]
 		if strings.HasPrefix(subDomains[0], ".") {
-			if lib.GetL4FqdnFormat() == 1 {
-				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + subDomains[0]
-			} else if lib.GetL4FqdnFormat() == 2 {
-				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + subDomains[0]
-			}
-		} else {
-			if lib.GetL4FqdnFormat() == 1 {
-				// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "." + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
-			} else if lib.GetL4FqdnFormat() == 2 {
-				// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
-				fqdn = svcObj.ObjectMeta.Name + "-" + svcObj.ObjectMeta.Namespace + "." + subDomains[0]
-			}
+			subdomain = strings.Replace(subDomains[0], ".", "", -1)
 		}
+		if lib.GetL4FqdnFormat() == 1 {
+			// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+			fqdn = svcObj.Name + "." + svcObj.ObjectMeta.Namespace + "." + subdomain
+		} else if lib.GetL4FqdnFormat() == 2 {
+			// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+			fqdn = svcObj.Name + "-" + svcObj.ObjectMeta.Namespace + "." + subdomain
+		}
+
 		fqdns = append(fqdns, fqdn)
 	}
 	avi_vs_meta = &AviVsNode{

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -329,18 +329,6 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string) *AviVsN
 	o.ConstructHTTPDataScript(vsName, key, avi_vs_meta)
 	var fqdns []string
 
-	subDomains := GetDefaultSubDomain()
-	if subDomains != nil {
-		var fqdn string
-		if strings.HasPrefix(subDomains[0], ".") {
-			fqdn = vsName + "." + lib.GetTenant() + subDomains[0]
-		} else {
-			fqdn = vsName + "." + lib.GetTenant() + "." + subDomains[0]
-		}
-		fqdns = append(fqdns, fqdn)
-	} else {
-		utils.AviLog.Warnf("key: %s, msg: there is no nsipamdns configured in the cloud, not configuring the default fqdn", key)
-	}
 	vsVipNode := &AviVSVIPNode{Name: lib.GetVsVipName(vsName), Tenant: lib.GetTenant(), FQDNs: fqdns,
 		EastWest: false, VrfContext: vrfcontext}
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)

--- a/tests/oshiftroutetests/oshift_crd_test.go
+++ b/tests/oshiftroutetests/oshift_crd_test.go
@@ -241,7 +241,7 @@ func TestOshiftMultiRouteToSecureHostRule(t *testing.T) {
 			}
 		}
 		return false
-	}, 60*time.Second).Should(gomega.Equal(true))
+	}, 90*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisahostruleref-sslkey"))


### PR DESCRIPTION
    This commit intorduces the following changes:

    - Allows an option to disable FQDN generation for L4 VSes.
    - Allows specification of formats for FQDNs for L4.
    - Allows specification of an annoation to generate custom FQDNs for L4 VSes.