### PR TITLE
Handle error in rest layer to sync requests from multiple K8s objects

### DIFF
--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -49,7 +49,6 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 
 	var path string
 	var rest_op utils.RestOp
-	macro := utils.AviRestObjMacro{ModelName: "VSDataScriptSet", Data: vsdatascriptset}
 	if cache_obj != nil {
 		path = "/api/vsdatascriptset/" + cache_obj.Uuid
 		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsdatascriptset,
@@ -64,8 +63,8 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsdatascriptset,
 				Tenant: ds_meta.Tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
 		} else {
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			path = "/api/vsdatascriptset"
+			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vsdatascriptset,
 				Tenant: ds_meta.Tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
 		}
 	}
@@ -86,7 +85,7 @@ func (rest *RestOperations) AviDSDel(uuid string, tenant string, key string) *ut
 
 func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no response for datascriptset err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for datascriptset err: %v, response: %v", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -333,9 +333,8 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 
 		} else {
 			rest_method = utils.RestPost
-			macro := utils.AviRestObjMacro{ModelName: "VirtualService", Data: vs}
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: macro,
+			path = "/api/virtualservice/"
+			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
 				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
 			rest_ops = append(rest_ops, &rest_op)
 
@@ -462,10 +461,8 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		rest_ops = append(rest_ops, &rest_op)
 
 	} else {
-
-		macro := utils.AviRestObjMacro{ModelName: "VirtualService", Data: evhChild}
-		path = "/api/macro"
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: macro,
+		path = "/api/virtualservice"
+		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: evhChild,
 			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
 		rest_ops = append(rest_ops, &rest_op)
 

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -133,7 +133,6 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 		idx = idx + 1
 	}
 
-	macro := utils.AviRestObjMacro{ModelName: "HTTPPolicySet", Data: hps}
 	var path string
 	var rest_op utils.RestOp
 	if cache_obj != nil {
@@ -151,8 +150,8 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
 				Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
 		} else {
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			path = "/api/httppolicyset/"
+			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: hps,
 				Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
 		}
 	}

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -86,7 +86,6 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 		}
 	}
 	hps.L4ConnectionPolicy = &l4Policy
-	macro := utils.AviRestObjMacro{ModelName: "L4PolicySet", Data: hps}
 	var path string
 	var rest_op utils.RestOp
 	if cache_obj != nil {
@@ -104,8 +103,8 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
 				Tenant: hps_meta.Tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
 		} else {
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			path = "/api/l4policyset/"
+			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: hps,
 				Tenant: hps_meta.Tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
 		}
 	}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -139,14 +139,12 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		pool.HealthMonitorRefs = append(pool.HealthMonitorRefs, hm)
 	}
 
-	macro := utils.AviRestObjMacro{ModelName: "Pool", Data: pool}
-
 	// TODO Version should be latest from configmap
 	var path string
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/pool/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pool,
+		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: pool,
 			Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
 	} else {
 		// Patch an existing pool if it exists in the cache but not associated with this VS.
@@ -155,11 +153,11 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		if ok {
 			pool_cache_obj, _ := pool_cache.(*avicache.AviPoolCache)
 			path = "/api/pool/" + pool_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pool,
+			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: pool,
 				Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
 		} else {
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			path = "/api/pool/"
+			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: pool,
 				Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
 		}
 	}
@@ -180,7 +178,7 @@ func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *
 
 func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no response for POOL, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for POOL, err: %v, response: %v", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -175,17 +175,13 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		if rest_method == utils.RestPut && cache_obj.Uuid != "" {
 			path = "/api/virtualservice/" + cache_obj.Uuid
 			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion, ObjName: *vs.Name}
 			rest_ops = append(rest_ops, &rest_op)
-
 		} else {
-			rest_method = utils.RestPost
-			macro := utils.AviRestObjMacro{ModelName: "VirtualService", Data: vs}
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: macro,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+			path = "/api/virtualservice/"
+			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vs,
+				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion, ObjName: *vs.Name}
 			rest_ops = append(rest_ops, &rest_op)
