### PR TITLE
update status of k8s objects through a queue

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -165,6 +165,8 @@ func InitializeAKC() {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 	go c.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	<-stopCh
 	close(ctrlCh)
@@ -174,6 +176,7 @@ func InitializeAKC() {
 		wgIngestion.Wait()
 		wgGraph.Wait()
 		wgFastRetry.Wait()
+		wgStatus.Wait()
 	}()
 	// Timeout after 60 seconds.
 	timeout := 60 * time.Second

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -148,12 +148,6 @@ func InitializeAKC() {
 		return
 	}
 
-	err = k8s.PopulateCache()
-	if err != nil {
-		c.DisableSync = true
-		utils.AviLog.Errorf("failed to populate cache, disabling sync")
-		lib.ShutdownApi()
-	}
 	c.InitializeNamespaceSync()
 	k8s.PopulateNodeCache(kubeClient)
 	waitGroupMap := make(map[string]*sync.WaitGroup)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -105,8 +105,8 @@ const (
 	DefaultRouteCert                           = "router-certs-default"
 	autoAnnotateService                        = "AUTO_ANNOTATE_SERVICE"
 	SeGroupLabelKey                            = "clustername"
-	UpdateOperation                            = "update"
-	DeleteOperation                            = "delete"
+	UpdateStatus                               = "UpdateStatus"
+	DeleteStatus                               = "DeleteStatus"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -105,6 +105,8 @@ const (
 	DefaultRouteCert                           = "router-certs-default"
 	autoAnnotateService                        = "AUTO_ANNOTATE_SERVICE"
 	SeGroupLabelKey                            = "clustername"
+	UpdateOperation                            = "update"
+	DeleteOperation                            = "delete"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -265,15 +265,13 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 					}
 					statusOption := status.StatusOptions{
 						ObjType: utils.Ingress,
-						Op:      lib.UpdateOperation,
+						Op:      lib.UpdateStatus,
 						Options: &updateOptions,
 					}
 					if utils.GetInformers().RouteInformer != nil {
 						statusOption.ObjType = utils.OshiftRoute
 					}
-					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
-					bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
-					statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+					status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 				}
 			}
 		} else {
@@ -323,16 +321,14 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.Ingress,
-					Op:      lib.DeleteOperation,
+					Op:      lib.DeleteStatus,
 					IsVSDel: isVSDelete,
 					Options: &updateOptions,
 				}
 				if utils.GetInformers().RouteInformer != nil {
 					statusOption.ObjType = utils.OshiftRoute
 				}
