### PR TITLE
Do not delete FQDN-vsuuid map from ingress annotation if host is present in ingress

### DIFF
--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -354,7 +354,7 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 			key, oldIngressStatus.Ingress, mIngress.Status.LoadBalancer.Ingress)
 	}
 
-	if err = deleteIngressAnnotation(updatedIng, svc_mdata_obj, isVSDelete, key, mClient, mIngress); err != nil {
+	if err = deleteIngressAnnotation(updatedIng, svc_mdata_obj, isVSDelete, key, mClient, mIngress, hostListIng); err != nil {
 		utils.AviLog.Errorf("key: %s, msg: error in deleting ingress annotation: %v", key, err)
 	}
 
@@ -363,7 +363,7 @@ func deleteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, isVSDel
 
 func deleteIngressAnnotation(ingObj *networkingv1beta1.Ingress, svcMeta avicache.ServiceMetadataObj, isVSDelete bool,
 	key string, mClient kubernetes.Interface, oldIng *networkingv1beta1.Ingress,
-	retryNum ...int) error {
+	ingHostList []string, retryNum ...int) error {
 	if ingObj == nil {
 		ingObj = oldIng
 	}
@@ -387,14 +387,24 @@ func deleteIngressAnnotation(ingObj *networkingv1beta1.Ingress, svcMeta avicache
 	for k := range existingAnnotations {
 		for _, host := range svcMeta.HostNames {
 			if k == host {
-				delete(existingAnnotations, k)
+				// Check if:
+				// 1. this host is still present in the spec, if so - don't delete it from annotations
+				// 2. in case of NS migration, if NS is moved from selected to rejected, this host then
+				//    has to be removed from the annotations list.
+				nsMigrationFilterFlag := utils.CheckIfNamespaceAccepted(svcMeta.Namespace)
+
+				if !utils.HasElem(ingHostList, host) || isVSDelete || !nsMigrationFilterFlag {
+					delete(existingAnnotations, k)
+				} else {
+					utils.AviLog.Debugf("key: %s, msg: skipping annotation update since host is present in the ing: %v", key, host)
+				}
 			}
 		}
 	}
 
 	if isAnnotationsUpdateRequired(ingObj.Annotations, existingAnnotations) {
 		if err := patchIngressAnnotations(ingObj, existingAnnotations, mClient); err != nil {
-			return deleteIngressAnnotation(ingObj, svcMeta, isVSDelete, key, mClient, oldIng, retry+1)
+			return deleteIngressAnnotation(ingObj, svcMeta, isVSDelete, key, mClient, oldIng, ingHostList, retry+1)
 		}
 	}
 	utils.AviLog.Debugf("key: %s, msg: Annotations unchanged for ingress %s/%s", key, ingObj.Namespace, ingObj.Name)

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -516,7 +516,7 @@ func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta avicache.ServiceMeta
 		utils.AviLog.Infof("key: %s, msg: retrying to update route annotations", key)
 		retry = retryNum[0]
 		if retry >= 3 {
-			return fmt.Errorf("deleteIngressAnnotation retried 3 times, aborting")
+			return fmt.Errorf("deleteRouteAnnotation retried 3 times, aborting")
 		}
 	}
 	existingAnnotations := make(map[string]string)
@@ -539,7 +539,7 @@ func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta avicache.ServiceMeta
 				if !utils.HasElem(routeHostList, host) || isVSDelete || !nsMigrationFilterFlag {
 					delete(existingAnnotations, k)
 				} else {
-					utils.AviLog.Debugf("key: %s, msg: skipping annotation update since host is present in the ingress: %v", key, host)
+					utils.AviLog.Debugf("key: %s, msg: skipping annotation update since host is present in the route: %v", key, host)
 				}
 			}
 		}


### PR DESCRIPTION
This PR take cares of not deleting FQDN-vsuuid map from ingress annotation if host/fqdn is present in ingress host rules.