### PR TITLE
Update the AKOConfig object with layer7only flag

### DIFF
--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -55,6 +55,8 @@ type AKOSettings struct {
 	CNIPlugin string `json:"cniPlugin,omitempty"`
 	// Namespace selector specifies the namespace labels from which AKO should sync from
 	NSSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
+	// Layer7Only flag, if set to true, then AKO controller will only do layer 7 loadbalancing
+	Layer7Only bool `json:"layer7Only,omitempty"`
 }
 
 type NodeNetwork struct {

--- a/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
@@ -60,6 +60,10 @@ spec:
                   description: FullSyncFrequency defines the interval at which full
                     sync is carried out by the AKO controller
                   type: string
+                layer7Only:
+                  description: Layer7Only flag, if set to true, then AKO controller
+                    will only do layer 7 loadbalancing
+                  type: boolean
                 logLevel:
                   description: LogLevel defines the log level to be used by the AKO
                     controller

--- a/ako-operator/controllers/configmap.go
+++ b/ako-operator/controllers/configmap.go
@@ -124,45 +124,21 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 	cm.Data[CloudName] = ako.Spec.ControllerSettings.CloudName
 	cm.Data[ClusterName] = ako.Spec.AKOSettings.ClusterName
 	cm.Data[DefaultDomain] = ako.Spec.L4Settings.DefaultDomain
-	disableStaticRouteSync := "false"
-	if ako.Spec.AKOSettings.DisableStaticRouteSync {
-		disableStaticRouteSync = "true"
-	}
-	cm.Data[DisableStaticRouteSync] = disableStaticRouteSync
-
-	defaultIngController := "false"
-	if ako.Spec.L7Settings.DefaultIngController {
-		defaultIngController = "true"
-	}
-	cm.Data[DefaultIngController] = defaultIngController
-
+	cm.Data[DisableStaticRouteSync] = strconv.FormatBool(ako.Spec.AKOSettings.DisableStaticRouteSync)
+	cm.Data[DefaultIngController] = strconv.FormatBool(ako.Spec.L7Settings.DefaultIngController)
 	cm.Data[SubnetIP] = ako.Spec.NetworkSettings.SubnetIP
 	cm.Data[SubnetPrefix] = ako.Spec.NetworkSettings.SubnetPrefix
 	cm.Data[NetworkName] = ako.Spec.NetworkSettings.NetworkName
 	cm.Data[L7ShardingScheme] = ako.Spec.L7Settings.ShardingScheme
 	cm.Data[LogLevel] = string(ako.Spec.LogLevel)
-
-	deleteConfig := "false"
-	if ako.Spec.AKOSettings.DeleteConfig {
-		deleteConfig = "true"
-	}
-	cm.Data[DeleteConfig] = deleteConfig
-
-	advancedL4 := "false"
-	if ako.Spec.L4Settings.AdvancedL4 {
-		advancedL4 = "true"
-	}
-
-	enableRHI := "false"
-	if ako.Spec.NetworkSettings.EnableRHI {
-		enableRHI = "true"
-	}
-	cm.Data[EnableRHI] = enableRHI
-	cm.Data[AdvancedL4] = advancedL4
+	cm.Data[DeleteConfig] = strconv.FormatBool(ako.Spec.AKOSettings.DeleteConfig)
+	cm.Data[AdvancedL4] = strconv.FormatBool(ako.Spec.L4Settings.AdvancedL4)
+	cm.Data[EnableRHI] = strconv.FormatBool(ako.Spec.NetworkSettings.EnableRHI)
 	cm.Data[ServiceType] = string(ako.Spec.L7Settings.ServiceType)
 	cm.Data[NodeKey] = ako.Spec.NodePortSelector.Key
 	cm.Data[NodeValue] = ako.Spec.NodePortSelector.Value
 	cm.Data[ServiceEngineGroupName] = ako.Spec.ControllerSettings.ServiceEngineGroupName
+
 	apiServerPort := ako.Spec.AKOSettings.APIServerPort
 	if apiServerPort > 0 {
 		cm.Data[APIServerPort] = strconv.Itoa(apiServerPort)
@@ -196,12 +172,8 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 	cm.Data[NSSyncLabelKey] = ako.Spec.AKOSettings.NSSelector.LabelKey
 	cm.Data[NSSyncLabelValue] = ako.Spec.AKOSettings.NSSelector.LabelValue
 
-	tenantsPerCluster := "false"
-	if ako.Spec.ControllerSettings.TenantsPerCluster {
-		tenantsPerCluster = "true"
-	}
-	cm.Data[TenantsPerCluster] = tenantsPerCluster
+	cm.Data[TenantsPerCluster] = strconv.FormatBool(ako.Spec.ControllerSettings.TenantsPerCluster)
 	cm.Data[TenantName] = ako.Spec.ControllerSettings.TenantName
-
+	cm.Data[Layer7Only] = strconv.FormatBool(ako.Spec.Layer7Only)
 	return cm, nil
 }

--- a/ako-operator/controllers/utils.go
+++ b/ako-operator/controllers/utils.go
@@ -11,6 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// Status messages
+const (
+	SuccessfullyDeployedMsg  = "Reconciled all artifacts"
+	CleanupErrMsg            = "Error in cleaning up artifacts: "
+	FinalizerRemoveErrMsg    = "Error in removing finalizer: "
+	ArtifactsReconcileErrMsg = "Error in reconciling: "
+)
+
 // properties used for naming the dependent artifacts
 const (
 	StatefulSetName    = "ako"
@@ -57,6 +65,7 @@ const (
 	NSSyncLabelValue       = "nsSyncLabelValue"
 	TenantsPerCluster      = "tenantsPerCluster"
 	TenantName             = "tenantName"
+	Layer7Only             = "layer7Only"
 )
 
 var SecretEnvVars = map[string]string{


### PR DESCRIPTION
Additional changes include:
- Update the status field to include the current state of AKO controller
  deloyment (including manifest deployment errors).
- Use `FormatBool` to convert to string.