### PR TITLE
AviInfraSetting shardSize configuration for EVH VSes

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -647,7 +647,7 @@ func SyncFromIngestionLayer(key string, wg *sync.WaitGroup) error {
 	// Let's route the key to the graph layer.
 	// NOTE: There's no error propagation from the graph layer back to the workerqueue. We will evaluate
 	// This condition in the future and visit as needed. But right now, there's no necessity for it.
-	//sharedQueue := SharedWorkQueueWrappers().GetQueueByName(queue.GraphLayer)
+	// sharedQueue := SharedWorkQueueWrappers().GetQueueByName(queue.GraphLayer)
 	nodes.DequeueIngestion(key, false)
 	return nil
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -199,15 +199,12 @@ func GetHeaderRewritePolicy(vsName, localHost string) string {
 	return vsName + "--host-hdr-re-write" + "--" + localHost
 }
 
-func GetSniNodeName(ingName, namespace, secret, infrasetting string, sniHostName ...string) string {
+func GetSniNodeName(ingName, infrasetting, sniHostName string) string {
 	namePrefix := NamePrefix
 	if infrasetting != "" {
 		namePrefix += infrasetting + "-"
 	}
-	if len(sniHostName) > 0 {
-		return namePrefix + sniHostName[0]
-	}
-	return namePrefix + ingName + "-" + namespace + "-" + secret
+	return namePrefix + sniHostName
 }
 
 func GetSniPoolName(ingName, namespace, host, path, infrasetting string, args ...string) string {
@@ -230,7 +227,6 @@ func GetSniHttpPolName(ingName, namespace, host, path, infrasetting string) stri
 	if infrasetting != "" {
 		return NamePrefix + infrasetting + "-" + namespace + "-" + host + path + "-" + ingName
 	}
-
 	return NamePrefix + namespace + "-" + host + path + "-" + ingName
 }
 
@@ -243,9 +239,13 @@ func GetSniPGName(ingName, namespace, host, path, infrasetting string) string {
 }
 
 // evh child
-func GetEvhVsPoolNPgName(ingName, namespace, host, path string, args ...string) string {
+func GetEvhVsPoolNPgName(ingName, namespace, host, path, infrasetting string, args ...string) string {
 	path = strings.ReplaceAll(path, "/", "_")
-	poolName := NamePrefix + namespace + "-" + host + path + "-" + ingName
+	namePrefix := NamePrefix
+	if infrasetting != "" {
+		namePrefix += infrasetting + "-"
+	}
+	poolName := namePrefix + namespace + "-" + host + path + "-" + ingName
 	if len(args) > 0 {
 		svcName := args[0]
 		poolName = poolName + "-" + svcName
@@ -253,24 +253,27 @@ func GetEvhVsPoolNPgName(ingName, namespace, host, path string, args ...string) 
 	return poolName
 }
 
-func GetEvhNodeName(ingName, namespace, host string) string {
+func GetEvhNodeName(ingName, namespace, host, infrasetting string) string {
+	if infrasetting != "" {
+		return NamePrefix + infrasetting + "-" + namespace + "-" + host
+	}
 	return NamePrefix + namespace + "-" + host
 }
 
-func GetEvhPGName(ingName, namespace, host, path string) string {
+func GetEvhPGName(ingName, namespace, host, path, infrasetting string) string {
 	path = strings.ReplaceAll(path, "/", "_")
+	if infrasetting != "" {
+		return NamePrefix + infrasetting + "-" + namespace + "-" + host + path + "-" + ingName
+	}
 	return NamePrefix + namespace + "-" + host + path + "-" + ingName
 }
 
-func GetTLSKeyCertNodeName(namespace, secret, infrasetting string, sniHostName ...string) string {
+func GetTLSKeyCertNodeName(infrasetting, sniHostName string) string {
 	namePrefix := NamePrefix
 	if infrasetting != "" {
 		namePrefix += infrasetting + "-"
 	}
-	if len(sniHostName) > 0 {
-		return namePrefix + sniHostName[0]
-	}
-	return namePrefix + namespace + "-" + secret
+	return namePrefix + sniHostName
 }
 
 func GetCACertNodeName(keycertname string) string {
@@ -752,30 +755,9 @@ func GetPassthroughShardVSName(s string, key string) string {
 	shardSize := PassthroughShardSize()
 	shardVsPrefix := GetClusterName() + "--" + PassthroughPrefix
 	vsNum = utils.Bkt(s, shardSize)
-	vsName := shardVsPrefix + fmt.Sprint(vsNum)
+	vsName := shardVsPrefix + strconv.Itoa(int(vsNum))
 	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
 	return vsName
-}
-
-func VSVipChecksum(FQDNs []string, IPAddress string, networkNames []string) uint32 {
-	sort.Strings(FQDNs)
-	sort.Strings(networkNames)
-	var checksum uint32
-	if len(FQDNs) != 0 {
-		checksum = utils.Hash(utils.Stringify(FQDNs))
-	}
-	if IPAddress != "" {
-		checksum += utils.Hash(IPAddress)
-	}
-	if len(networkNames) != 0 {
-		if len(networkNames) == 1 {
-			checksum += utils.Hash(networkNames[0])
-		} else {
-			checksum += utils.Hash(utils.Stringify(networkNames))
-		}
-	}
-	checksum += GetClusterLabelChecksum()
-	return checksum
 }
 
 // GetLabels returns the key value pair used for tagging the segroups and routes in vrfcontext

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -401,8 +401,22 @@ func GetSubnetPrefixInt() int32 {
 	return int32(intCidr)
 }
 
-func GetNetworkName() string {
+func GetNetworkNamesForVsVipNode() ([]string, error) {
+	if networkName := GetNetworkName(); networkName != "" {
+		return []string{networkName}, nil
+	} else if IsPublicCloud() && GetCloudType() == CLOUD_AWS {
+		vipNetworkList, err := GetVipNetworkList()
+		if err != nil {
+			return nil, err
+		}
+		if len(vipNetworkList) != 0 {
+			return vipNetworkList, nil
+		}
+	}
+	return []string{}, nil
+}
 
+func GetNetworkName() string {
 	networkName := os.Getenv(NETWORK_NAME)
 	if networkName != "" {
 		return networkName
@@ -411,7 +425,6 @@ func GetNetworkName() string {
 }
 
 func GetVipNetworkList() ([]string, error) {
-
 	var vipNetworkList []string
 	type Row struct {
 		NetworkName string `json:"networkName"`

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -106,17 +106,11 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 			VrfContext: lib.GetVrf(),
 		}
 
-		if networkName := lib.GetNetworkName(); networkName != "" {
-			vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, networkName)
-		} else if lib.IsPublicCloud() && lib.GetCloudType() == lib.CLOUD_AWS {
-			vipNetworkList, err := lib.GetVipNetworkList()
-			if err != nil {
-				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-				return nil
-			}
-			if len(vipNetworkList) != 0 {
-				vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, vipNetworkList...)
-			}
+		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
+			return nil
+		} else {
+			vsVipNode.NetworkNames = networkNames
 		}
 
 		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
@@ -188,17 +182,11 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			VrfContext: lib.GetVrf(),
 		}
 
-		if networkName := lib.GetNetworkName(); networkName != "" {
-			vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, networkName)
-		} else if lib.IsPublicCloud() && lib.GetCloudType() == lib.CLOUD_AWS {
-			vipNetworkList, err := lib.GetVipNetworkList()
-			if err != nil {
-				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-				return nil
-			}
-			if len(vipNetworkList) != 0 {
-				vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, vipNetworkList...)
-			}
+		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
+			return nil
+		} else {
+			vsVipNode.NetworkNames = networkNames
 		}
 
 		// configures VS and VsVip nodes using infraSetting object (via CRD).

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -570,17 +570,11 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName string, key str
 		VrfContext: vrfcontext,
 	}
 
-	if networkName := lib.GetNetworkName(); networkName != "" {
-		vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, networkName)
-	} else if lib.IsPublicCloud() && lib.GetCloudType() == lib.CLOUD_AWS {
-		vipNetworkList, err := lib.GetVipNetworkList()
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-			return nil
-		}
-		if len(vipNetworkList) != 0 {
-			vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, vipNetworkList...)
-		}
+	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
+		return nil
+	} else {
+		vsVipNode.NetworkNames = networkNames
 	}
 
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1192,7 +1192,9 @@ func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (s
 
 	oldShardSize, newShardSize := lib.GetshardSize(), lib.GetshardSize()
 	if oldSetting != nil {
-		oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		if oldSetting.Spec.L7Settings != (akov1alpha1.AviInfraL7Settings{}) {
+			oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		}
 		oldInfraPrefix = oldSetting.Name
 	}
 
@@ -1201,7 +1203,9 @@ func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (s
 		newShardSize = oldShardSize
 		newInfraPrefix = oldInfraPrefix
 	} else if newSetting != nil {
-		newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		if newSetting.Spec.L7Settings != (akov1alpha1.AviInfraL7Settings{}) {
+			newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		}
 		newInfraPrefix = newSetting.Name
 	}
 

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
@@ -586,7 +587,7 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName string, key str
 	return avi_vs_meta
 }
 
-func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childNode *AviEvhVsNode, namespace string, ingName string, key string, host string, paths []IngressHostPathSvc) {
+func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childNode *AviEvhVsNode, namespace, ingName, key, host, infraSettingName string, paths []IngressHostPathSvc) {
 	localPGList := make(map[string]*AviPoolGroupNode)
 
 	// Update the VSVIP with the host information.
@@ -615,7 +616,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 			httpPGPath.Path = append(httpPGPath.Path, path.Path)
 		}
 
-		pgName := lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path)
+		pgName := lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path, infraSettingName)
 		var pgNode *AviPoolGroupNode
 		// There can be multiple services for the same path in case of alternate backend.
 		// In that case, make sure we are creating only one PG per path
