### PR TITLE
Introduce dedicated VS for ingress FQDNs

### DIFF
--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -47,7 +47,7 @@ L7Settings:
   defaultIngController: "true"
   l7ShardingScheme: "hostname"
   serviceType: ClusterIP #enum NodePort|ClusterIP
-  shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL
+  shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL, DEDICATED
   passthroughShardSize: "SMALL" # Control the passthrough virtualservice numbers using this ENUM. ENUMs: LARGE, MEDIUM, SMALL
 
 ### This section outlines all the knobs  used to control Layer 4 loadbalancing settings in AKO.

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -236,6 +236,10 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 		numWorkers = 1
 		ingestionQueueParams := utils.WorkerQueue{NumWorkers: numWorkers, WorkqueueName: utils.ObjectIngestionLayer}
 		numGraphWorkers := lib.GetshardSize()
+		if numGraphWorkers == 0 {
+			// For dedicated VSes - we will have 8 layer 3 threads
+			numGraphWorkers = 8
+		}
 		graphQueueParams := utils.WorkerQueue{NumWorkers: numGraphWorkers, WorkqueueName: utils.GraphLayer}
 		graphQueue = utils.SharedWorkQueue(&ingestionQueueParams, &graphQueueParams, &slowRetryQParams, &fastRetryQParams).GetQueueByName(utils.GraphLayer)
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -42,9 +42,10 @@ var ShardSchemeMap = map[string]string{
 }
 
 var shardSizeMap = map[string]uint32{
-	"LARGE":  8,
-	"MEDIUM": 4,
-	"SMALL":  1,
+	"LARGE":     8,
+	"MEDIUM":    4,
+	"SMALL":     1,
+	"DEDICATED": 0,
 }
 
 var fqdnEnum = map[string]int32{

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -513,14 +513,15 @@ func GetShardVSPrefix(key string) string {
 func GetShardVSName(s string, key string) string {
 	var vsNum uint32
 	shardSize := lib.GetshardSize()
-	shardVsPrefix := GetShardVSPrefix(key)
 	if shardSize != 0 {
 		vsNum = utils.Bkt(s, shardSize)
 		utils.AviLog.Debugf("key: %s, msg: VS number: %v", key, vsNum)
 	} else {
-		utils.AviLog.Warnf("key: %s, msg: the value for shard_vs_size does not match the ENUM values", key)
-		return ""
+		utils.AviLog.Debugf("key: %s, msg: Processing dedicated VS", key)
+		//format: my-cluster--foo.com-dedicated for dedicated VS. This is to avoid any SNI naming conflicts
+		return lib.GetNamePrefix() + s + "-dedicated"
 	}
+	shardVsPrefix := GetShardVSPrefix(key)
 	vsName := shardVsPrefix + fmt.Sprint(vsNum)
 	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
 	return vsName

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -476,6 +476,10 @@ func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_o
 func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) bool {
 	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
 	shardSize := lib.GetshardSize()
+	if shardSize == 0 {
+		// Dedicated VS case
+		shardSize = 8
+	}
 	var retry, fastRetry bool
 	if shardSize != 0 {
 		bkt := utils.Bkt(key, shardSize)
@@ -1094,6 +1098,10 @@ func (rest *RestOperations) SNINodeDelete(del_sni avicache.NamespaceName, namesp
 			// Some relationships are missing, do a manual refresh of the VS cache.
 			aviObjCache := avicache.SharedAviObjCache()
 			shardSize := lib.GetshardSize()
+			if shardSize == 0 {
+				// Dedicated VS case
+				shardSize = 8
+			}
 			if shardSize != 0 {
 				bkt := utils.Bkt(key, shardSize)
 				utils.AviLog.Warnf("key: %s, msg: corrupted sni cache found, retrying in bkt: %v", key, bkt)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -844,7 +844,6 @@ func GetShardVSNumber(s string) string {
 	var vsNum uint32
 	shardSize := lib.GetshardSize()
 	if shardSize != 0 {
-
 		vsNum = utils.Bkt(s, shardSize)
 	} else {
 		return ""


### PR DESCRIPTION
This commit introduces another ENUM value for the SHARD_SIZE called
DEDICATED. If this value is set, then AKO will create a dedicated
virtualservice per FQDN. If there are multiple paths configured
for the same FQDN across multiple ingress objects, then AKO would
create a single virtual service for the FQDN and patch all the paths
to the same VS.