### PR TITLE
NsxAlbInfraSetting implementation init

### DIFF
--- a/hack/update-codegen-akocrd.sh
+++ b/hack/update-codegen-akocrd.sh
@@ -27,7 +27,7 @@ readonly AKO_PACKAGE=github.com/vmware/load-balancer-and-ingress-services-for-ku
 readonly SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE}")"/.. && pwd)"
 
 readonly GO111MODULE="on"
-readonly GOFLAGS="-mod=readonly"
+readonly GOFLAGS="-mod=mod"
 readonly GOPATH="$(mktemp -d)"
 
 export GO111MODULE GOFLAGS GOPATH

--- a/helm/ako/crds/nsxalbinfrasetting.yaml
+++ b/helm/ako/crds/nsxalbinfrasetting.yaml
@@ -10,16 +10,13 @@ spec:
     kind: NsxAlbInfraSetting
     listKind: NsxAlbInfraSettingList
     plural: nsxalbinfrasettings
-    shortNames:
-    - nsxalbinfrasettings
-    - nas
     singular: nsxalbinfrasetting
   scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NSX ALB Settings is used to select specific Avi controller infra attributes.
+        description: NSX ALB Setting is used to select specific Avi controller infra attributes.
         properties:
           spec:
             properties:
@@ -43,9 +40,9 @@ spec:
                 properties:
                   shardSize:
                     enum:
-                    - LARGE
                     - SMALL
                     - MEDIUM
+                    - LARGE
                     - DEDICATED
                     type: string
                 type: object

--- a/internal/apis/ako/v1alpha1/nsxalbinfrasetting.go
+++ b/internal/apis/ako/v1alpha1/nsxalbinfrasetting.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-202 VMware, Inc.
+ * Copyright 2020-2021 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package v1alpha1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NsxAlbInfraSetting is a top-level type

--- a/internal/apis/ako/v1alpha1/register.go
+++ b/internal/apis/ako/v1alpha1/register.go
@@ -49,10 +49,10 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(
 		SchemeGroupVersion,
 		&HostRule{},
-		&NsxAlbInfraSetting{},
 		&HostRuleList{},
 		&HTTPRule{},
 		&HTTPRuleList{},
+		&NsxAlbInfraSetting{},
 		&NsxAlbInfraSettingList{},
 	)
 

--- a/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/ako_client.go
+++ b/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/ako_client.go
@@ -44,8 +44,8 @@ func (c *AkoV1alpha1Client) HostRules(namespace string) HostRuleInterface {
 	return newHostRules(c, namespace)
 }
 
-func (c *AkoV1alpha1Client) NsxAlbInfraSettings(namespace string) NsxAlbInfraSettingInterface {
-	return newNsxAlbInfraSettings(c, namespace)
+func (c *AkoV1alpha1Client) NsxAlbInfraSettings() NsxAlbInfraSettingInterface {
+	return newNsxAlbInfraSettings(c)
 }
 
 // NewForConfig creates a new AkoV1alpha1Client for the given config.

--- a/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/fake/fake_ako_client.go
+++ b/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/fake/fake_ako_client.go
@@ -36,8 +36,8 @@ func (c *FakeAkoV1alpha1) HostRules(namespace string) v1alpha1.HostRuleInterface
 	return &FakeHostRules{c, namespace}
 }
 