-				statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
-				bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
-				statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+				status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 			}
 		}
 	}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -257,7 +257,6 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 				vs_cache_obj.AddToPoolKeyCollection(k)
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for Pool Collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				if svc_mdata_obj.Namespace != "" {
-					utils.AviLog.Infof("xxx updating status3")
 					updateOptions := status.UpdateOptions{
 						Vip:                vs_cache_obj.Vip,
 						ServiceMetadata:    svc_mdata_obj,
@@ -266,7 +265,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 					}
 					statusOption := status.StatusOptions{
 						ObjType: utils.Ingress,
-						Op:      "update",
+						Op:      lib.UpdateOperation,
 						Options: &updateOptions,
 					}
 					if utils.GetInformers().RouteInformer != nil {
@@ -320,10 +319,12 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				// SNI VSes use the VS object metadata, delete ingress status for others
 				updateOptions := status.UpdateOptions{
 					ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
+					Key:             key,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.Ingress,
-					Op:      "delete",
+					Op:      lib.DeleteOperation,
+					IsVSDel: isVSDelete,
 					Options: &updateOptions,
 				}
 				if utils.GetInformers().RouteInformer != nil {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -406,34 +406,53 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				utils.AviLog.Debug(spew.Sprintf("key: %s, msg: updated VS cache key %v val %v\n", key, k,
 					utils.Stringify(vs_cache_obj)))
 				if svc_mdata_obj.Gateway != "" {
-					if lib.UseServicesAPI() {
-						status.UpdateSvcApiGatewayStatusAddress([]status.UpdateOptions{{
-							Vip:             vs_cache_obj.Vip,
-							ServiceMetadata: svc_mdata_obj,
-							Key:             key,
-						}}, false)
-					} else {
-						status.UpdateGatewayStatusAddress([]status.UpdateOptions{{
-							Vip:             vs_cache_obj.Vip,
-							ServiceMetadata: svc_mdata_obj,
-							Key:             key,
-						}}, false)
+					updateOptions := status.UpdateOptions{
+						Vip:             vs_cache_obj.Vip,
+						ServiceMetadata: svc_mdata_obj,
+						Key:             key,
 					}
+					statusOption := status.StatusOptions{
+						ObjType: lib.Gateway,
+						Op:      "update",
+						Options: &updateOptions,
+					}
+					if lib.UseServicesAPI() {
+						statusOption.ObjType = lib.SERVICES_API
+					}
+					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+					statusQueue.Workqueue[0].AddRateLimited(statusOption)
+
 				} else if len(svc_mdata_obj.NamespaceServiceName) > 0 {
 					// This service needs an update of the status
-					status.UpdateL4LBStatus([]status.UpdateOptions{{
+					updateOptions := status.UpdateOptions{
 						Vip:                vs_cache_obj.Vip,
 						ServiceMetadata:    svc_mdata_obj,
 						Key:                key,
 						VirtualServiceUUID: vs_cache_obj.Uuid,
-					}}, false)
+					}
+					statusOption := status.StatusOptions{
+						ObjType: utils.L4LBService,
+						Op:      "update",
+						Options: &updateOptions,
+					}
+					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+					bkt := utils.Bkt(svc_mdata_obj.NamespaceServiceName[0], statusQueue.NumWorkers)
+					statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 				} else if (svc_mdata_obj.IngressName != "" || len(svc_mdata_obj.NamespaceIngressName) > 0) && svc_mdata_obj.Namespace != "" && parentVsObj != nil {
-					status.UpdateRouteIngressStatus([]status.UpdateOptions{{
+					updateOptions := status.UpdateOptions{
 						Vip:                parentVsObj.Vip,
 						ServiceMetadata:    svc_mdata_obj,
 						Key:                key,
 						VirtualServiceUUID: vs_cache_obj.Uuid,
-					}}, false)
+					}
+					statusOption := status.StatusOptions{
+						ObjType: utils.Ingress,
+						Op:      "update",
+						Options: &updateOptions,
+					}
+					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+					bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
+					statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 				}
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
 				// But before this a pool may have got created as a part of the macro operation, so update the ingress status here.
@@ -446,12 +465,24 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 							pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
 							if found {
 								if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
-									status.UpdateRouteIngressStatus([]status.UpdateOptions{{
+									utils.AviLog.Infof("xxx updating status2")
+									updateOptions := status.UpdateOptions{
 										Vip:                vs_cache_obj.Vip,
 										ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
 										Key:                key,
 										VirtualServiceUUID: vs_cache_obj.Uuid,
-									}}, false)
+									}
+									statusOption := status.StatusOptions{
+										ObjType: utils.Ingress,
+										Op:      "update",
+										Options: &updateOptions,
+									}
+									if utils.GetInformers().RouteInformer != nil {
+										statusOption.ObjType = utils.OshiftRoute
+									}
+									statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+									bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
+									statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 								}
 							}
 						}
@@ -486,12 +517,18 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 			}
 
 			if len(svc_mdata_obj.NamespaceServiceName) > 0 {
-				// This service needs an update of the status
-				status.UpdateL4LBStatus([]status.UpdateOptions{{
-					Vip:             vs_cache_obj.Vip,
-					ServiceMetadata: svc_mdata_obj,
+				updateOptions := status.UpdateOptions{
+					ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
 					Key:             key,
-				}}, false)
+				}
+				statusOption := status.StatusOptions{
+					ObjType: utils.L4LBService,
+					Op:      "delete",
+					Options: &updateOptions,
+				}
+				statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+				bkt := utils.Bkt(svc_mdata_obj.NamespaceServiceName[0], statusQueue.NumWorkers)
+				statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 			}
 			rest.cache.VsCacheMeta.AviCacheAdd(k, &vs_cache_obj)
 			utils.AviLog.Infof("key: %s, msg: added VS cache key %v val %v\n", key, k, utils.Stringify(&vs_cache_obj))
@@ -539,8 +576,22 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 
 			// Reset the LB status field as well.
 			if vs_cache_obj.ServiceMetadataObj.Gateway != "" {
-				status.DeleteGatewayStatusAddress(vs_cache_obj.ServiceMetadataObj, key)
-				status.DeleteL4LBStatus(vs_cache_obj.ServiceMetadataObj, key)
+				updateOptions := status.UpdateOptions{
+					ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
+					Key:             key,
+				}
+				statusOption := status.StatusOptions{
+					ObjType: lib.Gateway,
+					Op:      "delete",
+					Options: &updateOptions,
+				}
+				statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+				bkt := utils.Bkt(updateOptions.ServiceMetadata.Gateway, statusQueue.NumWorkers)
+				statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+
+				statusOption.ObjType = utils.L4LBService
+				statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+
 			} else if len(vs_cache_obj.ServiceMetadataObj.NamespaceServiceName) > 0 {
 				status.DeleteL4LBStatus(vs_cache_obj.ServiceMetadataObj, key)
 			}
@@ -548,7 +599,21 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 			if (vs_cache_obj.ServiceMetadataObj.IngressName != "" || len(vs_cache_obj.ServiceMetadataObj.NamespaceIngressName) > 0) && vs_cache_obj.ServiceMetadataObj.Namespace != "" {
 				// SNI VS deletion related ingress status update
 				if !hostFoundInParentPool {
-					status.DeleteRouteIngressStatus(vs_cache_obj.ServiceMetadataObj, true, key)
+					updateOptions := status.UpdateOptions{
+						ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
+						Key:             key,
+					}
+					statusOption := status.StatusOptions{
+						ObjType: utils.Ingress,
+						Op:      "delete",
+						Options: &updateOptions,
+					}
+					if utils.GetInformers().RouteInformer != nil {
+						statusOption.ObjType = utils.OshiftRoute
+					}
+					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
+					bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
+					statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 				}
 			} else {
 				// Shared VS deletion related ingress status update

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -413,7 +413,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					}
 					statusOption := status.StatusOptions{
 						ObjType: lib.Gateway,
-						Op:      "update",
+						Op:      lib.UpdateOperation,
 						Options: &updateOptions,
 					}
 					if lib.UseServicesAPI() {
@@ -432,7 +432,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					}
 					statusOption := status.StatusOptions{
 						ObjType: utils.L4LBService,
-						Op:      "update",
+						Op:      lib.UpdateOperation,
 						Options: &updateOptions,
 					}
 					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
@@ -447,8 +447,11 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					}
 					statusOption := status.StatusOptions{
 						ObjType: utils.Ingress,
-						Op:      "update",
+						Op:      lib.UpdateOperation,
 						Options: &updateOptions,
+					}
+					if utils.GetInformers().RouteInformer != nil {
+						statusOption.ObjType = utils.OshiftRoute
 					}
 					statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
 					bkt := utils.Bkt(updateOptions.ServiceMetadata.IngressName, statusQueue.NumWorkers)
