### PR TITLE
configure applicationPersistenceProfile via HttpRule

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_httprules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_httprules.yaml
@@ -51,8 +51,16 @@ spec:
                     target:
                       pattern: ^\/.*$
                       type: string
+                    healthMonitors:
+                      items:
+                        type: string
+                      type: array
+                    applicationPersistence:
+                      type: string
                     tls:
                       properties:
+                        destinationCA:
+                          type: string
                         sslProfile:
                           type: string
                         type:

--- a/helm/ako/crds/ako.vmware.com_httprules.yaml
+++ b/helm/ako/crds/ako.vmware.com_httprules.yaml
@@ -55,6 +55,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    applicationPersistence:
+                      type: string
                     tls:
                       properties:
                         destinationCA:

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1041,25 +1041,26 @@ func (v *AviPkiProfileNode) CalculateCheckSum() {
 }
 
 type AviPoolNode struct {
-	Name             string
-	Tenant           string
-	CloudConfigCksum uint32
-	Port             int32
-	TargetPort       int32
-	PortName         string
-	Servers          []AviPoolMetaServer
-	Protocol         string
-	LbAlgorithm      string
-	LbAlgorithmHash  string
-	LbAlgoHostHeader string
-	IngressName      string
-	PriorityLabel    string
-	ServiceMetadata  avicache.ServiceMetadataObj
-	SniEnabled       bool
-	SslProfileRef    string
-	PkiProfile       *AviPkiProfileNode
-	HealthMonitors   []string
-	VrfContext       string
+	Name                   string
+	Tenant                 string
+	CloudConfigCksum       uint32
+	Port                   int32
+	TargetPort             int32
+	PortName               string
+	Servers                []AviPoolMetaServer
+	Protocol               string
+	LbAlgorithm            string
+	LbAlgorithmHash        string
+	LbAlgoHostHeader       string
+	IngressName            string
+	PriorityLabel          string
+	ServiceMetadata        avicache.ServiceMetadataObj
+	SniEnabled             bool
+	SslProfileRef          string
+	PkiProfile             *AviPkiProfileNode
+	HealthMonitors         []string
+	ApplicationPersistence string
+	VrfContext             string
 }
 
 func (v *AviPoolNode) GetCheckSum() uint32 {
@@ -1100,6 +1101,11 @@ func (v *AviPoolNode) CalculateCheckSum() {
 	if v.PkiProfile != nil {
 		checksum += v.PkiProfile.GetCheckSum()
 	}
+
+	if v.ApplicationPersistence != "" {
+		checksum += utils.Hash(v.ApplicationPersistence)
+	}
+
 	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -219,6 +219,11 @@ func BuildPoolHTTPRule(host, path, ingName, namespace, key string, vsNode AviVsE
 					}
 				}
 
+				var persistenceProfile string
+				if httpRulePath.ApplicationPersistence != "" {
+					persistenceProfile = fmt.Sprintf("/api/applicationpersistenceprofile?name=%s", httpRulePath.ApplicationPersistence)
+				}
+
 				for _, hm := range httpRulePath.HealthMonitors {
 					if !utils.HasElem(pathHMs, fmt.Sprintf("/api/healthmonitor?name=%s", hm)) {
 						pathHMs = append(pathHMs, fmt.Sprintf("/api/healthmonitor?name=%s", hm))
@@ -229,6 +234,7 @@ func BuildPoolHTTPRule(host, path, ingName, namespace, key string, vsNode AviVsE
 				pool.SslProfileRef = pathSslProfile
 				pool.PkiProfile = destinationCertNode
 				pool.HealthMonitors = pathHMs
+				pool.ApplicationPersistence = persistenceProfile
 
 				// from this path, generate refs to this pool node
 				pool.LbAlgorithm = httpRulePath.LoadBalancerPolicy.Algorithm
@@ -311,6 +317,7 @@ func validateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
 	refData := make(map[string]string)
 	for _, path := range httprule.Spec.Paths {
 		refData[path.TLS.SSLProfile] = "SslProfile"
+		refData[path.ApplicationPersistence] = "ApplicationPersistence"
 
 		for _, hm := range path.HealthMonitors {
 			refData[hm] = "HealthMonitor"
@@ -377,17 +384,18 @@ func addSeGroupLabel(key, segName string) {
 }
 
 var refModelMap = map[string]string{
-	"SslKeyCert":         "sslkeyandcertificate",
-	"WafPolicy":          "wafpolicy",
-	"HttpPolicySet":      "httppolicyset",
-	"SslProfile":         "sslprofile",
-	"AppProfile":         "applicationprofile",
-	"AnalyticsProfile":   "analyticsprofile",
-	"ErrorPageProfile":   "errorpageprofile",
-	"VsDatascript":       "vsdatascriptset",
-	"HealthMonitor":      "healthmonitor",
-	"ServiceEngineGroup": "serviceenginegroup",
-	"Network":            "network",
+	"SslKeyCert":             "sslkeyandcertificate",
+	"WafPolicy":              "wafpolicy",
+	"HttpPolicySet":          "httppolicyset",
+	"SslProfile":             "sslprofile",
+	"AppProfile":             "applicationprofile",
+	"AnalyticsProfile":       "analyticsprofile",
+	"ErrorPageProfile":       "errorpageprofile",
+	"VsDatascript":           "vsdatascriptset",
+	"HealthMonitor":          "healthmonitor",
+	"ApplicationPersistence": "applicationpersistenceprofile",
+	"ServiceEngineGroup":     "serviceenginegroup",
+	"Network":                "network",
 }
 
 func checkRefsOnController(key string, refMap map[string]string) error {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -112,6 +112,10 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		}
 	}
 
+	if pool_meta.ApplicationPersistence != "" {
+		pool.ApplicationPersistenceProfileRef = &pool_meta.ApplicationPersistence
+	}
+
 	for i, server := range pool_meta.Servers {
 		port := pool_meta.Port
 		sip := server.Ip

--- a/pkg/apis/ako/v1alpha1/httprule.go
+++ b/pkg/apis/ako/v1alpha1/httprule.go
@@ -39,10 +39,11 @@ type HTTPRuleSpec struct {
 
 // HTTPRulePaths has settings for a specific target path
 type HTTPRulePaths struct {
-	Target             string           `json:"target,omitempty"`
-	LoadBalancerPolicy HTTPRuleLBPolicy `json:"loadBalancerPolicy,omitempty"`
-	TLS                HTTPRuleTLS      `json:"tls,omitempty"`
-	HealthMonitors     []string         `json:"healthMonitors,omitempty"`
+	Target                 string           `json:"target,omitempty"`
+	LoadBalancerPolicy     HTTPRuleLBPolicy `json:"loadBalancerPolicy,omitempty"`
+	TLS                    HTTPRuleTLS      `json:"tls,omitempty"`
+	HealthMonitors         []string         `json:"healthMonitors,omitempty"`
+	ApplicationPersistence string           `json:"applicationPersistence,omitempty"`
 }
 
 // HTTPRuleLBPolicy holds a path/pool's load balancer policies

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -1097,7 +1097,7 @@ func TestServicesAPIWithInfraSettingStatusUpdates(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 15*time.Second).Should(gomega.Equal("Accepted"))
+	}, 30*time.Second).Should(gomega.Equal("Accepted"))
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found && aviModel != nil {


### PR DESCRIPTION
This adds the ability to configure custom application Persistence Profile to Avi Pools via AKO's HttpRule CRD.