### PR TITLE
L4 Namespace Sync for GatewayAPI/ServiceAPI services

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -403,7 +403,7 @@ func (c *AviController) FullSyncK8s() error {
 		if isSvcLb && !lib.GetLayer7Only() {
 			/*
 				Key added to Ingestion queue if
-				1. Advance L4 or ServiceAPI enabled or
+				1. Advance L4 enabled or
 				2. Namespace is valid
 			*/
 			if !utils.IsServiceNSValid(ns[0]) {
@@ -505,9 +505,13 @@ func (c *AviController) FullSyncK8s() error {
 				return err
 			}
 			for _, gatewayObj := range gatewayObjs {
-				key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
-				InformerStatusUpdatesForSvcApiGateway(key, gatewayObj)
-				nodes.DequeueIngestion(key, true)
+				gatewayLabel := utils.ObjKey(gatewayObj)
+				ns := strings.Split(gatewayLabel, "/")
+				if utils.CheckIfNamespaceAccepted(ns[0]) {
+					key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
+					InformerStatusUpdatesForSvcApiGateway(key, gatewayObj)
+					nodes.DequeueIngestion(key, true)
+				}
 			}
 
 			gwClassObjs, err := lib.GetSvcAPIInformers().GatewayClassInformer.Lister().List(labels.Set(nil).AsSelector())

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -337,7 +337,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			route := obj.(*routev1.Route)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Route add event: Namespace: %s didn't qualify filter. Not adding route", namespace)
+				utils.AviLog.Debugf("Route add event: Namespace: %s didn't qualify filter. Not adding route", namespace)
 				return
 			}
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
@@ -367,7 +367,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Route delete event: Namespace: %s didn't qualify filter. Not deleting route", namespace)
+				utils.AviLog.Debugf("Route delete event: Namespace: %s didn't qualify filter. Not deleting route", namespace)
 				return
 			}
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
@@ -384,7 +384,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			if isRouteUpdated(oldRoute, newRoute) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newRoute))
 				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Infof("Route update event: Namespace: %s didn't qualify filter. Not updating route", namespace)
+					utils.AviLog.Debugf("Route update event: Namespace: %s didn't qualify filter. Not updating route", namespace)
 					return
 				}
 				key := utils.OshiftRoute + "/" + utils.ObjKey(newRoute)
@@ -540,7 +540,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isSvcLb && !lib.GetLayer7Only() {
 				//L4 Namespace sync not applicable for advance L4 and service API
 				if !utils.IsServiceNSValid(namespace) {
-					utils.AviLog.Infof("L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", namespace)
+					utils.AviLog.Debugf("L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", namespace)
 					return
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
@@ -583,7 +583,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 			if isSvcLb && !lib.GetLayer7Only() {
 				if !utils.IsServiceNSValid(namespace) {
-					utils.AviLog.Infof("L4 Service delete event: Namespace: %s didn't qualify filter. Not deleting service.", namespace)
+					utils.AviLog.Debugf("L4 Service delete event: Namespace: %s didn't qualify filter. Not deleting service.", namespace)
 					return
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
@@ -610,7 +610,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				var key string
 				if isSvcLb && !lib.GetLayer7Only() {
 					if !utils.IsServiceNSValid(namespace) {
-						utils.AviLog.Infof("L4 Service update event: Namespace: %s didn't qualify filter. Not updating service.", namespace)
+						utils.AviLog.Debugf("L4 Service update event: Namespace: %s didn't qualify filter. Not updating service.", namespace)
 						return
 					}
 					key = utils.L4LBService + "/" + utils.ObjKey(svc)
@@ -807,7 +807,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			ingress := obj.(*networkingv1beta1.Ingress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Ingress add event: Namespace: %s didn't qualify filter. Not adding ingress", namespace)
+				utils.AviLog.Debugf("Ingress add event: Namespace: %s didn't qualify filter. Not adding ingress", namespace)
 				return
 			}
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
@@ -835,7 +835,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Ingress Delete event: Namespace: %s didn't qualify filter. Not deleting ingress", namespace)
+				utils.AviLog.Debugf("Ingress Delete event: Namespace: %s didn't qualify filter. Not deleting ingress", namespace)
 				return
 			}
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
@@ -852,7 +852,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isIngressUpdated(oldobj, ingress) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
 				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Infof("Ingress Update event: Namespace: %s didn't qualify filter. Not updating ingress", namespace)
+					utils.AviLog.Debugf("Ingress Update event: Namespace: %s didn't qualify filter. Not updating ingress", namespace)
 					return
 				}
 				key := utils.Ingress + "/" + utils.ObjKey(ingress)

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -192,6 +192,10 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			}
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
+			if !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Infof("Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", namespace)
+				return
+			}
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
 			utils.AviLog.Infof("key: %s, msg: ADD", key)
 
@@ -210,6 +214,10 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 
 			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
+				if !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Infof("Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", namespace)
+					return
+				}
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
 				utils.AviLog.Infof("key: %s, msg: UPDATE", key)
 
