### PR TITLE
fix default ingressclass transitioning issues

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_aviinfrasettings.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_aviinfrasettings.yaml
@@ -16,7 +16,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NSX ALB Setting is used to select specific Avi controller infra attributes.
+        description: AviInfraSetting is used to select specific Avi controller infra attributes.
         properties:
           spec:
             properties:

--- a/helm/ako/crds/ako.vmware.com_aviinfrasettings.yaml
+++ b/helm/ako/crds/ako.vmware.com_aviinfrasettings.yaml
@@ -16,7 +16,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NSX ALB Setting is used to select specific Avi controller infra attributes.
+        description: AviInfraSetting is used to select specific Avi controller infra attributes.
         properties:
           spec:
             properties:

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -300,23 +300,15 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 					status.DeleteSvcAnnotation(key, namespace, svc)
 				}
 			}
-			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
+			if utils.GetIngressClassEnabled() {
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
+			}
 		}
 	} else {
-
 		// simple validator check for duplicate hostpaths, logs Warning if duplicates found
 		success := validateSpecFromHostnameCache(key, ingObj.Namespace, ingObj.Name, ingObj.Spec)
 		if !success {
 			return ingresses, false
-		}
-
-		if ingObj.Spec.IngressClassName != nil {
-			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
-		} else if aviIngClassName, found := isAviLBDefaultIngressClass(); found {
-			// check if default IngressClass is present, and it is Avi's IngressClass, in which case add mapping for that.
-			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, aviIngClassName)
-		} else {
-			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
 		}
 
 		// If the Ingress Class is not found or is not valid, then return.
@@ -329,6 +321,17 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 				}
 			}
 			return ingresses, true
+		}
+
+		if utils.GetIngressClassEnabled() {
+			if ingObj.Spec.IngressClassName != nil {
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
+			} else if aviIngClassName, found := isAviLBDefaultIngressClass(); found {
+				// check if default IngressClass is present, and it is Avi's IngressClass, in which case add mapping for that.
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, aviIngClassName)
+			} else {
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
+			}
 		}
 
 		_, oldSvcs := objects.SharedSvcLister().IngressMappings(namespace).GetIngToSvc(ingName)

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -312,6 +312,9 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 
 		if ingObj.Spec.IngressClassName != nil {
 			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
+		} else if aviIngClassName, found := isAviLBDefaultIngressClass(); found {
+			// check if default IngressClass is present, and it is Avi's IngressClass, in which case add mapping for that.
+			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, aviIngClassName)
 		} else {
 			objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
 		}
@@ -868,8 +871,8 @@ func validateIngressForClass(key string, ingress *networkingv1beta1.Ingress) boo
 
 	if ingress.Spec.IngressClassName == nil {
 		// check whether avi-lb ingress class is set as the default ingress class
-		if isAviLBDefaultIngressClass() {
-			utils.AviLog.Debugf("key: %s, msg: ingress class name is not specified but ako.vmware.com/avi-lb is default ingress controller", key)
+		if _, found := isAviLBDefaultIngressClass(); found {
+			utils.AviLog.Infof("key: %s, msg: ingress class name is not specified but ako.vmware.com/avi-lb is default ingress controller", key)
 			return true
 		} else {
 			utils.AviLog.Warnf("key: %s, msg: ingress class name not specified for ingress %s and ako.vmware.com/avi-lb is not default ingress controller", key, ingress.Name)
@@ -894,18 +897,18 @@ func validateIngressForClass(key string, ingress *networkingv1beta1.Ingress) boo
 	return true
 }
 
-func isAviLBDefaultIngressClass() bool {
+func isAviLBDefaultIngressClass() (string, bool) {
 	ingClassObjs, _ := utils.GetInformers().IngressClassInformer.Lister().List(labels.Set(nil).AsSelector())
 	for _, ingClass := range ingClassObjs {
 		if ingClass.Spec.Controller == lib.AviIngressController {
 			annotations := ingClass.GetAnnotations()
 			isDefaultClass, ok := annotations[lib.DefaultIngressClassAnnotation]
 			if ok && isDefaultClass == "true" {
-				return true
+				return ingClass.Name, true
 			}
 		}
 	}
 
 	utils.AviLog.Debugf("IngressClass with controller ako.vmware.com/avi-lb not found in the cluster")
-	return false
+	return "", false
 }

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -309,22 +309,11 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 	}
 
 	oldIngressStatus := mIngress.Status.LoadBalancer.DeepCopy()
-	var hostListIng []string
-	for _, rule := range mIngress.Spec.Rules {
-		hostListIng = append(hostListIng, rule.Host)
-	}
 
 	for i, status := range mIngress.Status.LoadBalancer.Ingress {
 		for _, host := range svc_mdata_obj.HostNames {
 			if status.Hostname == host {
-				// Check if this host is still present in the spec, if so - don't delete it
-				//NS migration case: if false -> ns invalid event happened so remove status
-				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace)
-				if !utils.HasElem(hostListIng, host) || isVSDelete || !nsMigrationFilterFlag {
-					mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)
-				} else {
-					utils.AviLog.Debugf("key: %s, msg: skipping status update since host is present in the ingress: %v", key, host)
-				}
+				mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)
 			}
 		}
 	}

