### PR TITLE
Graph Layer Changes to support EVH model in AKO.

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
   clusterName: {{ .Values.AKOSettings.clusterName | quote }}
   servicesAPI: {{ .Values.AKOSettings.servicesAPI | quote }}
+  enableEVH: {{ .Values.AKOSettings.enableEVH | quote }}
   tenantsPerCluster: {{ .Values.ControllerSettings.tenantsPerCluster | quote }}
   tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
   defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -117,6 +117,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: enableRHI
+          - name: ENABLE_EVH
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: enableEVH
           - name: SERVICES_API
             valueFrom:
               configMapKeyRef:
@@ -206,6 +211,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: advancedL4
+          - name: EVH
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: evh
           - name: AUTO_L4_FQDN
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -211,11 +211,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: advancedL4
-          - name: EVH
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: evh
           - name: AUTO_L4_FQDN
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -17,6 +17,7 @@ AKOSettings:
   disableStaticRouteSync: "false" # If the POD networks are reachable from the Avi SE, set this knob to true.
   clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
   cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift 
+  enableEVH: false # This enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services 
   #NamespaceSelector contains label key and value used for namespacemigration
   #Same label has to be present on namespace/s which needs migration/sync to AKO
   namespaceSelector:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -17,6 +17,7 @@ package lib
 const (
 	DISABLE_STATIC_ROUTE_SYNC = "DISABLE_STATIC_ROUTE_SYNC"
 	ENABLE_RHI                = "ENABLE_RHI"
+	ENABLE_EVH                = "ENABLE_EVH"
 	CNI_PLUGIN                = "CNI_PLUGIN"
 	CALICO_CNI                = "calico"
 	OPENSHIFT_CNI             = "openshift"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -184,6 +184,31 @@ func GetSniPGName(ingName, namespace, host, path string) string {
 	return NamePrefix + namespace + "-" + host + path + "-" + ingName
 }
 
+// evh child
+func GetEvhVsPoolNPgName(ingName, namespace, host, path string, args ...string) string {
+	path = strings.ReplaceAll(path, "/", "_")
+	poolName := NamePrefix + namespace + "-" + host + path + "-" + ingName
+	if len(args) > 0 {
+		svcName := args[0]
+		poolName = poolName + "-" + svcName
+	}
+	return poolName
+}
+
+func GetEvhTlsNodeName(ingName, namespace, secret string, host string, path string) string {
+	path = strings.ReplaceAll(path, "/", "_")
+	if len(host) > 0 {
+		return NamePrefix + namespace + "-" + host + path + "-" + ingName
+	}
+
+	return NamePrefix + namespace + "-" + host + path + "-" + ingName + "-" + secret
+}
+
+func GetEvhPGName(ingName, namespace, host, path string) string {
+	path = strings.ReplaceAll(path, "/", "_")
+	return NamePrefix + namespace + "-" + host + path + "-" + ingName
+}
+
 func GetTLSKeyCertNodeName(namespace, secret string, sniHostName ...string) string {
 	if len(sniHostName) > 0 {
 		return NamePrefix + sniHostName[0]
@@ -389,6 +414,16 @@ func GetAdvancedL4() bool {
 	advanceL4 := os.Getenv(ADVANCED_L4)
 	if advanceL4 == "true" {
 
+		return true
+	}
+	return false
+}
+
+// This utility returns true if AKO is configured to create
+// VS with Enhanced Virtual Hosting
+func IsEvhEnabled() bool {
+	evh := os.Getenv(ENABLE_EVH)
+	if evh == "true" {
 		return true
 	}
 	return false

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1,0 +1,1029 @@
+package nodes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+
+	avimodels "github.com/avinetworks/sdk/go/models"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AviEvhVsNode struct {
+	EVHParent        bool
+	VHParentName     string
+	VHDomainNames    []string
+	EvhNodes         []*AviEvhVsNode
+	EvhHostName      string
+	EvhPath          string
+	EvhMatchCriteria string
+	// props from avi vs node
+	Name                  string
+	Tenant                string
+	ServiceEngineGroup    string
+	ApplicationProfile    string
+	NetworkProfile        string
+	Enabled               *bool
+	PortProto             []AviPortHostProtocol // for listeners
+	DefaultPool           string
+	EastWest              bool
+	CloudConfigCksum      uint32
+	DefaultPoolGroup      string
+	HTTPChecksum          uint32
+	PoolGroupRefs         []*AviPoolGroupNode
+	PoolRefs              []*AviPoolNode
+	TCPPoolGroupRefs      []*AviPoolGroupNode
+	HTTPDSrefs            []*AviHTTPDataScriptNode
+	PassthroughChildNodes []*AviEvhVsNode
+	SharedVS              bool
+	CACertRefs            []*AviTLSKeyCertNode
+	SSLKeyCertRefs        []*AviTLSKeyCertNode
+	HttpPolicyRefs        []*AviHttpPolicySetNode
+	VSVIPRefs             []*AviVSVIPNode
+	L4PolicyRefs          []*AviL4PolicyNode
+	TLSType               string
+	ServiceMetadata       avicache.ServiceMetadataObj
+	VrfContext            string
+	WafPolicyRef          string
+	AppProfileRef         string
+	AnalyticsProfileRef   string
+	ErrorPageProfileRef   string
+	HttpPolicySetRefs     []string
+	SSLProfileRef         string
+	VsDatascriptRefs      []string
+	SSLKeyCertAviRef      string
+}
+
+func (o *AviObjectGraph) GetAviEvhVS() []*AviEvhVsNode {
+	var aviVs []*AviEvhVsNode
+	for _, model := range o.modelNodes {
+		vs, ok := model.(*AviEvhVsNode)
+		if ok {
+			aviVs = append(aviVs, vs)
+		}
+	}
+	return aviVs
+}
+
+func (v *AviEvhVsNode) GetCheckSum() uint32 {
+	// Calculate checksum and return
+	v.CalculateCheckSum()
+	return v.CloudConfigCksum
+}
+
+func (v *AviEvhVsNode) GetEvhNodeForName(EVHNodeName string) *AviEvhVsNode {
+	for _, evhNode := range v.EvhNodes {
+		if evhNode.Name == EVHNodeName {
+			return evhNode
+		}
+	}
+	return nil
+}
+
+func (o *AviEvhVsNode) CheckCACertNodeNameNChecksum(cacertNodeName string, checksum uint32) bool {
+	for _, caCert := range o.CACertRefs {
+		if caCert.Name == cacertNodeName {
+			//Check if their checksums are same
+			if caCert.GetCheckSum() == checksum {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (o *AviEvhVsNode) CheckSSLCertNodeNameNChecksum(sslNodeName string, checksum uint32) bool {
+	for _, sslCert := range o.SSLKeyCertRefs {
+		if sslCert.Name == sslNodeName {
+			//Check if their checksums are same
+			if sslCert.GetCheckSum() == checksum {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (o *AviEvhVsNode) CheckPGNameNChecksum(pgNodeName string, checksum uint32) bool {
+	for _, pg := range o.PoolGroupRefs {
+		if pg.Name == pgNodeName {
+			//Check if their checksums are same
+			if pg.GetCheckSum() == checksum {
+				return false
+			} else {
+				return true
+			}
+		}
+	}
+	return true
+}
+
+func (o *AviEvhVsNode) CheckPoolNChecksum(poolNodeName string, checksum uint32) bool {
+	for _, pool := range o.PoolRefs {
+		if pool.Name == poolNodeName {
+			//Check if their checksums are same
+			if pool.GetCheckSum() == checksum {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (o *AviEvhVsNode) GetPGForVSByName(pgName string) *AviPoolGroupNode {
+	for _, pgNode := range o.PoolGroupRefs {
+		if pgNode.Name == pgName {
+			return pgNode
+		}
+	}
+	return nil
+}
+
+func (o *AviEvhVsNode) ReplaceEvhPoolInEVHNode(newPoolNode *AviPoolNode, key string) {
+	for i, pool := range o.PoolRefs {
+		if pool.Name == newPoolNode.Name {
+			o.PoolRefs = append(o.PoolRefs[:i], o.PoolRefs[i+1:]...)
+			o.PoolRefs = append(o.PoolRefs, newPoolNode)
+			utils.AviLog.Infof("key: %s, msg: replaced evh pool in model: %s Pool name: %s", key, o.Name, pool.Name)
+			return
+		}
+	}
+	// If we have reached here it means we haven't found a match. Just append the pool.
+	o.PoolRefs = append(o.PoolRefs, newPoolNode)
+	return
+}
+
+func (o *AviEvhVsNode) ReplaceEvhPGInEVHNode(newPGNode *AviPoolGroupNode, key string) {
+	for i, pg := range o.PoolGroupRefs {
+		if pg.Name == newPGNode.Name {
+			o.PoolGroupRefs = append(o.PoolGroupRefs[:i], o.PoolGroupRefs[i+1:]...)
+			o.PoolGroupRefs = append(o.PoolGroupRefs, newPGNode)
+			utils.AviLog.Infof("key: %s, msg: replaced evh pg in model: %s Pool name: %s", key, o.Name, pg.Name)
+			return
+		}
+	}
+	// If we have reached here it means we haven't found a match. Just append.
+	o.PoolGroupRefs = append(o.PoolGroupRefs, newPGNode)
+	return
+}
+
+func (o *AviEvhVsNode) DeleteCACertRefInEVHNode(cacertNodeName, key string) {
+	for i, cacert := range o.CACertRefs {
+		if cacert.Name == cacertNodeName {
+			o.CACertRefs = append(o.CACertRefs[:i], o.CACertRefs[i+1:]...)
+			utils.AviLog.Infof("key: %s, msg: replaced cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
+			return
+		}
+	}
+}
+
+func (o *AviEvhVsNode) ReplaceCACertRefInEVHNode(cacertNode *AviTLSKeyCertNode, key string) {
+	for i, cacert := range o.CACertRefs {
+		if cacert.Name == cacertNode.Name {
+			o.CACertRefs = append(o.CACertRefs[:i], o.CACertRefs[i+1:]...)
+			o.CACertRefs = append(o.CACertRefs, cacertNode)
+			utils.AviLog.Infof("key: %s, msg: replaced cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
+			return
+		}
+	}
+	// If we have reached here it means we haven't found a match. Just append.
+	o.CACertRefs = append(o.CACertRefs, cacertNode)
+}
+
+func (o *AviEvhVsNode) ReplaceEvhSSLRefInEVHNode(newSslNode *AviTLSKeyCertNode, key string) {
+	for i, ssl := range o.SSLKeyCertRefs {
+		if ssl.Name == newSslNode.Name {
+			o.SSLKeyCertRefs = append(o.SSLKeyCertRefs[:i], o.SSLKeyCertRefs[i+1:]...)
+			o.SSLKeyCertRefs = append(o.SSLKeyCertRefs, newSslNode)
+			utils.AviLog.Infof("key: %s, msg: replaced evh ssl in model: %s Pool name: %s", key, o.Name, ssl.Name)
+			return
+		}
+	}
+	// If we have reached here it means we haven't found a match. Just append.
+	o.SSLKeyCertRefs = append(o.SSLKeyCertRefs, newSslNode)
+	return
+}
+
+func (v *AviEvhVsNode) GetNodeType() string {
+	return "VirtualServiceNode"
+}
+
+func (v *AviEvhVsNode) CalculateCheckSum() {
+	portproto := v.PortProto
+	sort.Slice(portproto, func(i, j int) bool {
+		return portproto[i].Name < portproto[j].Name
+	})
+
+	var dsChecksum, httppolChecksum, evhChecksum, sslkeyChecksum, l4policyChecksum, passthroughChecksum, vsvipChecksum uint32
+
+	for _, ds := range v.HTTPDSrefs {
+		dsChecksum += ds.GetCheckSum()
+	}
+
+	for _, httppol := range v.HttpPolicyRefs {
+		httppolChecksum += httppol.GetCheckSum()
+	}
+
+	for _, EVHNode := range v.EvhNodes {
+		evhChecksum += EVHNode.GetCheckSum()
+	}
+
+	for _, cacert := range v.CACertRefs {
+		sslkeyChecksum += cacert.GetCheckSum()
+	}
+
+	for _, sslkeycert := range v.SSLKeyCertRefs {
+		sslkeyChecksum += sslkeycert.GetCheckSum()
+	}
+
+	for _, vsvipref := range v.VSVIPRefs {
+		vsvipChecksum += vsvipref.GetCheckSum()
+	}
+
+	for _, l4policy := range v.L4PolicyRefs {
+		l4policyChecksum += l4policy.GetCheckSum()
+	}
+
+	for _, passthroughChild := range v.PassthroughChildNodes {
+		passthroughChecksum += passthroughChild.GetCheckSum()
+	}
+
+	// keep the order of these policies
+	policies := v.HttpPolicySetRefs
+	scripts := v.VsDatascriptRefs
+
+	vsRefs := v.WafPolicyRef +
+		v.AppProfileRef +
+		utils.Stringify(policies) +
+		v.AnalyticsProfileRef +
+		v.ErrorPageProfileRef +
+		v.SSLProfileRef
+
+	if len(scripts) > 0 {
+		vsRefs += utils.Stringify(scripts)
+	}
+
+	checksum := dsChecksum +
+		httppolChecksum +
+		evhChecksum +
+		utils.Hash(v.ApplicationProfile) +
+		utils.Hash(v.NetworkProfile) +
+		utils.Hash(utils.Stringify(portproto)) +
+		sslkeyChecksum +
+		vsvipChecksum +
+		utils.Hash(vsRefs) +
+		l4policyChecksum +
+		passthroughChecksum +
+		utils.Hash(v.EvhHostName) +
+		utils.Hash(v.EvhPath)
+
+	if v.Enabled != nil {
+		checksum += utils.Hash(utils.Stringify(v.Enabled))
+	}
+
+	v.CloudConfigCksum = checksum
+}
+
+func (v *AviEvhVsNode) CopyNode() AviModelNode {
+	newNode := AviEvhVsNode{}
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		utils.AviLog.Warnf("Unable to marshal AviEvhVsNode: %s", err)
+	}
+	err = json.Unmarshal(bytes, &newNode)
+	if err != nil {
+		utils.AviLog.Warnf("Unable to unmarshal AviEvhVsNode: %s", err)
+	}
+	return &newNode
+}
+
+// Insecure ingress graph functions below
+
+func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName string, key string) *AviEvhVsNode {
+	o.Lock.Lock()
+	defer o.Lock.Unlock()
+
+	// This is a shared VS - always created in the admin namespace for now.
+	avi_vs_meta := &AviEvhVsNode{Name: vsName, Tenant: lib.GetTenant(),
+		EastWest: false, SharedVS: true}
+	if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
+		avi_vs_meta.ServiceEngineGroup = lib.GetSEGName()
+	}
+	// Hard coded ports for the shared VS
+	var portProtocols []AviPortHostProtocol
+	httpPort := AviPortHostProtocol{Port: 80, Protocol: utils.HTTP}
+	httpsPort := AviPortHostProtocol{Port: 443, Protocol: utils.HTTP, EnableSSL: true}
+	portProtocols = append(portProtocols, httpPort)
+	portProtocols = append(portProtocols, httpsPort)
+	avi_vs_meta.PortProto = portProtocols
+	// Default case.
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L7_SECURE_APP_PROFILE
+	avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+	avi_vs_meta.EVHParent = true
+
+	vrfcontext := lib.GetVrf()
+	avi_vs_meta.VrfContext = vrfcontext
+
+	o.AddModelNode(avi_vs_meta)
+
+	var fqdns []string
+
+	subDomains := GetDefaultSubDomain()
+	if subDomains != nil {
+		var fqdn string
+		if strings.HasPrefix(subDomains[0], ".") {
+			fqdn = vsName + "." + lib.GetTenant() + subDomains[0]
+		} else {
+			fqdn = vsName + "." + lib.GetTenant() + "." + subDomains[0]
+		}
+		fqdns = append(fqdns, fqdn)
+	} else {
+		utils.AviLog.Warnf("key: %s, msg: there is no nsipamdns configured in the cloud, not configuring the default fqdn", key)
+	}
+	vsVipNode := &AviVSVIPNode{Name: lib.GetVsVipName(vsName), Tenant: lib.GetTenant(), FQDNs: fqdns,
+		EastWest: false, VrfContext: vrfcontext}
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
+}
+
+func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childNode *AviEvhVsNode, namespace string, ingName string, key string, isIngr bool, host string, path IngressHostPathSvc) {
+	localPGList := make(map[string]*AviPoolGroupNode)
+
+	pgName := lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path)
+	var pgNode *AviPoolGroupNode
+	// There can be multiple services for the same path in case of alternate backend.
+	// In that case, make sure we are creating only one PG per path
+	pgNode, pgfound := localPGList[pgName]
+	if !pgfound {
+		pgNode = &AviPoolGroupNode{Name: pgName, Tenant: lib.GetTenant()}
+		localPGList[pgName] = pgNode
+	}
+
+	var poolName string
+	// Do not use serviceName in evh Pool Name for ingress for backward compatibility
+	if isIngr {
+		poolName = lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path)
+	} else {
+		poolName = lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path, path.ServiceName)
+	}
+	hostSlice := []string{host}
+	poolNode := &AviPoolNode{
+		Name:       poolName,
+		PortName:   path.PortName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: avicache.ServiceMetadataObj{
+			IngressName: ingName,
+			Namespace:   namespace,
+			HostNames:   hostSlice,
+		},
+	}
+
+	if !lib.IsNodePortMode() {
+		if servers := PopulateServers(poolNode, namespace, path.ServiceName, true, key); servers != nil {
+			poolNode.Servers = servers
+		}
+	} else {
+		if servers := PopulateServersForNodePort(poolNode, namespace, path.ServiceName, true, key); servers != nil {
+			poolNode.Servers = servers
+		}
+	}
+	pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
+	ratio := path.weight
+	pgNode.Members = append(pgNode.Members, &avimodels.PoolGroupMember{PoolRef: &pool_ref, Ratio: &ratio})
+
+	if childNode.CheckPGNameNChecksum(pgNode.Name, pgNode.GetCheckSum()) {
+		childNode.ReplaceEvhPGInEVHNode(pgNode, key)
+	}
+	if childNode.CheckPoolNChecksum(poolNode.Name, poolNode.GetCheckSum()) {
+		// Replace the poolNode.
+		childNode.ReplaceEvhPoolInEVHNode(poolNode, key)
+	}
+	o.AddModelNode(poolNode)
+
+	utils.AviLog.Infof("key: %s, msg: added pools and poolgroups. childNodeChecksum for childNode :%s is :%v", key, childNode.Name, childNode.GetCheckSum())
+
+}
+
+func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parsedIng IngressConfig, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost, hostsMap map[string]*objects.RouteIngrhost) {
+	for host, pathsvcmap := range parsedIng.IngressHostMap {
+		// Remove this entry from storedHosts. First check if the host exists in the stored map or not.
+		hostData, found := Storedhosts[host]
+		if found && hostData.InsecurePolicy != lib.PolicyNone {
+			// Verify the paths and take out the paths that are not need.
+			pathSvcDiff := routeIgrObj.GetDiffPathSvc(hostData.PathSvc, pathsvcmap)
+			if len(pathSvcDiff) == 0 {
+				// Marking the entry as None to handle delete stale config
+				Storedhosts[host].InsecurePolicy = lib.PolicyNone
+				Storedhosts[host].SecurePolicy = lib.PolicyNone
+			} else {
+				hostData.PathSvc = pathSvcDiff
+			}
+		}
+		if _, ok := hostsMap[host]; !ok {
+			hostsMap[host] = &objects.RouteIngrhost{
+				SecurePolicy: lib.PolicyNone,
+			}
+		}
+		hostsMap[host].InsecurePolicy = lib.PolicyAllow
+		hostsMap[host].PathSvc = getPathSvc(pathsvcmap)
+
+		shardVsName := DeriveHostNameShardVSForEvh(host, key)
+		if shardVsName == "" {
+			// If we aren't able to derive the ShardVS name, we should return
+			return
+		}
+		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found || aviModel == nil {
+			utils.AviLog.Infof("key: %s, msg: model not found, generating new model with name: %s", key, modelName)
+			aviModel = NewAviObjectGraph()
+			aviModel.(*AviObjectGraph).ConstructAviL7SharedVsNodeForEvh(shardVsName, key)
+		}
+
+		// fill PG pool and pool members for host + path
+
+		// We create evh child vs, pg, pools and attach servers to them here.
+		vsNode := aviModel.(*AviObjectGraph).GetAviEvhVS()
+		ingName := routeIgrObj.GetName()
+		namespace := routeIgrObj.GetNamespace()
+		for _, path := range pathsvcmap {
+			evhNodeName := lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path)
+			evhNode := vsNode[0].GetEvhNodeForName(evhNodeName)
+			if evhNode == nil {
+				evhNode = &AviEvhVsNode{
+					Name:         evhNodeName,
+					VHParentName: vsNode[0].Name,
+					Tenant:       lib.GetTenant(),
+					EVHParent:    false,
+					EvhHostName:  host,
+					EvhPath:      path.Path,
+				}
+
+				if path.PathType == networkingv1beta1.PathTypeExact {
+					evhNode.EvhMatchCriteria = "EQUALS"
+				} else {
+					// PathTypePrefix and PathTypeImplementationSpecific
+					// default behaviour for AKO set be Prefix match on the path
+					evhNode.EvhMatchCriteria = "BEGINS_WITH"
+				}
+			}
+			if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
+				evhNode.ServiceEngineGroup = lib.GetSEGName()
+			}
+			evhNode.VrfContext = lib.GetVrf()
+			isIngr := routeIgrObj.GetType() == utils.Ingress
+			aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, isIngr, host, path)
+			foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)
+			if !foundEvhModel {
+				vsNode[0].EvhNodes = append(vsNode[0].EvhNodes, evhNode)
+			}
+		}
+
+		utils.AviLog.Debugf("key: %s, Saving Model in ProcessInsecureHostsForEVH : %v", key, utils.Stringify(vsNode))
+		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
+		if !utils.HasElem(modelList, modelName) && changedModel {
+			*modelList = append(*modelList, modelName)
+		}
+	}
+
+	utils.AviLog.Debugf("key: %s, msg: Storedhosts after processing insecurehosts: %s", key, utils.Stringify(Storedhosts))
+}
+
+// secure ingress graph functions
+
+// BuildCACertNode : Build a new node to store CA cert, this would be referred by the corresponding keycert
+func (o *AviObjectGraph) BuildCACertNodeForEvh(tlsNode *AviEvhVsNode, cacert, keycertname, key string) string {
+	cacertNode := &AviTLSKeyCertNode{Name: lib.GetCACertNodeName(keycertname), Tenant: lib.GetTenant()}
+	cacertNode.Type = lib.CertTypeCA
+	cacertNode.Cert = []byte(cacert)
+
+	if tlsNode.CheckCACertNodeNameNChecksum(cacertNode.Name, cacertNode.GetCheckSum()) {
+		if len(tlsNode.CACertRefs) == 1 {
+			tlsNode.CACertRefs[0] = cacertNode
+			utils.AviLog.Warnf("key: %s, msg: duplicate cacerts detected for %s, overwriting", key, cacertNode.Name)
+		} else {
+			tlsNode.ReplaceCACertRefInEVHNode(cacertNode, key)
+		}
+	}
+	return cacertNode.Name
+}
+
+func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tlsNode *AviEvhVsNode, namespace string, tlsData TlsSettings, key string, host ...string) bool {
+	mClient := utils.GetInformers().ClientSet
+	secretName := tlsData.SecretName
+	secretNS := tlsData.SecretNS
+	if secretNS == "" {
+		secretNS = namespace
+	}
+
+	var certNode *AviTLSKeyCertNode
+	if len(host) > 0 {
+		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName, host[0]), Tenant: lib.GetTenant()}
+	} else {
+		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName), Tenant: lib.GetTenant()}
+	}
+	certNode.Type = lib.CertTypeVS
+
+	// Openshift Routes do not refer to a secret, instead key/cert values are mentioned in the route
+	if strings.HasPrefix(secretName, lib.RouteSecretsPrefix) {
+		if tlsData.cert != "" && tlsData.key != "" {
+			certNode.Cert = []byte(tlsData.cert)
+			certNode.Key = []byte(tlsData.key)
+			if tlsData.cacert != "" {
+				certNode.CACert = o.BuildCACertNodeForEvh(tlsNode, tlsData.cacert, certNode.Name, key)
+			} else {
+				tlsNode.DeleteCACertRefInEVHNode(lib.GetCACertNodeName(certNode.Name), key)
+			}
+		} else {
+			ok, _ := svcLister.IngressMappings(namespace).GetSecretToIng(secretName)
+			if ok {
+				svcLister.IngressMappings(namespace).DeleteSecretToIngMapping(secretName)
+			}
+			utils.AviLog.Infof("key: %s, msg: no cert/key specified for TLS route")
+			//To Do: use a Default secret if required
+			return false
+		}
+	} else {
+		secretObj, err := mClient.CoreV1().Secrets(secretNS).Get(context.TODO(), secretName, metav1.GetOptions{})
+		if err != nil || secretObj == nil {
+			// This secret has been deleted.
+			ok, ingNames := svcLister.IngressMappings(namespace).GetSecretToIng(secretName)
+			if ok {
+				// Delete the secret key in the cache if it has no references
+				if len(ingNames) == 0 {
+					svcLister.IngressMappings(namespace).DeleteSecretToIngMapping(secretName)
+				}
+			}
+			utils.AviLog.Infof("key: %s, msg: secret: %s has been deleted, err: %s", key, secretName, err)
+			return false
+		}
+		keycertMap := secretObj.Data
+		cert, ok := keycertMap[tlsCert]
+		if ok {
+			certNode.Cert = cert
+		} else {
+			utils.AviLog.Infof("key: %s, msg: certificate not found for secret: %s", key, secretObj.Name)
+			return false
+		}
+		tlsKey, keyfound := keycertMap[utils.K8S_TLS_SECRET_KEY]
+		if keyfound {
+			certNode.Key = tlsKey
+		} else {
+			utils.AviLog.Infof("key: %s, msg: key not found for secret: %s", key, secretObj.Name)
+			return false
+		}
+		utils.AviLog.Infof("key: %s, msg: Added the secret object to tlsnode: %s", key, secretObj.Name)
+	}
+	// If this SSLCertRef is already present don't add it.
+	if len(host) > 0 {
+		if tlsNode.CheckSSLCertNodeNameNChecksum(lib.GetTLSKeyCertNodeName(namespace, secretName, host[0]), certNode.GetCheckSum()) {
+			tlsNode.ReplaceEvhSSLRefInEVHNode(certNode, key)
+		}
+	} else {
+		tlsNode.SSLKeyCertRefs = append(tlsNode.SSLKeyCertRefs, certNode)
+	}
+	return true
+}
+
+func ProcessSecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parsedIng IngressConfig, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost,
+	hostsMap map[string]*objects.RouteIngrhost, fullsync bool, sharedQueue *utils.WorkerQueue) {
+	utils.AviLog.Debugf("key: %s, msg: Storedhosts before processing securehosts: %v", key, utils.Stringify(Storedhosts))
+
+	for _, tlssetting := range parsedIng.TlsCollection {
+		locEvhHostMap := evhNodeHostName(routeIgrObj, tlssetting, routeIgrObj.GetName(), routeIgrObj.GetNamespace(), key, fullsync, sharedQueue, modelList)
+		for host, newPathSvc := range locEvhHostMap {
+			// Remove this entry from storedHosts. First check if the host exists in the stored map or not.
+			hostData, found := Storedhosts[host]
+			if found && hostData.SecurePolicy == lib.PolicyEdgeTerm {
+				// Verify the paths and take out the paths that are not need.
+				pathSvcDiff := routeIgrObj.GetDiffPathSvc(hostData.PathSvc, newPathSvc)
+
+				if len(pathSvcDiff) == 0 {
+					Storedhosts[host].SecurePolicy = lib.PolicyNone
+					Storedhosts[host].InsecurePolicy = lib.PolicyNone
+				} else {
+					hostData.PathSvc = pathSvcDiff
+				}
+			}
+			if _, ok := hostsMap[host]; !ok {
+				hostsMap[host] = &objects.RouteIngrhost{
+					InsecurePolicy: lib.PolicyNone,
+				}
+			}
+			hostsMap[host].SecurePolicy = lib.PolicyEdgeTerm
+			if tlssetting.redirect == true {
+				hostsMap[host].InsecurePolicy = lib.PolicyRedirect
+			}
+			hostsMap[host].PathSvc = getPathSvc(newPathSvc)
+		}
+	}
+	utils.AviLog.Debugf("key: %s, msg: Storedhosts after processing securehosts: %s", key, utils.Stringify(Storedhosts))
+}
+
+func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingName, namespace, key string, fullsync bool, sharedQueue *utils.WorkerQueue, modelList *[]string) map[string][]IngressHostPathSvc {
+	hostPathSvcMap := make(map[string][]IngressHostPathSvc)
+	for host, paths := range tlssetting.Hosts {
+		var hosts []string
+		hostPathSvcMap[host] = paths
+		hostMap := HostNamePathSecrets{paths: getPaths(paths), secretName: tlssetting.SecretName}
+		found, ingressHostMap := SharedHostNameLister().Get(host)
+		if found {
+			// Replace the ingress map for this host.
+			ingressHostMap.HostNameMap[namespace+"/"+ingName] = hostMap
+			ingressHostMap.GetIngressesForHostName(host)
+		} else {
+			// Create the map
+			ingressHostMap = NewSecureHostNameMapProp()
+			ingressHostMap.HostNameMap[namespace+"/"+ingName] = hostMap
+		}
+		SharedHostNameLister().Save(host, ingressHostMap)
+		hosts = append(hosts, host)
+		shardVsName := DeriveHostNameShardVSForEvh(host, key)
+		// For each host, create a EVH node with the secret giving us the key and cert.
+		// construct a EVH child VS node per tls setting which corresponds to one secret
+		if shardVsName == "" {
+			// If we aren't able to derive the ShardVS name, we should return
+			//return hostPathMap
+			return hostPathSvcMap
+		}
+		model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
+		found, aviModel := objects.SharedAviGraphLister().Get(model_name)
+		if !found || aviModel == nil {
+			utils.AviLog.Infof("key: %s, msg: model not found, generating new model with name: %s", key, model_name)
+			aviModel = NewAviObjectGraph()
+			aviModel.(*AviObjectGraph).ConstructAviL7SharedVsNodeForEvh(shardVsName, key)
+		}
+		vsNode := aviModel.(*AviObjectGraph).GetAviEvhVS()
+
+		certsBuilt := false
+		evhSecretName := tlssetting.SecretName
+		re := regexp.MustCompile(fmt.Sprintf(`^%s.*`, lib.DummySecret))
+		if re.MatchString(evhSecretName) {
+			evhSecretName = strings.Split(evhSecretName, "/")[1]
+			certsBuilt = true
+		}
+
+		for _, path := range paths {
+			evhNode := vsNode[0].GetEvhNodeForName(lib.GetEvhTlsNodeName(ingName, namespace, evhSecretName, host, path.Path))
+			if evhNode == nil {
+				evhNode = &AviEvhVsNode{
+					Name:         lib.GetEvhTlsNodeName(ingName, namespace, evhSecretName, host, path.Path),
+					VHParentName: vsNode[0].Name,
+					Tenant:       lib.GetTenant(),
+					EVHParent:    false,
+					EvhHostName:  host,
+					EvhPath:      path.Path,
+					ServiceMetadata: avicache.ServiceMetadataObj{
+						NamespaceIngressName: ingressHostMap.GetIngressesForHostName(host),
+						Namespace:            namespace,
+						HostNames:            hosts,
+					},
+				}
+
+				if path.PathType == networkingv1beta1.PathTypeExact {
+					evhNode.EvhMatchCriteria = "EQUALS"
+				} else {
+					// PathTypePrefix and PathTypeImplementationSpecific
+					// default behaviour for AKO set be Prefix match on the path
+					evhNode.EvhMatchCriteria = "BEGINS_WITH"
+				}
+				if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
+					evhNode.ServiceEngineGroup = lib.GetSEGName()
+				}
+			} else {
+				// The evh node exists, just update the svc metadata
+				evhNode.ServiceMetadata.NamespaceIngressName = ingressHostMap.GetIngressesForHostName(host)
+				evhNode.ServiceMetadata.Namespace = namespace
+				evhNode.ServiceMetadata.HostNames = hosts
+				if evhNode.SSLKeyCertAviRef != "" {
+					certsBuilt = true
+				}
+			}
+			if lib.GetSEGName() != lib.DEFAULT_SE_GROUP {
+				evhNode.ServiceEngineGroup = lib.GetSEGName()
+			}
+			evhNode.VrfContext = lib.GetVrf()
+			if !certsBuilt {
+				certsBuilt = aviModel.(*AviObjectGraph).BuildTlsCertNodeForEvh(routeIgrObj.GetSvcLister(), vsNode[0], namespace, tlssetting, key, host)
+			}
+			if certsBuilt {
+				isIngr := routeIgrObj.GetType() == utils.Ingress
+				aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, isIngr, host, path)
+				foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)
+				if !foundEvhModel {
+					vsNode[0].EvhNodes = append(vsNode[0].EvhNodes, evhNode)
+				}
+
+				RemoveRedirectHTTPPolicyInModelForEvh(vsNode[0], host, key)
+
+				if tlssetting.redirect == true {
+					aviModel.(*AviObjectGraph).BuildPolicyRedirectForVSForEvh(vsNode, host, namespace, ingName, key)
+				}
+				// TODO: Enable host rule
+				// BuildL7HostRule(host, namespace, ingName, key, evhNode)
+			} else {
+				hostMapOk, ingressHostMap := SharedHostNameLister().Get(host)
+				if hostMapOk {
+					// Replace the ingress map for this host.
+					keyToRemove := namespace + "/" + ingName
+					delete(ingressHostMap.HostNameMap, keyToRemove)
+					SharedHostNameLister().Save(host, ingressHostMap)
+				}
+				// Since the cert couldn't be built, remove the evh node from the model
+				RemoveEvhInModel(evhNode.Name, vsNode, key)
+				RemoveRedirectHTTPPolicyInModelForEvh(vsNode[0], host, key)
+
+			}
+			// Only add this node to the list of models if the checksum has changed.
+			utils.AviLog.Debugf("key: %s, Saving Model: %v", key, utils.Stringify(vsNode))
+			modelChanged := saveAviModel(model_name, aviModel.(*AviObjectGraph), key)
+			if !utils.HasElem(*modelList, model_name) && modelChanged {
+				*modelList = append(*modelList, model_name)
+			}
+		}
+	}
+
+	return hostPathSvcMap
+}
+
+// Util functions
+
+func FindAndReplaceEvhInModel(currentEvhNode *AviEvhVsNode, modelEvhNodes []*AviEvhVsNode, key string) bool {
+	for i, modelEvhNode := range modelEvhNodes[0].EvhNodes {
+		if currentEvhNode.Name == modelEvhNode.Name {
+			// Check if the checksums are same
+			if !(modelEvhNode.GetCheckSum() == currentEvhNode.GetCheckSum()) {
+				// The checksums are not same. Replace this evh node
+				modelEvhNodes[0].EvhNodes = append(modelEvhNodes[0].EvhNodes[:i], modelEvhNodes[0].EvhNodes[i+1:]...)
+				modelEvhNodes[0].EvhNodes = append(modelEvhNodes[0].EvhNodes, currentEvhNode)
+				utils.AviLog.Infof("key: %s, msg: replaced evh node in model: %s", key, currentEvhNode.Name)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveEvhInModel(currentEvhNodeName string, modelEvhNodes []*AviEvhVsNode, key string) {
+	if len(modelEvhNodes[0].EvhNodes) > 0 {
+		for i, modelEvhNode := range modelEvhNodes[0].EvhNodes {
+			if currentEvhNodeName == modelEvhNode.Name {
+				modelEvhNodes[0].EvhNodes = append(modelEvhNodes[0].EvhNodes[:i], modelEvhNodes[0].EvhNodes[i+1:]...)
+				utils.AviLog.Infof("key: %s, msg: deleted evh node in model: %s", key, currentEvhNodeName)
+				return
+			}
+		}
+	}
+}
+
+func FindAndReplaceRedirectHTTPPolicyInModelforEvh(vsNode *AviEvhVsNode, httpPolicy *AviHttpPolicySetNode, hostname, key string) bool {
+	for _, policy := range vsNode.HttpPolicyRefs {
+		if policy.Name == httpPolicy.Name && policy.CloudConfigCksum != httpPolicy.CloudConfigCksum {
+			if !utils.HasElem(policy.RedirectPorts[0].Hosts, hostname) {
+				policy.RedirectPorts[0].Hosts = append(policy.RedirectPorts[0].Hosts, hostname)
+				utils.AviLog.Infof("key: %s, msg: replaced host %s for policy %s in model", key, hostname, policy.Name)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveRedirectHTTPPolicyInModelForEvh(vsNode *AviEvhVsNode, hostname, key string) {
+	policyName := lib.GetL7HttpRedirPolicy(vsNode.Name)
+	deletePolicy := false
+	for i, policy := range vsNode.HttpPolicyRefs {
+		if policy.Name == policyName {
+			// one redirect policy per shard vs
+			policy.RedirectPorts[0].Hosts = utils.Remove(policy.RedirectPorts[0].Hosts, hostname)
+			utils.AviLog.Infof("key: %s, msg: removed host %s from policy %s in model %v", key, hostname, policy.Name, policy.RedirectPorts[0].Hosts)
+			if len(policy.RedirectPorts[0].Hosts) == 0 {
+				deletePolicy = true
+			}
+
+			if deletePolicy {
+				vsNode.HttpPolicyRefs = append(vsNode.HttpPolicyRefs[:i], vsNode.HttpPolicyRefs[i+1:]...)
+				utils.AviLog.Infof("key: %s, msg: removed policy %s in model", key, policy.Name)
+			}
+		}
+	}
+}
+
+func RemoveFQDNsFromModelForEvh(vsNode *AviEvhVsNode, hosts []string, key string) {
+	if len(vsNode.VSVIPRefs) > 0 {
+		for i, fqdn := range vsNode.VSVIPRefs[0].FQDNs {
+			if utils.HasElem(hosts, fqdn) {
+				// remove logic conainer-lib candidate
+				vsNode.VSVIPRefs[0].FQDNs[i] = vsNode.VSVIPRefs[0].FQDNs[len(vsNode.VSVIPRefs[0].FQDNs)-1]
+				vsNode.VSVIPRefs[0].FQDNs[len(vsNode.VSVIPRefs[0].FQDNs)-1] = ""
+				vsNode.VSVIPRefs[0].FQDNs = vsNode.VSVIPRefs[0].FQDNs[:len(vsNode.VSVIPRefs[0].FQDNs)-1]
+			}
+		}
+	}
+}
+
+// RouteIngrDeletePoolsByHostname : Based on DeletePoolsByHostname, delete pools and policies that are no longer required
+func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespace, objname, key string, fullsync bool, sharedQueue *utils.WorkerQueue) {
+	ok, hostMap := routeIgrObj.GetSvcLister().IngressMappings(namespace).GetRouteIngToHost(objname)
+	if !ok {
+		utils.AviLog.Warnf("key: %s, msg: nothing to delete for route: %s", key, objname)
+		return
+	}
+
+	utils.AviLog.Debugf("key: %s, msg: hosts to delete are :%s", key, utils.Stringify(hostMap))
+	for host, hostData := range hostMap {
+		shardVsName := DeriveHostNameShardVSForEvh(host, key)
+		if hostData.SecurePolicy == lib.PolicyPass {
+			shardVsName = lib.GetPassthroughShardVSName(host, key)
+		}
+		if shardVsName == "" {
+			// If we aren't able to derive the ShardVS name, we should return
+			utils.AviLog.Infof("key: %s, shard vs ndoe not found for host: %s", host)
+			return
+		}
+		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found || aviModel == nil {
+			utils.AviLog.Warnf("key: %s, msg: model not found during delete: %s", key, modelName)
+			continue
+		}
+		// Delete the pool corresponding to this host
+		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
+			aviModel.(*AviObjectGraph).DeleteVsForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, true)
+		} else if hostData.SecurePolicy == lib.PolicyPass {
+			aviModel.(*AviObjectGraph).DeleteObjectsForPassthroughHost(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, true)
+		}
+		if hostData.InsecurePolicy == lib.PolicyAllow {
+			aviModel.(*AviObjectGraph).DeleteVsForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, false)
+		}
+		ok := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
+		if ok && len(aviModel.(*AviObjectGraph).GetOrderedNodes()) != 0 && !fullsync {
+			PublishKeyToRestLayer(modelName, key, sharedQueue)
+		}
+	}
+	// Now remove the secret relationship
+	routeIgrObj.GetSvcLister().IngressMappings(namespace).RemoveIngressSecretMappings(objname)
+	utils.AviLog.Infof("key: %s, removed ingress mapping for: %s", key, objname)
+
+	// Remove the hosts mapping for this ingress
+	routeIgrObj.GetSvcLister().IngressMappings(namespace).DeleteIngToHostMapping(objname)
+
+	// remove hostpath mappings
+	updateHostPathCacheV2(namespace, objname, hostMap, nil)
+}
+
+//DeleteStaleData : delete pool, EVH VS and redirect policy which are present in the object store but no longer required.
+func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost, hostsMap map[string]*objects.RouteIngrhost) {
+	utils.AviLog.Debugf("key: %s, msg: About to delete stale data EVH Stored hosts: %v, hosts map: %v", key, utils.Stringify(Storedhosts), utils.Stringify(hostsMap))
+	for host, hostData := range Storedhosts {
+		utils.AviLog.Debugf("host to del: %s, data : %s", host, utils.Stringify(hostData))
+		shardVsName := DeriveHostNameShardVSForEvh(host, key)
+
+		if shardVsName == "" {
+			// If we aren't able to derive the ShardVS name, we should return
+			return
+		}
+		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found || aviModel == nil {
+			utils.AviLog.Warnf("key: %s, msg: model not found during delete: %s", key, modelName)
+			continue
+		}
+		// By default remove both redirect and fqdn. So if the host isn't transitioning, then we will remove both.
+		removeFqdn := true
+		removeRedir := true
+		currentData, ok := hostsMap[host]
+		utils.AviLog.Warnf("key: %s, hostsMap: %s", key, utils.Stringify(hostsMap))
+		// if route is transitioning from/to passthrough route, then always remove fqdn
+		if ok && hostData.SecurePolicy != lib.PolicyPass && currentData.SecurePolicy != lib.PolicyPass {
+			if currentData.InsecurePolicy == lib.PolicyRedirect {
+				removeRedir = false
+			}
+			utils.AviLog.Infof("key: %s, host: %s, currentData: %v", key, host, currentData)
+			removeFqdn = false
+		}
+		// Delete the pool corresponding to this host
+		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
+			aviModel.(*AviObjectGraph).DeleteVsForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, removeFqdn, removeRedir, true)
+		}
+		if hostData.InsecurePolicy != lib.PolicyNone {
+			aviModel.(*AviObjectGraph).DeleteVsForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, removeFqdn, removeRedir, false)
+
+		}
+		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
+		if !utils.HasElem(modelList, modelName) && changedModel {
+			*modelList = append(*modelList, modelName)
+		}
+	}
+}
+
+func DeriveHostNameShardVSForEvh(hostname string, key string) string {
+	// Read the value of the num_shards from the environment variable.
+	utils.AviLog.Debugf("key: %s, msg: hostname for sharding: %s", key, hostname)
+	var vsNum uint32
+	shardSize := lib.GetshardSize()
+	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-EVH-"
+	if shardSize != 0 {
+		vsNum = utils.Bkt(hostname, shardSize)
+		utils.AviLog.Debugf("key: %s, msg: VS number: %v", key, vsNum)
+	} else {
+		utils.AviLog.Warnf("key: %s, msg: the value for shard_vs_size does not match the ENUM values", key)
+		return ""
+	}
+	vsName := shardVsPrefix + fmt.Sprint(vsNum)
+	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
+	return vsName
+}
+
+func (o *AviObjectGraph) DeleteVsForHostnameForEvh(vsName, hostname string, routeIgrObj RouteIngressModel, pathSvc map[string][]string, key string, removeFqdn, removeRedir, secure bool) {
+
+	o.Lock.Lock()
+	defer o.Lock.Unlock()
+
+	namespace := routeIgrObj.GetNamespace()
+	ingName := routeIgrObj.GetName()
+	vsNode := o.GetAviEvhVS()
+	keepEvh := false
+	if !secure {
+		// Fetch the ingress evh vs that are present in the model and delete them.
+		for path := range pathSvc {
+			evhVsName := lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path)
+			_ = o.RemoveEvhVsNode(evhVsName, vsNode, key, hostname)
+
+		}
+
+	} else {
+		// Remove the ingress from the hostmap
+		hostMapOk, ingressHostMap := SharedHostNameLister().Get(hostname)
+		if hostMapOk {
+			// Replace the ingress map for this host.
+			keyToRemove := namespace + "/" + ingName
+			delete(ingressHostMap.HostNameMap, keyToRemove)
+			SharedHostNameLister().Save(hostname, ingressHostMap)
+		}
+
+		for path := range pathSvc {
+			evhVsName := lib.GetEvhTlsNodeName(ingName, namespace, "", hostname, path)
+			utils.AviLog.Infof("key: %s, msg: evh node to delete: %s", key, evhVsName)
+			keepEvh = o.RemoveEvhVsNode(evhVsName, vsNode, key, hostname)
+
+			if removeFqdn && !keepEvh {
+				var hosts []string
+				hosts = append(hosts, hostname)
+				// Remove these hosts from the overall FQDN list
+				RemoveFQDNsFromModelForEvh(vsNode[0], hosts, key)
+			}
+			if removeRedir && !keepEvh {
+				RemoveRedirectHTTPPolicyInModelForEvh(vsNode[0], hostname, key)
+			}
+
+		}
+	}
+
+}
+
+func (o *AviObjectGraph) RemoveEvhVsNode(evhVsName string, vsNode []*AviEvhVsNode, key string, hostname string) bool {
+	utils.AviLog.Debugf("Removing EVH vs: %s", evhVsName)
+	for _, modelEvhNode := range vsNode[0].EvhNodes {
+		if evhVsName != modelEvhNode.Name {
+			continue
+		}
+		RemoveEvhInModel(evhVsName, vsNode, key)
+		SharedHostNameLister().Delete(hostname)
+		return false
+	}
+
+	return true
+}
+
+func (o *AviObjectGraph) BuildPolicyRedirectForVSForEvh(vsNode []*AviEvhVsNode, hostname string, namespace, ingName, key string) {
+	policyname := lib.GetL7HttpRedirPolicy(vsNode[0].Name)
+	myHppMap := AviRedirectPort{
+		Hosts:        []string{hostname},
+		RedirectPort: 443,
+		StatusCode:   lib.STATUS_REDIRECT,
+		VsPort:       80,
+	}
+
+	redirectPolicy := &AviHttpPolicySetNode{
+		Tenant:        lib.GetTenant(),
+		Name:          policyname,
+		RedirectPorts: []AviRedirectPort{myHppMap},
+	}
+
+	if policyFound := FindAndReplaceRedirectHTTPPolicyInModelforEvh(vsNode[0], redirectPolicy, hostname, key); !policyFound {
+		redirectPolicy.CalculateCheckSum()
+		vsNode[0].HttpPolicyRefs = append(vsNode[0].HttpPolicyRefs, redirectPolicy)
+	}
+
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -64,6 +64,7 @@ const (
 	TLS_PASSTHROUGH               = "TLS_PASSTHROUGH"
 	VS_TYPE_VH_PARENT             = "VS_TYPE_VH_PARENT"
 	VS_TYPE_VH_CHILD              = "VS_TYPE_VH_CHILD"
+	VS_TYPE_VH_ENHANCED           = "VS_TYPE_VH_ENHANCED"
 	NodeObj                       = "Node"
 	GlobalVRF                     = "global"
 	VRF_CONTEXT                   = "VRF_CONTEXT"

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
@@ -1,0 +1,2071 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package hostnameshardtests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func VerifyIngressDeletionForEvh(t *testing.T, g *gomega.WithT, aviModel interface{}, poolCount int, evhNodesCount int) {
+	var nodes []*avinodes.AviEvhVsNode
+	g.Eventually(func() []*avinodes.AviPoolNode {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return nodes[0].PoolRefs
+	}, 10*time.Second).Should(gomega.HaveLen(poolCount))
+
+	g.Eventually(func() []*avinodes.AviEvhVsNode {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return nodes[0].EvhNodes
+	}, 10*time.Second).Should(gomega.HaveLen(evhNodesCount))
+}
+
+func VerifyEvhIngressDeletion(t *testing.T, g *gomega.WithT, aviModel interface{}, evhCount int) {
+	var nodes []*avinodes.AviEvhVsNode
+	g.Eventually(func() []*avinodes.AviEvhVsNode {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return nodes[0].EvhNodes
+	}, 10*time.Second).Should(gomega.HaveLen(evhCount))
+
+}
+
+func TestL7ModelForEvh(t *testing.T) {
+
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, _ := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// We shouldn't get an update for this update since it neither belongs to an ingress nor a L4 LB service
+		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
+	}
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+// This tests the different objects associated in the evh model for ingress
+func TestHostnameShardObjectsForEvh(t *testing.T) {
+	// checks naming convention of all generated nodes
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+
+	// foo.com and noo.com compute the same hashed shard vs num
+	ingrFake := (integrationtest.FakeIngress{
+		Name:      "foo-with-targets",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com", "noo.com"},
+		Ips:       []string{"8.8.8.8"},
+		Paths:     []string{"/foo/bar"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).IngressMultiPath()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	verifyIng, _ := KubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	for i, host := range []string{"foo.com", "noo.com"} {
+		if verifyIng.Spec.Rules[i].Host == host {
+			g.Expect(verifyIng.Spec.Rules[i].Host).To(gomega.Equal(host))
+			g.Expect(verifyIng.Spec.Rules[i].HTTP.Paths[0].Path).To(gomega.Equal("/foo/bar"))
+		}
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--Shared-L7-EVH-0"))
+	// Shared VS in EVH will not have any pool or pool group unlike the normal VS
+	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+	g.Expect(nodes[0].HTTPDSrefs).Should(gomega.HaveLen(0))
+	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal("cluster--Shared-L7-EVH-0"))
+	// the certs will be associated to parent evh vs
+	g.Expect(nodes[0].SSLKeyCertRefs).Should(gomega.HaveLen(1))
+	// There will be 2 evh node one for each host+path combination
+	g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(2))
+	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-noo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-noo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-noo.com_foo_bar-foo-with-targets"))
+	// Shared VS in EVH will not have any certificates and httppolicy
+	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertRefs).Should(gomega.HaveLen(0))
+	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(0))
+
+	g.Expect(nodes[0].EvhNodes[1].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].EvhNodes[1].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].EvhNodes[1].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	// since foo is bound with cert this node will have the cert bound to it
+	g.Expect(nodes[0].EvhNodes[1].SSLKeyCertRefs).Should(gomega.HaveLen(0))
+	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs).Should(gomega.HaveLen(0))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestNoBackendL7ModelForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, _ := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// We shouldn't get an update for this update since it neither belongs to an ingress nor a L4 LB service
+		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
+	}
+	ingrFake := (integrationtest.FakeIngress{
+		Name:      "foo-with-targets",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Paths:     []string{"/"},
+	}).IngressOnlyHostNoBackend()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(false))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestMultiIngressToSameSvcForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	os.Setenv("SHARD_VS_SIZE", "LARGE")
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcExample := (integrationtest.FakeService{
+		Name:         "avisvc",
+		Namespace:    "default",
+		Type:         corev1.ServiceTypeClusterIP,
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+	}).Service()
+
+	_, err := KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	epExample := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "avisvc",
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+			Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+		}},
+	}
+	_, err = KubeClient.CoreV1().Endpoints("default").Create(context.TODO(), epExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating Endpoint: %v", err)
+	}
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets2",
+		Namespace:   "default",
+		DnsNames:    []string{"bar.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(nodes[0].SharedVS).To(gomega.Equal(true))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		// Delete the model.
+		objects.SharedAviGraphLister().Delete(modelName)
+	} else {
+		t.Fatalf("Could not find model on ingress delete: %v", err)
+	}
+	//====== VERIFICATION OF SERVICE DELETE
+	// Now we have cleared the layer 2 queue for both the models. Let's delete the service.
+	err = KubeClient.CoreV1().Endpoints("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Endpoint %v", err)
+	}
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Service %v", err)
+	}
+	// We should be able to get one model now in the queue
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model on service delete: %v", err)
+	}
+	_, err = KubeClient.CoreV1().Endpoints("default").Create(context.TODO(), epExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating Endpoint: %v", err)
+	}
+	//====== VERIFICATION OF ONE INGRESS DELETE
+	// Now let's delete one ingress and expect the update for that.
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+
+		// Delete the model.
+		objects.SharedAviGraphLister().Delete(modelName)
+	} else {
+		t.Fatalf("Could not find model on ingress delete: %v", err)
+	}
+	//====== VERIFICATION OF SERVICE ADD
+	// Let's add the service back now - the ingress's associated with this service should be returned
+	_, err = KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	modelName = "admin/cluster--Shared-L7-EVH-1"
+	integrationtest.PollForCompletion(t, modelName, 5)
+	// We should be able to get one model now in the queue
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+
+		objects.SharedAviGraphLister().Delete(modelName)
+	} else {
+		t.Fatalf("Could not find model on service ADD: %v", err)
+	}
+	//====== VERIFICATION OF ONE ENDPOINT DELETE
+	err = KubeClient.CoreV1().Endpoints("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Endpoint %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	// Deletion should also give us the affected ingress objects
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		// Delete the model.
+		objects.SharedAviGraphLister().Delete(modelName)
+	} else {
+		t.Fatalf("Could not find model on service ADD: %v", err)
+	}
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Service %v", err)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+}
+
+func TestMultiVSIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(1))
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/foo"))
+
+	} else {
+		t.Fatalf("Could not find model: %v", err)
+	}
+	randoming := (integrationtest.FakeIngress{
+		Name:        "randomNamespacethatyeildsdiff",
+		Namespace:   "randomNamespacethatyeildsdiff",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("randomNamespacethatyeildsdiff").Create(context.TODO(), randoming, metav1.CreateOptions{})
+	integrationtest.PollForCompletion(t, modelName, 10)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(2))
+
+	} else {
+		t.Fatalf("Could not find model: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("randomNamespacethatyeildsdiff").Delete(context.TODO(), "randomNamespacethatyeildsdiff", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+// TestMultiPathIngressForEvh in evh mode will validate if 2 evh nodes with host + path are created
+func TestMultiPathIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	var err error
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-multipath",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo", "/bar"},
+		ServiceName: "avisvc",
+	}).IngressMultiPath()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(0))
+
+		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(02))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multipath" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multipath" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[1].PoolGroupRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[1].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multipath", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestMultiPortServiceIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	var err error
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	objects.SharedAviGraphLister().Delete(modelName)
+	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, true)
+	integrationtest.CreateEP(t, "default", "avisvc", true, true, "1.1.1")
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-multipath",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress(true)
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multipath" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs).Should(gomega.HaveLen(1))
+				g.Expect(evhNode.PoolRefs).Should(gomega.HaveLen(1))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multipath" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+				g.Expect(evhNode.PoolGroupRefs).Should(gomega.HaveLen(1))
+				g.Expect(evhNode.PoolRefs).Should(gomega.HaveLen(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multipath", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestMultiIngressSameHostForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi2",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multi1" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs).Should(gomega.HaveLen(1))
+				g.Expect(evhNode.PoolRefs).Should(gomega.HaveLen(1))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multi2" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+				g.Expect(evhNode.PoolGroupRefs).Should(gomega.HaveLen(1))
+				g.Expect(evhNode.PoolRefs).Should(gomega.HaveLen(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 1)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestDeleteBackendServiceForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi2",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	// Delete the service
+	integrationtest.DelSVC(t, "default", "avisvc")
+	integrationtest.DelEP(t, "default", "avisvc")
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)
+		}, 10*time.Second).Should(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 1)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multi2"))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+}
+
+func TestUpdateBackendServiceForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "ingress-backend-svc",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(*nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal("1.1.1.1"))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	// Update the service
+
+	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "avisvc2", false, false, "2.2.2")
+
+	_, err = (integrationtest.FakeIngress{
+		Name:        "ingress-backend-svc",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc2",
+	}).UpdateIngress()
+	if err != nil {
+		t.Fatalf("error in updating ingress %s", err)
+	}
+
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		g.Eventually(func() string {
+			_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
+		}, 10*time.Second).Should(gomega.Equal("2.2.2.1"))
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-backend-svc", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DelSVC(t, "default", "avisvc2")
+	integrationtest.DelEP(t, "default", "avisvc2")
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestL2ChecksumsUpdateForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	//create ingress with tls secret
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:      "ingress-chksum",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		Paths:     []string{"/foo"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	initCheckSums := make(map[string]uint32)
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		t.Logf("nodes %s", utils.Stringify(nodes))
+		initCheckSums["nodes[0]"] = nodes[0].CloudConfigCksum
+
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+		initCheckSums["nodes[0].EvhNodes[0]"] = nodes[0].EvhNodes[0].CloudConfigCksum
+
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
+		initCheckSums["nodes[0].EvhNodes[0].PoolRefs[0]"] = nodes[0].EvhNodes[0].PoolRefs[0].CloudConfigCksum
+
+		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].SSLKeyCertRefs)).To(gomega.Equal(1))
+		initCheckSums["nodes[0].SSLKeyCertRefs[0]"] = nodes[0].SSLKeyCertRefs[0].CloudConfigCksum
+
+		g.Expect(len(nodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
+		initCheckSums["nodes[0].HttpPolicyRefs[0]"] = nodes[0].HttpPolicyRefs[0].CloudConfigCksum
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "avisvc2", false, false, "2.2.2")
+	integrationtest.AddSecret("my-secret-new", "default", "tlsCert-new", "tlsKey")
+
+	_, err = (integrationtest.FakeIngress{
+		Name:      "ingress-chksum",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		//to update httppolicyref checksum
+		Paths:     []string{"/bar"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			//to update tls secret checksum
+			"my-secret-new": {"foo.com"},
+		},
+		//to update poolref checksum
+		ServiceName: "avisvc2",
+	}).UpdateIngress()
+	if err != nil {
+		t.Fatalf("error in updating ingress %s", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		t.Logf("nodes: %v", utils.Stringify(nodes))
+		g.Eventually(len(nodes), 5*time.Second).Should(gomega.Equal(1))
+
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+		g.Eventually(func() uint32 {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return nodes[0].EvhNodes[0].CloudConfigCksum
+		}, 5*time.Second).ShouldNot(gomega.Equal(initCheckSums["nodes[0].EvhNodes[0]"]))
+
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
+		g.Eventually(func() uint32 {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return nodes[0].EvhNodes[0].PoolRefs[0].CloudConfigCksum
+		}, 5*time.Second).ShouldNot(gomega.Equal(initCheckSums["nodes[0].EvhNodes[0].PoolRefs[0]"]))
+
+		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
+		g.Eventually(func() uint32 {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return nodes[0].SSLKeyCertRefs[0].CloudConfigCksum
+		}, 5*time.Second).ShouldNot(gomega.Equal(initCheckSums["nodes[0].SSLKeyCertRefs[0]"]))
+
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-chksum", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DelSVC(t, "default", "avisvc2")
+	integrationtest.DelEP(t, "default", "avisvc2")
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret-new", metav1.DeleteOptions{})
+	VerifyEvhIngressDeletion(t, g, aviModel, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+func TestMultiHostIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-multihost",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com", "bar.com"},
+		Paths:       []string{"/foo", "/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 10)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	modelName = "admin/cluster--Shared-L7-EVH-1"
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-bar.com_foo-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("bar.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+			} else if evhNode.Name == "cluster--default-bar.com_bar-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("bar.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multihost", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-multihost",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com", "foo.com"},
+		Paths:       []string{"/foo", "/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multihost" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multihost", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestEditPathIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-edit",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingrFake.ResourceVersion = "1"
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(1))
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/foo"))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "ingress-edit",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingrFake.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		dsNodes := aviModel.(*avinodes.AviObjectGraph).GetAviHTTPDSNode()
+		g.Expect(len(dsNodes)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(1))
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-edit"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/bar"))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-edit", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestEditMultiPathIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-multipath-edit",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingrFake.ResourceVersion = "1"
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "ingress-multipath-edit",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo", "/bar"},
+		ServiceName: "avisvc",
+	}).IngressMultiPath()
+	ingrFake.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multipath-edit" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multipath-edit"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multipath-edit"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multipath-edit" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multipath-edit"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multipath-edit"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "ingress-multipath-edit",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo", "/foobar"},
+		ServiceName: "avisvc",
+	}).IngressMultiPath()
+	ingrFake.ResourceVersion = "3"
+	objects.SharedAviGraphLister().Delete(modelName)
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multipath-edit" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multipath-edit"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multipath-edit"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else if evhNode.Name == "cluster--default-foo.com_foobar-ingress-multipath-edit" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foobar"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foobar-ingress-multipath-edit"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foobar-ingress-multipath-edit"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multipath-edit", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestEditMultiIngressSameHostForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	model_name := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, model_name)
+
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := integrationtest.KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi2",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = integrationtest.KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	ingrFake2 = (integrationtest.FakeIngress{
+		Name:        "ingress-multi2",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foobar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = integrationtest.KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake2, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	// time.Sleep(10 * time.Second)
+
+	integrationtest.PollForCompletion(t, model_name, 5)
+	integrationtest.DetectModelChecksumChange(t, model_name, 15)
+	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multi1" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else if evhNode.Name == "cluster--default-foo.com_foobar-ingress-multi2" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foobar"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foobar-ingress-multi2"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foobar-ingress-multi2"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", model_name)
+	}
+	err = integrationtest.KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, model_name, 5)
+	VerifyEvhIngressDeletion(t, g, aviModel, 1)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	err = integrationtest.KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.DetectModelChecksumChange(t, model_name, 5)
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, model_name)
+}
+
+func TestNoHostIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-2"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-nohost",
+		Namespace:   "default",
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).IngressNoHost()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("ingress-nohost.default.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/foo"))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-nohost", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestEditNoHostToHostIngressForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-2"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "ingress-nohost",
+		Namespace:   "default",
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).IngressNoHost()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-ingress-nohost.default.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("ingress-nohost.default.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/foo"))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "ingress-nohost",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	ingrFake.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in Updating Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	modelName = "admin/cluster--Shared-L7-EVH-0"
+	integrationtest.PollForCompletion(t, modelName, 5)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+
+		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-nohost"))
+		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
+		g.Expect(nodes[0].EvhNodes[0].EvhPath).To(gomega.Equal("/foo"))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-nohost", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestScaleEndpointsForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:        "ingress-multi2",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Paths:       []string{"/bar"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multi1" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multi2" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multi2"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multi2"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(1))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	integrationtest.ScaleCreateEP(t, "default", "avisvc")
+	integrationtest.PollForCompletion(t, modelName, 5)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		for _, evhNode := range nodes[0].EvhNodes {
+			if evhNode.Name == "cluster--default-foo.com_foo-ingress-multi1" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/foo"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-ingress-multi1"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(2))
+			} else if evhNode.Name == "cluster--default-foo.com_bar-ingress-multi2" {
+				g.Expect(evhNode.EvhHostName).To(gomega.Equal("foo.com"))
+				g.Expect(evhNode.EvhPath).To(gomega.Equal("/bar"))
+				g.Expect(evhNode.PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multi2"))
+				g.Expect(evhNode.PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_bar-ingress-multi2"))
+				g.Expect(len(evhNode.PoolGroupRefs[0].Members)).To(gomega.Equal(1))
+				g.Expect(len(evhNode.PoolRefs[0].Servers)).To(gomega.Equal(2))
+			} else {
+				t.Fatalf("unexpected evh node name: %s", evhNode.Name)
+			}
+		}
+		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 1)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+	TearDownTestForIngress(t, modelName)
+
+}
+
+// Additional SNI test cases follow:
+
+func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, _ := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// We shouldn't get an update for this update since it neither belongs to an ingress nor a L4 LB service
+		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
+	}
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-no-secret",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(0))
+		g.Expect(nodes[0].VHDomainNames).To(gomega.HaveLen(0))
+		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(0))
+	} else {
+		t.Fatalf("Could not find Model: %v", err)
+	}
+
+	// Now create the secret and verify the models.
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(1))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-no-secret", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	VerifyIngressDeletionForEvh(t, g, aviModel, 0, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, _ := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// We shouldn't get an update for this update since it neither belongs to an ingress nor a L4 LB service
+		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
+	}
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:        "foo-no-secret1",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	ingrFake2 := (integrationtest.FakeIngress{
+		Name:      "foo-no-secret2",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find Model: %v", err)
+	}
+
+	// Now create the secret and verify the models.
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// Check if the secret affected both the models.
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(2))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	time.Sleep(10 * time.Second)
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	integrationtest.DetectModelChecksumChange(t, modelName, 5)
+
+	VerifyEvhIngressDeletion(t, g, aviModel, 0)
+	// Since we deleted the secret, both EVH should get removed.
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// Check if the secret affected both the models.
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(0))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-no-secret1", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-no-secret2", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestL7ModelMultiSNIForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	modelName := "admin/cluster--Shared-L7-EVH-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com", "noo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com", "noo.com"},
+		},
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
+	} else {
+		t.Fatalf("Could not find Model: %v", err)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	VerifyEvhIngressDeletion(t, g, aviModel, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
+	// This test covers creating multiple SNI nodes via multiple secrets.
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
+	// Clean up any earlier models.
+	modelName := "admin/cluster--Shared-L7-EVH-1"
+	objects.SharedAviGraphLister().Delete(modelName)
+	modelName = "admin/cluster--Shared-L7-EVH-0"
+	objects.SharedAviGraphLister().Delete(modelName)
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com", "FOO.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret":  {"foo.com"},
+			"my-secret2": {"FOO.com"},
+		},
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+		g.Expect(nodes[0].HttpPolicyRefs[0].RedirectPorts[0].Hosts).To(gomega.HaveLen(2))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(0))
+	} else {
+		t.Fatalf("Could not find Model: %v", err)
+	}
+
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com", "bar.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret":  {"foo.com"},
+			"my-secret2": {"bar.com"},
+		},
+	}).Ingress()
+	ingrFake.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	// Because of change of the hostnames, the SNI nodes should now get distributed to two shared VSes.
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// Check if the secret affected both the models.
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(1))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	modelName = "admin/cluster--Shared-L7-EVH-1"
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		g.Eventually(func() int {
+			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+			return len(nodes[0].EvhNodes)
+		}, 10*time.Second).Should(gomega.Equal(1))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret2", metav1.DeleteOptions{})
+	VerifyEvhIngressDeletion(t, g, aviModel, 0)
+
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
+	integrationtest.EnableEVH()
+	defer integrationtest.DisableEVH()
+
+	g := gomega.NewGomegaWithT(t)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
+	modelName := "admin/cluster--Shared-L7-EVH-1"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.org"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.org"},
+		},
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, _ := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		// This will not generate a model.
+		t.Fatalf("Could not find Model: %v", err)
+	}
+	ingrFake = (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.org", "bar.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+		TlsSecretDNS: map[string][]string{
+			"my-secret":  {"foo.org"},
+			"my-secret2": {"bar.com"},
+		},
+	}).Ingress()
+	ingrFake.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		g.Expect(len(nodes)).To(gomega.Equal(1))
+		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
+		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
+		g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(0))
+	} else {
+		t.Fatalf("Could not find Model: %v", err)
+	}
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	VerifyEvhIngressDeletion(t, g, aviModel, 0)
+
+	TearDownTestForIngress(t, modelName)
+}

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -114,6 +114,8 @@ func AddConfigMap() {
 			Name:      "avi-k8s-config",
 		},
 	}