@@ -226,6 +234,10 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			}
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
+			if !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Infof("Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", namespace)
+				return
+			}
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
 			utils.AviLog.Infof("key: %s, msg: DELETE", key)
 			bkt := utils.Bkt(namespace, numWorkers)

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -193,7 +193,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", namespace)
+				utils.AviLog.Debugf("Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", namespace)
 				return
 			}
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
@@ -215,7 +215,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Infof("Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", namespace)
+					utils.AviLog.Debugf("Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", namespace)
 					return
 				}
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
@@ -235,7 +235,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Infof("Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", namespace)
+				utils.AviLog.Debugf("Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", namespace)
 				return
 			}
 			key := lib.Gateway + "/" + utils.ObjKey(gw)

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -256,6 +256,10 @@ func isGatewayDelete(gatewayKey string, key string) bool {
 			return true
 		}
 	} else if lib.UseServicesAPI() {
+		//If namespace is not accepted, return true to delete model
+		if !utils.CheckIfNamespaceAccepted(namespace) {
+			return true
+		}
 		gateway, err := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
 		if err != nil && errors.IsNotFound(err) {
 			return true

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -63,7 +63,7 @@ func validateSpecFromHostnameCache(key, ns, ingName string, ingSpec networkingv1
 		if rule.IngressRuleValue.HTTP != nil {
 			for _, svcPath := range rule.IngressRuleValue.HTTP.Paths {
 				found, val := SharedHostNameLister().GetHostPathStoreIngresses(rule.Host, svcPath.Path)
-				if found && len(val) > 0 && utils.HasElem(val, nsIngress) && len(val) > 1 {
+				if found && len(val) > 1 && utils.HasElem(val, nsIngress) {
 					// TODO: push in ako apiserver
 					utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s%s: %s in ingresses: %+v", key, nsIngress, rule.Host, svcPath.Path, utils.Stringify(val))
 				}
@@ -79,7 +79,7 @@ func validateSpecFromHostnameCache(key, ns, ingName string, ingSpec networkingv1
 func validateRouteSpecFromHostnameCache(key, ns, routeName string, routeSpec routev1.RouteSpec) {
 	nsRoute := ns + "/" + routeName
 	found, val := SharedHostNameLister().GetHostPathStoreIngresses(routeSpec.Host, routeSpec.Path)
-	if found && len(val) > 0 && utils.HasElem(val, nsRoute) && len(val) > 1 {
+	if found && len(val) > 1 && utils.HasElem(val, nsRoute) {
 		utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s%s: %s in routes: %+v", key, nsRoute, routeSpec.Host, routeSpec.Path, utils.Stringify(val))
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -386,9 +386,8 @@ func CheckIfNamespaceAccepted(namespace string, opts ...interface{}) bool {
 	return false
 }
 func IsServiceNSValid(namespace string) bool {
-	//L4 Namespace sync not applicable for advance L4 and service API
-
-	if !GetAdvancedL4() && !UseServicesAPI() {
+	//L4 Namespace sync not applicable for advance L4
+	if !GetAdvancedL4() {
 		if !CheckIfNamespaceAccepted(namespace) {
 			return false
 		}
@@ -400,12 +399,6 @@ func IsServiceNSValid(namespace string) bool {
 // the user requires advanced L4 functionality
 func GetAdvancedL4() bool {
 	if ok, _ := strconv.ParseBool(os.Getenv(ADVANCED_L4)); ok {
-		return true
-	}
-	return false
-}
-func UseServicesAPI() bool {
-	if ok, _ := strconv.ParseBool(os.Getenv(SERVICES_API)); ok {
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR has changes for:
1. L4 namespace sync for Service API
2. Few code corrections.

@sudswasavi @chauhanshubham : Recently, K8 Upstream changed project name from ServiceAPI to GatewayAPI.  I think we should also reflect out that change in our code base. (https://github.com/kubernetes-sigs/gateway-api). 