-func (c *FakeAkoV1alpha1) NsxAlbInfraSettings(namespace string) v1alpha1.NsxAlbInfraSettingInterface {
-	return &FakeNsxAlbInfraSettings{c, namespace}
+func (c *FakeAkoV1alpha1) NsxAlbInfraSettings() v1alpha1.NsxAlbInfraSettingInterface {
+	return &FakeNsxAlbInfraSettings{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/fake/fake_nsxalbinfrasetting.go
+++ b/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/fake/fake_nsxalbinfrasetting.go
@@ -33,7 +33,6 @@ import (
 // FakeNsxAlbInfraSettings implements NsxAlbInfraSettingInterface
 type FakeNsxAlbInfraSettings struct {
 	Fake *FakeAkoV1alpha1
-	ns   string
 }
 
 var nsxalbinfrasettingsResource = schema.GroupVersionResource{Group: "ako.vmware.com", Version: "v1alpha1", Resource: "nsxalbinfrasettings"}
@@ -43,8 +42,7 @@ var nsxalbinfrasettingsKind = schema.GroupVersionKind{Group: "ako.vmware.com", V
 // Get takes name of the nsxAlbInfraSetting, and returns the corresponding nsxAlbInfraSetting object, and an error if there is any.
 func (c *FakeNsxAlbInfraSettings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(nsxalbinfrasettingsResource, c.ns, name), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootGetAction(nsxalbinfrasettingsResource, name), &v1alpha1.NsxAlbInfraSetting{})
 	if obj == nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (c *FakeNsxAlbInfraSettings) Get(ctx context.Context, name string, options 
 // List takes label and field selectors, and returns the list of NsxAlbInfraSettings that match those selectors.
 func (c *FakeNsxAlbInfraSettings) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.NsxAlbInfraSettingList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(nsxalbinfrasettingsResource, nsxalbinfrasettingsKind, c.ns, opts), &v1alpha1.NsxAlbInfraSettingList{})
-
+		Invokes(testing.NewRootListAction(nsxalbinfrasettingsResource, nsxalbinfrasettingsKind, opts), &v1alpha1.NsxAlbInfraSettingList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,15 +73,13 @@ func (c *FakeNsxAlbInfraSettings) List(ctx context.Context, opts v1.ListOptions)
 // Watch returns a watch.Interface that watches the requested nsxAlbInfraSettings.
 func (c *FakeNsxAlbInfraSettings) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(nsxalbinfrasettingsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(nsxalbinfrasettingsResource, opts))
 }
 
 // Create takes the representation of a nsxAlbInfraSetting and creates it.  Returns the server's representation of the nsxAlbInfraSetting, and an error, if there is any.
 func (c *FakeNsxAlbInfraSettings) Create(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.CreateOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(nsxalbinfrasettingsResource, c.ns, nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootCreateAction(nsxalbinfrasettingsResource, nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
 	if obj == nil {
 		return nil, err
 	}
@@ -94,8 +89,7 @@ func (c *FakeNsxAlbInfraSettings) Create(ctx context.Context, nsxAlbInfraSetting
 // Update takes the representation of a nsxAlbInfraSetting and updates it. Returns the server's representation of the nsxAlbInfraSetting, and an error, if there is any.
 func (c *FakeNsxAlbInfraSettings) Update(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.UpdateOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(nsxalbinfrasettingsResource, c.ns, nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootUpdateAction(nsxalbinfrasettingsResource, nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,8 +100,7 @@ func (c *FakeNsxAlbInfraSettings) Update(ctx context.Context, nsxAlbInfraSetting
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNsxAlbInfraSettings) UpdateStatus(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.UpdateOptions) (*v1alpha1.NsxAlbInfraSetting, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(nsxalbinfrasettingsResource, "status", c.ns, nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(nsxalbinfrasettingsResource, "status", nsxAlbInfraSetting), &v1alpha1.NsxAlbInfraSetting{})
 	if obj == nil {
 		return nil, err
 	}
@@ -117,14 +110,13 @@ func (c *FakeNsxAlbInfraSettings) UpdateStatus(ctx context.Context, nsxAlbInfraS
 // Delete takes name of the nsxAlbInfraSetting and deletes it. Returns an error if one occurs.
 func (c *FakeNsxAlbInfraSettings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(nsxalbinfrasettingsResource, c.ns, name), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootDeleteAction(nsxalbinfrasettingsResource, name), &v1alpha1.NsxAlbInfraSetting{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNsxAlbInfraSettings) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(nsxalbinfrasettingsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(nsxalbinfrasettingsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.NsxAlbInfraSettingList{})
 	return err
@@ -133,8 +125,7 @@ func (c *FakeNsxAlbInfraSettings) DeleteCollection(ctx context.Context, opts v1.
 // Patch applies the patch and returns the patched nsxAlbInfraSetting.
 func (c *FakeNsxAlbInfraSettings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(nsxalbinfrasettingsResource, c.ns, name, pt, data, subresources...), &v1alpha1.NsxAlbInfraSetting{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(nsxalbinfrasettingsResource, name, pt, data, subresources...), &v1alpha1.NsxAlbInfraSetting{})
 	if obj == nil {
 		return nil, err
 	}

--- a/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/nsxalbinfrasetting.go
+++ b/internal/client/v1alpha1/clientset/versioned/typed/ako/v1alpha1/nsxalbinfrasetting.go
@@ -33,7 +33,7 @@ import (
 // NsxAlbInfraSettingsGetter has a method to return a NsxAlbInfraSettingInterface.
 // A group's client should implement this interface.
 type NsxAlbInfraSettingsGetter interface {
-	NsxAlbInfraSettings(namespace string) NsxAlbInfraSettingInterface
+	NsxAlbInfraSettings() NsxAlbInfraSettingInterface
 }
 
 // NsxAlbInfraSettingInterface has methods to work with NsxAlbInfraSetting resources.
@@ -53,14 +53,12 @@ type NsxAlbInfraSettingInterface interface {
 // nsxAlbInfraSettings implements NsxAlbInfraSettingInterface
 type nsxAlbInfraSettings struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNsxAlbInfraSettings returns a NsxAlbInfraSettings
-func newNsxAlbInfraSettings(c *AkoV1alpha1Client, namespace string) *nsxAlbInfraSettings {
+func newNsxAlbInfraSettings(c *AkoV1alpha1Client) *nsxAlbInfraSettings {
 	return &nsxAlbInfraSettings{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -68,7 +66,6 @@ func newNsxAlbInfraSettings(c *AkoV1alpha1Client, namespace string) *nsxAlbInfra
 func (c *nsxAlbInfraSettings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	result = &v1alpha1.NsxAlbInfraSetting{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,7 +82,6 @@ func (c *nsxAlbInfraSettings) List(ctx context.Context, opts v1.ListOptions) (re
 	}
 	result = &v1alpha1.NsxAlbInfraSettingList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,7 +98,6 @@ func (c *nsxAlbInfraSettings) Watch(ctx context.Context, opts v1.ListOptions) (w
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,7 +108,6 @@ func (c *nsxAlbInfraSettings) Watch(ctx context.Context, opts v1.ListOptions) (w
 func (c *nsxAlbInfraSettings) Create(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.CreateOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	result = &v1alpha1.NsxAlbInfraSetting{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(nsxAlbInfraSetting).
@@ -126,7 +120,6 @@ func (c *nsxAlbInfraSettings) Create(ctx context.Context, nsxAlbInfraSetting *v1
 func (c *nsxAlbInfraSettings) Update(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.UpdateOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	result = &v1alpha1.NsxAlbInfraSetting{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		Name(nsxAlbInfraSetting.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *nsxAlbInfraSettings) Update(ctx context.Context, nsxAlbInfraSetting *v1
 func (c *nsxAlbInfraSettings) UpdateStatus(ctx context.Context, nsxAlbInfraSetting *v1alpha1.NsxAlbInfraSetting, opts v1.UpdateOptions) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	result = &v1alpha1.NsxAlbInfraSetting{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		Name(nsxAlbInfraSetting.Name).
 		SubResource("status").
@@ -155,7 +147,6 @@ func (c *nsxAlbInfraSettings) UpdateStatus(ctx context.Context, nsxAlbInfraSetti
 // Delete takes name of the nsxAlbInfraSetting and deletes it. Returns an error if one occurs.
 func (c *nsxAlbInfraSettings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		Name(name).
 		Body(&opts).
@@ -170,7 +161,6 @@ func (c *nsxAlbInfraSettings) DeleteCollection(ctx context.Context, opts v1.Dele
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -183,7 +173,6 @@ func (c *nsxAlbInfraSettings) DeleteCollection(ctx context.Context, opts v1.Dele
 func (c *nsxAlbInfraSettings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NsxAlbInfraSetting, err error) {
 	result = &v1alpha1.NsxAlbInfraSetting{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("nsxalbinfrasettings").
 		Name(name).
 		SubResource(subresources...).

--- a/internal/client/v1alpha1/informers/externalversions/ako/v1alpha1/interface.go
+++ b/internal/client/v1alpha1/informers/externalversions/ako/v1alpha1/interface.go
@@ -55,5 +55,5 @@ func (v *version) HostRules() HostRuleInformer {
 
 // NsxAlbInfraSettings returns a NsxAlbInfraSettingInformer.
 func (v *version) NsxAlbInfraSettings() NsxAlbInfraSettingInformer {
-	return &nsxAlbInfraSettingInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &nsxAlbInfraSettingInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/internal/client/v1alpha1/informers/externalversions/ako/v1alpha1/nsxalbinfrasetting.go
+++ b/internal/client/v1alpha1/informers/externalversions/ako/v1alpha1/nsxalbinfrasetting.go
@@ -42,33 +42,32 @@ type NsxAlbInfraSettingInformer interface {
 type nsxAlbInfraSettingInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewNsxAlbInfraSettingInformer constructs a new informer for NsxAlbInfraSetting type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewNsxAlbInfraSettingInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredNsxAlbInfraSettingInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewNsxAlbInfraSettingInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredNsxAlbInfraSettingInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredNsxAlbInfraSettingInformer constructs a new informer for NsxAlbInfraSetting type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredNsxAlbInfraSettingInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredNsxAlbInfraSettingInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AkoV1alpha1().NsxAlbInfraSettings(namespace).List(context.TODO(), options)
+				return client.AkoV1alpha1().NsxAlbInfraSettings().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AkoV1alpha1().NsxAlbInfraSettings(namespace).Watch(context.TODO(), options)
+				return client.AkoV1alpha1().NsxAlbInfraSettings().Watch(context.TODO(), options)
 			},
 		},
 		&akov1alpha1.NsxAlbInfraSetting{},
@@ -78,7 +77,7 @@ func NewFilteredNsxAlbInfraSettingInformer(client versioned.Interface, namespace
 }
 
 func (f *nsxAlbInfraSettingInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNsxAlbInfraSettingInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredNsxAlbInfraSettingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *nsxAlbInfraSettingInformer) Informer() cache.SharedIndexInformer {

--- a/internal/client/v1alpha1/listers/ako/v1alpha1/expansion_generated.go
+++ b/internal/client/v1alpha1/listers/ako/v1alpha1/expansion_generated.go
@@ -37,7 +37,3 @@ type HostRuleNamespaceListerExpansion interface{}
 // NsxAlbInfraSettingListerExpansion allows custom methods to be added to
 // NsxAlbInfraSettingLister.
 type NsxAlbInfraSettingListerExpansion interface{}
-
-// NsxAlbInfraSettingNamespaceListerExpansion allows custom methods to be added to
-// NsxAlbInfraSettingNamespaceLister.
-type NsxAlbInfraSettingNamespaceListerExpansion interface{}

--- a/internal/client/v1alpha1/listers/ako/v1alpha1/nsxalbinfrasetting.go
+++ b/internal/client/v1alpha1/listers/ako/v1alpha1/nsxalbinfrasetting.go
@@ -31,8 +31,9 @@ type NsxAlbInfraSettingLister interface {
 	// List lists all NsxAlbInfraSettings in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.NsxAlbInfraSetting, err error)
-	// NsxAlbInfraSettings returns an object that can list and get NsxAlbInfraSettings.
-	NsxAlbInfraSettings(namespace string) NsxAlbInfraSettingNamespaceLister
+	// Get retrieves the NsxAlbInfraSetting from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.NsxAlbInfraSetting, error)
 	NsxAlbInfraSettingListerExpansion
 }
 
@@ -54,41 +55,9 @@ func (s *nsxAlbInfraSettingLister) List(selector labels.Selector) (ret []*v1alph
 	return ret, err
 }
 
-// NsxAlbInfraSettings returns an object that can list and get NsxAlbInfraSettings.
-func (s *nsxAlbInfraSettingLister) NsxAlbInfraSettings(namespace string) NsxAlbInfraSettingNamespaceLister {
-	return nsxAlbInfraSettingNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// NsxAlbInfraSettingNamespaceLister helps list and get NsxAlbInfraSettings.
-// All objects returned here must be treated as read-only.
-type NsxAlbInfraSettingNamespaceLister interface {
-	// List lists all NsxAlbInfraSettings in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.NsxAlbInfraSetting, err error)
-	// Get retrieves the NsxAlbInfraSetting from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.NsxAlbInfraSetting, error)
-	NsxAlbInfraSettingNamespaceListerExpansion
-}
-
-// nsxAlbInfraSettingNamespaceLister implements the NsxAlbInfraSettingNamespaceLister
-// interface.
-type nsxAlbInfraSettingNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all NsxAlbInfraSettings in the indexer for a given namespace.
-func (s nsxAlbInfraSettingNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.NsxAlbInfraSetting, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.NsxAlbInfraSetting))
-	})
-	return ret, err
-}
-
-// Get retrieves the NsxAlbInfraSetting from the indexer for a given namespace and name.
-func (s nsxAlbInfraSettingNamespaceLister) Get(name string) (*v1alpha1.NsxAlbInfraSetting, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the NsxAlbInfraSetting from the index for a given name.
+func (s *nsxAlbInfraSettingLister) Get(name string) (*v1alpha1.NsxAlbInfraSetting, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -421,7 +421,7 @@ func (c *AviController) FullSyncK8s() error {
 			}
 		}
 
-		albInfraObjs, err := lib.GetCRDInformers().NsxAlbInfraSettingInformer.Lister().NsxAlbInfraSettings("").List(labels.Set(nil).AsSelector())
+		albInfraObjs, err := lib.GetCRDInformers().NsxAlbInfraSettingInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the alinfraobjs during full sync: %s", err)
 		} else {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -110,6 +110,7 @@ const (
 	ExternalDNSAnnotation                      = "external-dns.alpha.kubernetes.io/hostname"
 	DefaultRouteCert                           = "router-certs-default"
 	NPLPodAnnotation                           = "nodeportlocal.antrea.io"
+	AkoGroup                                   = "ako.vmware.com"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd    = "ADD"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -32,7 +32,7 @@ const (
 	SUBNET_PREFIX                              = "SUBNET_PREFIX"
 	NETWORK_NAME                               = "NETWORK_NAME"
 	SEG_NAME                                   = "SEG_NAME"
-	DEFAULT_GROUP                              = "Default-Group"
+	DEFAULT_SE_GROUP                           = "Default-Group"
 	NODE_NETWORK_LIST                          = "NODE_NETWORK_LIST"
 	NODE_NETWORK_MAX_ENTRIES                   = 5
 	L7_SHARD_SCHEME                            = "L7_SHARD_SCHEME"
@@ -98,7 +98,6 @@ const (
 	PassthroughInsecure                        = "-insecure"
 	AviControllerVSVipIDChangeError            = "Changing an existing VIP's vip_id is not supported"
 	AviControllerRecreateVIPError              = "If a new preferred IP is needed, please recreate the VIP"
-	DefaultSEGroup                             = "Default-Group"
 	GatewayFinalizer                           = "gateway.ako.vmware.com"
 	ClusterStatusCacheKey                      = "cluster-runtime"
 	AviObjDeletionTime                         = 30 // Minutes
@@ -112,9 +111,22 @@ const (
 	DefaultRouteCert                           = "router-certs-default"
 	NPLPodAnnotation                           = "nodeportlocal.antrea.io"
 
-	//Specifies command used in namespace event handler
+	// Specifies command used in namespace event handler
 	NsFilterAdd    = "ADD"
 	NsFilterDelete = "DELETE"
+)
+
+// Cache Indexer constants.
+const (
+	// NsxAlbSettingGWClassIndex maintains a map of NsxAlbInfraSetting Name to
+	// GatewayClass Objects. This helps in fetching all GatewayClasses with a
+	// given NsxAlbinfraSetting Name.
+	NsxAlbSettingGWClassIndex = "nsxAlbSettingGWClass"
+
+	// GatewayClassGatewayIndex maintains a map of GatewayClass Name to
+	// Gateway Objects. This helps in fetching all Gateways with a
+	// given GatewayClass Name.
+	GatewayClassGatewayIndex = "gatewayClassGateway"
 )
 
 const (

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -340,9 +340,9 @@ func GetSEGName() string {
 		return segName
 	}
 	if GetAdvancedL4() {
-		return DefaultSEGroup
+		return DEFAULT_SE_GROUP
 	}
-	return ""
+	return DEFAULT_SE_GROUP
 }
 
 func GetNodeNetworkMap() (map[string][]string, error) {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -158,7 +158,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		if err != nil {
 			utils.AviLog.Warnf("Unable to get corresponding GatewayClass %s", err.Error())
 		} else {
-			if gwClass.Spec.ParametersRef.Group == "ako.vmware.com" && gwClass.Spec.ParametersRef.Kind == "NsxAlbInfraSetting" {
+			if gwClass.Spec.ParametersRef != nil && gwClass.Spec.ParametersRef.Group == "ako.vmware.com" && gwClass.Spec.ParametersRef.Kind == "NsxAlbInfraSetting" {
 				infraSetting, err := lib.GetCRDInformers().NsxAlbInfraSettingInformer.Lister().Get(gwClass.Spec.ParametersRef.Name)
 				if err != nil {
 					utils.AviLog.Warnf("Unable to get corresponding NsxAlbInfraSetting: %s", err.Error())

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -158,7 +158,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		if err != nil {
 			utils.AviLog.Warnf("Unable to get corresponding GatewayClass %s", err.Error())
 		} else {
-			if gwClass.Spec.ParametersRef != nil && gwClass.Spec.ParametersRef.Group == "ako.vmware.com" && gwClass.Spec.ParametersRef.Kind == "NsxAlbInfraSetting" {
+			if gwClass.Spec.ParametersRef != nil && gwClass.Spec.ParametersRef.Group == lib.AkoGroup && gwClass.Spec.ParametersRef.Kind == lib.NsxAlbInfraSetting {
 				infraSetting, err := lib.GetCRDInformers().NsxAlbInfraSettingInformer.Lister().Get(gwClass.Spec.ParametersRef.Name)
 				if err != nil {
 					utils.AviLog.Warnf("Unable to get corresponding NsxAlbInfraSetting: %s", err.Error())

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -79,7 +79,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		},
 	}
 
-	if lib.GetSEGName() != lib.DEFAULT_GROUP {
+	if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 		avi_vs_meta.ServiceEngineGroup = lib.GetSEGName()
 	}
 	vrfcontext := lib.GetVrf()

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -358,7 +358,7 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 				certsBuilt = true
 			}
 		}
-		if lib.GetSEGName() != lib.DEFAULT_GROUP {
+		if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 			sniNode.ServiceEngineGroup = lib.GetSEGName()
 		}
 		sniNode.VrfContext = lib.GetVrf()

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -173,7 +173,7 @@ func (o *AviObjectGraph) BuildL7VSGraph(vsName string, namespace string, ingName
 							Namespace:   namespace,
 						},
 					}
-					if lib.GetSEGName() != lib.DEFAULT_GROUP {
+					if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 						sniNode.ServiceEngineGroup = lib.GetSEGName()
 					}
 					sniNode.VrfContext = lib.GetVrf()
@@ -306,7 +306,7 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string) *AviVsN
 	// This is a shared VS - always created in the admin namespace for now.
 	avi_vs_meta = &AviVsNode{Name: vsName, Tenant: lib.GetTenant(),
 		EastWest: false, SharedVS: true}
-	if lib.GetSEGName() != lib.DEFAULT_GROUP {
+	if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 		avi_vs_meta.ServiceEngineGroup = lib.GetSEGName()
 	}
 	// Hard coded ports for the shared VS

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -547,6 +547,7 @@ func (v *AviVsNode) CalculateCheckSum() {
 		httppolChecksum +
 		sniChecksum +
 		utils.Hash(v.ApplicationProfile) +
+		utils.Hash(v.ServiceEngineGroup) +
 		utils.Hash(v.NetworkProfile) +
 		utils.Hash(utils.Stringify(portproto)) +
 		sslkeyChecksum +

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -34,7 +34,7 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 	// create the secured shared VS to listen on port 443
 	avi_vs_meta = &AviVsNode{Name: vsName, Tenant: lib.GetTenant(),
 		EastWest: false, SharedVS: true}
-	if lib.GetSEGName() != lib.DEFAULT_GROUP {
+	if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 		avi_vs_meta.ServiceEngineGroup = lib.GetSEGName()
 	}
 	var portProtocols []AviPortHostProtocol
@@ -168,7 +168,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 		passChildVS = &AviVsNode{
 			Name: secureSharedVS.Name + lib.PassthroughInsecure, Tenant: lib.GetTenant(), EastWest: false, VrfContext: lib.GetVrf(),
 		}
-		if lib.GetSEGName() != lib.DEFAULT_GROUP {
+		if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
 			passChildVS.ServiceEngineGroup = lib.GetSEGName()
 		}
 		passChildVS.ApplicationProfile = utils.DEFAULT_L7_APP_PROFILE

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -126,7 +126,8 @@ func DequeueIngestion(key string, fullsync bool) {
 	}
 
 	// handle the services APIs
-	if lib.GetAdvancedL4() || lib.UseServicesAPI() && (objType == utils.L4LBService || objType == lib.Gateway || objType == lib.GatewayClass || objType == utils.Endpoints) {
+	if lib.GetAdvancedL4() || lib.UseServicesAPI() &&
+		(objType == utils.L4LBService || objType == lib.Gateway || objType == lib.GatewayClass || objType == utils.Endpoints || objType == lib.NsxAlbInfraSetting) {
 		if !valid && objType == utils.L4LBService {
 			schema, _ = ConfigDescriptor().GetByType(utils.Service)
 		}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
@@ -32,6 +30,7 @@ import (
 	avimodels "github.com/avinetworks/sdk/go/models"
 	"github.com/davecgh/go-spew/spew"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const VSVIP_NOTFOUND = "VsVip object not found"
@@ -61,7 +60,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 		svc_mdata := string(svc_mdata_json)
 		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
-		seGroupRef := "/api/serviceenginegroup?name=" + lib.GetSEGName()
+		seGroupRef := "/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup
 		enableRHI := lib.GetEnableRHI() // We don't impact the checksum of the VS since it's a global setting in AKO.
 		vs := avimodels.VirtualService{
 			Name:                  &name,

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -84,7 +84,7 @@ func AddDefaultIngressClass() {
 			},
 		},
 		Spec: networking.IngressClassSpec{
-			Controller: "ako.vmware.com/avi-lb",
+			Controller: lib.AviIngressController,
 		},
 	}
 


### PR DESCRIPTION
This introduces indexers to fetch corresponding GW/Services and push to layer 2.
Implements configuring ServiceEngineGroup for Gateway VSes, Network configuration
will be part of a subsequent PR.
This PR also fixes the NsxAlbInfraSetting client sets/listers/informers to be non-Namespaced.
Minor log consistency fixes in ingress_model_rel.go