### PR TITLE
Temporary support for http caching via pools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,9 @@ namespacesynctests:
 	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/namespacesynctests -failfast
 
 .PHONY: misc 
-misc:
+temp:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
-	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/misc -failfast
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/temp -failfast
 
 .PHONY: npltests 
 npltests:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOCLEAN=$(GOCMD) clean
 GOGET=$(GOCMD) get
 GOTEST=$(GOCMD) test
 BINARY_NAME_AKO=ako
-AKO_VERSION=v1.3.1
+AKO_VERSION=v1.4.1
 PACKAGE_PATH_AKO=github.com/vmware/load-balancer-and-ingress-services-for-kubernetes
 REL_PATH_AKO=$(PACKAGE_PATH_AKO)/cmd/ako-main
 AKO_OPERATOR_IMAGE=ako-operator
@@ -121,6 +121,11 @@ namespacesynctests:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
 	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/namespacesynctests -failfast
 
+.PHONY: misc 
+misc:
+	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/misc -failfast
+
 .PHONY: npltests 
 npltests:
 	sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
@@ -128,7 +133,7 @@ npltests:
 
 .PHONY: int_test
 int_test:
-	make -j 1 k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests
+	make -j 1 k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc
 
 .PHONY: scale_test
 scale_test:

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}
   disableStaticRouteSync: {{ .Values.AKOSettings.disableStaticRouteSync | quote }}
   defaultIngController: {{ .Values.L7Settings.defaultIngController | quote }}
+  noPGForSNI: {{ .Values.L7Settings.noPGForSNI | quote }}
   subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
   enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -48,6 +48,7 @@ NetworkSettings:
 ### This section outlines all the knobs  used to control Layer 7 loadbalancing settings in AKO.
 L7Settings:
   defaultIngController: "true"