@@ -465,7 +468,6 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 							pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
 							if found {
 								if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
-									utils.AviLog.Infof("xxx updating status2")
 									updateOptions := status.UpdateOptions{
 										Vip:                vs_cache_obj.Vip,
 										ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
@@ -474,7 +476,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 									}
 									statusOption := status.StatusOptions{
 										ObjType: utils.Ingress,
-										Op:      "update",
+										Op:      lib.UpdateOperation,
 										Options: &updateOptions,
 									}
 									if utils.GetInformers().RouteInformer != nil {
@@ -523,7 +525,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,
-					Op:      "delete",
+					Op:      lib.DeleteOperation,
 					Options: &updateOptions,
 				}
 				statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
@@ -582,7 +584,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				}
 				statusOption := status.StatusOptions{
 					ObjType: lib.Gateway,
-					Op:      "delete",
+					Op:      lib.DeleteOperation,
 					Options: &updateOptions,
 				}
 				statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
@@ -605,7 +607,8 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					}
 					statusOption := status.StatusOptions{
 						ObjType: utils.Ingress,
-						Op:      "delete",
+						Op:      lib.DeleteOperation,
+						IsVSDel: true,
 						Options: &updateOptions,
 					}
 					if utils.GetInformers().RouteInformer != nil {

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -113,37 +113,31 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		for i := range allGatewayUpdateOptions {
 			statusOption := status.StatusOptions{
 				ObjType: lib.Gateway,
-				Op:      lib.UpdateOperation,
+				Op:      lib.UpdateStatus,
 				Options: &allGatewayUpdateOptions[i],
 			}
-			statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
-			bkt := utils.Bkt(allGatewayUpdateOptions[i].ServiceMetadata.Gateway, statusQueue.NumWorkers)
-			statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+			status.PublishToStatusQueue(allGatewayUpdateOptions[i].ServiceMetadata.Gateway, statusOption)
 		}
 	} else {
 		for i := range allIngressUpdateOptions {
 			statusOption := status.StatusOptions{
 				ObjType: utils.Ingress,
-				Op:      lib.UpdateOperation,
+				Op:      lib.UpdateStatus,
 				Options: &allIngressUpdateOptions[i],
 				IsVSDel: true,
 			}
 			if utils.GetInformers().RouteInformer != nil {
 				statusOption.ObjType = utils.OshiftRoute
 			}
-			statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
-			bkt := utils.Bkt(allIngressUpdateOptions[i].ServiceMetadata.IngressName, statusQueue.NumWorkers)
-			statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+			status.PublishToStatusQueue(allIngressUpdateOptions[i].ServiceMetadata.IngressName, statusOption)
 		}
 		for i := range allServiceLBUpdateOptions {
 			statusOption := status.StatusOptions{
 				ObjType: utils.L4LBService,
-				Op:      lib.UpdateOperation,
+				Op:      lib.UpdateStatus,
 				Options: &allServiceLBUpdateOptions[i],
 			}
-			statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
-			bkt := utils.Bkt(allServiceLBUpdateOptions[i].ServiceMetadata.NamespaceServiceName[0], statusQueue.NumWorkers)
-			statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
+			status.PublishToStatusQueue(allServiceLBUpdateOptions[i].ServiceMetadata.NamespaceServiceName[0], statusOption)
 		}
 	}
 	utils.AviLog.Infof("Status syncing completed")

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -266,7 +266,12 @@ func patchIngressAnnotations(ingObj *networkingv1beta1.Ingress, vsAnnotations ma
 	return nil
 }
 
