### PR TITLE
Allow AKO to function as a pure layer 7 ingress controller (#294)

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   fullSyncFrequency: {{ .Values.AKOSettings.fullSyncFrequency | quote }}
   cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
   clusterName: {{ .Values.AKOSettings.clusterName | quote }}
+  layer7Only: {{ .Values.AKOSettings.layer7Only | quote }}
   tenantsPerCluster: {{ .Values.ControllerSettings.tenantsPerCluster | quote }}
   tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
   defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -17,6 +17,7 @@ AKOSettings:
   disableStaticRouteSync: "false" # If the POD networks are reachable from the Avi SE, set this knob to true.
   clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
   cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift 
+  layer7Only: false # If this flag is switched on, then AKO will only do layer 7 loadbalancing.
   #NamespaceSelector contains label key and value used for namespacemigration
   #Same label has to be present on namespace/s which needs migration/sync to AKO
   namespaceSelector:

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -133,6 +133,8 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			}
 			utils.AviLog.Infof("avi k8s configmap created")
 			utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
+			// Check if AKO is configured to only use Ingress. This value can be only set during bootup and can't be edited dynamically.
+			lib.SetLayer7Only(cm.Data[lib.LAYER7_ONLY])
 			delModels := delConfigFromData(cm.Data)
 			if !delModels {
 				status.ResetStatefulSetStatus()
@@ -385,7 +387,7 @@ func (c *AviController) FullSyncK8s() error {
 		for _, svcObj := range svcObjs {
 			isSvcLb := isServiceLBType(svcObj)
 			var key string
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
 			} else {
 				if lib.GetAdvancedL4() {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -426,7 +426,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 			isSvcLb := isServiceLBType(svc)
 			var key string
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
 				if lib.GetAdvancedL4() {
 					checkSvcForGatewayPortConflict(svc, key)
@@ -462,7 +462,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			isSvcLb := isServiceLBType(svc)
 			var key string
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
-			if isSvcLb {
+			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
 			} else {
 				if lib.GetAdvancedL4() {
@@ -485,7 +485,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 				isSvcLb := isServiceLBType(svc)
 				var key string
-				if isSvcLb {
+				if isSvcLb && !lib.GetLayer7Only() {
 					key = utils.L4LBService + "/" + utils.ObjKey(svc)
 					if lib.GetAdvancedL4() {
 						checkSvcForGatewayPortConflict(svc, key)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -54,6 +54,7 @@ const (
 	STATUS_REDIRECT                            = "HTTP_REDIRECT_STATUS_CODE_302"
 	SLOW_SYNC_TIME                             = 90 // seconds
 	LOG_LEVEL                                  = "logLevel"
+	LAYER7_ONLY                                = "layer7Only"
 	SERVICE_TYPE                               = "SERVICE_TYPE"
 	NODE_PORT                                  = "NodePort"
 	NODE_KEY                                   = "NODE_KEY"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -62,10 +62,22 @@ func GetNamePrefix() string {
 }
 
 var DisableSync bool
+var layer7Only bool
 
 func SetDisableSync(state bool) {
 	DisableSync = state
 	utils.AviLog.Infof("Setting Disable Sync to: %v", state)
+}
+
+func SetLayer7Only(val string) {
+	if boolVal, err := strconv.ParseBool(val); err == nil {
+		layer7Only = boolVal
+	}
+	utils.AviLog.Infof("Setting the value for the layer7Only flag %v", layer7Only)
+}
+
+func GetLayer7Only() bool {
+	return layer7Only
 }
 
 var AKOUser string

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -67,7 +67,7 @@ func GetSvcKeysForNodeCRUD() (svcl4Keys []string, svcl7Keys []string) {
 	}
 	for _, svc := range svcObjs {
 		var key string
-		if isServiceLBType(svc) {
+		if isServiceLBType(svc) && !GetLayer7Only() {
 			key = utils.L4LBService + "/" + utils.ObjKey(svc)
 			svcl4Keys = append(svcl4Keys, key)
 		}


### PR DESCRIPTION
* Allow AKO to function as a pure layer 7 ingress controller

This commit introduces a flag that would allow AKO to function as
a pure Layer 7 ingress controller. This flag should be used where
AKO isn't needed for layer 4 functionality. Note, this flag can be
only set during AKO bootup and cannot be changed while the AKO pod
is already in running state.

If the system had layer 4 LBs synced as virtual services, AKO would
delete those if the flag is set to `true` and AKO is rebooted.

* Incoporated code review comment

* Incorporated code review comments