### PR TITLE
Update vs uuids in the object annotations

### DIFF
--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: ["get","watch","list"]
 {{- end}}
   - apiGroups: [""]
-    resources: ["services/status"]
+    resources: ["services", "services/status"]
     verbs: ["get","watch","list","patch", "update"]
   - apiGroups: [""]
     resources: ["services"]

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -15,7 +15,6 @@ package cache
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -529,43 +528,4 @@ func (c *AviCache) ShallowCopy() map[interface{}]interface{} {
 		newMap[key] = value
 	}
 	return newMap
-}
-
-var controllerClusterUUID string
-
-// SetControllerClusterUUID sets the controller cluster's UUID value which is fetched from
-// /api/cluster. If the variable controllerClusterUUID is already set, no API call will be
-// made.
-func SetControllerClusterUUID(clientPool *utils.AviRestClientPool) error {
-	if controllerClusterUUID != "" {
-		// controller cluster UUID already set
-		return nil
-	}
-	uri := "/api/cluster"
-	var clusterIntf interface{}
-
-	if err := clientPool.AviClient[0].AviSession.Get(uri, &clusterIntf); err != nil {
-		return fmt.Errorf("error in get uri %s: %v", uri, err)
-	}
-
-	if clusterIntf == nil {
-		return fmt.Errorf("unexpected response for get cluster, get URI %s returned %v type %T",
-			uri, clusterIntf, clusterIntf)
-	}
-	if cluster, ok := clusterIntf.(map[string]interface{}); ok {
-		if clusterUUID, parsed := cluster["uuid"].(string); parsed {
-			controllerClusterUUID = clusterUUID
-		} else {
-			return fmt.Errorf("error in parsing controller cluster uuid field from %v", cluster)
-		}
-	} else {
-		return fmt.Errorf("response %v couldn't be parsed to map[string][interface]", clusterIntf)
-	}
-
-	return nil
-}
-
-// GetControllerClusterUUID returns the value in controllerClusterUUID variable.
-func GetControllerClusterUUID() string {
-	return controllerClusterUUID
 }

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/avinetworks/sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
@@ -537,7 +536,7 @@ var controllerClusterUUID string
 // SetControllerClusterUUID sets the controller cluster's UUID value which is fetched from
 // /api/cluster. If the variable controllerClusterUUID is already set, no API call will be
 // made.
