### PR TITLE
Allow AKO to function as a pure layer 7 ingress controller

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
   clusterName: {{ .Values.AKOSettings.clusterName | quote }}
   servicesAPI: {{ .Values.AKOSettings.servicesAPI | quote }}
   enableEVH: {{ .Values.AKOSettings.enableEVH | quote }}
+  layer7Only: {{ .Values.AKOSettings.layer7Only | quote }}
   tenantsPerCluster: {{ .Values.ControllerSettings.tenantsPerCluster | quote }}
   tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
   defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -18,6 +18,7 @@ AKOSettings:
   clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
   cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift 
   enableEVH: false # This enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services 
+  layer7Only: false # If this flag is switched on, then AKO will only do layer 7 loadbalancing.
   #NamespaceSelector contains label key and value used for namespacemigration
   #Same label has to be present on namespace/s which needs migration/sync to AKO
   namespaceSelector:

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -136,6 +136,8 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			}
 			utils.AviLog.Infof("avi k8s configmap created")
 			utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
+			// Check if AKO is configured to only use Ingress. This value can be only set during bootup and can't be edited dynamically.
+			lib.SetLayer7Only(cm.Data[lib.LAYER7_ONLY])
 			delModels := delConfigFromData(cm.Data)
 			if !delModels {
 				status.ResetStatefulSetStatus()
@@ -391,7 +393,7 @@ func (c *AviController) FullSyncK8s() error {
 		for _, svcObj := range svcObjs {
 			isSvcLb := isServiceLBType(svcObj)
 			var key string
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
 			} else {
 				if lib.GetAdvancedL4() {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -479,7 +479,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 			isSvcLb := isServiceLBType(svc)
 			var key string
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
 				if lib.GetAdvancedL4() {
 					checkSvcForGatewayPortConflict(svc, key)
@@ -518,7 +518,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			isSvcLb := isServiceLBType(svc)
 			var key string
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
 			} else {
 				if lib.GetAdvancedL4() || lib.UseServicesAPI() {
@@ -541,7 +541,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 				isSvcLb := isServiceLBType(svc)
 				var key string
-				if isSvcLb {
+				if isSvcLb && !lib.GetLayer7Only() {
 					key = utils.L4LBService + "/" + utils.ObjKey(svc)
 					if lib.GetAdvancedL4() {
 						checkSvcForGatewayPortConflict(svc, key)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -55,6 +55,7 @@ const (
 	STATUS_REDIRECT                            = "HTTP_REDIRECT_STATUS_CODE_302"
 	SLOW_SYNC_TIME                             = 90 // seconds
 	LOG_LEVEL                                  = "logLevel"
+	LAYER7_ONLY                                = "layer7Only"
 	SERVICE_TYPE                               = "SERVICE_TYPE"
 	NODE_PORT                                  = "NodePort"
 	NODE_KEY                                   = "NODE_KEY"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -63,10 +63,26 @@ func GetNamePrefix() string {
 }
 
 var DisableSync bool
+var layer7Only bool
 
 func SetDisableSync(state bool) {
 	DisableSync = state
 	utils.AviLog.Infof("Setting Disable Sync to: %v", state)
+}
+
+func SetLayer7Only(val string) {
+	if boolVal, err := strconv.ParseBool(val); err == nil {
+		layer7Only = boolVal
+
+	} else {
+		// If the variable could not be converted, default to this being false
+		layer7Only = false
+	}
+	utils.AviLog.Infof("Setting the value for the layer7Only flag %v", layer7Only)
+}
+
+func GetLayer7Only() bool {
+	return layer7Only
 }
 
 var AKOUser string

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -73,10 +73,6 @@ func SetDisableSync(state bool) {
 func SetLayer7Only(val string) {
 	if boolVal, err := strconv.ParseBool(val); err == nil {
 		layer7Only = boolVal
-
-	} else {
-		// If the variable could not be converted, default to this being false
-		layer7Only = false
 	}
 	utils.AviLog.Infof("Setting the value for the layer7Only flag %v", layer7Only)
 }

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -75,7 +75,7 @@ func GetSvcKeysForNodeCRUD() (svcl4Keys []string, svcl7Keys []string) {
 	}
 	for _, svc := range svcObjs {
 		var key string
-		if isServiceLBType(svc) {
+		if isServiceLBType(svc) && !GetLayer7Only() {
 			key = utils.L4LBService + "/" + utils.ObjKey(svc)
 			svcl4Keys = append(svcl4Keys, key)
 		}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -123,7 +123,7 @@ func DequeueIngestion(key string, fullsync bool) {
 				return
 			}
 
-			if svcObj.Spec.Type == utils.LoadBalancer {
+			if svcObj.Spec.Type == utils.LoadBalancer && !lib.GetLayer7Only() {
 				// This endpoint update affects a LB service.
 				aviModelGraph := NewAviObjectGraph()
 				aviModelGraph.BuildL4LBGraph(namespace, name, key)

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -291,6 +291,11 @@ func handleRoute(key string, fullsync bool, routeNames []string) {
 }
 
 func handleL4Service(key string, fullsync bool) {
+	if lib.GetLayer7Only() {
+		// If the layer 7 only flag is set, then we shouldn't handling layer 4 VSes.
+		utils.AviLog.Debugf("key: %s, msg: not handling service of type loadbalancer since AKO is configured to run in layer 7 mode only", key)
+		return
+	}
 	_, namespace, name := extractTypeNameNamespace(key)
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 	// L4 type of services need special handling. We create a dedicated VS in Avi for these.


### PR DESCRIPTION
This commit introduces a flag that would allow AKO to function as
a pure Layer 7 ingress controller. This flag should be used where
AKO isn't needed for layer 4 functionality. Note, this flag can be
only set during AKO bootup and cannot be changed while the AKO pod
is already in running state.

If the system had layer 4 LBs synced as virtual services, AKO would
delete those if the flag is set to `true` and AKO is rebooted.