@@ -629,7 +630,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 		}
 
 		var poolName string
-		poolName = lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path, path.ServiceName)
+		poolName = lib.GetEvhVsPoolNPgName(ingName, namespace, host, path.Path, infraSettingName, path.ServiceName)
 		poolNode := &AviPoolNode{
 			Name:       poolName,
 			PortName:   path.PortName,
@@ -665,7 +666,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 		}
 		o.AddModelNode(poolNode)
 		if !pgfound {
-			httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path, "")
+			httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path, infraSettingName)
 			policyNode := &AviHttpPolicySetNode{Name: httppolname, HppMap: httpPolicySet, Tenant: lib.GetTenant()}
 			if childNode.CheckHttpPolNameNChecksumForEvh(httppolname, policyNode.GetCheckSum()) {
 				childNode.ReplaceHTTPRefInNodeForEvh(policyNode, key)
@@ -682,6 +683,11 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 
 func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parsedIng IngressConfig, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost, hostsMap map[string]*objects.RouteIngrhost) {
 	utils.AviLog.Debugf("key: %s, msg: Storedhosts before  processing insecurehosts: %s", key, utils.Stringify(Storedhosts))
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	for host, pathsvcmap := range parsedIng.IngressHostMap {
 		// Remove this entry from storedHosts. First check if the host exists in the stored map or not.
 		hostData, found := Storedhosts[host]
@@ -706,7 +712,7 @@ func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parse
 		hostsMap[host].InsecurePolicy = lib.PolicyAllow
 		hostsMap[host].PathSvc = getPathSvc(pathsvcmap.ingressHPSvc)
 
-		shardVsName := DeriveShardVSForEvh(host, key)
+		_, shardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if !found || aviModel == nil {
@@ -720,7 +726,7 @@ func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parse
 		vsNode := aviModel.(*AviObjectGraph).GetAviEvhVS()
 		ingName := routeIgrObj.GetName()
 		namespace := routeIgrObj.GetNamespace()
-		evhNodeName := lib.GetEvhNodeName(ingName, namespace, host)
+		evhNodeName := lib.GetEvhNodeName(ingName, namespace, host, infraSettingName)
 		evhNode := vsNode[0].GetEvhNodeForName(evhNodeName)
 		hostSlice := []string{host}
 
@@ -773,7 +779,7 @@ func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parse
 		RemoveRedirectHTTPPolicyInModelForEvh(evhNode, host, key)
 
 		// build poolgroup and pool
-		aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, host, pathsvcmap.ingressHPSvc)
+		aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, host, infraSettingName, pathsvcmap.ingressHPSvc)
 		foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)
 		if !foundEvhModel {
 			vsNode[0].EvhNodes = append(vsNode[0].EvhNodes, evhNode)
@@ -809,7 +815,7 @@ func (o *AviObjectGraph) BuildCACertNodeForEvh(tlsNode *AviEvhVsNode, cacert, ke
 	return cacertNode.Name
 }
 
-func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tlsNode *AviEvhVsNode, namespace string, tlsData TlsSettings, key string, host ...string) bool {
+func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tlsNode *AviEvhVsNode, namespace string, tlsData TlsSettings, key, infraSettingName, host string) bool {
 	mClient := utils.GetInformers().ClientSet
 	secretName := tlsData.SecretName
 	secretNS := tlsData.SecretNS
@@ -817,19 +823,11 @@ func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tl
 		secretNS = namespace
 	}
 