-func SetControllerClusterUUID(client *clients.AviClient) error {
+func SetControllerClusterUUID(clientPool *utils.AviRestClientPool) error {
 	if controllerClusterUUID != "" {
 		// controller cluster UUID already set
 		return nil
@@ -545,7 +544,7 @@ func SetControllerClusterUUID(client *clients.AviClient) error {
 	uri := "/api/cluster"
 	var clusterIntf interface{}
 
-	if err := client.AviSession.Get(uri, &clusterIntf); err != nil {
+	if err := clientPool.AviClient[0].AviSession.Get(uri, &clusterIntf); err != nil {
 		return fmt.Errorf("error in get uri %s: %v", uri, err)
 	}
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2322,6 +2322,40 @@ func (c *AviObjCache) AviDNSPropertyPopulate(client *clients.AviClient, cloudUUI
 	return dnsSubDomains
 }
 
+var controllerClusterUUID string
+
+// SetControllerClusterUUID sets the controller cluster's UUID value which is fetched from
+// /api/cluster. If the variable controllerClusterUUID is already set, no API call will be
+// made.
+func SetControllerClusterUUID(clientPool *utils.AviRestClientPool) error {
+	if controllerClusterUUID != "" {
+		// controller cluster UUID already set
+		return nil
+	}
+	uri := "/api/cluster"
+	var result interface{}
+	err := lib.AviGet(clientPool.AviClient[0], uri, &result)
+	if err != nil {
+		return fmt.Errorf("cluster get uri %s returned error %v", uri, err)
+	}
+	controllerClusterData, ok := result.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("error in parsing controller cluster response: %v", result)
+	}
+	if clusterUUID, parsed := controllerClusterData["uuid"].(string); parsed {
+		controllerClusterUUID = clusterUUID
+	} else {
+		return fmt.Errorf("error in parsing controller cluster uuid field from %v", controllerClusterData)
+	}
+
+	return nil
+}
+
+// GetControllerClusterUUID returns the value in controllerClusterUUID variable.
+func GetControllerClusterUUID() string {
+	return controllerClusterUUID
+}
+
 func ValidateUserInput(client *clients.AviClient) bool {
 	// add other step0 validation logics here -> isValid := check1 && check2 && ...
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -55,7 +55,7 @@ func PopulateCache() error {
 			utils.AviLog.Warnf("failed to populate avi cache with error: %v", err.Error())
 			return err
 		}
-		if err = avicache.SetControllerClusterUUID(avi_rest_client_pool.AviClient[0]); err != nil {
+		if err = avicache.SetControllerClusterUUID(avi_rest_client_pool); err != nil {
 			utils.AviLog.Warnf("Failed to set the controller cluster uuid with error: %v", err)
 		}
 		// once the l3 cache is populated, we can call the updatestatus functions from here

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -55,6 +55,9 @@ func PopulateCache() error {
 			utils.AviLog.Warnf("failed to populate avi cache with error: %v", err.Error())
 			return err
 		}
+		if err = avicache.SetControllerClusterUUID(avi_rest_client_pool.AviClient[0]); err != nil {
+			utils.AviLog.Warnf("Failed to set the controller cluster uuid with error: %v", err)
+		}
 		// once the l3 cache is populated, we can call the updatestatus functions from here
 		restlayer := rest.NewRestOperations(avi_obj_cache, avi_rest_client_pool)
 		restlayer.SyncObjectStatuses()

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -256,10 +256,11 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 				vs_cache_obj.AddToPoolKeyCollection(k)
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for Pool Collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				if svc_mdata_obj.Namespace != "" {
-					status.UpdateRouteIngressStatus([]status.UpdateStatusOptions{{
-						Vip:             vs_cache_obj.Vip,
-						ServiceMetadata: svc_mdata_obj,
-						Key:             key,
+					status.UpdateRouteIngressStatus([]status.UpdateOptions{{
+						Vip:                vs_cache_obj.Vip,
+						ServiceMetadata:    svc_mdata_obj,
+						Key:                key,
+						VirtualServiceUUID: vs_cache_obj.Uuid,
 					}}, false)
 				}
 			}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -423,13 +423,13 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					utils.Stringify(vs_cache_obj)))
 				if svc_mdata_obj.Gateway != "" {
 					if lib.UseServicesAPI() {
-						status.UpdateSvcApiGatewayStatusAddress([]status.UpdateStatusOptions{{
+						status.UpdateSvcApiGatewayStatusAddress([]status.UpdateOptions{{
 							Vip:             vs_cache_obj.Vip,
 							ServiceMetadata: svc_mdata_obj,
 							Key:             key,
 						}}, false)
 					} else {
-						status.UpdateGatewayStatusAddress([]status.UpdateStatusOptions{{
+						status.UpdateGatewayStatusAddress([]status.UpdateOptions{{
 							Vip:             vs_cache_obj.Vip,
 							ServiceMetadata: svc_mdata_obj,
 							Key:             key,
@@ -437,16 +437,18 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					}
 				} else if len(svc_mdata_obj.NamespaceServiceName) > 0 {
 					// This service needs an update of the status
-					status.UpdateL4LBStatus([]status.UpdateStatusOptions{{
-						Vip:             vs_cache_obj.Vip,
-						ServiceMetadata: svc_mdata_obj,
-						Key:             key,
+					status.UpdateL4LBStatus([]status.UpdateOptions{{
+						Vip:                vs_cache_obj.Vip,
+						ServiceMetadata:    svc_mdata_obj,
+						Key:                key,
+						VirtualServiceUUID: vs_cache_obj.Uuid,
 					}}, false)
 				} else if (svc_mdata_obj.IngressName != "" || len(svc_mdata_obj.NamespaceIngressName) > 0) && svc_mdata_obj.Namespace != "" && parentVsObj != nil {
-					status.UpdateRouteIngressStatus([]status.UpdateStatusOptions{{
-						Vip:             parentVsObj.Vip,
-						ServiceMetadata: svc_mdata_obj,
-						Key:             key,
+					status.UpdateRouteIngressStatus([]status.UpdateOptions{{
+						Vip:                parentVsObj.Vip,
+						ServiceMetadata:    svc_mdata_obj,
+						Key:                key,
+						VirtualServiceUUID: vs_cache_obj.Uuid,
 					}}, false)
 				}
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
@@ -460,10 +462,11 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 							pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
 							if found {
 								if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
-									status.UpdateRouteIngressStatus([]status.UpdateStatusOptions{{
-										Vip:             vs_cache_obj.Vip,
-										ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
-										Key:             key,
+									status.UpdateRouteIngressStatus([]status.UpdateOptions{{
+										Vip:                vs_cache_obj.Vip,
+										ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
+										Key:                key,
+										VirtualServiceUUID: vs_cache_obj.Uuid,
 									}}, false)
 								}
 							}
@@ -500,7 +503,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 
 			if len(svc_mdata_obj.NamespaceServiceName) > 0 {
 				// This service needs an update of the status
-				status.UpdateL4LBStatus([]status.UpdateStatusOptions{{
+				status.UpdateL4LBStatus([]status.UpdateOptions{{
 					Vip:             vs_cache_obj.Vip,
 					ServiceMetadata: svc_mdata_obj,
 					Key:             key,

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -29,9 +29,9 @@ func (rest *RestOperations) SyncObjectStatuses() {
 	vsKeys := rest.cache.VsCacheMeta.AviGetAllKeys()
 	utils.AviLog.Debugf("Ingress status sync for vsKeys %+v", utils.Stringify(vsKeys))
 
-	var allIngressUpdateOptions []status.UpdateStatusOptions
-	var allServiceLBUpdateOptions []status.UpdateStatusOptions
-	var allGatewayUpdateOptions []status.UpdateStatusOptions
+	var allIngressUpdateOptions []status.UpdateOptions
+	var allServiceLBUpdateOptions []status.UpdateOptions
+	var allGatewayUpdateOptions []status.UpdateOptions
 	for _, vsKey := range vsKeys {
 		if vsKey.Name == lib.DummyVSForStaleData {
 			continue
@@ -51,7 +51,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		if vsSvcMetadataObj.Gateway != "" {
 			// gateway based VSes
 			allGatewayUpdateOptions = append(allGatewayUpdateOptions,
-				status.UpdateStatusOptions{
+				status.UpdateOptions{
 					Vip:             vsCacheObj.Vip,
 					ServiceMetadata: vsSvcMetadataObj,
 					Key:             "syncstatus",
@@ -66,19 +66,21 @@ func (rest *RestOperations) SyncObjectStatuses() {
 			parentVsObj, _ := parentVs.(*avicache.AviVsCache)
 			if (vsSvcMetadataObj.IngressName != "" || len(vsSvcMetadataObj.NamespaceIngressName) > 0) && vsSvcMetadataObj.Namespace != "" && parentVsObj != nil {
 				allIngressUpdateOptions = append(allIngressUpdateOptions,
-					status.UpdateStatusOptions{
-						Vip:             parentVsObj.Vip,
-						ServiceMetadata: vsSvcMetadataObj,
-						Key:             "syncstatus",
+					status.UpdateOptions{
+						Vip:                parentVsObj.Vip,
+						ServiceMetadata:    vsSvcMetadataObj,
+						Key:                "syncstatus",
+						VirtualServiceUUID: vsCacheObj.Uuid,
 					})
 			}
 		} else if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
 			// serviceLB
 			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
-				status.UpdateStatusOptions{
-					Vip:             vsCacheObj.Vip,
-					ServiceMetadata: vsSvcMetadataObj,
-					Key:             "syncstatus",
+				status.UpdateOptions{
+					Vip:                vsCacheObj.Vip,
+					ServiceMetadata:    vsSvcMetadataObj,
+					Key:                "syncstatus",
+					VirtualServiceUUID: vsCacheObj.Uuid,
 				})
 		} else {
 			// insecure VSes handler
@@ -96,10 +98,11 @@ func (rest *RestOperations) SyncObjectStatuses() {
 				// insecure pools
 				if poolCacheObj.ServiceMetadataObj.Namespace != "" {
 					allIngressUpdateOptions = append(allIngressUpdateOptions,
-						status.UpdateStatusOptions{
-							Vip:             vsCacheObj.Vip,
-							ServiceMetadata: poolCacheObj.ServiceMetadataObj,
-							Key:             "syncstatus",
+						status.UpdateOptions{
+							Vip:                vsCacheObj.Vip,
+							ServiceMetadata:    poolCacheObj.ServiceMetadataObj,
+							Key:                "syncstatus",
+							VirtualServiceUUID: vsCacheObj.Uuid,
 						})
 				}
 			}

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -41,9 +41,9 @@ type UpdateGWStatusConditionOptions struct {
 	Reason  string               // reason for transition
 }
 
-func UpdateGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) {
+func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	gatewaysToUpdate, updateGWOptions := parseOptionsFromMetadata(options, bulk)
-	var updateServiceOptions []UpdateStatusOptions
+	var updateServiceOptions []UpdateOptions
 
 	// gatewayMap: {ns/gateway: gatewayObj}
 	// this pre-fetches all gateways to be candidates for status update
@@ -51,7 +51,7 @@ func UpdateGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) {
 	// in which case gateway will be fetched again in updateObject, as part of a retry
 	gatewayMap := getGateways(gatewaysToUpdate, bulk)
 	for _, option := range updateGWOptions {
-		updateServiceOptions = append(updateServiceOptions, UpdateStatusOptions{
+		updateServiceOptions = append(updateServiceOptions, UpdateOptions{
 			Vip: option.Vip,
 			Key: option.Key,
 			ServiceMetadata: avicache.ServiceMetadataObj{
@@ -81,9 +81,9 @@ func UpdateGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) {
 	return
 }
 
-func parseOptionsFromMetadata(options []UpdateStatusOptions, bulk bool) ([]string, []UpdateStatusOptions) {
+func parseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, []UpdateOptions) {
 	var objectsToUpdate []string
-	var updateGWOptions []UpdateStatusOptions
+	var updateGWOptions []UpdateOptions
 
 	for _, option := range options {
 		if option.ServiceMetadata.Gateway != "" {

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -42,7 +42,7 @@ type UpdateOptions struct {
 
 const (
 	VSAnnotation         = "ako.vmware.com/virtualservices"
-	ControllerAnnotation = "ako.vmware.com/controller-uuid"
+	ControllerAnnotation = "ako.vmware.com/controller-cluster-uuid"
 )
 
 // VSUuidAnnotation is maps a hostname to the UUID of the virtual service where it is placed.
@@ -239,6 +239,7 @@ func getAnnotationsPayload(vsAnnotations map[string]string, existingAnnotations 
 		existingAnnotations = make(map[string]string)
 	}
 	existingAnnotations[VSAnnotation] = string(vsAnnotationsStr)
+	existingAnnotations[ControllerAnnotation] = avicache.GetControllerClusterUUID()
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]string{
 			"annotations": existingAnnotations,

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
@@ -27,17 +28,26 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 )
 
-type UpdateStatusOptions struct {
+type UpdateOptions struct {
 	// IngSvc format: namespace/name, not supposed to be provided by the caller
-	IngSvc          string
-	Vip             string
-	ServiceMetadata avicache.ServiceMetadataObj
-	Key             string
+	IngSvc             string
+	Vip                string
+	ServiceMetadata    avicache.ServiceMetadataObj
+	Key                string
+	VirtualServiceUUID string
 }
 
-func UpdateIngressStatus(options []UpdateStatusOptions, bulk bool) {
+const (
+	VSAnnotation         = "ako.vmware.com/virtualservices"
+	ControllerAnnotation = "ako.vmware.com/controller-uuid"
+)
+
+// VSUuidAnnotation is maps a hostname to the UUID of the virtual service where it is placed.
+
+func UpdateIngressStatus(options []UpdateOptions, bulk bool) {
 	var err error
 	ingressesToUpdate, updateIngressOptions := ParseOptionsFromMetadata(options, bulk)
 
@@ -57,7 +67,7 @@ func UpdateIngressStatus(options []UpdateStatusOptions, bulk bool) {
 	return
 }
 
-func updateObject(mIngress *networkingv1beta1.Ingress, updateOption UpdateStatusOptions, retryNum ...int) error {
+func updateObject(mIngress *networkingv1beta1.Ingress, updateOption UpdateOptions, retryNum ...int) error {
 	if updateOption.Vip == "" {
 		return nil
 	}
@@ -105,28 +115,154 @@ func updateObject(mIngress *networkingv1beta1.Ingress, updateOption UpdateStatus
 		}
 	}
 
-	if sameStatus := compareLBStatus(oldIngressStatus, &mIngress.Status.LoadBalancer); sameStatus {
-		utils.AviLog.Debugf("key: %s, msg: No changes detected in ingress status. old: %+v new: %+v",
-			key, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
-		return nil
+	sameStatus := compareLBStatus(oldIngressStatus, &mIngress.Status.LoadBalancer)
+
+	var updatedIng *networkingv1beta1.Ingress
+	var err error
+	if !sameStatus {
+		patchPayload, _ := json.Marshal(map[string]interface{}{
+			"status": mIngress.Status,
+		})
+		updatedIng, err = mClient.NetworkingV1beta1().Ingresses(mIngress.Namespace).Patch(context.TODO(), mIngress.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+		if err != nil {
+			utils.AviLog.Errorf("key: %s, msg: there was an error in updating the ingress status: %v", key, err)
+			// fetch updated ingress and feed for update status
+			mIngresses := getIngresses([]string{mIngress.Namespace + "/" + mIngress.Name}, false)
+			if len(mIngresses) > 0 {
+				return updateObject(mIngresses[mIngress.Namespace+"/"+mIngress.Name], updateOption, retry+1)
+			}
+		}
+		utils.AviLog.Infof("key: %s, msg: Successfully updated the ingress status of ingress: %s/%s old: %+v new: %+v",
+			key, mIngress.Namespace, mIngress.Name, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
+	} else {
+		utils.AviLog.Debugf("key: %s, msg: no changes detected in the ingress %s/%s status", key, mIngress.Namespace, mIngress.Name)
 	}
 
-	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": mIngress.Status,
-	})
-	_, err := mClient.NetworkingV1beta1().Ingresses(mIngress.Namespace).Patch(context.TODO(), mIngress.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	// update the annotations for this object
+	err = updateIngAnnotations(mClient, updatedIng, hostnames, updateOption.VirtualServiceUUID, key, hostListIng, mIngress)
 	if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the ingress status: %v", key, err)
-		// fetch updated ingress and feed for update status
-		mIngresses := getIngresses([]string{mIngress.Namespace + "/" + mIngress.Name}, false)
-		if len(mIngresses) > 0 {
-			return updateObject(mIngresses[mIngress.Namespace+"/"+mIngress.Name], updateOption, retry+1)
+		return fmt.Errorf("key: %s, error in updating the Ingress annotations: %v", key, err)
+	}
+	return nil
+}
+
+func updateIngAnnotations(mClient kubernetes.Interface, ingObj *networkingv1beta1.Ingress, svcMetaHostnames []string,
+	vsUUID, key string, ingHostList []string, oldIng *networkingv1beta1.Ingress, retryNum ...int) error {
+
+	if ingObj == nil {
+		ingObj = oldIng
+	}
+	retry := 0
+	if len(retryNum) > 0 {
+		retry = retryNum[0]
+		if retry >= 3 {
+			return fmt.Errorf("retried 3 times to update ingress annotations, aborting")
+		}
+	}
+	var err error
+	vsAnnotations := make(map[string]string)
+
+	if value, ok := ingObj.Annotations[VSAnnotation]; ok {
+		if err := json.Unmarshal([]byte(value), &vsAnnotations); err != nil {
+			// just print an error and continue, this will be taken care of during the update
+			utils.AviLog.Errorf("key: %s, error in unmarshalling Ingress %s/%s annotations for VS: %v",
+				key, ingObj.Namespace, ingObj.Name, err)
 		}
 	}
 
-	utils.AviLog.Infof("key: %s, msg: Successfully updated the ingress status of ingress: %s/%s old: %+v new: %+v",
-		key, mIngress.Namespace, mIngress.Name, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
-	return err
+	// update the existing hostname vs uuid for the current update
+	for i := 0; i < len(svcMetaHostnames); i++ {
+		vsAnnotations[svcMetaHostnames[i]] = vsUUID
+	}
+
+	// remove the hostname from annotations which is not part of the spec
+	for k := range vsAnnotations {
+		if !utils.HasElem(ingHostList, k) {
+			delete(vsAnnotations, k)
+		}
+	}
+
+	// compare the vs annotations for this ingress object
+	req := isAnnotationsUpdateRequired(ingObj.Annotations, vsAnnotations)
+	if !req {
+		utils.AviLog.Debugf("annotations update not required for this ingress: %s/%s", ingObj.Namespace, ingObj.Name)
+		return nil
+	}
+	if err = patchIngressAnnotations(ingObj, vsAnnotations, mClient); err != nil {
+		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the ingress annotations: %v", key, err)
+		// fetch updated ingress and feed for update status
+		mIngresses := getIngresses([]string{ingObj.Namespace + "/" + ingObj.Name}, false)
+		if len(mIngresses) > 0 {
+			return updateIngAnnotations(mClient, mIngresses[ingObj.Namespace+"/"+ingObj.Name], svcMetaHostnames, vsUUID, key, ingHostList, oldIng, retry+1)
+		}
+	}
+
+	return nil
+}
+
+func isAnnotationsUpdateRequired(ingAnnotations map[string]string, newVSAnnotations map[string]string) bool {
+	oldVSAnnotationsStr, ok := ingAnnotations[VSAnnotation]
+	if !ok {
+		if len(newVSAnnotations) > 0 {
+			return true
+		}
+		return false
+	}
+
+	var oldVSAnnotations map[string]string
+	if err := json.Unmarshal([]byte(oldVSAnnotationsStr), &oldVSAnnotations); err != nil {
+		utils.AviLog.Errorf("error in unmarshalling old vs annotations %s: %v", oldVSAnnotationsStr, err)
+		return true
+	}
+
+	if len(oldVSAnnotations) != len(newVSAnnotations) {
+		return true
+	}
+	for oldHost, oldVS := range oldVSAnnotations {
+		newVS, exists := newVSAnnotations[oldHost]
+		if !exists {
+			return true
+		}
+		if newVS != oldVS {
+			return true
+		}
+	}
+	return false
+}
+
+func getAnnotationsPayload(vsAnnotations map[string]string, existingAnnotations map[string]string) ([]byte, error) {
+	vsAnnotationsStr, err := json.Marshal(vsAnnotations)
+	if err != nil {
+		return nil, fmt.Errorf("error in marshalling vs annotations: %v", err)
+	}
+	if len(existingAnnotations) == 0 {
+		existingAnnotations = make(map[string]string)
+	}
+	existingAnnotations[VSAnnotation] = string(vsAnnotationsStr)
+	patchPayload := map[string]interface{}{
+		"metadata": map[string]map[string]string{
+			"annotations": existingAnnotations,
+		},
+	}
+	patchPayloadBytes, err := json.Marshal(patchPayload)
+	if err != nil {
+		return nil, fmt.Errorf("error in marshalling patch payload %v: %v", patchPayloadBytes, err)
+	}
+	return patchPayloadBytes, nil
+}
+
+func patchIngressAnnotations(ingObj *networkingv1beta1.Ingress, vsAnnotations map[string]string, mClient kubernetes.Interface) error {
+	annotations := ingObj.GetAnnotations()
+	patchPayloadBytes, err := getAnnotationsPayload(vsAnnotations, annotations)
+	if err != nil {
+		return fmt.Errorf("error in generating payload for vs annotations %v: %v", vsAnnotations, err)
+	}
+
+	_, err = mClient.NetworkingV1beta1().Ingresses(ingObj.Namespace).Patch(context.TODO(), ingObj.Name, types.MergePatchType, patchPayloadBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("error in updating ingress: %v", err)
+	}
+	return nil
 }
 
 func DeleteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
@@ -193,28 +329,86 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 		}
 	}
 
-	if sameStatus := compareLBStatus(oldIngressStatus, &mIngress.Status.LoadBalancer); sameStatus {
+	sameStatus := compareLBStatus(oldIngressStatus, &mIngress.Status.LoadBalancer)
+
+	var updatedIng *networkingv1beta1.Ingress
+	if !sameStatus {
+		patchPayload, _ := json.Marshal(map[string]interface{}{
+			"status": mIngress.Status,
+		})
+		if len(mIngress.Status.LoadBalancer.Ingress) == 0 {
+			patchPayload, _ = json.Marshal(map[string]interface{}{
+				"status": nil,
+			})
+		}
+		updatedIng, err = mClient.NetworkingV1beta1().Ingresses(svc_mdata_obj.Namespace).Patch(context.TODO(), mIngress.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+		if err != nil {
+			utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the ingress status: %v", key, err)
+			return deleteObject(svc_mdata_obj, key, isVSDelete, retry+1)
+		}
+
+		utils.AviLog.Infof("key: %s, msg: Successfully deleted the ingress status of ingress: %s/%s old: %+v new: %+v",
+			key, mIngress.Namespace, mIngress.Name, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
+
+	} else {
 		utils.AviLog.Debugf("key: %s, msg: No changes detected in ingress status. old: %+v new: %+v",
 			key, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
-		return nil
 	}
 
-	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": mIngress.Status,
-	})
-	if len(mIngress.Status.LoadBalancer.Ingress) == 0 {
-		patchPayload, _ = json.Marshal(map[string]interface{}{
-			"status": nil,
-		})
-	}
-	_, err = mClient.NetworkingV1beta1().Ingresses(svc_mdata_obj.Namespace).Patch(context.TODO(), mIngress.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
-	if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the ingress status: %v", key, err)
-		return deleteObject(svc_mdata_obj, key, isVSDelete, retry+1)
+	if err = deleteIngressAnnotation(updatedIng, svc_mdata_obj, isVSDelete, hostListIng, key, mClient, mIngress); err != nil {
+		utils.AviLog.Errorf("key: %s, msg: error in deleting ingress annotation: %v", key, err)
 	}
 
-	utils.AviLog.Infof("key: %s, msg: Successfully deleted the ingress status of ingress: %s/%s old: %+v new: %+v",
-		key, mIngress.Namespace, mIngress.Name, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
+	return nil
+}
+
+func deleteIngressAnnotation(ingObj *networkingv1beta1.Ingress, svcMeta avicache.ServiceMetadataObj, isVSDelete bool,
+	ingHostList []string, key string, mClient kubernetes.Interface, oldIng *networkingv1beta1.Ingress,
+	retryNum ...int) error {
+	if ingObj == nil {
+		ingObj = oldIng
+	}
+	retry := 0
+	if len(retryNum) > 0 {
+		utils.AviLog.Infof("key: %s, msg: Retrying to update the ingress status", key)
+		retry = retryNum[0]
+		if retry >= 3 {
+			return fmt.Errorf("retried 3 times to delete the ingress annotations, aborting")
+		}
+	}
+	existingAnnotations := make(map[string]string)
+	if annotations, exists := ingObj.Annotations[VSAnnotation]; exists {
+		if err := json.Unmarshal([]byte(annotations), &existingAnnotations); err != nil {
+			return fmt.Errorf("error in unmarshalling annotations for ingress: %v", err)
+		}
+	} else {
+		return fmt.Errorf("error in fetching annotations for ingress %s/%s", ingObj.Namespace, ingObj.Name)
+	}
+
+	for k := range existingAnnotations {
+		for _, host := range svcMeta.HostNames {
+			if k == host {
+				// Check if:
+				// 1. this host is still present in the spec, if so - don't delete it from annotations
+				// 2. in case of NS migration, if NS is moved from selected to rejected, this host then
+				//    has to be removed from the annotations list.
+				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svcMeta.Namespace, utils.GetGlobalNSFilter(), nil, true)
+				if !utils.HasElem(ingHostList, host) || isVSDelete || !nsMigrationFilterFlag {
+					delete(existingAnnotations, k)
+				} else {
+					utils.AviLog.Debugf("key: %s, msg: skipping annotation update since host is present in the ingress: %v", key, host)
+				}
+			}
+		}
+	}
+
+	if isAnnotationsUpdateRequired(ingObj.Annotations, existingAnnotations) {
+		if err := patchIngressAnnotations(ingObj, existingAnnotations, mClient); err != nil {
+			return deleteIngressAnnotation(ingObj, svcMeta, isVSDelete, ingHostList, key, mClient, oldIng, retry+1)
+		}
+	}
+	utils.AviLog.Debugf("key: %s, msg: Annotations unchanged for ingress %s/%s", ingObj.Namespace, ingObj.Name)
+
 	return nil
 }
 

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
@@ -30,9 +31,9 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 )
 
-func ParseOptionsFromMetadata(options []UpdateStatusOptions, bulk bool) ([]string, []UpdateStatusOptions) {
+func ParseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, []UpdateOptions) {
 	var objectsToUpdate []string
-	var updateIngressOptions []UpdateStatusOptions
+	var updateIngressOptions []UpdateOptions
 
 	for _, option := range options {
 		if len(option.ServiceMetadata.NamespaceIngressName) > 0 {
@@ -64,7 +65,7 @@ func ParseOptionsFromMetadata(options []UpdateStatusOptions, bulk bool) ([]strin
 // Currently there are too many api calls, which are different for routes and ingresses,
 // to have them under same function.
 
-func UpdateRouteIngressStatus(options []UpdateStatusOptions, bulk bool) {
+func UpdateRouteIngressStatus(options []UpdateOptions, bulk bool) {
 	if utils.GetInformers().IngressInformer != nil {
 		UpdateIngressStatus(options, bulk)
 	} else if utils.GetInformers().RouteInformer != nil {
@@ -85,7 +86,7 @@ func DeleteRouteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDel
 	}
 }
 
-func UpdateRouteStatus(options []UpdateStatusOptions, bulk bool) {
+func UpdateRouteStatus(options []UpdateOptions, bulk bool) {
 	var err error
 	routesToUpdate, updateRouteOptions := ParseOptionsFromMetadata(options, bulk)
 
@@ -230,7 +231,7 @@ func routeStatusCheck(key string, oldStatus []routev1.RouteIngress, hostname str
 	return false
 }
 
-func updateRouteObject(mRoute *routev1.Route, updateOption UpdateStatusOptions, retryNum ...int) error {
+func updateRouteObject(mRoute *routev1.Route, updateOption UpdateOptions, retryNum ...int) error {
 	if updateOption.Vip == "" {
 		return nil
 	}
@@ -286,28 +287,98 @@ func updateRouteObject(mRoute *routev1.Route, updateOption UpdateStatusOptions, 
 		}
 	}
 
-	if sameStatus := compareRouteStatus(oldRouteStatus.Ingress, mRoute.Status.Ingress); sameStatus {
+	var updatedRoute *routev1.Route
+
+	sameStatus := compareRouteStatus(oldRouteStatus.Ingress, mRoute.Status.Ingress)
+	if !sameStatus {
+		patchPayload, _ := json.Marshal(map[string]interface{}{
+			"status": mRoute.Status,
+		})
+
+		updatedRoute, err = utils.GetInformers().OshiftClient.RouteV1().Routes(mRoute.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+		if err != nil {
+			utils.AviLog.Errorf("key: %s, msg: there was an error in updating the route status: %v", key, err)
+			// fetch updated route and feed for update status
+			mRoutes := getRoutes([]string{mRoute.Namespace + "/" + mRoute.Name}, false)
+			if len(mRoutes) > 0 {
+				return updateRouteObject(mRoutes[mRoute.Namespace+"/"+mRoute.Name], updateOption, retry+1)
+			}
+		}
+
+		utils.AviLog.Infof("key: %s, msg: Successfully updated the status of route: %s/%s old: %+v new: %+v",
+			key, mRoute.Namespace, mRoute.Name, oldRouteStatus.Ingress, mRoute.Status.Ingress)
+	} else {
 		utils.AviLog.Debugf("key: %s, msg: No changes detected in route status. old: %+v new: %+v",
 			key, oldRouteStatus.Ingress, mRoute.Status.Ingress)
-		return nil
 	}
+	err = updateRouteAnnotations(updatedRoute, updateOption, mRoute, key, hostListIng)
 
-	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": mRoute.Status,
-	})
-	_, err = utils.GetInformers().OshiftClient.RouteV1().Routes(mRoute.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
-	if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the route status: %v", key, err)
-		// fetch updated route and feed for update status
-		mRoutes := getRoutes([]string{mRoute.Namespace + "/" + mRoute.Name}, false)
-		if len(mRoutes) > 0 {
-			return updateRouteObject(mRoutes[mRoute.Namespace+"/"+mRoute.Name], updateOption, retry+1)
+	return err
+}
+
+func updateRouteAnnotations(mRoute *routev1.Route, updateOption UpdateOptions, oldRoute *routev1.Route,
+	key string, routeHostList []string, retryNum ...int) error {
+	if mRoute == nil {
+		mRoute = oldRoute
+	}
+	retry := 0
+	if len(retryNum) > 0 {
+		retry = retryNum[0]
+		if retry >= 3 {
+			return errors.New("UpdateRouteStatus retried 3 times, aborting")
 		}
 	}
 
-	utils.AviLog.Infof("key: %s, msg: Successfully updated the status of route: %s/%s old: %+v new: %+v",
-		key, mRoute.Namespace, mRoute.Name, oldRouteStatus.Ingress, mRoute.Status.Ingress)
-	return err
+	vsAnnotations := make(map[string]string)
+	if value, ok := mRoute.Annotations[VSAnnotation]; ok {
+		if err := json.Unmarshal([]byte(value), &vsAnnotations); err != nil {
+			utils.AviLog.Errorf("key: %s, msg: error in unmarshalling route annotations: %v", key, err)
+			// nothing else to be done, invalid annotations will be taken care of in the update call
+		}
+	}
+
+	// update the current hostname's VirtualService UUID
+	for i := 0; i < len(updateOption.ServiceMetadata.HostNames); i++ {
+		vsAnnotations[updateOption.ServiceMetadata.HostNames[i]] = updateOption.VirtualServiceUUID
+	}
+
+	// remove the non-spec hostnames
+	for k := range vsAnnotations {
+		if !utils.HasElem(routeHostList, k) {
+			delete(vsAnnotations, k)
+		}
+	}
+
+	// compare the VirtualService annotations for this ingress object
+	if req := isAnnotationsUpdateRequired(mRoute.Annotations, vsAnnotations); req {
+		if err := patchRouteAnnotations(mRoute, vsAnnotations); err != nil {
+			utils.AviLog.Errorf("key: %s, msg: error in updating the route annotations: %v", key, err)
+			// fetch updated route and retry for updating annotations
+			mRoutes := getRoutes([]string{mRoute.Namespace + "/" + mRoute.Name}, false)
+			if len(mRoutes) > 0 {
+				return updateRouteAnnotations(mRoute, updateOption, oldRoute, key, routeHostList, retry+1)
+			}
+		}
+		utils.AviLog.Infof("key: %s, msg: successfully updated route annotations: %s/%s, old: %+v, new: %+v",
+			key, mRoute.Namespace, mRoute.Name, oldRoute.Annotations, mRoute.Annotations)
+	} else {
+		utils.AviLog.Debugf("No annotations update required for this route: %s/%s", mRoute.Namespace,
+			mRoute.Name)
+	}
+
+	return nil
+}
+
+func patchRouteAnnotations(mRoute *routev1.Route, vsAnnotations map[string]string) error {
+	patchPayloadBytes, err := getAnnotationsPayload(vsAnnotations, mRoute.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("error in generating payload for vs annotations %v: %v", vsAnnotations, err)
+	}
+	if _, err = utils.GetInformers().OshiftClient.RouteV1().Routes(mRoute.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayloadBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("error in updating route annotations %v: %v", mRoute.Annotations, err)
+	}
+
+	return nil
 }
 
 func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) bool {
@@ -412,22 +483,73 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 		}
 	}
 
-	if sameStatus := compareRouteStatus(oldRouteStatus.Ingress, mRoute.Status.Ingress); sameStatus {
+	var updatedRoute *routev1.Route
+	sameStatus := compareRouteStatus(oldRouteStatus.Ingress, mRoute.Status.Ingress)
+	if sameStatus {
 		utils.AviLog.Debugf("key: %s, msg: No changes detected in ingress status. old: %+v new: %+v",
 			key, oldRouteStatus.Ingress, mRoute.Status.Ingress)
-		return nil
+	} else {
+		patchPayload, _ := json.Marshal(map[string]interface{}{
+			"status": mRoute.Status,
+		})
+		updatedRoute, err = utils.GetInformers().OshiftClient.RouteV1().Routes(svc_mdata_obj.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+		if err != nil {
+			utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the ingress status: %v", key, err)
+			return deleteObject(svc_mdata_obj, key, isVSDelete, retry+1)
+		}
+
+		utils.AviLog.Infof("key: %s, msg: Successfully deleted status of route: %s/%s old: %+v new: %+v",
+			key, mRoute.Namespace, mRoute.Name, oldRouteStatus.Ingress, mRoute.Status.Ingress)
 	}
 
-	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": mRoute.Status,
-	})
-	_, err = utils.GetInformers().OshiftClient.RouteV1().Routes(svc_mdata_obj.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
-	if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the ingress status: %v", key, err)
-		return deleteObject(svc_mdata_obj, key, isVSDelete, retry+1)
+	return deleteRouteAnnotation(updatedRoute, svc_mdata_obj, isVSDelete, hostListIng, key, mRoute)
+}
+
+func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta avicache.ServiceMetadataObj, isVSDelete bool,
+	routeHostList []string, key string, oldRoute *routev1.Route, retryNum ...int) error {
+	if routeObj == nil {
+		routeObj = oldRoute
+	}
+	retry := 0
+	if len(retryNum) > 0 {
+		utils.AviLog.Infof("key: %s, msg: retrying to update route annotations", key)
+		retry = retryNum[0]
+		if retry >= 3 {
+			return fmt.Errorf("deleteIngressAnnotation retried 3 times, aborting")
+		}
+	}
+	existingAnnotations := make(map[string]string)
+	if annotations, exists := routeObj.Annotations[VSAnnotation]; exists {
+		if err := json.Unmarshal([]byte(annotations), &existingAnnotations); err != nil {
+			return fmt.Errorf("error in unmarshalling annotations %s, %v", annotations, err)
+		}
+	} else {
+		return fmt.Errorf("error in fetching VS annotations %v", routeObj.Annotations)
 	}
 
-	utils.AviLog.Infof("key: %s, msg: Successfully deleted status of route: %s/%s old: %+v new: %+v",
-		key, mRoute.Namespace, mRoute.Name, oldRouteStatus.Ingress, mRoute.Status.Ingress)
+	for k := range existingAnnotations {
+		for _, host := range svcMeta.HostNames {
+			if k == host {
+				// Check if:
+				// 1. this host is still present in the spec, if so - don't delete it from annotations
+				// 2. in case of NS migration, if NS is moved from selected to rejected, this host then
+				//    has to be removed from the annotations list.
+				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svcMeta.Namespace, utils.GetGlobalNSFilter(), nil, true)
+				if !utils.HasElem(routeHostList, host) || isVSDelete || !nsMigrationFilterFlag {
+					delete(existingAnnotations, k)
+				} else {
+					utils.AviLog.Debugf("key: %s, msg: skipping annotation update since host is present in the ingress: %v", key, host)
+				}
+			}
+		}
+	}
+
+	if isAnnotationsUpdateRequired(routeObj.Annotations, existingAnnotations) {
+		if err := patchRouteAnnotations(routeObj, existingAnnotations); err != nil {
+			return deleteRouteAnnotation(routeObj, svcMeta, isVSDelete, routeHostList, key, oldRoute, retry+1)
+		}
+		utils.AviLog.Debugf("key: %s, msg: annotations updated for route", key)
+	}
+
 	return nil
 }

--- a/internal/status/services_api_status.go
+++ b/internal/status/services_api_status.go
@@ -38,9 +38,9 @@ type UpdateSvcApiGWStatusConditionOptions struct {
 	Reason  string                 // reason for transition
 }
 
-func UpdateSvcApiGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) {
+func UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	gatewaysToUpdate, updateGWOptions := parseOptionsFromMetadata(options, bulk)
-	var updateServiceOptions []UpdateStatusOptions
+	var updateServiceOptions []UpdateOptions
 
 	// gatewayMap: {ns/gateway: gatewayObj}
 	// this pre-fetches all gateways to be candidates for status update
@@ -48,7 +48,7 @@ func UpdateSvcApiGatewayStatusAddress(options []UpdateStatusOptions, bulk bool) 
 	// in which case gateway will be fetched again in updateObject, as part of a retry
 	gatewayMap := getSvcApiGateways(gatewaysToUpdate, bulk)
 	for _, option := range updateGWOptions {
-		updateServiceOptions = append(updateServiceOptions, UpdateStatusOptions{
+		updateServiceOptions = append(updateServiceOptions, UpdateOptions{
 			Vip: option.Vip,
 			Key: option.Key,
 			ServiceMetadata: avicache.ServiceMetadataObj{

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -87,7 +87,7 @@ func UpdateL4LBStatus(options []UpdateOptions, bulk bool) {
 			utils.AviLog.Debugf("key: %s, msg: No changes detected in service status. old: %+v new: %+v",
 				key, oldServiceStatus.Ingress, service.Status.LoadBalancer.Ingress)
 
-			if err = updateSvcAnnotations(updatedSvc, option, service); err != nil {
+			if err = updateSvcAnnotations(updatedSvc, option, service, svcHostname); err != nil {
 				utils.AviLog.Errorf("key: %s, msg: there was an error in updating the service annotations: %v", key, err)
 				continue
 			}
@@ -97,7 +97,10 @@ func UpdateL4LBStatus(options []UpdateOptions, bulk bool) {
 	return
 }
 
-func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSvc *corev1.Service) error {
+func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSvc *corev1.Service, svcHostname string) error {
+	if svcHostname == "" {
+		return fmt.Errorf("can't update the service annotations as hostname for this service is empty")
+	}
 	if svc == nil {
 		svc = oldSvc
 	}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -120,6 +120,8 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 		annotations = map[string]string{}
 	}
 	annotations[VSAnnotation] = string(vsAnnotationsStr)
+	annotations[ControllerAnnotation] = avicache.GetControllerClusterUUID()
+
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]string{
 			"annotations": annotations,
@@ -158,6 +160,7 @@ func DeleteL4LBStatus(svc_mdata_obj avicache.ServiceMetadataObj, key string) err
 func deleteSvcAnnotation(svc *corev1.Service) error {
 	payloadValue := make(map[string]*string)
 	payloadValue[VSAnnotation] = nil
+	payloadValue[ControllerAnnotation] = nil
 
 	payloadData := map[string]interface{}{
 		"metadata": map[string]map[string]*string{


### PR DESCRIPTION
Piggybacks on the objects' status updates. Once a call to update the
status for a route/ingress/LB service is made, first the status is
updated and then the annotations are updated.
- Sets the UUID for the virtualservice to which the object is mapped
  to, in the `UpdateOptions`.
- Call to update the annotations is made. For route/ingress annotations
  updates:
  * Update the VS uuid for the hostname in the current update context.
  * Remove the non-required hostnames from the annotations.
  * Check if a patch is required (by comparing with the previous
    annotations).

  For LB service annotation updates:
  * Just update the VS uuid for the hostname.
  * Compare the new annotation with the previous one and update if
    required.

This PR also fetches the controller cluster's UUID and sets it in the
objects' annotations field.

Example of both of these annotations:
```
metadata:
  annotations:
    ako.vmware.com/controller-cluster-uuid: cluster-XXXXX
    ako.vmware.com/virtualservices: '{"host1.fqdn":"virtualservice-XXXXXX","host2.fqdn":"virtualservice-YYYYYYYY"}'
```

Added an additional permission for services in the clusterrole.