### PR TITLE
Introduce skipnodeport annotation

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -124,6 +124,7 @@ const (
 	NPLPodAnnotation               = "nodeportlocal.antrea.io"
 	NPLSvcAnnotation               = "nodeportlocal.antrea.io/enabled"
 	InfraSettingNameAnnotation     = "aviinfrasetting.ako.vmware.com/name"
+	SkipNodePortAnnotation         = "skipnodeport.ako.vmware.com/enabled"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -151,6 +151,11 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 			if servers := PopulateServersForNPL(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
 				poolNode.Servers = servers
 			}
+		} else if _, ok := svcObj.GetAnnotations()[lib.SkipNodePortAnnotation]; ok {
+			// This annotation's presence on the svc object means that the node ports should be skipped.
+			if servers := PopulateServers(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+				poolNode.Servers = servers
+			}
 		} else if serviceType == lib.NodePort {
 			if servers := PopulateServersForNodePort(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
 				poolNode.Servers = servers

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -418,6 +418,9 @@ func checkRefOnController(key, refKey, refValue string) error {
 
 	// assign the last avi client for ref checks
 	aviClientLen := lib.GetshardSize()
+	if aviClientLen != 0 {
+		aviClientLen = aviClientLen - 1
+	}
 	result, err := lib.AviGetCollectionRaw(clients.AviClient[aviClientLen], uri)
 	if err != nil {
 		utils.AviLog.Warnf("key: %s, msg: Get uri %v returned err %v", key, uri, err)

--- a/tests/hostnameshardtests/ingressclass_hostname_test.go
+++ b/tests/hostnameshardtests/ingressclass_hostname_test.go
@@ -285,10 +285,15 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 	shardPoolName := "cluster--my-infrasetting-bar.com_foo-default-foo-with-class"
 	sniPoolName := "cluster--my-infrasetting-default-baz.com_foo-foo-with-class"
 
-	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
-		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
+	g.Eventually(func() string {
+		found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+		if found {
+			settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+			return settingNodes[0].SniNodes[0].Name
+		} else {
+			return ""
+		}
+	}, 55*time.Second).Should(gomega.Equal(sniVsName))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal(shardPoolName))
@@ -296,7 +301,6 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 	g.Expect(settingNodes[0].PoolGroupRefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HTTPDSrefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HttpPolicyRefs[0].Name).Should(gomega.Equal(shardVsName))
-	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal(sniVsName))
 	g.Expect(settingNodes[0].SniNodes[0].PoolRefs[0].Name).Should(gomega.Equal(sniPoolName))
 	g.Expect(settingNodes[0].SniNodes[0].PoolGroupRefs[0].Name).Should(gomega.Equal(sniPoolName))
 	g.Expect(settingNodes[0].SniNodes[0].SSLKeyCertRefs[0].Name).Should(gomega.Equal(sniVsName))
@@ -536,7 +540,15 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
+	g.Eventually(func() int {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		if found {
+			settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+			return len(settingNodes[0].PoolRefs)
+		} else {
+			return 0
+		}
+	}, 25*time.Second).Should(gomega.Equal(1))
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
 
 	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -539,6 +539,7 @@ type FakeService struct {
 	LoadBalancerIP string
 	ServicePorts   []Serviceport
 	Selectors      map[string]string
+	Annotations    map[string]string
 }
 
 type Serviceport struct {
@@ -568,9 +569,10 @@ func (svc FakeService) Service() *corev1.Service {
 			Selector:       svc.Selectors,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: svc.Namespace,
-			Name:      svc.Name,
-			Labels:    svc.Labels,
+			Namespace:   svc.Namespace,
+			Name:        svc.Name,
+			Labels:      svc.Labels,
+			Annotations: svc.Annotations,
 		},
 	}
 	return svcExample


### PR DESCRIPTION
This PR introduces a new annotation called skipnodeport. In scenarios
where the global `serviceType` is set to `NodePort` the NodeIPs are
processed as Servers inside the Avi pool.

But in case, the user wants to skip these nodeports for such Services
and instead rely on an Endpoint object for the servers, the services
could be annotated with:

skipnodeport.ako.vmware.com/enabled: "true"

If this is set on a service, then AKO will look for the actual endpoint
object to figure out the servers for the pools instead of deriving the
nodeport info.

It is the responsibility of the network admin to ensure that the endpoints
are routable from the Avi Service Engines since static routes will be
skipped if service is set to NodePort.

Implements: https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/issues/313