-func DeleteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
+func DeleteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error {
+	//func DeleteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
+	if len(options) == 0 {
+		return fmt.Errorf("Length of options is zero")
+	}
+	svc_mdata_obj := options[0].ServiceMetadata
 	var err error
 	if len(svc_mdata_obj.NamespaceIngressName) > 0 {
 		// This is SNI with hostname sharding.

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -267,7 +267,6 @@ func patchIngressAnnotations(ingObj *networkingv1beta1.Ingress, vsAnnotations ma
 }
 
 func DeleteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error {
-	//func DeleteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
 	if len(options) == 0 {
 		return fmt.Errorf("Length of options is zero")
 	}

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -76,11 +76,11 @@ func UpdateRouteIngressStatus(options []UpdateOptions, bulk bool) {
 	}
 }
 
-func DeleteRouteIngressStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
+func DeleteRouteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error {
 	if utils.GetInformers().IngressInformer != nil {
-		return DeleteIngressStatus(svc_mdata_obj, isVSDelete, key)
+		return DeleteIngressStatus(options, isVSDelete, key)
 	} else if utils.GetInformers().RouteInformer != nil {
-		return DeleteRouteStatus(svc_mdata_obj, isVSDelete, key)
+		return DeleteRouteStatus(options, isVSDelete, key)
 	} else {
 		utils.AviLog.Errorf("key: %s, msg: Status delete failed, no suitable informers found", key)
 		return errors.New("Status delete failed, no suitable informers found")
@@ -416,7 +416,11 @@ func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) bool {
 	return true
 }
 
-func DeleteRouteStatus(svc_mdata_obj avicache.ServiceMetadataObj, isVSDelete bool, key string) error {
+func DeleteRouteStatus(options []UpdateOptions, isVSDelete bool, key string) error {
+	if len(options) == 0 {
+		return fmt.Errorf("Length of options is zero")
+	}
+	svc_mdata_obj := options[0].ServiceMetadata
 	var err error
 	if len(svc_mdata_obj.NamespaceIngressName) > 0 {
 		// This is SNI with hostname sharding.

--- a/internal/status/status_toiler.go
+++ b/internal/status/status_toiler.go
@@ -22,6 +22,7 @@ import (
 type StatusOptions struct {
 	ObjType string
 	Op      string
+	IsVSDel bool
 	Options *UpdateOptions
 }
 
@@ -32,33 +33,33 @@ func DequeueStatus(objIntf interface{}) error {
 		return nil
 	}
 	if obj.ObjType == utils.L4LBService {
-		if obj.Op == "update" {
+		if obj.Op == lib.UpdateOperation {
 			UpdateL4LBStatus([]UpdateOptions{*obj.Options}, false)
-		} else if obj.Op == "delete" {
+		} else if obj.Op == lib.DeleteOperation {
 			DeleteL4LBStatus(obj.Options.ServiceMetadata, obj.Options.Key)
 		}
 	} else if obj.ObjType == utils.Ingress {
-		if obj.Op == "update" {
+		if obj.Op == lib.UpdateOperation {
 			UpdateIngressStatus([]UpdateOptions{*obj.Options}, false)
-		} else if obj.Op == "delete" {
-			DeleteIngressStatus([]UpdateOptions{*obj.Options}, true, obj.Options.Key)
+		} else if obj.Op == lib.DeleteOperation {
+			DeleteIngressStatus([]UpdateOptions{*obj.Options}, obj.IsVSDel, obj.Options.Key)
 		}
 	} else if obj.ObjType == utils.OshiftRoute {
-		if obj.Op == "update" {
+		if obj.Op == lib.UpdateOperation {
 			UpdateRouteStatus([]UpdateOptions{*obj.Options}, false)
-		} else if obj.Op == "delete" {
-			DeleteRouteStatus([]UpdateOptions{*obj.Options}, true, obj.Options.Key)
+		} else if obj.Op == lib.DeleteOperation {
+			DeleteRouteStatus([]UpdateOptions{*obj.Options}, obj.IsVSDel, obj.Options.Key)
 		}
 	} else if obj.ObjType == lib.Gateway {
-		if obj.Op == "update" {
+		if obj.Op == lib.UpdateOperation {
 			UpdateGatewayStatusAddress([]UpdateOptions{*obj.Options}, false)
-		} else if obj.Op == "delete" {
+		} else if obj.Op == lib.DeleteOperation {
 			DeleteGatewayStatusAddress(obj.Options.ServiceMetadata, "")
 		}
 	} else if obj.ObjType == lib.SERVICES_API {
-		if obj.Op == "update" {
+		if obj.Op == lib.UpdateOperation {
 			UpdateSvcApiGatewayStatusAddress([]UpdateOptions{*obj.Options}, false)
-		} else if obj.Op == "delete" {
+		} else if obj.Op == lib.DeleteOperation {
 			DeleteSvcApiGatewayStatusAddress(obj.Options.Key, obj.Options.ServiceMetadata)
 		}
 	}

--- a/internal/status/status_toiler.go
+++ b/internal/status/status_toiler.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type StatusOptions struct {
+	ObjType string
+	Op      string
+	Options *UpdateOptions
+}
+
+func DequeueStatus(objIntf interface{}) error {
+	obj, ok := objIntf.(StatusOptions)
+	if !ok {
+		utils.AviLog.Warnf("key: %s, object is not of type StatusOptions, %T", obj.Options.Key, objIntf)
+		return nil
+	}
+	if obj.ObjType == utils.L4LBService {
+		if obj.Op == "update" {
+			UpdateL4LBStatus([]UpdateOptions{*obj.Options}, false)
+		} else if obj.Op == "delete" {
+			DeleteL4LBStatus(obj.Options.ServiceMetadata, obj.Options.Key)
+		}
+	} else if obj.ObjType == utils.Ingress {
+		if obj.Op == "update" {
+			UpdateIngressStatus([]UpdateOptions{*obj.Options}, false)
+		} else if obj.Op == "delete" {
+			DeleteIngressStatus([]UpdateOptions{*obj.Options}, true, obj.Options.Key)
+		}
+	} else if obj.ObjType == utils.OshiftRoute {
+		if obj.Op == "update" {
+			UpdateRouteStatus([]UpdateOptions{*obj.Options}, false)
+		} else if obj.Op == "delete" {
+			DeleteRouteStatus([]UpdateOptions{*obj.Options}, true, obj.Options.Key)
+		}
+	} else if obj.ObjType == lib.Gateway {
+		if obj.Op == "update" {
+			UpdateGatewayStatusAddress([]UpdateOptions{*obj.Options}, false)
+		} else if obj.Op == "delete" {
+			DeleteGatewayStatusAddress(obj.Options.ServiceMetadata, "")
+		}
+	} else if obj.ObjType == lib.SERVICES_API {
+		if obj.Op == "update" {
+			UpdateSvcApiGatewayStatusAddress([]UpdateOptions{*obj.Options}, false)
+		} else if obj.Op == "delete" {
+			DeleteSvcApiGatewayStatusAddress(obj.Options.Key, obj.Options.ServiceMetadata)
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -17,6 +17,7 @@ package utils
 const (
 	GraphLayer                    = "GraphLayer"
 	ObjectIngestionLayer          = "ObjectIngestionLayer"
+	StatusQueue                   = "StatusQueue"
 	LeastConnection               = "LB_ALGORITHM_LEAST_CONNECTIONS"
 	RandomConnection              = "RANDOM_CONN"
 	PassthroughConnection         = "PASSTHROUGH_CONN"

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -37,6 +37,7 @@ const (
 	DeleteEv            EvType = "DELETE"
 	NumWorkersIngestion uint32 = 2
 	NumWorkersGraph     uint32 = 2
+	NumWorkersStatus    uint32 = 2
 )
 
 const (

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -37,7 +37,6 @@ const (
 	DeleteEv            EvType = "DELETE"
 	NumWorkersIngestion uint32 = 2
 	NumWorkersGraph     uint32 = 2
-	NumWorkersStatus    uint32 = 2
 )
 
 const (

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -89,6 +89,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 	addConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -380,11 +380,17 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
-	g.Expect(settingNodes[0].SniNodes).Should(gomega.HaveLen(1))
+	g.Eventually(func() int {
+		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+		settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(settingNodes[0].SniNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
 	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal("cluster--my-infrasetting-baz.com"))
-	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
-	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(0))
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs)
+	}, 25*time.Second).Should(gomega.Equal(0))
 
 	ingClassUpdate = (FakeIngressClass{
 		Name:       ingClassName,

--- a/tests/hostnameshardtests/l7_hostname_rest_test.go
+++ b/tests/hostnameshardtests/l7_hostname_rest_test.go
@@ -141,7 +141,7 @@ func TestIngressStatusCheck(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 5*time.Second).Should(gomega.Equal(1))
+	}, 20*time.Second).Should(gomega.Equal(1))
 	ingress, _ := KubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
 	g.Expect(ingress.Status.LoadBalancer.Ingress).To(gomega.HaveLen(1))
 	g.Expect(ingress.Status.LoadBalancer.Ingress[0].IP).To(gomega.Equal("10.250.250.10"))

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -97,6 +97,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -121,6 +121,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -44,8 +44,12 @@ var dynamicClient *dynamicfake.FakeDynamicClient
 var keyChan chan string
 var ctrl *k8s.AviController
 
-func syncFuncForTest(key string, wg *sync.WaitGroup) error {
-	keyChan <- key
+func syncFuncForTest(key interface{}, wg *sync.WaitGroup) error {
+	keyStr, ok := key.(string)
+	if !ok {
+		return nil
+	}
+	keyChan <- keyStr
 	return nil
 }
 

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -59,8 +59,12 @@ var RegisteredInformers = []string{
 	utils.ConfigMapInformer,
 }
 
-func syncFuncForTest(key string, wg *sync.WaitGroup) error {
-	keyChan <- key
+func syncFuncForTest(key interface{}, wg *sync.WaitGroup) error {
+	keyStr, ok := key.(string)
+	if !ok {
+		return nil
+	}
+	keyChan <- keyStr
 	return nil
 }
 

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -93,6 +93,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -217,6 +217,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -164,6 +164,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -98,6 +98,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["slowretry"] = wgSlowRetry
 	wgGraph := &sync.WaitGroup{}
 	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
 	addConfigMap()
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)


### PR DESCRIPTION
Currently function for updating and deleting status are called directly from rest layer.
This means multiple threads of rest layer may try to update the same object simultaneously,
To avoid this race condition, introducing a queue where objects would be added for status update,
which would be dequeued and processed later.

Unlike other worker queues in AKO, for status udpate we can not use only the key, hence the complete
object is added in the queue.