-	var certNode *AviTLSKeyCertNode
-	if len(host) > 0 {
-		certNode = &AviTLSKeyCertNode{
-			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, "", host[0]),
-			Tenant: lib.GetTenant(),
-		}
-	} else {
-		certNode = &AviTLSKeyCertNode{
-			Name:   lib.GetTLSKeyCertNodeName(namespace, secretName, ""),
-			Tenant: lib.GetTenant(),
-		}
+	certNode := &AviTLSKeyCertNode{
+		Name:   lib.GetTLSKeyCertNodeName(infraSettingName, host),
+		Tenant: lib.GetTenant(),
+		Type:   lib.CertTypeVS,
 	}
-	certNode.Type = lib.CertTypeVS
 
 	// Openshift Routes do not refer to a secret, instead key/cert values are mentioned in the route
 	if strings.HasPrefix(secretName, lib.RouteSecretsPrefix) {
@@ -882,13 +880,10 @@ func (o *AviObjectGraph) BuildTlsCertNodeForEvh(svcLister *objects.SvcLister, tl
 		utils.AviLog.Infof("key: %s, msg: Added the secret object to tlsnode: %s", key, secretObj.Name)
 	}
 	// If this SSLCertRef is already present don't add it.
-	if len(host) > 0 {
-		if tlsNode.CheckSSLCertNodeNameNChecksum(lib.GetTLSKeyCertNodeName(namespace, secretName, "", host[0]), certNode.GetCheckSum()) {
-			tlsNode.ReplaceEvhSSLRefInEVHNode(certNode, key)
-		}
-	} else {
-		tlsNode.SSLKeyCertRefs = append(tlsNode.SSLKeyCertRefs, certNode)
+	if tlsNode.CheckSSLCertNodeNameNChecksum(lib.GetTLSKeyCertNodeName(infraSettingName, host), certNode.GetCheckSum()) {
+		tlsNode.ReplaceEvhSSLRefInEVHNode(certNode, key)
 	}
+
 	return true
 }
 
@@ -933,6 +928,11 @@ func ProcessSecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parsedI
 
 func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingName, namespace, key string, fullsync bool, sharedQueue *utils.WorkerQueue, modelList *[]string) map[string][]IngressHostPathSvc {
 	hostPathSvcMap := make(map[string][]IngressHostPathSvc)
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	for host, paths := range tlssetting.Hosts {
 		var hosts []string
 		hostPathSvcMap[host] = paths.ingressHPSvc
@@ -949,7 +949,7 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		}
 		SharedHostNameLister().Save(host, ingressHostMap)
 		hosts = append(hosts, host)
-		shardVsName := DeriveShardVSForEvh(host, key)
+		_, shardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
 		// For each host, create a EVH node with the secret giving us the key and cert.
 		// construct a EVH child VS node per tls setting which corresponds to one secret
 		model_name := lib.GetModelName(lib.GetTenant(), shardVsName)
@@ -972,10 +972,10 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			certsBuilt = true
 		}
 
-		evhNode := vsNode[0].GetEvhNodeForName(lib.GetEvhNodeName(ingName, namespace, host))
+		evhNode := vsNode[0].GetEvhNodeForName(lib.GetEvhNodeName(ingName, namespace, host, infraSettingName))
 		if evhNode == nil {
 			evhNode = &AviEvhVsNode{
-				Name:         lib.GetEvhNodeName(ingName, namespace, host),
+				Name:         lib.GetEvhNodeName(ingName, namespace, host, infraSettingName),
 				VHParentName: vsNode[0].Name,
 				Tenant:       lib.GetTenant(),
 				EVHParent:    false,
@@ -1004,10 +1004,10 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 		evhNode.ApplicationProfile = utils.DEFAULT_L7_APP_PROFILE
 		evhNode.VrfContext = lib.GetVrf()
 		if !certsBuilt {
-			certsBuilt = aviModel.(*AviObjectGraph).BuildTlsCertNodeForEvh(routeIgrObj.GetSvcLister(), vsNode[0], namespace, tlssetting, key, host)
+			certsBuilt = aviModel.(*AviObjectGraph).BuildTlsCertNodeForEvh(routeIgrObj.GetSvcLister(), vsNode[0], namespace, tlssetting, key, infraSettingName, host)
 		}
 		if certsBuilt {
-			aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, host, paths.ingressHPSvc)
+			aviModel.(*AviObjectGraph).BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, host, infraSettingName, paths.ingressHPSvc)
 			foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)
 			if !foundEvhModel {
 				vsNode[0].EvhNodes = append(vsNode[0].EvhNodes, evhNode)
@@ -1030,7 +1030,7 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			}
 			// Since the cert couldn't be built, check if this EVH is affected by only in ingress if so remove the EVH node from the model
 			if len(ingressHostMap.GetIngressesForHostName(host)) == 0 {
-				vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, tlssetting.SecretName, "", host), key)
+				vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, host), key)
 				RemoveEvhInModel(evhNode.Name, vsNode, key)
 				RemoveRedirectHTTPPolicyInModelForEvh(evhNode, host, key)
 			}