-
 		}
 		return rest_ops
 	}
@@ -301,13 +297,10 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 		rest_ops = append(rest_ops, &rest_op)
 
 	} else {
-
-		macro := utils.AviRestObjMacro{ModelName: "VirtualService", Data: sniChild}
-		path = "/api/macro"
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: macro,
+		path = "/api/virtualservice"
+		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: sniChild,
 			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
 		rest_ops = append(rest_ops, &rest_op)
-
 	}
 
 	return rest_ops
@@ -315,7 +308,7 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 
 func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no response for VS, err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for VS, err: %v, response: %v", key, rest_op.Err, rest_op.Response)
 		return errors.New("Error rest_op")
 	}
 

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -101,6 +101,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			vsvip.Labels = lib.GetLabels()
 		}
 		rest_op = utils.RestOp{
+			ObjName: name,
 			Path:    "/api/vsvip/" + cache_obj.Uuid,
 			Method:  utils.RestPut,
 			Obj:     vsvip,
@@ -202,8 +203,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			vsvip.Labels = lib.GetLabels()
 		}
 		vsvip.VsvipCloudConfigCksum = &cksumstr
-		macro := utils.AviRestObjMacro{ModelName: "VsVip", Data: vsvip}
-		path = "/api/macro"
+		path = "/api/vsvip"
 		// Patch an existing vsvip if it exists in the cache but not associated with this VS.
 		vsvip_key := avicache.NamespaceName{Namespace: vsvip_meta.Tenant, Name: name}
 		utils.AviLog.Debugf("key: %s, searching in cache for vsVip Key: %s", key, vsvip_key)
@@ -216,7 +216,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 					// Clear the cache for this key
 					rest.cache.VSVIPCache.AviCacheDelete(vsvip_key)
 					utils.AviLog.Warnf("key: %s, Removed the vsvip object from the cache", key)
-					rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+					rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vsvip,
 						Tenant: vsvip_meta.Tenant, Model: "VsVip", Version: utils.CtrlVersion}
 					return &rest_op, nil
 				}
@@ -244,7 +244,9 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			}
 			vsvip_avi.VsvipCloudConfigCksum = &cksumstr
 			path = "/api/vsvip/" + vsvip_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path,
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
 				Method:  utils.RestPut,
 				Obj:     vsvip_avi,
 				Tenant:  vsvip_meta.Tenant,
