### PR TITLE
Check if AKO can access API of Service before checking Route API

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -117,7 +117,10 @@ func InitializeAKC() {
 		utils.AviLog.Warnf("Error in creating openshift clientset")
 	}
 
-	registeredInformers := lib.InformersToRegister(oshiftClient, kubeClient)
+	registeredInformers, err := lib.InformersToRegister(oshiftClient, kubeClient)
+	if err != nil {
+		utils.AviLog.Fatalf("Failed to initialize informers: %v, shutting down AKO, going to reboot", err)
+	}
 
 	informersArg := make(map[string]interface{})
 	informersArg[utils.INFORMERS_OPENSHIFT_CLIENT] = oshiftClient

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -17,6 +17,7 @@ package lib
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -633,7 +634,7 @@ func DSChecksum(pgrefs []string) uint32 {
 	return checksum
 }
 
-func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Clientset) []string {
+func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Clientset) ([]string, error) {
 	allInformers := []string{
 		utils.ServiceInformer,
 		utils.EndpointInformer,
@@ -651,7 +652,11 @@ func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Cl
 		allInformers = append(allInformers, utils.NodeInformer)
 
 		informerTimeout := int64(120)
-		_, err := oclient.RouteV1().Routes("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
+		_, err := kclient.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
+		if err != nil {
+			return allInformers, errors.New("Error in fetching services: " + err.Error())
+		}
+		_, err = oclient.RouteV1().Routes("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
 		if err == nil {
 			// Openshift cluster with route support, we will just add route informer
 			allInformers = append(allInformers, utils.RouteInformer)
@@ -661,7 +666,7 @@ func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Cl
 			allInformers = append(allInformers, utils.IngressClassInformer)
 		}
 	}
-	return allInformers
+	return allInformers, nil
 }
 
 func SSLKeyCertChecksum(sslName, certificate, cacert string) uint32 {


### PR DESCRIPTION
- This prevents a case where due to a temprary network issue, we can't recognise an openshift cluster