@@ -1127,9 +1127,14 @@ func RemoveFQDNsFromModelForEvh(vsNode *AviEvhVsNode, hosts []string, key string
 //DeleteStaleData : delete pool, EVH VS and redirect policy which are present in the object store but no longer required.
 func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList *[]string, Storedhosts map[string]*objects.RouteIngrhost, hostsMap map[string]*objects.RouteIngrhost) {
 	utils.AviLog.Debugf("key: %s, msg: About to delete stale data EVH Stored hosts: %v, hosts map: %v", key, utils.Stringify(Storedhosts), utils.Stringify(hostsMap))
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	for host, hostData := range Storedhosts {
 		utils.AviLog.Debugf("host to del: %s, data : %s", host, utils.Stringify(hostData))
-		shardVsName := DeriveShardVSForEvh(host, key)
+		_, shardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
 
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1152,11 +1157,10 @@ func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList 
 		}
 		// Delete the pool corresponding to this host
 		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, removeFqdn, removeRedir, true)
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, removeFqdn, removeRedir, true)
 		}
 		if hostData.InsecurePolicy != lib.PolicyNone {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, removeFqdn, removeRedir, false)
-
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, removeFqdn, removeRedir, false)
 		}
 		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if !utils.HasElem(modelList, modelName) && changedModel {
@@ -1165,22 +1169,43 @@ func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList 
 	}
 }
 
