### PR TITLE
skip status deletion for Ingress if hostname is present in spec

### DIFF
--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -475,7 +475,7 @@ func buildL7IngressInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, 
 	if !utils.GetIngressClassEnabled() {
 		return
 	} else if ingClassName == "" {
-		if defaultIngressClass, found := isAviLBDefaultIngressClass(); !found {
+		if defaultIngressClass, found := lib.IsAviLBDefaultIngressClass(); !found {
 			return
 		} else {
 			ingClassName = defaultIngressClass

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -143,7 +143,7 @@ func GetK8sIngressModel(name, namespace, key string) (*K8sIngressModel, error, b
 	if err != nil {
 		return &ingrModel, err, processObj
 	}
-	processObj = validateIngressForClass(key, ingObj) && utils.CheckIfNamespaceAccepted(namespace)
+	processObj = lib.ValidateIngressForClass(key, ingObj) && utils.CheckIfNamespaceAccepted(namespace)
 	ingrModel.spec = ingObj.Spec
 	ingrModel.annotations = ingObj.GetAnnotations()
 	return &ingrModel, nil, processObj

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -316,12 +317,13 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 
 	for i, status := range mIngress.Status.LoadBalancer.Ingress {
 		for _, host := range svc_mdata_obj.HostNames {
-			if status.Hostname == host {
-				if !utils.HasElem(hostListIng, host) || isVSDelete {
-					mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)
-				} else {
-					utils.AviLog.Debugf("key: %s, msg: skipping status deletion since host is present in the ingress: %v", key, host)
-				}
+			if status.Hostname != host {
+				continue
+			}
+			if !lib.ValidateIngressForClass(key, mIngress) || !utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace) || !utils.HasElem(hostListIng, host) || isVSDelete {
+				mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)
+			} else {
+				utils.AviLog.Debugf("key: %s, msg: skipping status deletion since host is present in the ingress: %v", key, host)
 			}
 		}
 	}

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -471,15 +471,15 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 
 	for i := len(mRoute.Status.Ingress) - 1; i >= 0; i-- {
 		for _, host := range svc_mdata_obj.HostNames {
-			if mRoute.Status.Ingress[i].Host == host {
-				// Check if this host is still present in the spec, if so - don't delete it
-				//NS migration case: if false -> ns invalid event happened so remove status
-				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace)
-				if !utils.HasElem(hostListIng, host) || isVSDelete || !nsMigrationFilterFlag {
-					mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)
-				} else {
-					utils.AviLog.Debugf("key: %s, msg: skipping status update since host is present in the route: %v", key, host)
-				}
+			if mRoute.Status.Ingress[i].Host != host {
+				continue
+			}
+			// Check if this host is still present in the spec, if so - don't delete it
+			//NS migration case: if false -> ns invalid event happened so remove status
+			if !utils.HasElem(hostListIng, host) || isVSDelete || !utils.CheckIfNamespaceAccepted(svc_mdata_obj.Namespace) {
+				mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)
+			} else {
+				utils.AviLog.Debugf("key: %s, msg: skipping status update since host is present in the route: %v", key, host)
 			}
 		}
 	}


### PR DESCRIPTION
Without this fix we may delete an ingress status on path update, if
the pool for old path gets deleted in the end after addition of new pool.