### PR TITLE
Layer7 AviInfraSetting shardSize based modelName

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -438,12 +438,12 @@ func (c *AviController) FullSyncK8s() error {
 			}
 		}
 
-		albInfraObjs, err := lib.GetCRDInformers().AviInfraSettingInformer.Lister().List(labels.Set(nil).AsSelector())
+		aviInfraObjs, err := lib.GetCRDInformers().AviInfraSettingInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
-			utils.AviLog.Errorf("Unable to retrieve the alinfraobjs during full sync: %s", err)
+			utils.AviLog.Errorf("Unable to retrieve the avinfrasettings during full sync: %s", err)
 		} else {
-			for _, albInfraObj := range albInfraObjs {
-				key := lib.AviInfraSetting + "/" + utils.ObjKey(albInfraObj)
+			for _, aviInfraObj := range aviInfraObjs {
+				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviInfraObj)
 				nodes.DequeueIngestion(key, true)
 			}
 		}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -152,6 +152,16 @@ const (
 	// Service Namespace/Name. This helps in fettching all Services
 	// with a given AviInfraSetting.
 	AviSettingServicesIndex = "aviSettingServices"
+
+	// AviSettingIngClassIndex maintains a map of AviInfraSetting Name to
+	// IngressClass Objects. This helps in fetching all IngressClasses with a
+	// given AviinfraSetting Name.
+	AviSettingIngClassIndex = "aviSettingIngClass"
+
+	// v maintains a map of AviInfraSetting Name to
+	// Route Objects. This helps in fetching all Routes with a
+	// given AviinfraSetting Name.
+	AviSettingRouteIndex = "aviSettingRoute"
 )
 
 const (

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -854,7 +854,7 @@ func ValidateIngressForClass(key string, ingress *networkingv1beta1.Ingress) boo
 		return false
 	}
 
-	// Additional check to see if the gatewayclass is a valid avi gateway class or not.
+	// Additional check to see if the ingressclass is a valid avi ingress class or not.
 	if ingClassObj.Spec.Controller != AviIngressController {
 		// Return an error since this is not our object.
 		utils.AviLog.Warnf("key: %s, msg: Unexpected controller in ingress class %s", key, *ingress.Spec.IngressClassName)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -199,10 +199,10 @@ func GetHeaderRewritePolicy(vsName, localHost string) string {
 	return vsName + "--host-hdr-re-write" + "--" + localHost
 }
 
-func GetSniNodeName(ingName, namespace, secret, settingName string, sniHostName ...string) string {
+func GetSniNodeName(ingName, namespace, secret, infrasetting string, sniHostName ...string) string {
 	namePrefix := NamePrefix
-	if settingName != "" {
-		namePrefix = NamePrefix + "-" + settingName + "-"
+	if infrasetting != "" {
+		namePrefix += infrasetting + "-"
 	}
 	if len(sniHostName) > 0 {
 		return namePrefix + sniHostName[0]
@@ -262,11 +262,15 @@ func GetEvhPGName(ingName, namespace, host, path string) string {
 	return NamePrefix + namespace + "-" + host + path + "-" + ingName
 }
 
-func GetTLSKeyCertNodeName(namespace, secret string, sniHostName ...string) string {
-	if len(sniHostName) > 0 {
-		return NamePrefix + sniHostName[0]
+func GetTLSKeyCertNodeName(namespace, secret, infrasetting string, sniHostName ...string) string {
+	namePrefix := NamePrefix
+	if infrasetting != "" {
+		namePrefix += infrasetting + "-"
 	}
-	return NamePrefix + namespace + "-" + secret
+	if len(sniHostName) > 0 {
+		return namePrefix + sniHostName[0]
+	}
+	return namePrefix + namespace + "-" + secret
 }
 
 func GetCACertNodeName(keycertname string) string {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -202,7 +202,9 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		}
 
 		// configures VS and VsVip nodes using infraSetting object (via CRD).
-		buildL4InfraSetting(key, avi_vs_meta, vsVipNode, nil, &gw.Spec.GatewayClassName)
+		if infraSetting := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); infraSetting != nil {
+			buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
+		}
 
 		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
 			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -665,7 +665,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 		}
 		o.AddModelNode(poolNode)
 		if !pgfound {
-			httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path)
+			httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path, "")
 			policyNode := &AviHttpPolicySetNode{Name: httppolname, HppMap: httpPolicySet, Tenant: lib.GetTenant()}
 			if childNode.CheckHttpPolNameNChecksumForEvh(httppolname, policyNode.GetCheckSum()) {
 				childNode.ReplaceHTTPRefInNodeForEvh(policyNode, key)
@@ -707,10 +707,6 @@ func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parse
 		hostsMap[host].PathSvc = getPathSvc(pathsvcmap.ingressHPSvc)
 
 		shardVsName := DeriveShardVSForEvh(host, key)
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			return
-		}
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if !found || aviModel == nil {
@@ -950,11 +946,6 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		shardVsName := DeriveShardVSForEvh(host, key)
 		// For each host, create a EVH node with the secret giving us the key and cert.
 		// construct a EVH child VS node per tls setting which corresponds to one secret
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			//return hostPathMap
-			return hostPathSvcMap
-		}
 		model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(model_name)
 		if !found || aviModel == nil {
@@ -1134,10 +1125,6 @@ func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList 
 		utils.AviLog.Debugf("host to del: %s, data : %s", host, utils.Stringify(hostData))
 		shardVsName := DeriveShardVSForEvh(host, key)
 
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			return
-		}
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if !found || aviModel == nil {
@@ -1366,11 +1353,7 @@ func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespa
 		if hostData.SecurePolicy == lib.PolicyPass {
 			shardVsName = lib.GetPassthroughShardVSName(host, key)
 		}
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			utils.AviLog.Infof("key: %s, shard vs ndoe not found for host: %s", host)
-			return
-		}
+
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if !found || aviModel == nil {

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -819,9 +819,15 @@ func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tl
 
 	var certNode *AviTLSKeyCertNode
 	if len(host) > 0 {
-		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName, host[0]), Tenant: lib.GetTenant()}
+		certNode = &AviTLSKeyCertNode{
+			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, "", host[0]),
+			Tenant: lib.GetTenant(),
+		}
 	} else {
-		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName), Tenant: lib.GetTenant()}
+		certNode = &AviTLSKeyCertNode{
+			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, ""),
+			Tenant: lib.GetTenant(),
+		}
 	}
 	certNode.Type = lib.CertTypeVS
 
@@ -877,7 +883,7 @@ func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tl
 	}
 	// If this SSLCertRef is already present don't add it.
 	if len(host) > 0 {
-		if tlsNode.CheckSSLCertNodeNameNChecksum(lib.GetTLSKeyCertNodeName(namespace, secretName, host[0]), certNode.GetCheckSum()) {
+		if tlsNode.CheckSSLCertNodeNameNChecksum(lib.GetTLSKeyCertNodeName(namespace, secretName, "", host[0]), certNode.GetCheckSum()) {
 			tlsNode.ReplaceEvhSSLRefInEVHNode(certNode, key)
 		}
 	} else {
@@ -1024,7 +1030,7 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			}
 			// Since the cert couldn't be built, check if this EVH is affected by only in ingress if so remove the EVH node from the model
 			if len(ingressHostMap.GetIngressesForHostName(host)) == 0 {
-				vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, tlssetting.SecretName, host), key)
+				vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, tlssetting.SecretName, "", host), key)
 				RemoveEvhInModel(evhNode.Name, vsNode, key)
 				RemoveRedirectHTTPPolicyInModelForEvh(evhNode, host, key)
 			}
@@ -1289,7 +1295,7 @@ func (o *AviObjectGraph) DeletePoolForHostnameForEvh(vsName, hostname string, ro
 	keepEvh = o.ManipulateEvhNode(evhNodeName, ingName, namespace, hostname, pathSvc, vsNode, key)
 	if !keepEvh {
 		// Delete the cert ref for the host
-		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, lib.GetTLSKeyCertNodeName(namespace, "", hostname), hostname), key)
+		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, lib.GetTLSKeyCertNodeName(namespace, "", "", hostname), hostname), key)
 	}
 	if removeFqdn && !keepEvh {
 		var hosts []string

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -349,7 +349,7 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		sniNode.ServiceEngineGroup = lib.GetSEGName()
 		sniNode.VrfContext = lib.GetVrf()
 		if !certsBuilt {
-			certsBuilt = aviModel.(*AviObjectGraph).BuildTlsCertNode(routeIgrObj.GetSvcLister(), sniNode, namespace, tlssetting, key, sniHost)
+			certsBuilt = aviModel.(*AviObjectGraph).BuildTlsCertNode(routeIgrObj.GetSvcLister(), sniNode, namespace, tlssetting, key, infraSettingName, sniHost)
 		}
 		if certsBuilt {
 			isIngr := routeIgrObj.GetType() == utils.Ingress

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -48,6 +48,12 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 	}
 	var priorityLabel string
 	var poolName string
+
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	utils.AviLog.Infof("key: %s, msg: The pathsvc mapping: %v", key, pathsvc)
 	for _, obj := range pathsvc {
 		if obj.Path != "" {
@@ -56,12 +62,12 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 			priorityLabel = hostname
 		}
 
-		// Using servciename in poolname for routes, but not in ingress for consistency with existing naming convention.
+		// Using servicename in poolname for routes, but not in ingress for consistency with existing naming convention.
 		// If possible, we would make this uniform
 		if routeIgrObj.GetType() == utils.Ingress {
-			poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName)
+			poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, infraSettingName)
 		} else {
-			poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, obj.ServiceName)
+			poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, infraSettingName, obj.ServiceName)
 		}
 
 		// First check if there are pools related to this ingress present in the model already