-func DeriveShardVSForEvh(hostname string, key string) string {
+func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (string, string) {
 	// Read the value of the num_shards from the environment variable.
 	utils.AviLog.Debugf("key: %s, msg: hostname for sharding: %s", key, hostname)
-	var vsNum uint32
-	shardSize := lib.GetshardSize()
-	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-EVH-"
-	if shardSize != 0 {
-		vsNum = utils.Bkt(hostname, shardSize)
-		utils.AviLog.Debugf("key: %s, msg: VS number: %v", key, vsNum)
-	} else {
-		utils.AviLog.Warnf("key: %s, msg: the value for shard_vs_size does not match the ENUM values", key)
-		return ""
+
+	// get stored infrasetting from ingress/route
+	// figure out the current infrasetting via class/annotation
+	oldSetting, newSetting := AviInfraSettingChange(routeIgrObj)
+	var oldInfraPrefix, newInfraPrefix string
+
+	oldShardSize, newShardSize := lib.GetshardSize(), lib.GetshardSize()
+	if oldSetting != nil {
+		oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		oldInfraPrefix = oldSetting.Name
 	}
-	vsName := shardVsPrefix + fmt.Sprint(vsNum)
-	utils.AviLog.Infof("key: %s, msg: ShardVSName: %s", key, vsName)
-	return vsName
+
+	if !routeIgrObj.Exists() {
+		// get the old ones.
+		newShardSize = oldShardSize
+		newInfraPrefix = oldInfraPrefix
+	} else if newSetting != nil {
+		newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		newInfraPrefix = newSetting.Name
+	}
+
+	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-EVH-"
+	oldVsName, newVsName := shardVsPrefix, shardVsPrefix
+	if oldInfraPrefix != "" {
+		oldVsName += "-" + oldInfraPrefix + "-"
+	}
+	if newInfraPrefix != "" {
+		newVsName += "-" + newInfraPrefix + "-"
+	}
+	oldVsName += strconv.Itoa(int(utils.Bkt(hostname, oldShardSize)))
+	newVsName += strconv.Itoa(int(utils.Bkt(hostname, newShardSize)))
+
+	utils.AviLog.Infof("key: %s, msg: ShardVSNames: %s %s", key, oldVsName, newVsName)
+	return oldVsName, newVsName
 }
 
 func (o *AviObjectGraph) RemovePoolNodeRefsFromEvh(poolName string, evhNode *AviEvhVsNode) {
@@ -1222,18 +1247,18 @@ func (o *AviObjectGraph) RemovePGNodeRefsForEvh(pgName string, vsNode *AviEvhVsN
 
 }
 
-func (o *AviObjectGraph) ManipulateEvhNode(currentEvhNodeName, ingName, namespace, hostname string, pathSvc map[string][]string, vsNode []*AviEvhVsNode, key string) bool {
+func (o *AviObjectGraph) ManipulateEvhNode(currentEvhNodeName, ingName, namespace, hostname string, pathSvc map[string][]string, vsNode []*AviEvhVsNode, infraSettingName, key string) bool {
 	for _, modelEvhNode := range vsNode[0].EvhNodes {
 		if currentEvhNodeName != modelEvhNode.Name {
 			continue
 		}
 
 		for path, services := range pathSvc {
-			pgName := lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path)
+			pgName := lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path, infraSettingName)
 			pgNode := modelEvhNode.GetPGForVSByName(pgName)
 			for _, svc := range services {
 				var evhPool string
-				evhPool = lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path, svc)
+				evhPool = lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path, infraSettingName, svc)
 				o.RemovePoolNodeRefsFromEvh(evhPool, modelEvhNode)
 				o.RemovePoolRefsFromPG(evhPool, pgNode)
 
@@ -1241,7 +1266,7 @@ func (o *AviObjectGraph) ManipulateEvhNode(currentEvhNodeName, ingName, namespac
 				if pgNode != nil {
 					if len(pgNode.Members) == 0 {
 						o.RemovePGNodeRefsForEvh(pgName, modelEvhNode)
-						httppolname := lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path)
+						httppolname := lib.GetEvhVsPoolNPgName(ingName, namespace, hostname, path, infraSettingName)
 						o.RemoveHTTPRefsFromEvh(httppolname, modelEvhNode)
 					}
 				}
@@ -1274,7 +1299,7 @@ func (o *AviObjectGraph) GetAviPoolNodesByIngressForEvh(tenant string, ingName s
 	return aviPool
 }
 
-func (o *AviObjectGraph) DeletePoolForHostnameForEvh(vsName, hostname string, routeIgrObj RouteIngressModel, pathSvc map[string][]string, key string, removeFqdn, removeRedir, secure bool) {
+func (o *AviObjectGraph) DeletePoolForHostnameForEvh(vsName, hostname string, routeIgrObj RouteIngressModel, pathSvc map[string][]string, key, infraSettingName string, removeFqdn, removeRedir, secure bool) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 
@@ -1290,12 +1315,12 @@ func (o *AviObjectGraph) DeletePoolForHostnameForEvh(vsName, hostname string, ro
 		SharedHostNameLister().Save(hostname, ingressHostMap)
 	}
 
-	evhNodeName := lib.GetEvhNodeName(ingName, namespace, hostname)
+	evhNodeName := lib.GetEvhNodeName(ingName, namespace, hostname, infraSettingName)
 	utils.AviLog.Infof("key: %s, msg: EVH node to delete: %s", key, evhNodeName)
-	keepEvh = o.ManipulateEvhNode(evhNodeName, ingName, namespace, hostname, pathSvc, vsNode, key)
+	keepEvh = o.ManipulateEvhNode(evhNodeName, ingName, namespace, hostname, pathSvc, vsNode, infraSettingName, key)
 	if !keepEvh {
 		// Delete the cert ref for the host
-		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(namespace, lib.GetTLSKeyCertNodeName(namespace, "", "", hostname), hostname), key)
+		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, hostname), key)
 	}
 	if removeFqdn && !keepEvh {
 		var hosts []string
@@ -1353,9 +1378,14 @@ func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespa
 		return
 	}
 
+	var infraSettingName string
+	if aviInfraSetting := routeIgrObj.GetAviInfraSetting(); aviInfraSetting != nil {
+		infraSettingName = aviInfraSetting.Name
+	}
+
 	utils.AviLog.Debugf("key: %s, msg: hosts to delete are :%s", key, utils.Stringify(hostMap))
 	for host, hostData := range hostMap {
-		shardVsName := DeriveShardVSForEvh(host, key)
+		_, shardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
 		if hostData.SecurePolicy == lib.PolicyPass {
 			shardVsName = lib.GetPassthroughShardVSName(host, key)
 		}
@@ -1369,12 +1399,12 @@ func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespa
 
 		// Delete the pool corresponding to this host
 		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, true)
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true)
 		} else if hostData.SecurePolicy == lib.PolicyPass {
 			aviModel.(*AviObjectGraph).DeleteObjectsForPassthroughHost(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, true)
 		}
 		if hostData.InsecurePolicy == lib.PolicyAllow {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, true, true, false)
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
 		}
 		ok := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if ok && len(aviModel.(*AviObjectGraph).GetOrderedNodes()) != 0 && !fullsync {
@@ -1390,4 +1420,41 @@ func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespa
 
 	// remove hostpath mappings
 	updateHostPathCache(namespace, objname, hostMap, nil)
+}
+
+func DeleteStaleDataForModelChangeForEvh(routeIgrObj RouteIngressModel, namespace, objname, key string, fullsync bool, sharedQueue *utils.WorkerQueue) {
+	ok, hostMap := routeIgrObj.GetSvcLister().IngressMappings(namespace).GetRouteIngToHost(objname)
+	if !ok {
+		utils.AviLog.Warnf("key: %s, msg: nothing to delete for route: %s", key, objname)
+		return
+	}
+
+	utils.AviLog.Debugf("key: %s, msg: hosts to delete %s", key, utils.Stringify(hostMap))
+	for host, hostData := range hostMap {
+		shardVsName, newShardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
+		if shardVsName == newShardVsName {
+			continue
+		}
+
+		_, infraSettingName := objects.InfraSettingL7Lister().GetIngRouteToInfraSetting(routeIgrObj.GetNamespace() + "/" + routeIgrObj.GetName())
+		modelName := lib.GetModelName(lib.GetTenant(), shardVsName)
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found || aviModel == nil {
+			utils.AviLog.Warnf("key: %s, msg: model not found during delete: %s", key, modelName)
+			continue
+		}
+
+		// Delete the pool corresponding to this host
+		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true)
+		}
+		if hostData.InsecurePolicy != lib.PolicyNone {
+			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
+		}
+
+		ok := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
+		if ok && len(aviModel.(*AviObjectGraph).GetOrderedNodes()) != 0 && !fullsync {
+			PublishKeyToRestLayer(modelName, key, sharedQueue)
+		}
+	}
 }

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -111,17 +111,11 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		VrfContext: vrfcontext,
 	}
 
