### PR TITLE
Fixing the ApplicationProfile and associating the redirect policy for EVH child VS.

### DIFF
--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -352,7 +352,7 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 
 	east_west := false
 	var app_prof string
-	app_prof = "/api/applicationprofile/?name=" + utils.DEFAULT_L7_SECURE_APP_PROFILE
+	app_prof = "/api/applicationprofile/?name=" + vs_meta.ApplicationProfile
 	if vs_meta.AppProfileRef != "" {
 		// hostrule ref overrides defaults
 		app_prof = vs_meta.AppProfileRef

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
@@ -376,7 +376,7 @@ func TestHostnameCreateCacheSyncForEvh(t *testing.T) {
 	g.Expect(sniCacheObj.PoolKeyCollection[0].Name).To(gomega.ContainSubstring("foo-with-targets"))
 	g.Expect(sniCacheObj.PGKeyCollection).To(gomega.HaveLen(1))
 	g.Expect(sniCacheObj.PGKeyCollection[0].Name).To(gomega.ContainSubstring("foo-with-targets"))
-	g.Expect(sniCacheObj.HTTPKeyCollection).To(gomega.HaveLen(1))
+	g.Expect(sniCacheObj.HTTPKeyCollection).To(gomega.HaveLen(2))
 
 	TearDownIngressForCacheSyncCheck(t, modelName)
 
@@ -440,7 +440,7 @@ func TestHostnameUpdateCacheSyncForEvh(t *testing.T) {
 	}, 15*time.Second).Should(gomega.Equal(oldSniCacheObj.CloudConfigCksum))
 	sniVSCache, _ := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 	sniVSCacheObj, _ := sniVSCache.(*cache.AviVsCache)
-	g.Expect(sniVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(1))
+	g.Expect(sniVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(2))
 	g.Expect(sniVSCacheObj.SSLKeyCertCollection).To(gomega.HaveLen(0))
 
 	TearDownIngressForCacheSyncCheck(t, modelName)
@@ -615,7 +615,7 @@ func TestHostnameMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 		sniCacheObj1, _ := sniCache1.(*cache.AviVsCache)
 		sniCacheObj2, _ := sniCache2.(*cache.AviVsCache)
 		if found1 && found2 &&
-			len(sniCacheObj1.HTTPKeyCollection) == 1 && len(sniCacheObj2.HTTPKeyCollection) == 1 {
+			len(sniCacheObj1.HTTPKeyCollection) == 2 && len(sniCacheObj2.HTTPKeyCollection) == 2 {
 			return true
 		}
 		return false
@@ -728,7 +728,7 @@ func TestHostnameDeleteCacheSyncForEvh(t *testing.T) {
 		parentSniCache, _ := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
 		parentSniCacheObj, _ := parentSniCache.(*cache.AviVsCache)
 
-		if found && len(parentSniCacheObj.SNIChildCollection) == 1 && len(parentSniCacheObj.HTTPKeyCollection) == 1 {
+		if found && len(parentSniCacheObj.SNIChildCollection) == 1 && len(parentSniCacheObj.HTTPKeyCollection) == 0 {
 			return true
 		}
 		return false
@@ -767,7 +767,7 @@ func TestHostnameCUDSecretCacheSyncForEvh(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(true))
 	parentVSCache, _ := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
 	parentVSCacheObj, _ := parentVSCache.(*cache.AviVsCache)
-	g.Expect(parentVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(1))
+	g.Expect(parentVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(0))
 	g.Expect(parentVSCacheObj.SSLKeyCertCollection).To(gomega.HaveLen(1))
 
 	// update Secret

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
@@ -172,8 +172,9 @@ func TestHostnameShardObjectsForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[1].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
 	// since foo is bound with cert this node will have the cert bound to it
 	g.Expect(nodes[0].EvhNodes[1].SSLKeyCertRefs).Should(gomega.HaveLen(0))
-	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs).Should(gomega.HaveLen(1))
+	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs).Should(gomega.HaveLen(2))
 	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[1].Name).To(gomega.Equal("cluster--default-foo.com"))
 
 	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {
@@ -906,8 +907,7 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 		g.Expect(len(nodes[0].SSLKeyCertRefs)).To(gomega.Equal(1))
 		initCheckSums["nodes[0].SSLKeyCertRefs[0]"] = nodes[0].SSLKeyCertRefs[0].CloudConfigCksum
 
-		g.Expect(len(nodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
-		initCheckSums["nodes[0].HttpPolicyRefs[0]"] = nodes[0].HttpPolicyRefs[0].CloudConfigCksum
+		g.Expect(len(nodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
 
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
@@ -962,7 +962,7 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 			return nodes[0].SSLKeyCertRefs[0].CloudConfigCksum
 		}, 5*time.Second).ShouldNot(gomega.Equal(initCheckSums["nodes[0].SSLKeyCertRefs[0]"]))
 
-		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(2))
 
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
@@ -1798,10 +1798,10 @@ func TestL7ModelMultiSNIForEvh(t *testing.T) {
 		g.Expect(len(nodes)).To(gomega.Equal(1))
 		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
-		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(0))
 		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
@@ -1859,11 +1859,11 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 		g.Expect(len(nodes)).To(gomega.Equal(1))
 		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
-		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
-		g.Expect(nodes[0].HttpPolicyRefs[0].RedirectPorts[0].Hosts).To(gomega.HaveLen(2))
+		g.Expect(nodes[0].HttpPolicyRefs).To(gomega.HaveLen(0))
 		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(2))
+		g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts).To(gomega.HaveLen(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
@@ -1977,7 +1977,7 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(1))
-		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
+		g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))


### PR DESCRIPTION
- DEFAULT_L7__APP_PROFILE is used for secure and insecure ingresses for the EVH Vs.
- The redirect policy should be bound to the child EVH VS instead of the Parent.
- Removed ServiceMetadata information from pool as it was causing a race in status update for insecure ingress path update.
Tested the secure, insecure and the CRD usecase with this change.