+	aviCM.Data = make(map[string]string)
+	aviCM.Data["logLevel"] = "DEBUG"
 	KubeClient.CoreV1().ConfigMaps("avi-system").Create(context.TODO(), aviCM, metav1.CreateOptions{})
 
 	integrationtest.PollForSyncStart(ctrl, 10)

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -114,8 +114,6 @@ func AddConfigMap() {
 			Name:      "avi-k8s-config",
 		},
 	}
-	aviCM.Data = make(map[string]string)
-	aviCM.Data["logLevel"] = "DEBUG"
 	KubeClient.CoreV1().ConfigMaps("avi-system").Create(context.TODO(), aviCM, metav1.CreateOptions{})
 
 	integrationtest.PollForSyncStart(ctrl, 10)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -621,6 +621,14 @@ func SetClusterIPMode() {
 	os.Setenv("SERVICE_TYPE", "ClusterIP")
 }
 
+func EnableEVH() {
+	os.Setenv("ENABLE_EVH", "true")
+}
+
+func DisableEVH() {
+	os.Setenv("ENABLE_EVH", "false")
+}
+
 func CreateNode(t *testing.T, nodeName string, nodeIP string) {
 	modelName := "admin/global"
 	objects.SharedAviGraphLister().Delete(modelName)


### PR DESCRIPTION
This PR adds support for the [EVH](https://avinetworks.com/docs/20.1/enhanced-virtual-hosting//) in AKO. 
- Introduces enableEVH flag which is currently set to false.
- Listing down overall scenarios tested for L2 changes.
- Create Insecure and secure ingress and check if there are no Pools and PoolGroups created for the shared VS
- Check that the model populated is of AviEvhVS when EVH is enabled.
- Create and edit multiple hosts + multiple Path + and editing of secret and check if model is updated appropriately.
- All the existing L2 layer tests are added with Evh Enabled but the validations differ.