-	if networkName := lib.GetNetworkName(); networkName != "" {
-		vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, networkName)
-	} else if lib.IsPublicCloud() && lib.GetCloudType() == lib.CLOUD_AWS {
-		vipNetworkList, err := lib.GetVipNetworkList()
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-			return nil
-		}
-		if len(vipNetworkList) != 0 {
-			vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, vipNetworkList...)
-		}
+	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
+		return nil
+	} else {
+		vsVipNode.NetworkNames = networkNames
 	}
 
 	// configures VS and VsVip nodes using infraSetting object (via CRD).

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -316,7 +316,6 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 
 		if found {
 			// if vsNode already exists, check for updates via AviInfraSetting
-			vsNode := aviModel.(*AviObjectGraph).GetAviVS()
 			if infraSetting := routeIgrObj.GetAviInfraSetting(); infraSetting != nil {
 				buildWithInfraSetting(key, vsNode[0], vsNode[0].VSVIPRefs[0], infraSetting)
 			}

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -308,10 +308,18 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			aviModel = NewAviObjectGraph()
 			aviModel.(*AviObjectGraph).ConstructAviL7VsNode(shardVsName, key, routeIgrObj)
 		}
-		vsNode := aviModel.(*AviObjectGraph).GetAviVS()
 
+		vsNode := aviModel.(*AviObjectGraph).GetAviVS()
 		if len(vsNode) < 1 {
 			return nil
+		}
+
+		if found {
+			// if vsNode already exists, check for updates via AviInfraSetting
+			vsNode := aviModel.(*AviObjectGraph).GetAviVS()
+			if infraSetting := routeIgrObj.GetAviInfraSetting(); infraSetting != nil {
+				buildWithInfraSetting(key, vsNode[0], vsNode[0].VSVIPRefs[0], infraSetting)
+			}
 		}
 
 		certsBuilt := false

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -201,7 +201,7 @@ func (o *AviObjectGraph) DeletePoolForHostname(vsName, hostname string, routeIgr
 		isIngr := routeIgrObj.GetType() == utils.Ingress
 		// SNI VSes donot have secretname in their names
 
-		sniNodeName := lib.GetSniNodeName(ingName, namespace, "", infraSettingName, hostname)
+		sniNodeName := lib.GetSniNodeName(ingName, infraSettingName, hostname)
 		utils.AviLog.Infof("key: %s, msg: sni node to delete: %s", key, sniNodeName)
 		keepSni = o.ManipulateSniNode(sniNodeName, ingName, namespace, hostname, pathSvc, vsNode, key, isIngr, infraSettingName)
 	}
