### PR TITLE
fix ingressclass template for defaultIngController

### DIFF
--- a/helm/ako/templates/ingressclass.yaml
+++ b/helm/ako/templates/ingressclass.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: avi-lb
-  {{ if .Values.L7Settings.defaultIngController }}
+  {{ if eq .Values.L7Settings.defaultIngController "true" }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{ end }}


### PR DESCRIPTION
`defaultIngController` in helm values.yaml is of type string. While we add the default ingress class annotation `ingressclass.kubernetes.io/is-default-class` assuming that the value is a boolean. This ends up making Avi IngressClass default even if the value set is `"false"`.