@@ -135,7 +141,7 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 	}
 }
 
-func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgrObj RouteIngressModel, pathSvc map[string][]string, key string, removeFqdn, removeRedir, secure bool) {
+func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgrObj RouteIngressModel, pathSvc map[string][]string, key string, infraSettingName string, removeFqdn, removeRedir, secure bool) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 
@@ -159,9 +165,9 @@ func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgr
 				}
 				for _, svcName := range services {
 					if routeIgrObj.GetType() == utils.Ingress {
-						poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName)
+						poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, infraSettingName)
 					} else {
-						poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, svcName)
+						poolName = lib.GetL7PoolName(priorityLabel, namespace, ingName, infraSettingName, svcName)
 					}
 					if poolName == pool.Name {
 						o.RemovePoolNodeRefs(poolName)
@@ -194,9 +200,10 @@ func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgr
 
 		isIngr := routeIgrObj.GetType() == utils.Ingress
 		// SNI VSes donot have secretname in their names
-		sniNodeName := lib.GetSniNodeName(ingName, namespace, "", hostname)
+
+		sniNodeName := lib.GetSniNodeName(ingName, namespace, "", infraSettingName, hostname)
 		utils.AviLog.Infof("key: %s, msg: sni node to delete: %s", key, sniNodeName)
-		keepSni = o.ManipulateSniNode(sniNodeName, ingName, namespace, hostname, pathSvc, vsNode, key, isIngr)
+		keepSni = o.ManipulateSniNode(sniNodeName, ingName, namespace, hostname, pathSvc, vsNode, key, isIngr, infraSettingName)
 	}
 	if removeFqdn && !keepSni {
 		var hosts []string
@@ -210,20 +217,20 @@ func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgr
 
 }
 
-func (o *AviObjectGraph) ManipulateSniNode(currentSniNodeName, ingName, namespace, hostname string, pathSvc map[string][]string, vsNode []*AviVsNode, key string, isIngr bool) bool {
+func (o *AviObjectGraph) ManipulateSniNode(currentSniNodeName, ingName, namespace, hostname string, pathSvc map[string][]string, vsNode []*AviVsNode, key string, isIngr bool, infraSettingName string) bool {
 	for _, modelSniNode := range vsNode[0].SniNodes {
 		if currentSniNodeName != modelSniNode.Name {
 			continue
 		}
 		for path, services := range pathSvc {
-			pgName := lib.GetSniPGName(ingName, namespace, hostname, path)
+			pgName := lib.GetSniPGName(ingName, namespace, hostname, path, infraSettingName)
 			pgNode := modelSniNode.GetPGForVSByName(pgName)
 			for _, svc := range services {
 				var sniPool string
 				if isIngr {
-					sniPool = lib.GetSniPoolName(ingName, namespace, hostname, path)
+					sniPool = lib.GetSniPoolName(ingName, namespace, hostname, path, infraSettingName)
 				} else {
-					sniPool = lib.GetSniPoolName(ingName, namespace, hostname, path, svc)
+					sniPool = lib.GetSniPoolName(ingName, namespace, hostname, path, infraSettingName, svc)
 				}
 				// Pls decprecate when PGs have http caching
 				if lib.GetNoPGForSNI() && isIngr {
@@ -236,13 +243,13 @@ func (o *AviObjectGraph) ManipulateSniNode(currentSniNodeName, ingName, namespac
 			if pgNode != nil {
 				if len(pgNode.Members) == 0 {
 					o.RemovePGNodeRefs(pgName, modelSniNode)
-					httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path)
+					httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path, infraSettingName)
 					o.RemoveHTTPRefsFromSni(httppolname, modelSniNode)
 				}
 			}
 			// Keeping this block separate for deprecation later.
 			if lib.GetNoPGForSNI() && isIngr {
-				httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path)
+				httppolname := lib.GetSniHttpPolName(ingName, namespace, hostname, path, infraSettingName)
 				o.RemoveHTTPRefsFromSni(httppolname, modelSniNode)
 			}
 		}
@@ -269,6 +276,11 @@ func getPaths(pathMapArr []IngressHostPathSvc) []string {
 
 func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingName, namespace, key string, fullsync bool, sharedQueue *utils.WorkerQueue, modelList *[]string) map[string][]IngressHostPathSvc {
 	hostPathSvcMap := make(map[string][]IngressHostPathSvc)
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	for sniHost, paths := range tlssetting.Hosts {
 		var sniHosts []string
 		hostPathSvcMap[sniHost] = paths.ingressHPSvc
@@ -285,14 +297,10 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		}
 		SharedHostNameLister().Save(sniHost, ingressHostMap)
 		sniHosts = append(sniHosts, sniHost)
-		shardVsName := DeriveShardVS(sniHost, key)
+		_, shardVsName := DeriveShardVS(sniHost, key, routeIgrObj)
+
 		// For each host, create a SNI node with the secret giving us the key and cert.
 		// construct a SNI VS node per tls setting which corresponds to one secret
-		if shardVsName == "" {
-			// If we aren't able to derive the ShardVS name, we should return
-			//return hostPathMap
-			return hostPathSvcMap
-		}
 		model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(model_name)
 		if !found || aviModel == nil {
@@ -314,10 +322,11 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			certsBuilt = true
 		}
 
-		sniNode := vsNode[0].GetSniNodeForName(lib.GetSniNodeName(ingName, namespace, sniSecretName, sniHost))
+		sniNodeName := lib.GetSniNodeName(ingName, namespace, sniSecretName, infraSettingName, sniHost)
+		sniNode := vsNode[0].GetSniNodeForName(sniNodeName)
 		if sniNode == nil {
 			sniNode = &AviVsNode{
-				Name:         lib.GetSniNodeName(ingName, namespace, sniSecretName, sniHost),
+				Name:         sniNodeName,
 				VHParentName: vsNode[0].Name,
 				Tenant:       lib.GetTenant(),
 				IsSNIChild:   true,
@@ -344,7 +353,7 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		}
 		if certsBuilt {
 			isIngr := routeIgrObj.GetType() == utils.Ingress
-			aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForSNI(vsNode, sniNode, namespace, ingName, tlssetting, sniSecretName, key, isIngr, sniHost)
+			aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForSNI(vsNode, sniNode, namespace, ingName, tlssetting, sniSecretName, key, isIngr, infraSettingName, sniHost)
 			foundSniModel := FindAndReplaceSniInModel(sniNode, vsNode, key)
 			if !foundSniModel {
 				vsNode[0].SniNodes = append(vsNode[0].SniNodes, sniNode)
@@ -375,6 +384,5 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		}
 	}
 
-	//return hostPathMap
 	return hostPathSvcMap
 }

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -181,7 +181,7 @@ func (o *AviObjectGraph) BuildCACertNode(tlsNode *AviVsNode, cacert, keycertname
 	return cacertNode.Name
 }
 
-func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode *AviVsNode, namespace string, tlsData TlsSettings, key string, sniHost ...string) bool {
+func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode *AviVsNode, namespace string, tlsData TlsSettings, key string, infraSettingName string, sniHost ...string) bool {
 	mClient := utils.GetInformers().ClientSet
 	secretName := tlsData.SecretName
 	secretNS := tlsData.SecretNS
@@ -191,9 +191,15 @@ func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode 
 
 	var certNode *AviTLSKeyCertNode
 	if len(sniHost) > 0 {
-		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName, sniHost[0]), Tenant: lib.GetTenant()}
+		certNode = &AviTLSKeyCertNode{
+			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, infraSettingName, sniHost[0]),
+			Tenant: lib.GetTenant(),
+		}
 	} else {
-		certNode = &AviTLSKeyCertNode{Name: lib.GetTLSKeyCertNodeName(namespace, secretName), Tenant: lib.GetTenant()}
+		certNode = &AviTLSKeyCertNode{
+			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, infraSettingName),
+			Tenant: lib.GetTenant(),
+		}
 	}
 	certNode.Type = lib.CertTypeVS
 

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -128,10 +128,8 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 		}
 	}
 
-	if routeIgrObj.GetType() == utils.Ingress {
-		buildL7IngressInfraSetting(key, avi_vs_meta, vsVipNode, routeIgrObj)
-	} else if routeIgrObj.GetType() == utils.OshiftRoute {
-		buildL7RouteInfraSetting(key, avi_vs_meta, vsVipNode, routeIgrObj)
+	if infraSetting := routeIgrObj.GetAviInfraSetting(); infraSetting != nil {
+		buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
 	}
 
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
@@ -266,7 +264,7 @@ func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode 
 	return true
 }
 
