### PR TITLE
cleanup test namespace in oshiftroutetests

### DIFF
--- a/tests/oshiftroutetests/oshift_l4_l7_nodeport_test.go
+++ b/tests/oshiftroutetests/oshift_l4_l7_nodeport_test.go
@@ -558,9 +558,9 @@ func TestSecureToInsecureRouteInNodePort(t *testing.T) {
 	TearDownTestForRouteInNodePort(t, defaultModelName)
 }
 
-// Removing this testcase for now, as we are missing events from non default Namespace with fakeclient in case of Routes
-/*func TestSecureRouteMultiNamespaceInNodePort(t *testing.T) {
+func TestSecureRouteMultiNamespaceInNodePort(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	integrationtest.DeleteNamespace("test")
 
 	integrationtest.SetNodePortMode()
 	defer integrationtest.SetClusterIPMode()
@@ -575,6 +575,7 @@ func TestSecureToInsecureRouteInNodePort(t *testing.T) {
 		t.Fatalf("error in adding route: %v", err)
 	}
 	AddLabelToNamespace(defaultKey, defaultValue, "test", defaultModelName, t)
+	defer integrationtest.DeleteNamespace("test")
 	integrationtest.CreateSVC(t, "test", "avisvc", corev1.ServiceTypeNodePort, false)
 	route2 := FakeRoute{Namespace: "test", Path: "/bar"}.SecureRoute()
 	_, err = OshiftClient.RouteV1().Routes("test").Create(context.TODO(), route2, metav1.CreateOptions{})
@@ -619,7 +620,7 @@ func TestSecureToInsecureRouteInNodePort(t *testing.T) {
 	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
 	TearDownTestForRouteInNodePort(t, defaultModelName)
 	integrationtest.DelSVC(t, "test", "avisvc")
-}*/
+}
 
 func TestPassthroughRouteInNodePort(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)

--- a/tests/oshiftroutetests/oshift_secure_route_test.go
+++ b/tests/oshiftroutetests/oshift_secure_route_test.go
@@ -310,6 +310,7 @@ func TestInsecureToSecureRoute(t *testing.T) {
 
 func TestSecureRouteMultiNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	integrationtest.DeleteNamespace("test")
 	SetUpTestForRoute(t, defaultModelName)
 	route1 := FakeRoute{Path: "/foo"}.SecureRoute()
 	_, err := OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), route1, metav1.CreateOptions{})
@@ -317,6 +318,8 @@ func TestSecureRouteMultiNamespace(t *testing.T) {
 		t.Fatalf("error in adding route: %v", err)
 	}
 	AddLabelToNamespace(defaultKey, defaultValue, "test", defaultModelName, t)
+	defer integrationtest.DeleteNamespace("test")
+
 	integrationtest.CreateSVC(t, "test", "avisvc", corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, "test", "avisvc", false, false, "1.1.1")
 	route2 := FakeRoute{Namespace: "test", Path: "/bar"}.SecureRoute()
@@ -767,6 +770,7 @@ func TestSecureRouteInsecureRedirectToNone(t *testing.T) {
 
 func TestSecureRouteInsecureRedirectMultiNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	integrationtest.DeleteNamespace("test")
 	SetUpTestForRoute(t, defaultModelName)
 	route1 := FakeRoute{Path: "/foo"}.SecureRoute()
 	route1.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyRedirect
@@ -775,6 +779,8 @@ func TestSecureRouteInsecureRedirectMultiNamespace(t *testing.T) {
 		t.Fatalf("error in adding route: %v", err)
 	}
 	AddLabelToNamespace(defaultKey, defaultValue, "test", defaultModelName, t)
+	defer integrationtest.DeleteNamespace("test")
+
 	integrationtest.CreateSVC(t, "test", "avisvc", corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, "test", "avisvc", false, false, "1.1.1")
 	route2 := FakeRoute{Namespace: "test", Path: "/bar"}.SecureRoute()
@@ -800,6 +806,8 @@ func TestSecureRouteInsecureRedirectMultiNamespace(t *testing.T) {
 
 func TestSecureRouteInsecureAllowMultiNamespace(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	integrationtest.DeleteNamespace("test")
+
 	SetUpTestForRoute(t, defaultModelName)
 	route1 := FakeRoute{Path: "/foo"}.SecureRoute()
 	route1.Spec.TLS.InsecureEdgeTerminationPolicy = routev1.InsecureEdgeTerminationPolicyAllow
@@ -808,6 +816,8 @@ func TestSecureRouteInsecureAllowMultiNamespace(t *testing.T) {
 		t.Fatalf("error in adding route: %v", err)
 	}
 	AddLabelToNamespace(defaultKey, defaultValue, "test", defaultModelName, t)
+	defer integrationtest.DeleteNamespace("test")
+
 	integrationtest.CreateSVC(t, "test", "avisvc", corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, "test", "avisvc", false, false, "1.1.1")
 	route2 := FakeRoute{Namespace: "test", Path: "/bar"}.SecureRoute()


### PR DESCRIPTION
- If the test NS is not cleaned up properly then it can create problem in multi NS tests