+  noPGForSNI: false # Switching this knob to true, will get rid of poolgroups from SNI VSes. Do not use this flag, if you don't want http caching. This will be deprecated once the controller support caching on PGs.
   serviceType: ClusterIP #enum NodePort|ClusterIP
   shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL, DEDICATED
   passthroughShardSize: "SMALL" # Control the passthrough virtualservice numbers using this ENUM. ENUMs: LARGE, MEDIUM, SMALL

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -350,6 +350,7 @@ type AviHTTPPolicyCache struct {
 	Uuid             string
 	CloudConfigCksum string
 	PoolGroups       []string
+	Pools            []string
 	LastModified     string
 	InvalidData      bool
 	HasReference     bool

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -138,6 +138,8 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
 			// Check if AKO is configured to only use Ingress. This value can be only set during bootup and can't be edited dynamically.
 			lib.SetLayer7Only(cm.Data[lib.LAYER7_ONLY])
+			// Check if we need to use PGs for SNIs or not.
+			lib.SetNoPGForSNI(cm.Data[lib.NO_PG_FOR_SNI])
 			delModels := delConfigFromData(cm.Data)
 			if !delModels {
 				status.ResetStatefulSetStatus()

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -56,6 +56,7 @@ const (
 	SLOW_SYNC_TIME                             = 90 // seconds
 	LOG_LEVEL                                  = "logLevel"
 	LAYER7_ONLY                                = "layer7Only"
+	NO_PG_FOR_SNI                              = "noPGForSNI"
 	SERVICE_TYPE                               = "SERVICE_TYPE"
 	NODE_PORT                                  = "NodePort"
 	NODE_KEY                                   = "NODE_KEY"
@@ -125,8 +126,9 @@ const (
 	InfraSettingNameAnnotation     = "aviinfrasetting.ako.vmware.com/name"
 
 	// Specifies command used in namespace event handler
-	NsFilterAdd    = "ADD"
-	NsFilterDelete = "DELETE"
+	NsFilterAdd                    = "ADD"
+	NsFilterDelete                 = "DELETE"
+	PoolNameSuffixForHttpPolToPool = "policy-to-pool"
 )
 
 // Cache Indexer constants.

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -65,6 +65,7 @@ func GetNamePrefix() string {
 
 var DisableSync bool
 var layer7Only bool
+var noPGForSNI bool
 
 func SetDisableSync(state bool) {
 	DisableSync = state
@@ -76,6 +77,17 @@ func SetLayer7Only(val string) {
 		layer7Only = boolVal
 	}
 	utils.AviLog.Infof("Setting the value for the layer7Only flag %v", layer7Only)
+}
+
+func SetNoPGForSNI(val string) {
+	if boolVal, err := strconv.ParseBool(val); err == nil {
+		noPGForSNI = boolVal
+	}
+	utils.AviLog.Infof("Setting the value for the noPGForSNI flag %v", noPGForSNI)
+}
+
+func GetNoPGForSNI() bool {
+	return noPGForSNI
 }
 
 func GetLayer7Only() bool {

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -217,6 +217,10 @@ func (o *AviObjectGraph) ManipulateSniNode(currentSniNodeName, ingName, namespac
 				} else {
 					sniPool = lib.GetSniPoolName(ingName, namespace, hostname, path, svc)
 				}
+				// Pls decprecate when PGs have http caching
+				if lib.GetNoPGForSNI() && isIngr {
+					sniPool = sniPool + "--" + lib.PoolNameSuffixForHttpPolToPool
+				}
 				o.RemovePoolNodeRefsFromSni(sniPool, modelSniNode)
 				o.RemovePoolRefsFromPG(sniPool, pgNode)
 			}
@@ -227,6 +231,11 @@ func (o *AviObjectGraph) ManipulateSniNode(currentSniNodeName, ingName, namespac
 					httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path)
 					o.RemoveHTTPRefsFromSni(httppolname, modelSniNode)
 				}
+			}
+			// Keeping this block separate for deprecation later.
+			if lib.GetNoPGForSNI() && isIngr {
+				httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path)
+				o.RemoveHTTPRefsFromSni(httppolname, modelSniNode)
 			}
 		}
 		// After going through the paths, if the SNI node does not have any PGs - then delete it.

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1151,7 +1151,6 @@ func (rest *RestOperations) SNINodeCU(sni_node *nodes.AviVsNode, vs_cache_obj *a
 				sni_pools_to_delete, rest_ops = rest.PoolCU(sni_node.PoolRefs, sni_cache_obj, namespace, rest_ops, key)
 				sni_pgs_to_delete, rest_ops = rest.PoolGroupCU(sni_node.PoolGroupRefs, sni_cache_obj, namespace, rest_ops, key)
 				http_policies_to_delete, rest_ops = rest.HTTPPolicyCU(sni_node.HttpPolicyRefs, sni_cache_obj, namespace, rest_ops, key)
-
 				// The checksums are different, so it should be a PUT call.
 				if sni_cache_obj.CloudConfigCksum != strconv.Itoa(int(sni_node.GetCheckSum())) {
 					restOp := rest.AviVsBuild(sni_node, utils.RestPut, sni_cache_obj, key)

--- a/tests/misc/temp_sni_to_pool_test.go
+++ b/tests/misc/temp_sni_to_pool_test.go
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package misc
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/clientset/versioned/fake"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
+	utils "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// Use this file to execute tests that need special handling like - configmap create/delete/update operations etc.
+
+var KubeClient *k8sfake.Clientset
+var CRDClient *crdfake.Clientset
+var ctrl *k8s.AviController
+var akoApiServer *api.FakeApiServer
+
+func TestMain(m *testing.M) {
+	os.Setenv("INGRESS_API", "extensionv1")
+	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("CLUSTER_NAME", "cluster")
+	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
+	os.Setenv("SEG_NAME", "Default-Group")
+	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
+
+	KubeClient = k8sfake.NewSimpleClientset()
+	CRDClient = crdfake.NewSimpleClientset()
+	lib.SetCRDClientset(CRDClient)
+
+	registeredInformers := []string{
+		utils.ServiceInformer,
+		utils.EndpointInformer,
+		utils.IngressInformer,
+		utils.IngressClassInformer,
+		utils.SecretInformer,
+		utils.NSInformer,
+		utils.NodeInformer,
+		utils.ConfigMapInformer,
+	}
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers)
+	informers := k8s.K8sinformers{Cs: KubeClient}
+	k8s.NewCRDInformers(CRDClient)
+
+	mcache := cache.SharedAviObjCache()
+	cloudObj := &cache.AviCloudPropertyCache{Name: "Default-Cloud", VType: "mock"}
+	subdomains := []string{"avi.internal", ".com"}
+	cloudObj.NSIpamDNS = subdomains
+	mcache.CloudKeyCache.AviCacheAdd("Default-Cloud", cloudObj)
+
+	akoApiServer = integrationtest.InitializeFakeAKOAPIServer()
+
+	integrationtest.NewAviFakeClientInstance()
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	ctrl = k8s.SharedAviController()
+	stopCh := utils.SetupSignalHandler()
+	ctrlCh := make(chan struct{})
+	quickSyncCh := make(chan struct{})
+	waitGroupMap := make(map[string]*sync.WaitGroup)
+	wgIngestion := &sync.WaitGroup{}
+	waitGroupMap["ingestion"] = wgIngestion
+	wgFastRetry := &sync.WaitGroup{}
+	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
+	wgGraph := &sync.WaitGroup{}
+	waitGroupMap["graph"] = wgGraph
+
+	AddConfigMap()
+	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
+	integrationtest.KubeClient = KubeClient
+	integrationtest.AddDefaultIngressClass()
+
+	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
+	os.Exit(m.Run())
+}
+func TestSniPoolNoPGForSNI(t *testing.T) {
+	/*
+		-> Create Ingress with TLS key/secret and 2 paths
+		-> Verify removing path works by updating Ingress with single path
+		-> Verify adding path works by updating Ingress with 2 new paths
+	*/
+	UpdateConfigMap(lib.NO_PG_FOR_SNI, "true")
+	g := gomega.NewGomegaWithT(t)
+	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	modelName := "admin/cluster--Shared-L7-0"
+	SetUpTestForIngress(t, modelName)
+	ingrFake1 := (integrationtest.FakeIngress{
+		Name:      "ingress-shp",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		Paths:     []string{"/foo", "/bar"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).IngressMultiPath()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Eventually(len(nodes), 30*time.Second).Should(gomega.Equal(1))
+		g.Expect(len(nodes[0].SniNodes[0].PoolRefs)).Should(gomega.Equal(2))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	_, err = (integrationtest.FakeIngress{
+		Name:      "ingress-shp",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		Paths:     []string{"/foo"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).UpdateIngress()
+	if err != nil {
+		t.Fatalf("error in updating ingress %s", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Eventually(func() []*avinodes.AviPoolNode {
+			return nodes[0].SniNodes[0].PoolRefs
+		}, 10*time.Second).Should(gomega.HaveLen(1))
+		g.Expect((nodes[0].SniNodes[0].PoolRefs[0].Name)).Should((gomega.Equal("cluster--default-foo.com_foo-ingress-shp--policy-to-pool")))
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	_, err = (integrationtest.FakeIngress{
+		Name:      "ingress-shp",
+		Namespace: "default",
+		DnsNames:  []string{"foo.com"},
+		Ips:       []string{"8.8.8.8"},
+		Paths:     []string{"/foo", "/bar", "/baz"},
+		HostNames: []string{"v1"},
+		TlsSecretDNS: map[string][]string{
+			"my-secret": {"foo.com"},
+		},
+		ServiceName: "avisvc",
+	}).UpdateIngress()
+	if err != nil {
+		t.Fatalf("error in updating ingress %s", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+
+	if found {
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Eventually(func() []*avinodes.AviPoolNode {
+			return nodes[0].SniNodes[0].PoolRefs
+		}, 10*time.Second).Should(gomega.HaveLen(3))
+
+	} else {
+		t.Fatalf("Could not find model: %s", modelName)
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "ingress-shp", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	VerifySNIIngressDeletion(t, g, aviModel, 0)
+
+	TearDownTestForIngress(t, modelName)
+	UpdateConfigMap(lib.NO_PG_FOR_SNI, "false")
+}
+
+func UpdateConfigMap(key, val string) {
+	KubeClient.CoreV1().ConfigMaps("avi-system").Delete(context.TODO(), "avi-k8s-config", metav1.DeleteOptions{})
+	aviCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "avi-system",
+			Name:      "avi-k8s-config",
+		},
+		Data: make(map[string]string),
+	}
+	aviCM.Data[key] = val
+	aviCM.ResourceVersion = "2"
+	KubeClient.CoreV1().ConfigMaps("avi-system").Create(context.TODO(), aviCM, metav1.CreateOptions{})
+	// Wait for the configmap changes to take effect
+	time.Sleep(3 * time.Second)
+}
+
+func AddConfigMap() {
+	aviCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "avi-system",
+			Name:      "avi-k8s-config",
+		},
+	}
+	KubeClient.CoreV1().ConfigMaps("avi-system").Create(context.TODO(), aviCM, metav1.CreateOptions{})
+
+	integrationtest.PollForSyncStart(ctrl, 10)
+}
+
+func SetUpTestForIngress(t *testing.T, modelNames ...string) {
+	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("L7_SHARD_SCHEME", "hostname")
+
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
+	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "avisvc", false, false, "1.1.1")
+}
+
+func TearDownTestForIngress(t *testing.T, modelNames ...string) {
+	os.Setenv("SHARD_VS_SIZE", "")
+	os.Setenv("CLOUD_NAME", "")
+
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
+	integrationtest.DelSVC(t, "default", "avisvc")
+	integrationtest.DelEP(t, "default", "avisvc")
+}
+
+func VerifySNIIngressDeletion(t *testing.T, g *gomega.WithT, aviModel interface{}, sniCount int) {
+	var nodes []*avinodes.AviVsNode
+	g.Eventually(func() []*avinodes.AviVsNode {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return nodes[0].SniNodes
+	}, 10*time.Second).Should(gomega.HaveLen(sniCount))
+
+	g.Expect(len(nodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(sniCount))
+}

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -12,7 +12,7 @@
 * limitations under the License.
 */
 
-package misc
+package temp
 
 import (
 	"context"
@@ -39,6 +39,7 @@ import (
 )
 
 // Use this file to execute tests that need special handling like - configmap create/delete/update operations etc.
+// Pls delete this file/folder once this feature is deprecated in value of http caching on PG.
 
 var KubeClient *k8sfake.Clientset
 var CRDClient *crdfake.Clientset


### PR DESCRIPTION
Currently http caching is not supported on PoolGroups. This means
that if customers had a httppolicyset refer to a PG instead of a pool,
then this feature cannot work.

This commit addresses this concern with an interim fix that removes the
poolgroup references from the httppolicies and instead references the pools
directly. This flag is not recommeded for use unless http caching is
required because removing Poolgroups would prohibit us from using
canary flows. Hence these are the restrictions of the commit:

 - Only works for SNI VSes (no other thing, not insecure, nor EVH).
 - Will be deprecated once the Avi controller builds the http caching
functionality on poolgroups.
 - Flipping the flag to `true` in a running AKO setup will not take
effect unless AKO is rebooted. Some stale PGs could linger if they
were pre-created in SNIs. In which case, another reboot of AKO will
get rid of them as per the stale object deletion workflow that kicks
on bootup.