-func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *AviVsNode, namespace string, ingName string, hostpath TlsSettings, secretName string, key string, isIngr bool, hostName ...string) {
+func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *AviVsNode, namespace string, ingName string, hostpath TlsSettings, secretName string, key string, isIngr bool, infraSettingName string, hostName ...string) {
 	localPGList := make(map[string]*AviPoolGroupNode)
 	var sniFQDNs []string
 	for host, paths := range hostpath.Hosts {
@@ -304,14 +302,15 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 			if path.Path != "" {
 				httpPGPath.Path = append(httpPGPath.Path, path.Path)
 			}
+
 			var poolName string
 			var pgfound bool
 			var pgNode *AviPoolGroupNode
 			// Do not use serviceName in SNI Pool Name for ingress for backward compatibility
 			if isIngr {
-				poolName = lib.GetSniPoolName(ingName, namespace, host, path.Path)
+				poolName = lib.GetSniPoolName(ingName, namespace, host, path.Path, infraSettingName)
 			} else {
-				poolName = lib.GetSniPoolName(ingName, namespace, host, path.Path, path.ServiceName)
+				poolName = lib.GetSniPoolName(ingName, namespace, host, path.Path, infraSettingName, path.ServiceName)
 			}
 			httpPGPath.Host = pathFQDNs
 			// There can be multiple services for the same path in case of alternate backend.
@@ -324,7 +323,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 				httpPGPath.Pool = poolName
 				utils.AviLog.Infof("key: %s, msg: using pool name: %s instead of poolgroups for http policy set", key, poolName)
 			} else {
-				pgName := lib.GetSniPGName(ingName, namespace, host, path.Path)
+				pgName := lib.GetSniPGName(ingName, namespace, host, path.Path, infraSettingName)
 				var pgfound bool
 				pgNode, pgfound = localPGList[pgName]
 				if !pgfound {
@@ -379,7 +378,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 			}
 			o.AddModelNode(poolNode)
 			if !pgfound {
-				httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path)
+				httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path, infraSettingName)
 				policyNode := &AviHttpPolicySetNode{Name: httppolname, HppMap: httpPolicySet, Tenant: lib.GetTenant()}
 				if tlsNode.CheckHttpPolNameNChecksum(httppolname, policyNode.GetCheckSum()) {
 					tlsNode.ReplaceSniHTTPRefInSNINode(policyNode, key)
@@ -514,41 +513,6 @@ func RemoveRedirectHTTPPolicyInModel(vsNode *AviVsNode, hostname, key string) {
 	}
 }
 
-func buildL7IngressInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, routeIgrObj RouteIngressModel) {
-	var infraSetting *akov1alpha1.AviInfraSetting
-
-	var ingClassName string
-	if ingSpec, ok := routeIgrObj.GetSpec().(networkingv1beta1.IngressSpec); ok && ingSpec.IngressClassName != nil {
-		ingClassName = *ingSpec.IngressClassName
-	}
-
-	if !utils.GetIngressClassEnabled() {
-		return
-	} else if ingClassName == "" {
-		if defaultIngressClass, found := lib.IsAviLBDefaultIngressClass(); !found {
-			return
-		} else {
-			ingClassName = defaultIngressClass
-		}
-	}
-
-	ingClass, err := utils.GetInformers().IngressClassInformer.Lister().Get(ingClassName)
-	if err != nil {
-		utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding IngressClass %s", key, err.Error())
-		return
-	} else {
-		if ingClass.Spec.Parameters != nil && *ingClass.Spec.Parameters.APIGroup == lib.AkoGroup && ingClass.Spec.Parameters.Kind == lib.AviInfraSetting {
-			infraSetting, err = lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(ingClass.Spec.Parameters.Name)
-			if err != nil {
-				utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding AviInfraSetting via IngressClass %s", key, err.Error())
-				return
-			}
-		}
-	}
-
-	buildWithInfraSetting(key, vs, vsvip, infraSetting)
-}
-
 func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infraSetting *akov1alpha1.AviInfraSetting) {
 	if infraSetting != nil && infraSetting.Status.Status == lib.StatusAccepted {
 		if infraSetting.Spec.SeGroup.Name != "" {
@@ -563,19 +527,4 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 		vsvip.NetworkNames = infraSetting.Spec.Network.Names
 	}
 	utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
-}
-
-func buildL7RouteInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, routeIgrObj RouteIngressModel) {
-	var err error
-	var infraSetting *akov1alpha1.AviInfraSetting
-
-	if infraSettingAnnotation, ok := routeIgrObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok && infraSettingAnnotation != "" {
-		infraSetting, err = lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(infraSettingAnnotation)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding AviInfraSetting via annotation %s", key, err.Error())
-			return
-		}
-	}
-
-	buildWithInfraSetting(key, vs, vsvip, infraSetting)
 }

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -314,14 +314,12 @@ func DeleteStaleDataForModelChange(routeIgrObj RouteIngressModel, namespace, obj
 
 	utils.AviLog.Debugf("key: %s, msg: hosts to delete %s", key, utils.Stringify(hostMap))
 	for host, hostData := range hostMap {
-		oldShardVsName, newShardVsName := DeriveShardVS(host, key, routeIgrObj)
-		if oldShardVsName == newShardVsName {
+		shardVsName, newShardVsName := DeriveShardVS(host, key, routeIgrObj)
+		if shardVsName == newShardVsName {
 			continue
 		}
 
-		shardVsName := oldShardVsName
 		_, infraSettingName := objects.InfraSettingL7Lister().GetIngRouteToInfraSetting(routeIgrObj.GetNamespace() + "/" + routeIgrObj.GetName())
-
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if !found || aviModel == nil {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -510,7 +510,6 @@ func AviInfraSettingChange(routeIgrObj RouteIngressModel) (*akov1alpha1.AviInfra
 
 // returns old and new models if changed, else just the current one.
 func DeriveShardVS(hostname string, key string, routeIgrObj RouteIngressModel) (string, string) {
-	// Read the value of the num_shards from the environment variable or the AviInfraSetting CRD.
 	utils.AviLog.Debugf("key: %s, msg: hostname for sharding: %s", key, hostname)
 
 	// get stored infrasetting from ingress/route
@@ -518,8 +517,7 @@ func DeriveShardVS(hostname string, key string, routeIgrObj RouteIngressModel) (
 	oldSetting, newSetting := AviInfraSettingChange(routeIgrObj)
 	var oldInfraPrefix, newInfraPrefix string
 
-	oldShardSize := lib.GetshardSize()
-	newShardSize := lib.GetshardSize()
+	oldShardSize, newShardSize := lib.GetshardSize(), lib.GetshardSize()
 	if oldSetting != nil {
 		oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
 		oldInfraPrefix = oldSetting.Name

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -111,7 +112,7 @@ func DequeueIngestion(key string, fullsync bool) {
 		}
 	}
 
-	if !ingressFound && (!lib.GetAdvancedL4() && !lib.UseServicesAPI()) {
+	if !ingressFound && !lib.GetAdvancedL4() && !lib.UseServicesAPI() {
 		// If ingress is not found, let's do the other checks.
 		if objType == utils.L4LBService {
 			// L4 type of services need special handling. We create a dedicated VS in Avi for these.
@@ -366,7 +367,7 @@ func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, st
 		return arr[0], arr[1]
 	}
 
-	if objType == utils.IngressClass {
+	if objType == utils.IngressClass || objType == lib.AviInfraSetting {
 		arr := strings.Split(nsname, "/")
 		return arr[0], arr[1]
 	}
@@ -392,7 +393,7 @@ func saveAviModel(model_name string, aviGraph *AviObjectGraph, key string) bool 
 			return false
 		}
 	}
-	// // Right before saving the model, let's reset the retry counter for the graph.
+	// Right before saving the model, let's reset the retry counter for the graph.
 	aviGraph.SetRetryCounter()
 	aviGraph.CalculateCheckSum()
 	objects.SharedAviGraphLister().Save(model_name, aviGraph)
@@ -470,26 +471,70 @@ func GetShardVSPrefix(key string) string {
 	return shardVsPrefix
 }
 
-func GetShardVSName(s string, key string) string {
+func GetShardVSName(s string, key string, shardSize uint32, prefix ...string) string {
 	var vsNum uint32
-	shardSize := lib.GetshardSize()
+	extraPrefix := strings.Join(prefix, "-")
+
 	if shardSize != 0 {
 		vsNum = utils.Bkt(s, shardSize)
 		utils.AviLog.Debugf("key: %s, msg: VS number: %v", key, vsNum)
 	} else {
 		utils.AviLog.Debugf("key: %s, msg: Processing dedicated VS", key)
 		//format: my-cluster--foo.com-dedicated for dedicated VS. This is to avoid any SNI naming conflicts
+		if extraPrefix != "" {
+			return lib.GetNamePrefix() + extraPrefix + "-" + s + "-dedicated"
+		}
 		return lib.GetNamePrefix() + s + "-dedicated"
 	}
 	shardVsPrefix := GetShardVSPrefix(key)
+	if extraPrefix != "" {
+		shardVsPrefix += extraPrefix + "-"
+	}
 	vsName := shardVsPrefix + fmt.Sprint(vsNum)
-	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
 	return vsName
 }
 
-func DeriveShardVS(hostname string, key string) string {
-	// Read the value of the num_shards from the environment variable.
+func AviInfraSettingChange(routeIgrObj RouteIngressModel) (*akov1alpha1.AviInfraSetting, *akov1alpha1.AviInfraSetting) {
+	var oldAviInfraSetting *akov1alpha1.AviInfraSetting
+	var err error
+	if found, oldInfraSettingName := objects.InfraSettingL7Lister().GetIngRouteToInfraSetting(routeIgrObj.GetNamespace() + "/" + routeIgrObj.GetName()); found {
+		oldAviInfraSetting, err = lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(oldInfraSettingName)
+		if err != nil {
+			utils.AviLog.Warnf("AviInfraSetting not found %s", err.Error())
+		}
+	}
+
+	aviInfraSetting := routeIgrObj.GetAviInfraSetting()
+	return oldAviInfraSetting, aviInfraSetting
+}
+
+// returns old and new models if changed, else just the current one.
+func DeriveShardVS(hostname string, key string, routeIgrObj RouteIngressModel) (string, string) {
+	// Read the value of the num_shards from the environment variable or the AviInfraSetting CRD.
 	utils.AviLog.Debugf("key: %s, msg: hostname for sharding: %s", key, hostname)
-	vsName := GetShardVSName(hostname, key)
-	return vsName
+
+	// get stored infrasetting from ingress/route
+	// figure out the current infrasetting via class/annotation
+	oldSetting, newSetting := AviInfraSettingChange(routeIgrObj)
+	var oldInfraPrefix, newInfraPrefix string
+
+	oldShardSize := lib.GetshardSize()
+	newShardSize := lib.GetshardSize()
+	if oldSetting != nil {
+		oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		oldInfraPrefix = oldSetting.Name
+	}
+
+	if !routeIgrObj.Exists() {
+		// get the old ones.
+		newShardSize = oldShardSize
+		newInfraPrefix = oldInfraPrefix
+	} else if newSetting != nil {
+		newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		newInfraPrefix = newSetting.Name
+	}
+
+	oldVsName, newVsName := GetShardVSName(hostname, key, oldShardSize, oldInfraPrefix), GetShardVSName(hostname, key, newShardSize, newInfraPrefix)
+	utils.AviLog.Infof("key: %s, msg: ShardVSNames: %s %s", key, oldVsName, newVsName)
+	return oldVsName, newVsName
 }

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -95,9 +95,11 @@ var (
 		GetParentGateways: GWClassToGateway,
 	}
 	AviInfraSetting = GraphSchema{
-		Type:              "AviInfraSetting",
-		GetParentGateways: AviSettingToGateway,
-		GetParentServices: AviSettingToSvc,
+		Type:               "AviInfraSetting",
+		GetParentIngresses: AviSettingToIng,
+		GetParentGateways:  AviSettingToGateway,
+		GetParentServices:  AviSettingToSvc,
+		GetParentRoutes:    AviSettingToRoute,
 	}
 	SupportedGraphTypes = GraphDescriptor{
 		Ingress,
@@ -306,6 +308,22 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 			return ingresses, false
 		}
 
+		if utils.GetIngressClassEnabled() {
+			var ingClassName string
+			if ingObj.Spec.IngressClassName != nil {
+				ingClassName = *ingObj.Spec.IngressClassName
+			} else if aviIngClassName, found := lib.IsAviLBDefaultIngressClass(); found {
+				// check if default IngressClass is present, and it is Avi's IngressClass, in which case add mapping for that.
+				ingClassName = aviIngClassName
+			}
+
+			if ingClassName != "" {
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, ingClassName)
+			} else {
+				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
+			}
+		}
+
 		// If the Ingress Class is not found or is not valid, then return.
 		// When the correct Ingress Class is added, then the Ingress would be processed again.
 		if !lib.ValidateIngressForClass(key, ingObj) {
@@ -316,17 +334,6 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 				}
 			}
 			return ingresses, true
-		}
-
-		if utils.GetIngressClassEnabled() {
-			if ingObj.Spec.IngressClassName != nil {
-				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, *ingObj.Spec.IngressClassName)
-			} else if aviIngClassName, found := lib.IsAviLBDefaultIngressClass(); found {
-				// check if default IngressClass is present, and it is Avi's IngressClass, in which case add mapping for that.
-				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).UpdateIngressClassMappings(namespace+"/"+ingName, aviIngClassName)
-			} else {
-				objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).RemoveIngressClassMappings(namespace + "/" + ingName)
-			}
 		}
 
 		_, oldSvcs := objects.SharedSvcLister().IngressMappings(namespace).GetIngToSvc(ingName)
@@ -364,8 +371,7 @@ func IngressChanges(ingName string, namespace string, key string) ([]string, boo
 
 func IngClassToIng(ingClassName string, namespace string, key string) ([]string, bool) {
 	found, ingresses := objects.SharedSvcLister().IngressMappings(metav1.NamespaceAll).GetClassToIng(ingClassName)
-
-	// Go though the list of ingresses again to populate the ingress Service mapping and annotate servies if needed
+	// Go through the list of ingresses again to populate the ingress Service mapping and annotate services if needed
 	for _, namespacedIngr := range ingresses {
 		ns, ingr := utils.ExtractNamespaceObjectName(namespacedIngr)
 		IngressChanges(ingr, ns, key)
@@ -637,6 +643,62 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 
 	utils.AviLog.Debugf("key: %s, msg: Ingresses retrieved %s", key, allIngresses)
 	return allIngresses, true
+}
+
+func AviSettingToIng(infraSettingName, namespace, key string) ([]string, bool) {
+	allIngresses := make([]string, 0)
+
+	infraSetting, err := lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(infraSettingName)
+	if err == nil {
+		// Validate Avi references and configurations in AviInfraSetting.
+		if err = validateAviInfraSetting(key, infraSetting); err != nil {
+			return allIngresses, false
+		}
+	}
+
+	// Get all IngressClasses from AviInfraSetting.
+	ingClasses, err := utils.GetInformers().IngressClassInformer.Informer().GetIndexer().ByIndex(lib.AviSettingIngClassIndex, lib.AkoGroup+"/"+lib.AviInfraSetting+"/"+infraSettingName)
+	if err != nil {
+		return allIngresses, false
+	}
+
+	for _, ingClass := range ingClasses {
+		if ingClassObj, isIngClass := ingClass.(*networkingv1beta1.IngressClass); isIngClass {
+			if ingresses, found := IngClassToIng(ingClassObj.Name, namespace, key); found {
+				allIngresses = append(allIngresses, ingresses...)
+			}
+		}
+	}
+
+	utils.AviLog.Infof("key: %s, msg: Ingresses retrieved %s", key, allIngresses)
+	return allIngresses, true
+}
+
+func AviSettingToRoute(infraSettingName, namespace, key string) ([]string, bool) {
+	allRoutes := make([]string, 0)
+
+	infraSetting, err := lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(infraSettingName)
+	if err == nil {
+		// Validate Avi references and configurations in AviInfraSetting.
+		if err = validateAviInfraSetting(key, infraSetting); err != nil {
+			return allRoutes, false
+		}
+	}
+
+	// Get all Routes from AviInfraSetting via annotation.
+	routes, err := utils.GetInformers().RouteInformer.Informer().GetIndexer().ByIndex(lib.AviSettingRouteIndex, infraSettingName)
+	if err != nil {
+		return allRoutes, false
+	}
+
+	for _, route := range routes {
+		if routeObj, isRoute := route.(*routev1.Route); isRoute {
+			RouteChanges(routeObj.Name, routeObj.Namespace, key)
+		}
+	}
+
+	utils.AviLog.Infof("key: %s, msg: Routes retrieved %s", key, allRoutes)
+	return allRoutes, true
 }
 
 func AviSettingToGateway(infraSettingName string, namespace string, key string) ([]string, bool) {

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -659,6 +659,7 @@ func AviSettingToIng(infraSettingName, namespace, key string) ([]string, bool) {
 	// Get all IngressClasses from AviInfraSetting.
 	ingClasses, err := utils.GetInformers().IngressClassInformer.Informer().GetIndexer().ByIndex(lib.AviSettingIngClassIndex, lib.AkoGroup+"/"+lib.AviInfraSetting+"/"+infraSettingName)
 	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: Unable to fetch IngressClasses corresponding to AviInfraSetting %s", key, infraSettingName)
 		return allIngresses, false
 	}
 
@@ -688,6 +689,7 @@ func AviSettingToRoute(infraSettingName, namespace, key string) ([]string, bool)
 	// Get all Routes from AviInfraSetting via annotation.
 	routes, err := utils.GetInformers().RouteInformer.Informer().GetIndexer().ByIndex(lib.AviSettingRouteIndex, infraSettingName)
 	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: Unable to fetch Routes corresponding to AviInfraSetting %s", key, infraSettingName)
 		return allRoutes, false
 	}
 
@@ -715,6 +717,7 @@ func AviSettingToGateway(infraSettingName string, namespace string, key string) 
 	// Get all GatewayClasses from AviInfraSetting.
 	gwClasses, err := lib.GetSvcAPIInformers().GatewayClassInformer.Informer().GetIndexer().ByIndex(lib.AviSettingGWClassIndex, lib.AkoGroup+"/"+lib.AviInfraSetting+"/"+infraSettingName)
 	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: Unable to fetch GatewayClasses corresponding to AviInfraSetting %s", key, infraSettingName)
 		return allGateways, false
 	}
 

--- a/internal/nodes/route_ingress_model.go
+++ b/internal/nodes/route_ingress_model.go
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package nodes
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+
+	routev1 "github.com/openshift/api/route/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+)
+
+// RouteIngressModel : High Level interfaces that should be implemenetd by
+// all l7 route objects, e.g: k8s ingress, openshift route
+type RouteIngressModel interface {
+	GetName() string
+	GetNamespace() string
+	GetType() string
+	GetSvcLister() *objects.SvcLister
+	GetSpec() interface{}
+	GetAnnotations() map[string]string
+	ParseHostPath() IngressConfig
+	Exists() bool
+	// this is required due to different naming convention used in ingress where we dont use service name
+	// later if we decide to have common naming for ingress and route, then we can hav a common method
+	GetDiffPathSvc(map[string][]string, []IngressHostPathSvc, bool) map[string][]string
+
+	GetAviInfraSetting() *akov1alpha1.AviInfraSetting
+}
+
+// OshiftRouteModel : Model for openshift routes with it's own service lister
+type OshiftRouteModel struct {
+	key          string
+	name         string
+	namespace    string
+	spec         routev1.RouteSpec
+	infrasetting *akov1alpha1.AviInfraSetting
+	annotations  map[string]string
+}
+
+// K8sIngressModel : Model for openshift routes with default service lister
+type K8sIngressModel struct {
+	key          string
+	name         string
+	namespace    string
+	spec         networkingv1beta1.IngressSpec
+	infrasetting *akov1alpha1.AviInfraSetting
+	annotations  map[string]string
+}
+
+func GetOshiftRouteModel(name, namespace, key string) (*OshiftRouteModel, error, bool) {
+	routeModel := OshiftRouteModel{
+		key:       key,
+		name:      name,
+		namespace: namespace,
+	}
+	processObj := true
+	processObj = utils.CheckIfNamespaceAccepted(namespace)
+
+	routeObj, err := utils.GetInformers().RouteInformer.Lister().Routes(namespace).Get(name)
+	if err != nil {
+		return &routeModel, err, processObj
+	}
+	routeModel.spec = routeObj.Spec
+	routeModel.annotations = routeObj.GetAnnotations()
+	if !lib.HasValidBackends(routeObj.Spec, name, namespace, key) {
+		err := errors.New("validation failed for alternate backends for route: " + name)
+		return &routeModel, err, false
+	}
+	routeModel.infrasetting, err = getL7RouteInfraSetting(key, routeObj.GetAnnotations())
+	if err != nil {
+		return &routeModel, err, processObj
+	}
+	return &routeModel, nil, processObj
+}
+
+func (m *OshiftRouteModel) GetName() string {
+	return m.name
+}
+
+func (m *OshiftRouteModel) GetNamespace() string {
+	return m.namespace
+}
+
+func (m *OshiftRouteModel) GetAnnotations() map[string]string {
+	return m.annotations
+}
+
+func (m *OshiftRouteModel) GetType() string {
+	return utils.OshiftRoute
+}
+
+func (m *OshiftRouteModel) GetSvcLister() *objects.SvcLister {
+	return objects.OshiftRouteSvcLister()
+}
+
+func (m *OshiftRouteModel) GetSpec() interface{} {
+	return m.spec
+}
+
+func (or *OshiftRouteModel) ParseHostPath() IngressConfig {
+	o := NewNodesValidator()
+	return o.ParseHostPathForRoute(or.namespace, or.name, or.spec, or.key)
+}
+
+func (m *OshiftRouteModel) Exists() bool {
+	if m.GetSpec() != nil {
+		return true
+	}
+	return false
+}
+
+func (m *OshiftRouteModel) GetDiffPathSvc(storedPathSvc map[string][]string, currentPathSvc []IngressHostPathSvc, checkSvc bool) map[string][]string {
+	pathSvcCopy := make(map[string][]string)
+	for k, v := range storedPathSvc {
+		pathSvcCopy[k] = v
+	}
+	currPathSvcMap := make(map[string][]string)
+	for _, val := range currentPathSvc {
+		currPathSvcMap[val.Path] = append(currPathSvcMap[val.Path], val.ServiceName)
+	}
+	for path, services := range currPathSvcMap {
+		// for OshiftRouteModel service diff is always checked
+		storedServices, ok := pathSvcCopy[path]
+		if ok {
+			pathSvcCopy[path] = lib.Difference(storedServices, services)
+			if len(pathSvcCopy[path]) == 0 {
+				delete(pathSvcCopy, path)
+			}
+		}
+	}
+	return pathSvcCopy
+}
+
+func (m *OshiftRouteModel) GetAviInfraSetting() *akov1alpha1.AviInfraSetting {
+	return m.infrasetting
+}
+
+func GetK8sIngressModel(name, namespace, key string) (*K8sIngressModel, error, bool) {
+	ingrModel := K8sIngressModel{
+		key:       key,
+		name:      name,
+		namespace: namespace,
+	}
+	processObj := true
+	ingObj, err := utils.GetInformers().IngressInformer.Lister().Ingresses(namespace).Get(name)
+	if err != nil {
+		return &ingrModel, err, processObj
+	}
+	processObj = lib.ValidateIngressForClass(key, ingObj) && utils.CheckIfNamespaceAccepted(namespace)
+	ingrModel.spec = ingObj.Spec
+	ingrModel.annotations = ingObj.GetAnnotations()
+	ingrModel.infrasetting, err = getL7IngressInfraSetting(key, ingObj.Spec.IngressClassName)
+	if err != nil {
+		return &ingrModel, err, processObj
+	}
+	return &ingrModel, nil, processObj
+}
+
+func (m *K8sIngressModel) GetName() string {
+	return m.name
+}
+
+func (m *K8sIngressModel) GetNamespace() string {
+	return m.namespace
+}
+
+func (m *K8sIngressModel) GetAnnotations() map[string]string {
+	return m.annotations
+}
+
+func (m *K8sIngressModel) GetType() string {
+	return utils.Ingress
+}
+
+func (m *K8sIngressModel) GetSvcLister() *objects.SvcLister {
+	return objects.SharedSvcLister()
+}
+
+func (m *K8sIngressModel) GetSpec() interface{} {
+	return m.spec
+}
+
+func (m *K8sIngressModel) ParseHostPath() IngressConfig {
+	o := NewNodesValidator()
+	return o.ParseHostPathForIngress(m.namespace, m.name, m.spec, m.annotations, m.key)
+}
+
+func (m *K8sIngressModel) Exists() bool {
+	if m.GetSpec() != nil {
+		return true
+	}
+	return false
+}
+
+func (m *K8sIngressModel) GetDiffPathSvc(storedPathSvc map[string][]string, currentPathSvc []IngressHostPathSvc, checkSvc bool) map[string][]string {
+	pathSvcCopy := make(map[string][]string)
+	for k, v := range storedPathSvc {
+		pathSvcCopy[k] = v
+	}
+	currPathSvcMap := make(map[string][]string)
+	for _, val := range currentPathSvc {
+		currPathSvcMap[val.Path] = append(currPathSvcMap[val.Path], val.ServiceName)
+	}
+	for path, services := range currPathSvcMap {
+		storedServices, ok := pathSvcCopy[path]
+		if ok {
+			if checkSvc {
+				pathSvcCopy[path] = lib.Difference(storedServices, services)
+				if len(pathSvcCopy[path]) == 0 {
+					delete(pathSvcCopy, path)
+				}
+			} else {
+				delete(pathSvcCopy, path)
+			}
+		}
+	}
+	return pathSvcCopy
+}
+
+func (m *K8sIngressModel) GetAviInfraSetting() *akov1alpha1.AviInfraSetting {
+	return m.infrasetting
+}
+
+func getL7IngressInfraSetting(key string, ingClassName *string) (*akov1alpha1.AviInfraSetting, error) {
+	var infraSetting *akov1alpha1.AviInfraSetting
+
+	if !utils.GetIngressClassEnabled() {
+		return nil, nil
+	} else if ingClassName == nil {
+		if defaultIngressClass, found := lib.IsAviLBDefaultIngressClass(); !found {
+			return nil, nil
+		} else {
+			ingClassName = &defaultIngressClass
+		}
+	}
+
+	ingClass, err := utils.GetInformers().IngressClassInformer.Lister().Get(*ingClassName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding IngressClass %s", key, err.Error())
+		return nil, err
+	} else {
+		if ingClass.Spec.Parameters != nil && *ingClass.Spec.Parameters.APIGroup == lib.AkoGroup && ingClass.Spec.Parameters.Kind == lib.AviInfraSetting {
+			infraSetting, err = lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(ingClass.Spec.Parameters.Name)
+			if err != nil {
+				utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding AviInfraSetting via IngressClass %s", key, err.Error())
+				return nil, err
+			}
+			if infraSetting.Status.Status != lib.StatusAccepted {
+				utils.AviLog.Warnf("key: %s, msg: Referred AviInfraSetting %s is invalid", key, infraSetting.Name)
+				return nil, fmt.Errorf("Referred AviInfraSetting %s is invalid", infraSetting.Name)
+			}
+		}
+	}
+
+	return infraSetting, nil
+}
+
+func getL7RouteInfraSetting(key string, routeAnnotations map[string]string) (*akov1alpha1.AviInfraSetting, error) {
+	var err error
+	var infraSetting *akov1alpha1.AviInfraSetting
+
+	if infraSettingAnnotation, ok := routeAnnotations[lib.InfraSettingNameAnnotation]; ok && infraSettingAnnotation != "" {
+		infraSetting, err = lib.GetCRDInformers().AviInfraSettingInformer.Lister().Get(infraSettingAnnotation)
+		if err != nil {
+			utils.AviLog.Warnf("key: %s, msg: Unable to get corresponding AviInfraSetting via annotation %s", key, err.Error())
+			return nil, err
+		}
+		if infraSetting.Status.Status != lib.StatusAccepted {
+			utils.AviLog.Warnf("key: %s, msg: Referred AviInfraSetting %s is invalid", key, infraSetting.Name)
+			return nil, fmt.Errorf("Referred AviInfraSetting %s is invalid", infraSetting.Name)
+		}
+	}
+
+	return infraSetting, nil
+}

--- a/internal/objects/infrasetting.go
+++ b/internal/objects/infrasetting.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package objects
+
+import (
+	"sync"
+)
+
+var infral7lister *AviInfraSettingL7Lister
+var infraonce sync.Once
+
+func InfraSettingL7Lister() *AviInfraSettingL7Lister {
+	infraonce.Do(func() {
+		infral7lister = &AviInfraSettingL7Lister{
+			IngRouteInfraSettingStore: NewObjectMapStore(),
+		}
+	})
+	return infral7lister
+}
+
+type AviInfraSettingL7Lister struct {
+	InfraSettingIngRouteLock sync.RWMutex
+
+	// namespaced ingress/route -> infrasetting
+	IngRouteInfraSettingStore *ObjectMapStore
+}
+
+func (v *AviInfraSettingL7Lister) GetIngRouteToInfraSetting(ingrouteNsName string) (bool, string) {
+	found, infraSetting := v.IngRouteInfraSettingStore.Get(ingrouteNsName)
+	if !found {
+		return false, ""
+	}
+	return true, infraSetting.(string)
+}
+
+func (v *AviInfraSettingL7Lister) UpdateIngRouteInfraSettingMappings(infraSetting, ingrouteNsName string) {
+	v.InfraSettingIngRouteLock.Lock()
+	defer v.InfraSettingIngRouteLock.Unlock()
+	v.IngRouteInfraSettingStore.AddOrUpdate(ingrouteNsName, infraSetting)
+}
+
+func (v *AviInfraSettingL7Lister) RemoveIngRouteInfraSettingMappings(ingrouteNsName string) bool {
+	v.InfraSettingIngRouteLock.Lock()
+	defer v.InfraSettingIngRouteLock.Unlock()
+	return v.IngRouteInfraSettingStore.Delete(ingrouteNsName)
+}

--- a/tests/hostnameshardtests/crd_evh_hostname_test.go
+++ b/tests/hostnameshardtests/crd_evh_hostname_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestHostnameCreateDeleteHostRuleForEvh(t *testing.T) {
+func TestCreateDeleteHostRuleForEvh(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.EnableEVH()
@@ -100,7 +100,7 @@ func TestHostnameCreateDeleteHostRuleForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCreateHostRuleBeforeIngressForEvh(t *testing.T) {
+func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
@@ -139,7 +139,7 @@ func TestHostnameCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameGoodToBadHostRuleForEvh(t *testing.T) {
+func TestGoodToBadHostRuleForEvh(t *testing.T) {
 	// create insecure ingress, apply good secure hostrule, transition to bad
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.EnableEVH()
@@ -186,7 +186,7 @@ func TestHostnameGoodToBadHostRuleForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameInsecureHostAndHostruleForEvh(t *testing.T) {
+func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 	// create insecure ingress, insecure hostrule, hostrule should be applied in case of EVH
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.EnableEVH()
@@ -214,7 +214,7 @@ func TestHostnameInsecureHostAndHostruleForEvh(t *testing.T) {
 
 // HttpRule tests
 
-func TestHostnameHTTPRuleCreateDeleteForEvh(t *testing.T) {
+func TestHTTPRuleCreateDeleteForEvh(t *testing.T) {
 	// ingress secure foo.com/foo /bar
 	// create httprule /foo, nothing happens
 	// create hostrule, httprule gets attached check on /foo /bar

--- a/tests/hostnameshardtests/crd_hostname_test.go
+++ b/tests/hostnameshardtests/crd_hostname_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestHostnameCreateDeleteHostRule(t *testing.T) {
+func TestCreateDeleteHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -101,7 +101,7 @@ func TestHostnameCreateDeleteHostRule(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCreateHostRuleBeforeIngress(t *testing.T) {
+func TestCreateHostRuleBeforeIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -138,7 +138,7 @@ func TestHostnameCreateHostRuleBeforeIngress(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameInsecureToSecureHostRule(t *testing.T) {
+func TestInsecureToSecureHostRule(t *testing.T) {
 	// insecure ingress to secure VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
@@ -222,7 +222,7 @@ func TestGSLBHostRewriteRule(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiIngressToSecureHostRule(t *testing.T) {
+func TestMultiIngressToSecureHostRule(t *testing.T) {
 	// 1 insecure ingress, 1 secure ingress -> secure VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
@@ -275,7 +275,7 @@ func TestHostnameMultiIngressToSecureHostRule(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiIngressSwitchHostRuleFqdn(t *testing.T) {
+func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	// 2 insecure ingresses -> VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
@@ -354,7 +354,7 @@ func TestHostnameMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameGoodToBadHostRule(t *testing.T) {
+func TestGoodToBadHostRule(t *testing.T) {
 	// create insecure ingress, apply good secure hostrule, transition to bad
 	g := gomega.NewGomegaWithT(t)
 
@@ -399,7 +399,7 @@ func TestHostnameGoodToBadHostRule(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameInsecureHostAndHostrule(t *testing.T) {
+func TestInsecureHostAndHostrule(t *testing.T) {
 	// create insecure ingress, insecure hostrule, nothing should be applied
 	g := gomega.NewGomegaWithT(t)
 
@@ -422,7 +422,7 @@ func TestHostnameInsecureHostAndHostrule(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameValidToInvalidHostSwitch(t *testing.T) {
+func TestValidToInvalidHostSwitch(t *testing.T) {
 	// create insecure host foo.com, attach hostrule, change hostrule to non existing bar.com
 	// foo.com should become insecure again
 	// change hostrule back to foo.com and it should become secure again
@@ -483,7 +483,7 @@ func TestHostnameValidToInvalidHostSwitch(t *testing.T) {
 
 // HttpRule tests
 
-func TestHostnameHTTPRuleCreateDelete(t *testing.T) {
+func TestHTTPRuleCreateDelete(t *testing.T) {
 	// ingress secure foo.com/foo /bar
 	// create httprule /foo, nothing happens
 	// create hostrule, httprule gets attached check on /foo /bar
@@ -545,7 +545,7 @@ func TestHostnameHTTPRuleCreateDelete(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostNameHTTPRuleHostSwitch(t *testing.T) {
+func TestHTTPRuleHostSwitch(t *testing.T) {
 	// ingress foo.com/foo voo.com/foo
 	// hr1: foo.com (secure), hr2: voo.com (insecure)
 	// rr1: hr1/foo ALGO1

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -440,15 +440,14 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(settingModelName1)
-		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
-
-	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName1)
-	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	g.Eventually(func() string {
+		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName1); found {
+			if settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS(); len(settingNodes[0].PoolRefs) == 1 {
+				return settingNodes[0].PoolRefs[0].Name
+			}
+		}
+		return ""
+	}, 25*time.Second).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
 
 	ingClassUpdate := (FakeIngressClass{
 		Name:            ingClassName,
@@ -466,8 +465,8 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 		found, _ := objects.SharedAviGraphLister().Get(settingModelName2)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
-	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName2)
-	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName2)
+	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting2-bar.com_foo-default-foo-with-class"))
 

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,9 +31,10 @@ import (
 )
 
 type FakeIngressClass struct {
-	Name       string
-	Controller string
-	Default    bool
+	Name            string
+	Controller      string
+	AviInfraSetting string
+	Default         bool
 }
 
 func (ingclass FakeIngressClass) IngressClass() *networkingv1beta1.IngressClass {
@@ -51,14 +53,24 @@ func (ingclass FakeIngressClass) IngressClass() *networkingv1beta1.IngressClass 
 		ingressclass.Annotations = map[string]string{lib.DefaultIngressClassAnnotation: "false"}
 	}
 
+	if ingclass.AviInfraSetting != "" {
+		akoGroup := lib.AkoGroup
+		ingressclass.Spec.Parameters = &corev1.TypedLocalObjectReference{
+			APIGroup: &akoGroup,
+			Kind:     lib.AviInfraSetting,
+			Name:     ingclass.AviInfraSetting,
+		}
+	}
+
 	return ingressclass
 }
 
-func SetupIngressClass(t *testing.T, ingclassName, controller string) {
+func SetupIngressClass(t *testing.T, ingclassName, controller, infraSetting string) {
 	ingclass := FakeIngressClass{
-		Name:       ingclassName,
-		Controller: controller,
-		Default:    false,
+		Name:            ingclassName,
+		Controller:      controller,
+		Default:         false,
+		AviInfraSetting: infraSetting,
 	}
 
 	ingClassCreate := ingclass.IngressClass()
@@ -82,19 +94,20 @@ func VerifyVSNodeDeletion(g *gomega.WithT, modelName string) {
 
 // Ingress - IngressClass mapping tests
 
-func TestHostnameAdvL4WrongClassMappingInIngress(t *testing.T) {
+func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
 	// create ingclass, ingress
 	// update wrong mapping of class in ingress, VS deleted
 	// fix class in ingress, VS created
 	g := gomega.NewGomegaWithT(t)
 
-	integrationtest.RemoveDefaultIngressClass()
-
 	ingClassName, ingressName, ns := "avi-lb", "foo-with-class", "default"
 	modelName := "admin/cluster--Shared-L7-1"
 
-	SetupIngressClass(t, ingClassName, lib.AviIngressController)
 	SetUpTestForIngress(t, modelName)
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController, "")
 	ingressCreate := (integrationtest.FakeIngress{
 		Name:        ingressName,
 		Namespace:   ns,
@@ -170,10 +183,9 @@ func TestHostnameAdvL4WrongClassMappingInIngress(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 	TeardownIngressClass(t, ingClassName)
 	VerifyVSNodeDeletion(g, modelName)
-	integrationtest.AddDefaultIngressClass()
 }
 
-func TestHostnameDefaultIngressClassChange(t *testing.T) {
+func TestDefaultIngressClassChange(t *testing.T) {
 	// use default ingress class, change default annotation to false
 	// check that ingress status is removed
 	// change back default class annotation to true
@@ -183,6 +195,7 @@ func TestHostnameDefaultIngressClassChange(t *testing.T) {
 	ingClassName, ingressName, ns := "avi-lb", "foo-with-class2", "default"
 	modelName := "admin/cluster--Shared-L7-1"
 
+	SetUpTestForIngress(t, modelName)
 	integrationtest.RemoveDefaultIngressClass()
 	defer integrationtest.AddDefaultIngressClass()
 
@@ -195,7 +208,6 @@ func TestHostnameDefaultIngressClassChange(t *testing.T) {
 		t.Fatalf("error in adding IngressClass: %v", err)
 	}
 
-	SetUpTestForIngress(t, modelName)
 	// ingress with no IngressClass
 	ingressCreate := (integrationtest.FakeIngress{
 		Name:        ingressName,
@@ -233,3 +245,244 @@ func TestHostnameDefaultIngressClassChange(t *testing.T) {
 	TeardownIngressClass(t, ingClassName)
 	VerifyVSNodeDeletion(g, modelName)
 }
+
+// AviInfraSetting CRD
+
+// Updating IngressClass
+func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
+	// create ingressclass/ingress, add infrasetting ref, model changes
+	// remove infrasetting ref, model changes again
+	g := gomega.NewGomegaWithT(t)
+
+	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
+	modelName := "admin/cluster--Shared-L7-1"
+
+	SetUpTestForIngress(t, modelName)
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController, "")
+	ingressCreate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(1))
+
+	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
+	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+
+	ingClassUpdate := (FakeIngressClass{
+		Name:            ingClassName,
+		Controller:      lib.AviIngressController,
+		AviInfraSetting: settingName,
+		Default:         false,
+	}).IngressClass()
+	ingClassUpdate.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().IngressClasses().Update(context.TODO(), ingClassUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error updating IngressClass")
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(0))
+
+	ingClassUpdate = (FakeIngressClass{
+		Name:       ingClassName,
+		Controller: lib.AviIngressController,
+		Default:    false,
+	}).IngressClass()
+	ingClassUpdate.ResourceVersion = "3"
+	_, err = KubeClient.NetworkingV1beta1().IngressClasses().Update(context.TODO(), ingClassUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error updating IngressClass")
+	}
+
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.TeardownAviInfraSetting(t, settingName)
+	TearDownTestForIngress(t, modelName, settingModelName)
+	TeardownIngressClass(t, ingClassName)
+	VerifyVSNodeDeletion(g, modelName)
+}
+
+func TestUpdateInfraSettingInIngressClass(t *testing.T) {
+	// create ingressclass/ingress/infrasetting
+	// update infrasetting ref, model changes
+	g := gomega.NewGomegaWithT(t)
+
+	ingClassName, ingressName, ns, settingName1, settingName2 := "avi-lb", "foo-with-class", "default", "my-infrasetting", "my-infrasetting2"
+	modelName := "admin/cluster--Shared-L7-1"
+
+	SetUpTestForIngress(t, modelName)
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+
+	integrationtest.SetupAviInfraSetting(t, settingName1, "SMALL")
+	integrationtest.SetupAviInfraSetting(t, settingName2, "SMALL")
+	settingModelName1 := "admin/cluster--Shared-L7-my-infrasetting-0"
+	settingModelName2 := "admin/cluster--Shared-L7-my-infrasetting2-0"
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName1)
+	ingressCreate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName1)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName1)
+	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+
+	ingClassUpdate := (FakeIngressClass{
+		Name:            ingClassName,
+		Controller:      lib.AviIngressController,
+		Default:         false,
+		AviInfraSetting: settingName2,
+	}).IngressClass()
+	ingClassUpdate.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().IngressClasses().Update(context.TODO(), ingClassUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error updating IngressClass")
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName2)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName2)
+	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting2-bar.com_foo-default-foo-with-class"))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	integrationtest.TeardownAviInfraSetting(t, settingName1)
+	integrationtest.TeardownAviInfraSetting(t, settingName2)
+	TearDownTestForIngress(t, modelName, settingModelName1)
+	TearDownTestForIngress(t, modelName, settingModelName2)
+	TeardownIngressClass(t, ingClassName)
+	VerifyVSNodeDeletion(g, modelName)
+}
+
+// Updating Ingress
+func TestAddIngressClassWithInfraSetting(t *testing.T) {
+	// add ingress, ingressclass with valid infrasetting,
+	// add ingressclass in ingress, delete ingress
+	g := gomega.NewGomegaWithT(t)
+
+	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
+	modelName := "admin/cluster--Shared-L7-1"
+
+	SetUpTestForIngress(t, modelName)
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+
+	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
+	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+
+	SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
+	ingressCreate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1beta1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	ingressUpdate := (integrationtest.FakeIngress{
+		Name:        ingressName,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	ingressUpdate.ResourceVersion = "2"
+	_, err = KubeClient.NetworkingV1beta1().Ingresses(ns).Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	g.Eventually(func() int {
+		found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+		nodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if found && len(nodes) > 0 {
+			return len(nodes[0].PoolRefs)
+		}
+		return -1
+	}, 25*time.Second).Should(gomega.Equal(0))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel).Should(gomega.BeNil())
+
+	integrationtest.TeardownAviInfraSetting(t, settingName)
+	TearDownTestForIngress(t, modelName, settingModelName)
+	TeardownIngressClass(t, ingClassName)
+	VerifyVSNodeDeletion(g, modelName)
+}
+
+// update ingressclass (with infrasetting) in ingress
+// remove ingressclass (with infrasetting) in ingress
+// update ingressclass (without infrasetting) in ingress
+
+// create ingress, ingressclass, infrasetting1
+// switch to infrasetting2 in ingressclass
+
+// create ingress, ingressclass1, infrasetting1
+// switch to ingressclass2, infrasetting2, in ingress

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestHostnameMultiHostIngressStatusCheckForEvh(t *testing.T) {
+func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 
@@ -103,7 +103,7 @@ func TestHostnameMultiHostIngressStatusCheckForEvh(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
+func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 
@@ -178,7 +178,7 @@ func TestHostnameMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameCreateIngressCacheSyncForEvh(t *testing.T) {
+func TestCreateIngressCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 
@@ -235,7 +235,7 @@ func TestHostnameCreateIngressCacheSyncForEvh(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameIngressStatusCheckForEvh(t *testing.T) {
+func TestIngressStatusCheckForEvh(t *testing.T) {
 
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
@@ -262,7 +262,7 @@ func TestHostnameIngressStatusCheckForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameUpdatePoolCacheSyncForEvh(t *testing.T) {
+func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 	g := gomega.NewGomegaWithT(t)
@@ -342,7 +342,7 @@ func TestHostnameUpdatePoolCacheSyncForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCreateCacheSyncForEvh(t *testing.T) {
+func TestCreateCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 	g := gomega.NewGomegaWithT(t)
@@ -382,7 +382,7 @@ func TestHostnameCreateCacheSyncForEvh(t *testing.T) {
 
 }
 
-func TestHostnameUpdateCacheSyncForEvh(t *testing.T) {
+func TestUpdateCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 	g := gomega.NewGomegaWithT(t)
@@ -446,7 +446,7 @@ func TestHostnameUpdateCacheSyncForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
+func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 	g := gomega.NewGomegaWithT(t)
@@ -547,7 +547,7 @@ func TestHostnameMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
+func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
@@ -694,7 +694,7 @@ func TestHostnameMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 }
 
 // Secure ingress to insecure ingress transition
-func TestHostnameDeleteCacheSyncForEvh(t *testing.T) {
+func TestDeleteCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 	g := gomega.NewGomegaWithT(t)
@@ -737,7 +737,7 @@ func TestHostnameDeleteCacheSyncForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCUDSecretCacheSyncForEvh(t *testing.T) {
+func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 
@@ -806,7 +806,7 @@ func TestHostnameCUDSecretCacheSyncForEvh(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameDeleteSecretSecureIngressStatusCheckForEvh(t *testing.T) {
+func TestDeleteSecretSecureIngressStatusCheckForEvh(t *testing.T) {
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()
 

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_test.go
@@ -104,7 +104,7 @@ func TestL7ModelForEvh(t *testing.T) {
 }
 
 // This tests the different objects associated in the evh model for ingress
-func TestHostnameShardObjectsForEvh(t *testing.T) {
+func TestShardObjectsForEvh(t *testing.T) {
 	// checks naming convention of all generated nodes
 	integrationtest.EnableEVH()
 	defer integrationtest.DisableEVH()

--- a/tests/hostnameshardtests/l7_hostname_rest_test.go
+++ b/tests/hostnameshardtests/l7_hostname_rest_test.go
@@ -77,7 +77,7 @@ func TearDownIngressForCacheSyncCheck(t *testing.T, modelName string) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameCreateIngressCacheSync(t *testing.T) {
+func TestCreateIngressCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var found bool
 
@@ -125,7 +125,7 @@ func TestHostnameCreateIngressCacheSync(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameIngressStatusCheck(t *testing.T) {
+func TestIngressStatusCheck(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -150,7 +150,7 @@ func TestHostnameIngressStatusCheck(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCreateIngressWithFaultCacheSync(t *testing.T) {
+func TestCreateIngressWithFaultCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var found bool
 
@@ -232,7 +232,7 @@ func TestHostnameCreateIngressWithFaultCacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameUpdatePoolCacheSync(t *testing.T) {
+func TestUpdatePoolCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
@@ -310,7 +310,7 @@ func TestHostnameUpdatePoolCacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameDeletePoolCacheSync(t *testing.T) {
+func TestDeletePoolCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
@@ -354,7 +354,7 @@ func TestHostnameDeletePoolCacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCreateSNICacheSync(t *testing.T) {
+func TestCreateSNICacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -385,7 +385,7 @@ func TestHostnameCreateSNICacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameUpdateSNICacheSync(t *testing.T) {
+func TestUpdateSNICacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
@@ -447,7 +447,7 @@ func TestHostnameUpdateSNICacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiHostMultiSecretSNICacheSync(t *testing.T) {
+func TestMultiHostMultiSecretSNICacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -530,7 +530,7 @@ func TestHostnameMultiHostMultiSecretSNICacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
+func TestMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName := "admin/cluster--Shared-L7-0"
 
@@ -663,7 +663,7 @@ func TestHostnameMultiHostMultiSecretUpdateSNICacheSync(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameDeleteSNICacheSync(t *testing.T) {
+func TestDeleteSNICacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
@@ -705,7 +705,7 @@ func TestHostnameDeleteSNICacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameCUDSecretCacheSync(t *testing.T) {
+func TestCUDSecretCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName := "admin/cluster--Shared-L7-0"
@@ -773,7 +773,7 @@ func TestHostnameCUDSecretCacheSync(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameDeleteSecretSecureIngressStatusCheck(t *testing.T) {
+func TestDeleteSecretSecureIngressStatusCheck(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName := "admin/cluster--Shared-L7-0"
 	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
@@ -794,7 +794,7 @@ func TestHostnameDeleteSecretSecureIngressStatusCheck(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }
 
-func TestHostnameMultiHostIngressStatusCheck(t *testing.T) {
+func TestMultiHostIngressStatusCheck(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName := "admin/cluster--Shared-L7-0"
 
@@ -870,7 +870,7 @@ func TestHostnameMultiHostIngressStatusCheck(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameMultiHostUpdateIngressStatusCheck(t *testing.T) {
+func TestMultiHostUpdateIngressStatusCheck(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 	modelName := "admin/cluster--Shared-L7-0"

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -209,7 +209,7 @@ func TestL7Model(t *testing.T) {
 	TearDownTestForIngress(t, modelName)
 }
 
-func TestHostnameShardNamingConvention(t *testing.T) {
+func TestShardNamingConvention(t *testing.T) {
 	// checks naming convention of all generated nodes
 	g := gomega.NewGomegaWithT(t)
 

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -804,7 +804,7 @@ func TestInfraSettingDelete(t *testing.T) {
 	CreateEP(t, NAMESPACE, SINGLEPORTSVC, false, false, "1.1.1")
 	PollForCompletion(t, SINGLEPORTMODEL, 5)
 
-	SetupAviInfraSetting(t, settingName)
+	SetupAviInfraSetting(t, settingName, "")
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(SINGLEPORTMODEL); found && aviModel != nil {
@@ -862,8 +862,8 @@ func TestInfraSettingChangeMapping(t *testing.T) {
 	CreateEP(t, NAMESPACE, SINGLEPORTSVC, false, false, "1.1.1")
 	PollForCompletion(t, SINGLEPORTMODEL, 5)
 
-	SetupAviInfraSetting(t, settingName1)
-	SetupAviInfraSetting(t, settingName2)
+	SetupAviInfraSetting(t, settingName1, "")
+	SetupAviInfraSetting(t, settingName2, "")
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(SINGLEPORTMODEL); found && aviModel != nil {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -192,6 +192,10 @@ func AddSecret(secretName string, namespace string, cert string, key string) {
 	KubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), fakeSecret, metav1.CreateOptions{})
 }
 
+func DeleteSecret(secretName string, namespace string) {
+	KubeClient.CoreV1().Secrets(namespace).Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+}
+
 // Fake ingress
 type FakeIngress struct {
 	DnsNames     []string

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1312,10 +1312,11 @@ type FakeAviInfraSetting struct {
 	SeGroupName string
 	NetworkName string
 	EnableRhi   bool
+	ShardSize   string
 }
 
 func (infraSetting FakeAviInfraSetting) AviInfraSetting() *akov1alpha1.AviInfraSetting {
-	gatewayclass := &akov1alpha1.AviInfraSetting{
+	setting := &akov1alpha1.AviInfraSetting{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: infraSetting.Name,
 		},
@@ -1330,15 +1331,20 @@ func (infraSetting FakeAviInfraSetting) AviInfraSetting() *akov1alpha1.AviInfraS
 		},
 	}
 
-	return gatewayclass
+	if infraSetting.ShardSize != "" {
+		setting.Spec.L7Settings.ShardSize = infraSetting.ShardSize
+	}
+
+	return setting
 }
 
-func SetupAviInfraSetting(t *testing.T, infraSettingName string) {
+func SetupAviInfraSetting(t *testing.T, infraSettingName, shardSize string) {
 	setting := FakeAviInfraSetting{
 		Name:        infraSettingName,
 		SeGroupName: "thisisaviref-" + infraSettingName + "-seGroup",
 		NetworkName: "thisisaviref-" + infraSettingName + "-networkName",
 		EnableRhi:   true,
+		ShardSize:   shardSize,
 	}
 	settingCreate := setting.AviInfraSetting()
 	if _, err := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Create(context.TODO(), settingCreate, metav1.CreateOptions{}); err != nil {

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -1147,7 +1147,7 @@ func TestServicesAPIInfraSettingDelete(t *testing.T) {
 	SetupGatewayClass(t, gwClassName, lib.SvcApiAviGatewayController, settingName)
 	SetupGateway(t, gatewayName, ns, gwClassName)
 	SetupSvcApiLBService(t, "svc", ns, gatewayName, ns)
-	integrationtest.SetupAviInfraSetting(t, settingName)
+	integrationtest.SetupAviInfraSetting(t, settingName, "")
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found && aviModel != nil {
@@ -1197,8 +1197,8 @@ func TestServicesAPIInfraSettingChangeMapping(t *testing.T) {
 	SetupGatewayClass(t, gwClassName, lib.SvcApiAviGatewayController, settingName1)
 	SetupGateway(t, gatewayName, ns, gwClassName)
 	SetupSvcApiLBService(t, "svc", ns, gatewayName, ns)
-	integrationtest.SetupAviInfraSetting(t, settingName1)
-	integrationtest.SetupAviInfraSetting(t, settingName2)
+	integrationtest.SetupAviInfraSetting(t, settingName1, "")
+	integrationtest.SetupAviInfraSetting(t, settingName2, "")
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found && aviModel != nil {


### PR DESCRIPTION
This commit introduces modelName generation based on AviInfraSetting CRD, and derives the shardVsName via the shardSize mentioned in the AviInfraSetting CR. To simplify transition cases between valid AviInfraSetting CRs, the Avi object names now include AviInfraSetting Name as well.