### PR TITLE
Use existing PG for http policy for SNI VS in object model

### DIFF
--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -326,9 +326,9 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 				pgNode, pgfound = localPGList[pgName]
 				if !pgfound {
 					pgNode = &AviPoolGroupNode{Name: pgName, Tenant: lib.GetTenant()}
-					localPGList[pgName] = pgNode
-					httpPGPath.PoolGroup = pgNode.Name
 				}
+				localPGList[pgName] = pgNode
+				httpPGPath.PoolGroup = pgNode.Name
 			}
 			httpPolicySet = append(httpPolicySet, httpPGPath)
 			hostSlice := []string{host}

--- a/tests/oshiftroutetests/oshift_secure_route_test.go
+++ b/tests/oshiftroutetests/oshift_secure_route_test.go
@@ -362,6 +362,9 @@ func TestSecureRouteAlternateBackend(t *testing.T) {
 		return sniVS.VHDomainNames[0]
 	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
 
+	g.Expect(sniVS.HttpPolicyRefs[0].HppMap[0].Host[0]).To(gomega.Equal("foo.com"))
+	g.Expect(sniVS.HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-foo"))
+
 	g.Expect(sniVS.CACertRefs).To(gomega.HaveLen(1))
 	g.Expect(sniVS.SSLKeyCertRefs).To(gomega.HaveLen(1))
 	g.Expect(sniVS.PoolGroupRefs).To(gomega.HaveLen(1))


### PR DESCRIPTION
- This fixes a problem with alternate backends in openshift route where http policy creation fails.
- Added a check in UT to catch this issue.