--- a/tests/hostnameshardtests/crd_evh_hostname_test.go
+++ b/tests/hostnameshardtests/crd_evh_hostname_test.go
@@ -36,7 +36,7 @@ func TestHostnameCreateDeleteHostRuleForEvh(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-EVH-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, true, true)
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
@@ -114,7 +114,7 @@ func TestHostnameCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
-	SetUpIngressForCacheSyncCheck(t, modelName, true, true)
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -147,7 +147,7 @@ func TestHostnameInsecureToSecureHostRuleForEvh(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-EVH-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
@@ -186,7 +186,7 @@ func TestHostnameGoodToBadHostRuleForEvh(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-EVH-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com"}
@@ -233,7 +233,7 @@ func TestHostnameInsecureHostAndHostruleForEvh(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-EVH-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 
 	g.Eventually(func() int {

--- a/tests/hostnameshardtests/crd_hostname_test.go
+++ b/tests/hostnameshardtests/crd_hostname_test.go
@@ -33,7 +33,7 @@ func TestHostnameCreateDeleteHostRule(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, true, true)
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
@@ -109,7 +109,7 @@ func TestHostnameCreateHostRuleBeforeIngress(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
-	SetUpIngressForCacheSyncCheck(t, modelName, true, true)
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -140,7 +140,7 @@ func TestHostnameInsecureToSecureHostRule(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
@@ -179,7 +179,7 @@ func TestHostnameMultiIngressToSecureHostRule(t *testing.T) {
 	hrname := "samplehr-foo"
 
 	// creating secure default/foo.com/foo
-	SetUpIngressForCacheSyncCheck(t, modelName, true, true)
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	// creating insecure red/foo.com/bar
 	ingressObject := integrationtest.FakeIngress{
@@ -232,7 +232,7 @@ func TestHostnameMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	hrname := "samplehr-foo"
 
 	// creating insecure default/foo.com/foo
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 
 	// creating insecure red/voo.com/voo
 	ingressObject := integrationtest.FakeIngress{
@@ -309,7 +309,7 @@ func TestHostnameGoodToBadHostRule(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
@@ -354,7 +354,7 @@ func TestHostnameInsecureHostAndHostrule(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 
 	g.Eventually(func() int {
@@ -379,7 +379,7 @@ func TestHostnameValidToInvalidHostSwitch(t *testing.T) {
 
 	modelName := "admin/cluster--Shared-L7-0"
 	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
@@ -507,7 +507,7 @@ func TestHostNameHTTPRuleHostSwitch(t *testing.T) {
 	rrnameFoo := "samplerr-foo"
 
 	// creates foo.com insecure
-	SetUpIngressForCacheSyncCheck(t, modelName, false, false)
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 
 	// creates voo.com insecure
 	ingressObject := integrationtest.FakeIngress{

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -225,6 +225,10 @@ func TestHostnameDefaultIngressClassChange(t *testing.T) {
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 35*time.Second).Should(gomega.Equal(0))
 
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
 	TearDownTestForIngress(t, modelName)
 	TeardownIngressClass(t, ingClassName)
 	VerifyVSNodeDeletion(g, modelName)

--- a/tests/integrationtest/l7_ingress_node_test.go
+++ b/tests/integrationtest/l7_ingress_node_test.go
@@ -31,10 +31,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func SetUpTestForIngress(t *testing.T, model_Name string) {
+func SetUpTestForIngress(t *testing.T, modelNames ...string) {
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("L7_SHARD_SCHEME", "namespace")
-	objects.SharedAviGraphLister().Delete(model_Name)
+
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
 	CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, false)
 	CreateEP(t, "default", "avisvc", false, false, "1.1.1")
 }


### PR DESCRIPTION
Changing the default ingress class annotation in Avi ingress class was not removing the VSes/Pools from Avi and does not remove status from the ingress objects. This PR fixes this issue.

This also includes a related ingress status update fix wherein the status is removed only when host is removed from the spec. But with new additions of namespace selector and ingress selection via ingress class, the status can be removed from ingress even when the host is still present in the spec. The check for the same has been removed from the workflow.