@@ -322,7 +322,7 @@ func sniNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 			certsBuilt = true
 		}
 
-		sniNodeName := lib.GetSniNodeName(ingName, namespace, sniSecretName, infraSettingName, sniHost)
+		sniNodeName := lib.GetSniNodeName(ingName, infraSettingName, sniHost)
 		sniNode := vsNode[0].GetSniNodeForName(sniNodeName)
 		if sniNode == nil {
 			sniNode = &AviVsNode{

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -898,7 +898,18 @@ func (v *AviVSVIPNode) GetCheckSum() uint32 {
 }
 
 func (v *AviVSVIPNode) CalculateCheckSum() {
-	checksum := lib.VSVipChecksum(v.FQDNs, v.IPAddress, v.NetworkNames)
+	var checksum uint32
+	sort.Strings(v.FQDNs)
+	sort.Strings(v.NetworkNames)
+	if len(v.FQDNs) > 0 {
+		checksum = utils.Hash(utils.Stringify(v.FQDNs))
+	}
+	if v.IPAddress != "" {
+		checksum += utils.Hash(v.IPAddress)
+	}
+	if len(v.NetworkNames) > 0 {
+		checksum += utils.Hash(utils.Stringify(v.NetworkNames))
+	}
 	checksum += lib.GetClusterLabelChecksum()
 	v.CloudConfigCksum = checksum
 }

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -54,12 +54,15 @@ func HostNameShardAndPublish(objType, objname, namespace, key string, fullsync b
 		}
 	}(routeIgrObj)
 
+	isIngr := routeIgrObj.GetType() == utils.Ingress
+
 	// delete old Models in case the modelNames changes because of shardSize updates via AviInfraSetting
-	if !lib.IsEvhEnabled() {
+	if isIngr && lib.IsEvhEnabled() {
+		DeleteStaleDataForModelChangeForEvh(routeIgrObj, namespace, objname, key, fullsync, sharedQueue)
+	} else {
 		DeleteStaleDataForModelChange(routeIgrObj, namespace, objname, key, fullsync, sharedQueue)
 	}
 
-	isIngr := routeIgrObj.GetType() == utils.Ingress
 	if err != nil || !processObj {
 		utils.AviLog.Warnf("key: %s, msg: Error %v", key, err)
 		// Detect a delete condition here.
@@ -329,7 +332,12 @@ func DeleteStaleDataForModelChange(routeIgrObj RouteIngressModel, namespace, obj
 		}
 
 		// Delete the pool corresponding to this host
-		aviModel.(*AviObjectGraph).DeletePoolForHostname(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
+		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
+			aviModel.(*AviObjectGraph).DeletePoolForHostname(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true)
+		}
+		if hostData.InsecurePolicy != lib.PolicyNone {
+			aviModel.(*AviObjectGraph).DeletePoolForHostname(shardVsName, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
+		}
 
 		ok := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if ok && len(aviModel.(*AviObjectGraph).GetOrderedNodes()) != 0 && !fullsync {

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -179,7 +179,6 @@ func ProcessInsecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng I
 		vsNode := aviModel.(*AviObjectGraph).GetAviVS()
 		if len(vsNode) > 0 && found {
 			// if vsNode already exists, check for updates via AviInfraSetting
-			vsNode := aviModel.(*AviObjectGraph).GetAviVS()
 			if infraSetting := routeIgrObj.GetAviInfraSetting(); infraSetting != nil {
 				buildWithInfraSetting(key, vsNode[0], vsNode[0].VSVIPRefs[0], infraSetting)
 			}

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -175,6 +175,16 @@ func ProcessInsecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng I
 			aviModel = NewAviObjectGraph()
 			aviModel.(*AviObjectGraph).ConstructAviL7VsNode(shardVsName, key, routeIgrObj)
 		}
+
+		vsNode := aviModel.(*AviObjectGraph).GetAviVS()
+		if len(vsNode) > 0 && found {
+			// if vsNode already exists, check for updates via AviInfraSetting
+			vsNode := aviModel.(*AviObjectGraph).GetAviVS()
+			if infraSetting := routeIgrObj.GetAviInfraSetting(); infraSetting != nil {
+				buildWithInfraSetting(key, vsNode[0], vsNode[0].VSVIPRefs[0], infraSetting)
+			}
+		}
+
 		aviModel.(*AviObjectGraph).BuildL7VSGraphHostNameShard(shardVsName, host, routeIgrObj, pathsvcmap.ingressHPSvc, pathsvcmap.gslbHostHeader, key)
 		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if !utils.HasElem(modelList, modelName) && changedModel {

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -65,17 +65,11 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 		VrfContext: vrfcontext,
 	}
 
-	if networkName := lib.GetNetworkName(); networkName != "" {
-		vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, networkName)
-	} else if lib.IsPublicCloud() && lib.GetCloudType() == lib.CLOUD_AWS {
-		vipNetworkList, err := lib.GetVipNetworkList()
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-			return nil
-		}
-		if len(vipNetworkList) != 0 {
-			vsVipNode.NetworkNames = append(vsVipNode.NetworkNames, vipNetworkList...)
-		}
+	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
+		return nil
+	} else {
+		vsVipNode.NetworkNames = networkNames
 	}
 
 	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -519,7 +519,9 @@ func DeriveShardVS(hostname string, key string, routeIgrObj RouteIngressModel) (
 
 	oldShardSize, newShardSize := lib.GetshardSize(), lib.GetshardSize()
 	if oldSetting != nil {
-		oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		if oldSetting.Spec.L7Settings != (akov1alpha1.AviInfraL7Settings{}) {
+			oldShardSize = lib.ShardSizeMap[oldSetting.Spec.L7Settings.ShardSize]
+		}
 		oldInfraPrefix = oldSetting.Name
 	}
 
@@ -528,7 +530,9 @@ func DeriveShardVS(hostname string, key string, routeIgrObj RouteIngressModel) (
 		newShardSize = oldShardSize
 		newInfraPrefix = oldInfraPrefix
 	} else if newSetting != nil {
-		newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		if newSetting.Spec.L7Settings != (akov1alpha1.AviInfraL7Settings{}) {
+			newShardSize = lib.ShardSizeMap[newSetting.Spec.L7Settings.ShardSize]
+		}
 		newInfraPrefix = newSetting.Name
 	}
 

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -467,7 +467,7 @@ func (descriptor GraphDescriptor) GetByType(name string) (GraphSchema, bool) {
 func GetShardVSPrefix(key string) string {
 	// sample prefix: clusterName--Shared-L7-
 	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-"
-	utils.AviLog.Infof("key: %s, msg: ShardVSPrefix: %s", key, shardVsPrefix)
+	utils.AviLog.Debugf("key: %s, msg: ShardVSPrefix: %s", key, shardVsPrefix)
 	return shardVsPrefix
 }
 

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -16,7 +16,7 @@ package nodes
 
 import (
 	"encoding/json"
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -490,7 +490,7 @@ func GetShardVSName(s string, key string, shardSize uint32, prefix ...string) st
 	if extraPrefix != "" {
 		shardVsPrefix += extraPrefix + "-"
 	}
-	vsName := shardVsPrefix + fmt.Sprint(vsNum)
+	vsName := shardVsPrefix + strconv.Itoa(int(vsNum))
 	return vsName
 }
 

--- a/tests/hostnameshardtests/crd_evh_hostname_test.go
+++ b/tests/hostnameshardtests/crd_evh_hostname_test.go
@@ -47,6 +47,10 @@ func TestCreateDeleteHostRuleForEvh(t *testing.T) {
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com"}
 	integrationtest.VerifyMetadataHostRule(g, sniVSKey, "default/samplehr-foo", true)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -345,13 +345,13 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(modelName)
-		return found
+		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found {
+			if nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS(); len(nodes) > 0 {
+				return len(nodes[0].PoolRefs) == 1 && len(nodes[0].SniNodes) == 1
+			}
+		}
+		return false
 	}, 25*time.Second).Should(gomega.Equal(true))
-	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
-	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(nodes[0].SniNodes).Should(gomega.HaveLen(1))
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
 	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
@@ -369,18 +369,21 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
-		return found
+		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
+			if settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS(); len(settingNodes) > 0 {
+				return len(settingNodes[0].PoolRefs) == 1
+			}
+		}
+		return false
 	}, 25*time.Second).Should(gomega.Equal(true))
-
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
 	g.Expect(settingNodes[0].SniNodes).Should(gomega.HaveLen(1))
 	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal("cluster--my-infrasetting-baz.com"))
-	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
-	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(0))
 
 	ingClassUpdate = (FakeIngressClass{

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -1097,7 +1097,7 @@ func TestServicesAPIWithInfraSettingStatusUpdates(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 30*time.Second).Should(gomega.Equal("Accepted"))
+	}, 45*time.Second).Should(gomega.Equal("Accepted"))
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found && aviModel != nil {


### PR DESCRIPTION
AviInfraSetting provides a way to configure ShardSizes for Shared VSes created by AKO. This PR facilitates modifying shardSize via the AviInfraSetting CRD for VSes created in EVH mode. In case of a shardSize change, the objects map to a differently named graph model, and objects from the old model are removed in  layer 2.

This commit also removes a few naming schemes that were previously used in namespace shardScheme.