### PR TITLE
Introduce GSLB host header re-write for insecure hosts

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -70,7 +70,7 @@ func SharedAVIClients() *utils.AviRestClientPool {
 					controllerVersion = lib.Advl4ControllerVersion
 				}
 				//Set GRBAC Flag
-				lib.SetEnableGRBAC(controllerVersion)
+				lib.SetEnableCtrl2014Features(controllerVersion)
 				utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
 				SetVersion := session.SetVersion(controllerVersion)
 				SetVersion(client.AviSession)

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -462,7 +462,7 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pki.Name, string(*pki.CaCerts[0].Certificate), "")
-		if lib.GetEnableGRBAC() && pki.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && pki.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(pki.Labels)
 		}
 		pkiCacheObj := AviPkiProfileCache{
@@ -789,8 +789,11 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 			PoolGroups: pgs,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
-		if lib.GetEnableGRBAC() && ds.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && ds.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(ds.Labels)
+			if len(ds.Datascript) == 1 {
+				checksum += utils.Hash(*ds.Datascript[0].Script)
+			}
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		*DsData = append(*DsData, dsCacheObj)
@@ -887,7 +890,7 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetEnableGRBAC() && sslkey.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && sslkey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -961,7 +964,7 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetEnableGRBAC() && sslkey.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && sslkey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -1011,7 +1014,7 @@ func (c *AviObjCache) AviPopulateOnePKICache(client *clients.AviClient,
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pkikey.Name, *pkikey.CaCerts[0].Certificate, "")
-		if lib.GetEnableGRBAC() && pkikey.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && pkikey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(pkikey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -1141,7 +1144,7 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 			PoolGroups: pgs,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
-		if lib.GetEnableGRBAC() && ds.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && ds.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(ds.Labels)
 		}
 		dsCacheObj.CloudConfigCksum = checksum
@@ -1408,7 +1411,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetEnableGRBAC() && l4pol.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && l4pol.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
 		}
 		l4PolCacheObj := AviL4PolicyCache{
@@ -1520,7 +1523,6 @@ func (c *AviObjCache) AviPopulateAllHttpPolicySets(client *clients.AviClient, cl
 			LastModified:     *httppol.LastModified,
 		}
 		*httpPolicyData = append(*httpPolicyData, httpPolCacheObj)
-
 	}
 	if result.Next != "" {
 		// It has a next page, let's recursively call the same method.
@@ -1628,7 +1630,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 			protocol = utils.UDP
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetEnableGRBAC() && l4pol.Labels != nil {
+		if lib.GetEnableCtrl2014Features() && l4pol.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
 		}
 		l4PolCacheObj := AviL4PolicyCache{

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -76,7 +76,7 @@ const (
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
 	VSVIPDELCTRLVER                            = "20.1.1"
 	Advl4ControllerVersion                     = "20.1.2"
-	GRBACControllerVersion                     = "20.1.4"
+	ControllerVersion2014                      = "20.1.4"
 	HostRule                                   = "HostRule"
 	HTTPRule                                   = "HTTPRule"
 	AviInfraSetting                            = "AviInfraSetting"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -107,14 +107,14 @@ func GetAKOUser() string {
 	return AKOUser
 }
 
-var enableGRBAC bool
+var enableCtrl2014Features bool
 
-func SetEnableGRBAC(controllerVersion string) {
-	enableGRBAC = CheckControllerVersionCompatibility(controllerVersion, ">=", GRBACControllerVersion)
+func SetEnableCtrl2014Features(controllerVersion string) {
+	enableCtrl2014Features = CheckControllerVersionCompatibility(controllerVersion, ">=", ControllerVersion2014)
 }
 
-func GetEnableGRBAC() bool {
-	return enableGRBAC
+func GetEnableCtrl2014Features() bool {
+	return enableCtrl2014Features
 }
 
 func GetshardSize() uint32 {
@@ -188,6 +188,10 @@ func GetL7PoolName(priorityLabel, namespace, ingName string, args ...string) str
 
 func GetL7HttpRedirPolicy(vsName string) string {
 	return vsName
+}
+
+func GetHeaderRewritePolicy(vsName, localHost string) string {
+	return vsName + "--host-hdr-re-write" + "--" + localHost
 }
 
 func GetSniNodeName(ingName, namespace, secret string, sniHostName ...string) string {
@@ -565,7 +569,7 @@ var clusterKey string
 var clusterValue string
 
 func SetClusterLabelChecksum() {
-	if GetEnableGRBAC() {
+	if GetEnableCtrl2014Features() {
 		labels := GetLabels()
 		clusterKey = *labels[0].Key
 		clusterValue = *labels[0].Value

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -755,6 +755,7 @@ type AviHttpPolicySetNode struct {
 	CloudConfigCksum uint32
 	HppMap           []AviHostPathPortPoolPG
 	RedirectPorts    []AviRedirectPort
+	HeaderReWrite    *AviHostHeaderRewrite
 }
 
 func (v *AviHttpPolicySetNode) GetCheckSum() uint32 {
@@ -776,6 +777,10 @@ func (v *AviHttpPolicySetNode) CalculateCheckSum() {
 		sort.Strings(redir.Hosts)
 		checksum = checksum + utils.Hash(utils.Stringify(redir.Hosts))
 	}
+	if v.HeaderReWrite != nil {
+		checksum = checksum + utils.Hash(utils.Stringify(v.HeaderReWrite))
+	}
+
 	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }
@@ -813,6 +818,11 @@ type AviRedirectPort struct {
 	RedirectPort int32
 	StatusCode   string
 	VsPort       int32
+}
+
+type AviHostHeaderRewrite struct {
+	SourceHost string
+	TargetHost string
 }
 
 type AviTLSKeyCertNode struct {
@@ -984,7 +994,10 @@ func (v *AviHTTPDataScriptNode) GetCheckSum() uint32 {
 func (v *AviHTTPDataScriptNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
 	checksum := lib.DSChecksum(v.PoolGroupRefs)
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetEnableCtrl2014Features() {
+		checksum += lib.GetClusterLabelChecksum()
+		checksum += utils.Hash(v.Script)
+	}
 	v.CloudConfigCksum = checksum
 }
 

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -344,7 +344,7 @@ func ProcessInsecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng I
 			aviModel = NewAviObjectGraph()
 			aviModel.(*AviObjectGraph).ConstructAviL7VsNode(shardVsName, key, routeIgrObj)
 		}
-		aviModel.(*AviObjectGraph).BuildL7VSGraphHostNameShard(shardVsName, host, routeIgrObj, pathsvcmap.ingressHPSvc, key)
+		aviModel.(*AviObjectGraph).BuildL7VSGraphHostNameShard(shardVsName, host, routeIgrObj, pathsvcmap.ingressHPSvc, pathsvcmap.gslbHostHeader, key)
 		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if !utils.HasElem(modelList, modelName) && changedModel {
 			*modelList = append(*modelList, modelName)

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -205,7 +205,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 		secureSharedVS.ServiceMetadata.PassthroughChildRef = passChildVS.Name
 	}
 
-	o.BuildPolicyRedirectForVS([]*AviVsNode{passChildVS}, hostname, namesapce, "", key)
+	o.BuildPolicyRedirectForVS([]*AviVsNode{passChildVS}, hostname, key)
 }
 
 func (o *AviObjectGraph) ConstructL4DataScript(vsName string, key string, vsNode *AviVsNode) *AviHTTPDataScriptNode {

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	tenant_ref := "/api/tenant/?name=" + ds_meta.Tenant
 	cr := lib.AKOUser
 	vsdatascriptset := avimodels.VSDataScriptSet{CreatedBy: &cr, Datascript: datascriptlist, Name: &ds_meta.Name, TenantRef: &tenant_ref, PoolGroupRefs: poolgroupref}
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		vsdatascriptset.Labels = lib.GetLabels()
 	}
 	if len(ds_meta.ProtocolParsers) > 0 {
@@ -125,7 +125,10 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 			Uuid: uuid, PoolGroups: poolgroups}
 
 		checksum := lib.DSChecksum(ds_cache_obj.PoolGroups)
-		checksum += lib.GetClusterLabelChecksum()
+		if lib.GetEnableCtrl2014Features() {
+			checksum += lib.GetClusterLabelChecksum()
+			checksum += utils.Hash(utils.HTTP_DS_SCRIPT_MODIFIED)
+		}
 		ds_cache_obj.CloudConfigCksum = checksum
 
 		k := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: name}

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -38,7 +38,7 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 
 	hps := avimodels.L4PolicySet{Name: &name,
 		CreatedBy: &cr, TenantRef: &tenant}
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		hps.Labels = lib.GetLabels()
 	}
 	var idx int32

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -93,7 +93,7 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		SslProfileRef:     &pool_meta.SslProfileRef,
 		PlacementNetworks: placementNetworks,
 	}
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		pool.Labels = lib.GetLabels()
 	}
 	if pool_meta.PkiProfile != nil {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -86,7 +86,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		}
 		tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
 		vs.TenantRef = &tenant
-		if lib.GetEnableGRBAC() {
+		if lib.GetEnableCtrl2014Features() {
 			vs.Labels = lib.GetLabels()
 		}
 		if vs_meta.SNIParent {
@@ -224,7 +224,7 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	sniChild.VhDomainName = vs_meta.VHDomainNames
 	ignPool := false
 	sniChild.IgnPoolNetReach = &ignPool
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		sniChild.Labels = lib.GetLabels()
 	}
 	if vs_meta.DefaultPool != "" {

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -97,7 +97,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 
 		// Override the Vip in VsVip tto bring in updates, keeping everything else as is.
 
-		if lib.GetEnableGRBAC() {
+		if lib.GetEnableCtrl2014Features() {
 			vsvip.Labels = lib.GetLabels()
 		}
 		rest_op = utils.RestOp{
@@ -199,7 +199,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			DNSInfo:           dns_info_arr,
 			Vip:               vips,
 		}
-		if lib.GetEnableGRBAC() {
+		if lib.GetEnableCtrl2014Features() {
 			vsvip.Labels = lib.GetLabels()
 		}
 		vsvip.VsvipCloudConfigCksum = &cksumstr
@@ -239,7 +239,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			}
 			vsvip_avi.DNSInfo = dns_info_arr
 			vsvip_avi.VrfContextRef = &vrfContextRef
-			if lib.GetEnableGRBAC() {
+			if lib.GetEnableCtrl2014Features() {
 				vsvip_avi.Labels = lib.GetLabels()
 			}
 			vsvip_avi.VsvipCloudConfigCksum = &cksumstr

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	pg := avimodels.PoolGroup{Name: &name, CloudConfigCksum: &cksumString,
 		CreatedBy: &cr, TenantRef: &tenant, Members: members, CloudRef: &cloudRef, ImplicitPriorityLabels: &pg_meta.ImplicitPriorityLabel}
 
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		pg.Labels = lib.GetLabels()
 	}
 

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 		CreatedBy: &cr, TenantRef: &tenant, Certificate: &avimodels.SSLCertificate{Certificate: &certificate},
 		Key: &key, Type: &certType}
 
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		sslkeycert.Labels = lib.GetLabels()
 	}
 	if ssl_node.CACert != "" {
@@ -188,7 +188,7 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 			Certificate: &caCert,
 		}),
 	}
-	if lib.GetEnableGRBAC() {
+	if lib.GetEnableCtrl2014Features() {
 		pkiobject.Labels = lib.GetLabels()
 	}
 

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -60,6 +60,7 @@ const (
 	L7_PG_PREFIX                  = "-PG-l7"
 	VS_DATASCRIPT_EVT_HTTP_REQ    = "VS_DATASCRIPT_EVT_HTTP_REQ"
 	HTTP_DS_SCRIPT                = "host = avi.http.get_host_tokens(1)\npath = avi.http.get_path_tokens(1)\nif host and path then\nlbl = host..\"/\"..path\nelse\nlbl = host..\"/\"\nend\navi.poolgroup.select(\"POOLGROUP\", string.lower(lbl) )"
+	HTTP_DS_SCRIPT_MODIFIED       = "host = avi.http.get_host_tokens(\"MODIFIED\", 1)\npath = avi.http.get_path_tokens(1)\nif host and path then\nlbl = host..\"/\"..path\nelse\nlbl = host..\"/\"\nend\navi.poolgroup.select(\"POOLGROUP\", string.lower(lbl) )"
 	ADMIN_NS                      = "admin"
 	TLS_PASSTHROUGH               = "TLS_PASSTHROUGH"
 	VS_TYPE_VH_PARENT             = "VS_TYPE_VH_PARENT"

--- a/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
+++ b/tests/hostnameshardtests/l7_evh_hostnameshard_rest_test.go
@@ -764,7 +764,7 @@ func TestHostnameCUDSecretCacheSyncForEvh(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.SSLKeyCache.AviCacheGet(sslKey)
 		return found
-	}, 10*time.Second).Should(gomega.Equal(true))
+	}, 30*time.Second).Should(gomega.Equal(true))
 	parentVSCache, _ := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
 	parentVSCacheObj, _ := parentVSCache.(*cache.AviVsCache)
 	g.Expect(parentVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(0))
@@ -801,7 +801,7 @@ func TestHostnameCUDSecretCacheSyncForEvh(t *testing.T) {
 			return true
 		}
 		return false
-	}, 10*time.Second).Should(gomega.Equal(true))
+	}, 30*time.Second).Should(gomega.Equal(true))
 
 	TearDownIngressForCacheSyncCheck(t, modelName)
 }


### PR DESCRIPTION
If a GSLB host header is specified in the HostRule CRD and the FQDN
is insecure then this commit introduces a way by which AKO programs
a URL re-write rule as a httppolicyset on the shared VS.

When the GSLB request is made to the global FQDN the request would
land on the VS which hosts the local FQDN. The HTTP re-write rule
would then modify the request header to the cluster local host header.

Following this, the header (which is the local host header) would be
matched with the local pools priority labels via the datascript.

This change requires a datascript change which is only available
with 20.1.4 and hence couple of things happen:

 - This feature only works with 20.1.4 and above controllers.
 - On switching the controller to 20.1.4 and starting an AKO during
upgrade would auto-matically upgrade the datascript.