### PR TITLE
Fix problem in deleting NPL annotation from Service

### DIFF
--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -213,7 +213,7 @@ func handlePod(key, namespace, podName string, fullsync bool) {
 		}
 		utils.AviLog.Infof("key: %s, msg: NPL Services retrieved: %s", key, services)
 	} else {
-		utils.AviLog.Info("key: %s, NPL annotation not found for Pod", key)
+		utils.AviLog.Infof("key: %s, NPL annotation not found for Pod", key)
 		objects.SharedNPLLister().Delete(podKey)
 	}
 }

--- a/internal/objects/npl.go
+++ b/internal/objects/npl.go
@@ -128,13 +128,13 @@ func (a *SvcPodLister) Delete(key string) {
 var podLBSvcInstance *PodLBSvcLister
 var podLBSvcOnce sync.Once
 
-func SharedPodToLBSvcLister() *PodSvcLister {
+func SharedPodToLBSvcLister() *PodLBSvcLister {
 	podLBSvcOnce.Do(func() {
 		store := NewObjectMapStore()
 		podLBSvcInstance = &PodLBSvcLister{}
 		podLBSvcInstance.store = store
 	})
-	return podSvcInstance
+	return podLBSvcInstance
 }
 
 // PodLBSvcLister stores list of services of type LB for a pod.

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -72,9 +72,6 @@ func DeleteSvcAnnotation(key, namespace, name string) {
 	}
 
 	payloadValue := make(map[string]*string)
-	for key, val := range ann {
-		payloadValue[key] = &val
-	}
 	// To delete an annotation with patch call, the value has to be set to nil
 	payloadValue[lib.NPLSvcAnnotation] = nil
 

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -54,7 +54,7 @@ func CheckUpdateSvcAnnotation(key, namespace, name string) bool {
 		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the Service annotation for NPL: %v", key, err)
 		return false
 	}
-	utils.AviLog.Debugf("key: %s, msg: updated NPL annotation from Service: %s/%s", key, namespace, name)
+	utils.AviLog.Infof("key: %s, msg: updated NPL annotation from Service: %s/%s", key, namespace, name)
 	return false
 }
 
@@ -70,18 +70,25 @@ func DeleteSvcAnnotation(key, namespace, name string) {
 	if _, found := ann[lib.NPLSvcAnnotation]; !found {
 		return
 	}
-	delete(ann, lib.NPLSvcAnnotation)
-	patchPayload := map[string]interface{}{
-		"metadata": map[string]map[string]string{
-			"annotations": ann,
+
+	payloadValue := make(map[string]*string)
+	for key, val := range ann {
+		payloadValue[key] = &val
+	}
+	// To delete an annotation with patch call, the value has to be set to nil
+	payloadValue[lib.NPLSvcAnnotation] = nil
+
+	newPayload := map[string]interface{}{
+		"metadata": map[string]map[string]*string{
+			"annotations": payloadValue,
 		},
 	}
 
-	payloadBytes, _ := json.Marshal(patchPayload)
+	payloadBytes, _ := json.Marshal(newPayload)
 	_, err = utils.GetInformers().ClientSet.CoreV1().Services(service.Namespace).Patch(context.TODO(), service.Name, types.MergePatchType, payloadBytes, metav1.PatchOptions{})
 	if err != nil {
 		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the Service annotation for NPL: %v", key, err)
 		return
 	}
-	utils.AviLog.Debugf("key: %s, msg: Deleted NPL annotation from Service: %s/%s", key, namespace, name)
+	utils.AviLog.Infof("key: %s, msg: Deleted NPL annotation from Service: %s/%s", key, namespace, name)
 }

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -130,11 +130,13 @@ func SetUpTestForIngress(t *testing.T, modelNames ...string) {
 	integrationtest.CreateEP(t, "default", "avisvc", false, false, "1.1.1")
 }
 
-func TearDownTestForIngress(t *testing.T, modelName string) {
+func TearDownTestForIngress(t *testing.T, modelNames ...string) {
 	os.Setenv("SHARD_VS_SIZE", "")
 	os.Setenv("CLOUD_NAME", "")
 
-	objects.SharedAviGraphLister().Delete(modelName)
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
 	integrationtest.DelSVC(t, "default", "avisvc")
 	integrationtest.DelEP(t, "default", "avisvc")
 }
@@ -1354,7 +1356,7 @@ func TestMultiHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, integrationtest.AllModels...)
 }
 
 func TestMultiHostSameHostNameIngress(t *testing.T) {


### PR DESCRIPTION
- Setting value for NPL annotation key to nil
- Instead of returning podLBSvcInstance podSvcInstance was being returned in SharedPodToLBSvcLister, fixed this.