@@ -252,9 +254,11 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 				Version: utils.CtrlVersion,
 			}
 		} else {
-			rest_op = utils.RestOp{Path: path,
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
 				Method:  utils.RestPost,
-				Obj:     macro,
+				Obj:     vsvip,
 				Tenant:  vsvip_meta.Tenant,
 				Model:   "VsVip",
 				Version: utils.CtrlVersion,
@@ -303,7 +307,7 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
 		if rest_op.Message == "" {
-			utils.AviLog.Warnf("key: %s, rest_op has err or no response for vsvip err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+			utils.AviLog.Warnf("key: %s, rest_op has err or no response for vsvip err: %v, response: %v", key, rest_op.Err, rest_op.Response)
 			return errors.New("Errored vsvip rest_op")
 		}
 

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -43,7 +43,6 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	if lib.GetEnableGRBAC() {
 		pg.Labels = lib.GetLabels()
 	}
-	macro := utils.AviRestObjMacro{ModelName: "PoolGroup", Data: pg}
 
 	var path string
 	var rest_op utils.RestOp
@@ -61,8 +60,8 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pg,
 				Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
 		} else {
-			path = "/api/macro"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+			path = "/api/poolgroup/"
+			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: pg,
 				Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
 		}
 	}
@@ -99,7 +98,7 @@ func (rest *RestOperations) AviPGDel(uuid string, tenant string, key string) *ut
 
 func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
-		utils.AviLog.Warnf("key: %s, rest_op has err or no response for PG err: %s, response: %s", key, rest_op.Err, rest_op.Response)
+		utils.AviLog.Warnf("key: %s, rest_op has err or no response for PG err: %v, response: %v", key, rest_op.Err, rest_op.Response)
 		return errors.New("Errored rest_op")
 	}
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -36,7 +36,6 @@ import (
 type RestOperations struct {
 	cache             *avicache.AviObjCache
 	aviRestPoolClient *utils.AviRestClientPool
-	// Add locks if some code needs to be protected.
 }
 
 func NewRestOperations(cache *avicache.AviObjCache, aviRestPoolClient *utils.AviRestClientPool) RestOperations {
@@ -679,7 +678,7 @@ func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, key s
 func (rest *RestOperations) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp) error {
 	restTimeoutChan := make(chan error, 1)
 	go func() {
-		err := rest.aviRestPoolClient.AviRestOperate(aviClient, rest_ops)
+		err := AviRestOperate(aviClient, rest_ops)
 		restTimeoutChan <- err
 	}()
 	select {

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+
+	"github.com/avinetworks/sdk/go/clients"
+	avimodels "github.com/avinetworks/sdk/go/models"
+	"github.com/avinetworks/sdk/go/session"
+)
+
+// modelSchema defines an interface to handle rest operations for an object type.
+// For each object type (e.g. VirtualService), a new Model has to be implemented for this interface,
+// and the instance should be added in supportedModelTypes.
+// Usually the Model should have a refMap which has a mapping between reference object type and
+// a function which removes the reference. The function of the interface - RemoveRef should return
+// different functions based on the key of refMap.
+type modelSchema interface {
+	GetType() string
+	RemoveRef(reftype string) func(*utils.RestOp, string) bool
+}
+
+var (
+	virtualServiceModel = initVSModel()
+	poolGroupModel      = initPGModel()
+
+	// List of Models for which we would try to remove object refs in case of error
+	supportedModelTypes = map[string]modelSchema{
+		"VirtualService": virtualServiceModel,
+		"PoolGroup":      poolGroupModel,
+	}
+
+	// List of Objects for which we would handle error
+	supportedObjForError = map[string]struct{}{
+		"Pool":                 {},
+		"VsVip":                {},
+		"SSLKeyAndCertificate": {},
+	}
+)
+
+type poolGroupSchema struct {
+	Type   string
+	refMap map[string]func(*utils.RestOp, string) bool
+}
+
+func (v *poolGroupSchema) GetType() string {
+	return v.Type
+}
+func (v *poolGroupSchema) RemoveRef(refType string) func(*utils.RestOp, string) bool {
+	return v.refMap[refType]
+}
+
+func initPGModel() *poolGroupSchema {
+	pg := poolGroupSchema{}
+	pg.Type = "PoolGroup"
+	pg.refMap = map[string]func(*utils.RestOp, string) bool{
+		"Pool": pg.removePoolRef,
+	}
+	return &pg
+}
+
+func (v *poolGroupSchema) removePoolRef(op *utils.RestOp, objRef string) bool {
+	pg, ok := op.Obj.(*avimodels.PoolGroup)
+	if !ok {
+		utils.AviLog.Infof("Failed to remove Pool ref, object is not of type PoolGroup")
+		return false
+	}
+
+	for i := range pg.Members {
+		if strings.EqualFold(*pg.Members[i].PoolRef, objRef) {
+			pg.Members = append(pg.Members[:i], pg.Members[i+1:]...)
+			utils.AviLog.Infof("Successfully removed pool ref %s from PoolGroup: %s", objRef, *pg.Name)
+			break
+		}
+	}
+	op.Obj = pg
+	return true
+}
+
+type virtualserviceSchema struct {
+	Type   string
+	refMap map[string]func(*utils.RestOp, string) bool
+}
+
+func (v *virtualserviceSchema) GetType() string {
+	return v.Type
+}
+
+func initVSModel() *virtualserviceSchema {
+	vs := virtualserviceSchema{}
+	vs.Type = "VirtualService"
+	vs.refMap = map[string]func(*utils.RestOp, string) bool{
+		"SSLKeyAndCertificate": vs.removeCertRef,
+		"Pool":                 vs.removePoolRef,
+		"VsVip":                vs.removeVsVipRef,
+	}
+	return &vs
+}
+
+func (v *virtualserviceSchema) RemoveRef(refType string) func(*utils.RestOp, string) bool {
+	return v.refMap[refType]
+}
+
+func (v *virtualserviceSchema) removeCertRef(op *utils.RestOp, objRef string) bool {
+	vs, ok := op.Obj.(*avimodels.VirtualService)
+	if !ok {
+		utils.AviLog.Infof("Failed to remove SSL Cert ref, object is not of type Virtualservice")
+		return false
+	}
+	for i, v := range vs.SslKeyAndCertificateRefs {
+		if strings.EqualFold(v, objRef) {
+			vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs[:i], vs.SslKeyAndCertificateRefs[i+1:]...)
+			utils.AviLog.Infof("Successfully removed SSl Cert ref %s from VS: %s", objRef, *vs.Name)
+		}
+	}
+	op.Obj = vs
+	return true
+}
+
+func (v *virtualserviceSchema) removePoolRef(op *utils.RestOp, objRef string) bool {
+	vs, ok := op.Obj.(*avimodels.VirtualService)
+	if !ok {
+		utils.AviLog.Infof("Failed to remove Pool ref, object is not of type Virtualservice")
+		return false
+	}
+	if strings.EqualFold(*vs.PoolRef, objRef) {
+		vs.PoolRef = nil
+	}
+	for i := range vs.ServicePoolSelect {
+		//check if normal equal can be made to work
+		if strings.EqualFold(*vs.ServicePoolSelect[i].ServicePoolRef, objRef) {
+			vs.ServicePoolSelect[i].ServicePoolRef = nil
+			utils.AviLog.Infof("Successfully removed Pool ref %s from VS: %s", objRef, *vs.Name)
+		}
+	}
+	op.Obj = vs
+	return true
+}
+
+func (v *virtualserviceSchema) removeVsVipRef(op *utils.RestOp, objRef string) bool {
+	vs, ok := op.Obj.(*avimodels.VirtualService)
+	if !ok {
+		utils.AviLog.Infof("Failed to remove VsVip ref, object is not of type Virtualservice")
+		return false
+	}
+	if strings.EqualFold(*vs.VsvipRef, objRef) {
+		// If VsVip creation failed, then the VS Operations should be aborted
+		utils.AviLog.Infof("VSVip creation failed, object ref won't be removed from Virtualservice")
+		return false
+	}
+	return true
+}
+
+func removeObjRefFromRestOps(restOps []*utils.RestOp, objName, objType string) bool {
+	if _, ok := supportedObjForError[objType]; !ok {
+		utils.AviLog.Debugf("Ignoring error for unsupported type: %v", objType)
+		return false
+	}
+	objRef := "/api/" + objType + "/?name=" + objName
+	for i, op := range restOps {
+		if m, ok := supportedModelTypes[op.Model]; ok {
+			if removeFunc := m.RemoveRef(objType); removeFunc != nil {
+				if !removeFunc(restOps[i], objRef) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func isErrorRetryable(statusCode int) bool {
+	// List of status codes for which we support retry
+	if (statusCode >= 500 && statusCode < 599) || statusCode == 404 || statusCode == 408 || statusCode == 409 {
+		return true
+	}
+	return false
+}
+
+type AviRestClientPool struct {
+	AviClient []*clients.AviClient
+}
+
+func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
+	for i, op := range rest_ops {
+		SetTenant := session.SetTenant(op.Tenant)
+		SetTenant(c.AviSession)
+		SetVersion := session.SetVersion(op.Version)
+		SetVersion(c.AviSession)
+		switch op.Method {
+		case utils.RestPost:
+			op.Err = c.AviSession.Post(op.Path, op.Obj, &op.Response)
+		case utils.RestPut:
+			op.Err = c.AviSession.Put(op.Path, op.Obj, &op.Response)
+		case utils.RestGet:
+			op.Err = c.AviSession.Get(op.Path, &op.Response)
+		case utils.RestPatch:
+			op.Err = c.AviSession.Patch(op.Path, op.Obj, op.PatchOp,
+				&op.Response)
+		case utils.RestDelete:
+			op.Err = c.AviSession.Delete(op.Path)
+		default:
+			utils.AviLog.Errorf("Unknown RestOp %v", op.Method)
+			op.Err = fmt.Errorf("Unknown RestOp %v", op.Method)
+		}
+		if op.Err != nil {
+			utils.AviLog.Warnf(`RestOp method %v path %v tenant %v Obj %s returned err %s with response %s`,
+				op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
+			// Wrap the error into a websync error.
+			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
+			aviErr := op.Err.(session.AviError)
+			if !isErrorRetryable(aviErr.HttpStatusCode) {
+				if op.Method != utils.RestPost {
+					continue
+				}
+				if removeObjRefFromRestOps(rest_ops, op.ObjName, op.Model) {
+					continue
+				}
+			}
+
+			for j := i + 1; j < len(rest_ops); j++ {
+				rest_ops[j].Err = errors.New("Aborted due to prev error")
+			}
+			return err
+		} else {
+			utils.AviLog.Debugf(`RestOp method %v path %v tenant %v response %v`,
+				op.Method, op.Path, op.Tenant, utils.Stringify(op.Response))
+		}
+	}
+	return nil
+}

--- a/internal/rest/rest_utils.go
+++ b/internal/rest/rest_utils.go
@@ -15,7 +15,6 @@
 package rest
 
 import (
-	"errors"
 	"regexp"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -23,36 +22,7 @@ import (
 
 func RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) ([]map[string]interface{}, error) {
 	var resp_elems []map[string]interface{}
-	if rest_op.Method == utils.RestPost {
-		resp_arr, ok := rest_op.Response.([]interface{})
-		if !ok {
-			utils.AviLog.Warnf("key: %s, msg: response has unknown type %T", key, rest_op.Response)
-			return nil, errors.New("Malformed response")
-		}
-
-		for _, resp_elem := range resp_arr {
-			resp, ok := resp_elem.(map[string]interface{})
-			if !ok {
-				utils.AviLog.Warnf("key: %s, msg: response has unknown type %T", key, resp_elem)
-				continue
-			}
-
-			avi_url, ok := resp["url"].(string)
-			if !ok {
-				utils.AviLog.Warnf("key: %s, msg:url not present in response %v", key, resp)
-				continue
-			}
-
-			avi_obj_type, err := utils.AviUrlToObjType(avi_url)
-			if err == nil && avi_obj_type == obj_type {
-				resp_elems = append(resp_elems, resp)
-			}
-		}
-	} else {
-		// The PUT calls are specific for the resource
-		resp_elems = append(resp_elems, rest_op.Response.(map[string]interface{}))
-	}
-
+	resp_elems = append(resp_elems, rest_op.Response.(map[string]interface{}))
 	return resp_elems, nil
 }
 

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -54,17 +54,16 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 
 	// TODO other fields like cloud_ref and lb algo
 
-	macro := utils.AviRestObjMacro{ModelName: "SSLKeyAndCertificate", Data: sslkeycert}
-
 	var path string
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/sslkeyandcertificate/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: sslkeycert,
+		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: sslkeycert,
 			Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+		rest_op.ObjName = name
 	} else {
-		path = "/api/macro"
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+		path = "/api/sslkeyandcertificate"
+		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: sslkeycert,
 			Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
 	}
 	return &rest_op
@@ -192,7 +191,6 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 	if lib.GetEnableGRBAC() {
 		pkiobject.Labels = lib.GetLabels()
 	}
-	macro := utils.AviRestObjMacro{ModelName: "PKIprofile", Data: pkiobject}
 
 	var path string
 	var rest_op utils.RestOp
@@ -201,8 +199,8 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pkiobject,
 			Tenant: pki_node.Tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
 	} else {
-		path = "/api/macro"
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: macro,
+		path = "/api/pkiprofile/"
+		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: pkiobject,
 			Tenant: pki_node.Tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
 	}
 	return &rest_op

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -427,7 +427,6 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 		if r.Method == "POST" && !strings.Contains(url, "login") {
 			data, _ := ioutil.ReadAll(r.Body)
 			json.Unmarshal(data, &resp)
-			fmt.Printf("xxx: resp: %v", resp)
 			if strings.Contains(url, "virtualservice") && injectFault {
 				injectFault = false
 				w.WriteHeader(http.StatusBadRequest)
@@ -438,7 +437,7 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 				} else if strings.Contains(url, "vsvip") {
 					rModelName = "vsvip"
 				} else if strings.Contains(url, "l4policy") {
-					rModelName = "l4policy"
+					rModelName = "l4policyset"
 				}
 				rName := resp["name"].(string)
 				objURL := fmt.Sprintf("https://localhost/api/%s/%s-%s#%s", rModelName, rModelName, RANDOMUUID, rName)

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -423,22 +423,30 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 		var finalResponse []byte
 		url := r.URL.EscapedPath()
 
-		if strings.Contains(url, "macro") && r.Method == "POST" {
+		rModelName := ""
+		if r.Method == "POST" && !strings.Contains(url, "login") {
 			data, _ := ioutil.ReadAll(r.Body)
 			json.Unmarshal(data, &resp)
-			rData, rModelName := resp["data"].(map[string]interface{}), strings.ToLower(resp["model_name"].(string))
-			if rModelName == "virtualservice" && injectFault {
+			fmt.Printf("xxx: resp: %v", resp)
+			if strings.Contains(url, "virtualservice") && injectFault {
 				injectFault = false
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintln(w, `{"error": "bad request"}`)
 			} else {
-				rName := rData["name"].(string)
+				if strings.Contains(url, "virtualservice") {
+					rModelName = "virtualservice"
+				} else if strings.Contains(url, "vsvip") {
+					rModelName = "vsvip"
+				} else if strings.Contains(url, "l4policy") {
+					rModelName = "l4policy"
+				}
+				rName := resp["name"].(string)
 				objURL := fmt.Sprintf("https://localhost/api/%s/%s-%s#%s", rModelName, rModelName, RANDOMUUID, rName)
 
 				// adding additional 'uuid' and 'url' (read-only) fields in the response
-				rData["url"] = objURL
-				rData["uuid"] = fmt.Sprintf("%s-%s-%s", rModelName, rName, RANDOMUUID)
-				finalResponse, _ = json.Marshal([]interface{}{resp["data"]})
+				resp["url"] = objURL
+				resp["uuid"] = fmt.Sprintf("%s-%s-%s", rModelName, rName, RANDOMUUID)
+				finalResponse, _ = json.Marshal(resp)
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, string(finalResponse))
 			}


### PR DESCRIPTION
Currently if we get an error in rest layer, then all other requests mapped to the
same shared VS are skipped. This leads to a scenario where problem in one ingress affects
other ingresses mapped to the same shared VS.

In this PR, not all requests are skipped in case of an error.
- If the failed request was anything other than POST call then we ignore the error and coninue.
- IF the failed request was POST then we attempt to remove its reference from other objects, then continue.

Also as part of this PR macro calls have been removed. In the current model it doesn't provide
any extra benifit as one macro call contains ony one request.