### PR TITLE
Provide a knob to switch off granular RBAC support

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   cloudName: {{ .Values.ControllerSettings.cloudName | quote }}
   clusterName: {{ .Values.AKOSettings.clusterName | quote }}
   servicesAPI: {{ .Values.AKOSettings.servicesAPI | quote }}
+  GRBAC: {{ .Values.AKOSettings.GRBAC | quote }}
   enableEVH: {{ .Values.AKOSettings.enableEVH | quote }}
   layer7Only: {{ .Values.AKOSettings.layer7Only | quote }}
   tenantsPerCluster: {{ .Values.ControllerSettings.tenantsPerCluster | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -17,7 +17,8 @@ AKOSettings:
   disableStaticRouteSync: "false" # If the POD networks are reachable from the Avi SE, set this knob to true.
   clusterName: "my-cluster" # A unique identifier for the kubernetes cluster, that helps distinguish the objects for this cluster in the avi controller. // MUST-EDIT
   cniPlugin: "" # Set the string if your CNI is calico or openshift. enum: calico|canal|flannel|openshift|antrea
-  enableEVH: false # This enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services 
+  enableEVH: false # This enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services
+  GRBAC: false # Granular RBAC support, switched off by default
   layer7Only: false # If this flag is switched on, then AKO will only do layer 7 loadbalancing.
   #NamespaceSelector contains label key and value used for namespacemigration
   #Same label has to be present on namespace/s which needs migration/sync to AKO

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -462,7 +462,7 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pki.Name, string(*pki.CaCerts[0].Certificate), "")
-		if lib.GetEnableCtrl2014Features() && pki.Labels != nil {
+		if lib.GetGRBACSupport() && pki.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(pki.Labels)
 		}
 		pkiCacheObj := AviPkiProfileCache{
@@ -789,11 +789,13 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 			PoolGroups: pgs,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
-		if lib.GetEnableCtrl2014Features() && ds.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		if lib.GetEnableCtrl2014Features() {
 			if len(ds.Datascript) == 1 {
 				checksum += utils.Hash(*ds.Datascript[0].Script)
 			}
+		}
+		if lib.GetGRBACSupport() && ds.Labels != nil {
+			checksum += lib.ObjectLabelChecksum(ds.Labels)
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		*DsData = append(*DsData, dsCacheObj)
@@ -890,7 +892,7 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetEnableCtrl2014Features() && sslkey.Labels != nil {
+		if lib.GetGRBACSupport() && sslkey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -964,7 +966,7 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetEnableCtrl2014Features() && sslkey.Labels != nil {
+		if lib.GetGRBACSupport() && sslkey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -1014,7 +1016,7 @@ func (c *AviObjCache) AviPopulateOnePKICache(client *clients.AviClient,
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pkikey.Name, *pkikey.CaCerts[0].Certificate, "")
-		if lib.GetEnableCtrl2014Features() && pkikey.Labels != nil {
+		if lib.GetGRBACSupport() && pkikey.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(pkikey.Labels)
 		}
 		sslCacheObj := AviSSLCache{
@@ -1144,8 +1146,13 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 			PoolGroups: pgs,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
-		if lib.GetEnableCtrl2014Features() && ds.Labels != nil {
+		if lib.GetGRBACSupport() && ds.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		}
+		if lib.GetEnableCtrl2014Features() {
+			if len(ds.Datascript) == 1 {
+				checksum += utils.Hash(*ds.Datascript[0].Script)
+			}
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *ds.Name}
@@ -1411,7 +1418,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetEnableCtrl2014Features() && l4pol.Labels != nil {
+		if lib.GetGRBACSupport() && l4pol.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
 		}
 		l4PolCacheObj := AviL4PolicyCache{
@@ -1630,7 +1637,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 			protocol = utils.UDP
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetEnableCtrl2014Features() && l4pol.Labels != nil {
+		if lib.GetGRBACSupport() && l4pol.Labels != nil {
 			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
 		}
 		l4PolCacheObj := AviL4PolicyCache{

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -140,6 +140,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			lib.SetLayer7Only(cm.Data[lib.LAYER7_ONLY])
 			// Check if we need to use PGs for SNIs or not.
 			lib.SetNoPGForSNI(cm.Data[lib.NO_PG_FOR_SNI])
+			lib.SetGRBACSupport(cm.Data[lib.GRBAC])
 			delModels := delConfigFromData(cm.Data)
 			if !delModels {
 				status.ResetStatefulSetStatus()

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -58,6 +58,7 @@ const (
 	LOG_LEVEL                                  = "logLevel"
 	LAYER7_ONLY                                = "layer7Only"
 	NO_PG_FOR_SNI                              = "noPGForSNI"
+	GRBAC                                      = "GRBAC"
 	SERVICE_TYPE                               = "SERVICE_TYPE"
 	NODE_PORT                                  = "NodePort"
 	NODE_KEY                                   = "NODE_KEY"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -68,7 +68,7 @@ func GetNamePrefix() string {
 
 var DisableSync bool
 var layer7Only bool
-var noPGForSNI bool
+var noPGForSNI, gRBAC bool
 
 func SetDisableSync(state bool) {
 	DisableSync = state
@@ -87,6 +87,17 @@ func SetNoPGForSNI(val string) {
 		noPGForSNI = boolVal
 	}
 	utils.AviLog.Infof("Setting the value for the noPGForSNI flag %v", noPGForSNI)
+}
+
+func SetGRBACSupport(val string) {
+	if boolVal, err := strconv.ParseBool(val); err == nil {
+		gRBAC = boolVal
+	}
+	utils.AviLog.Infof("Setting the value for the gRBAC flag %v", gRBAC)
+}
+
+func GetGRBACSupport() bool {
+	return gRBAC
 }
 
 func GetNoPGForSNI() bool {

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -682,7 +682,9 @@ func (v *AviVsNode) CalculateCheckSum() {
 	if v.Enabled != nil {
 		checksum += utils.Hash(utils.Stringify(v.Enabled))
 	}
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 
 	if v.EnableRhi != nil {
 		checksum += utils.Hash(utils.Stringify(*v.EnableRhi))
@@ -727,7 +729,9 @@ func (v *AviL4PolicyNode) CalculateCheckSum() {
 	if len(v.PortPool) > 0 {
 		checksum = lib.L4PolicyChecksum(ports, v.PortPool[0].Protocol)
 	}
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -780,8 +784,9 @@ func (v *AviHttpPolicySetNode) CalculateCheckSum() {
 	if v.HeaderReWrite != nil {
 		checksum = checksum + utils.Hash(utils.Stringify(v.HeaderReWrite))
 	}
-
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -839,7 +844,9 @@ type AviTLSKeyCertNode struct {
 func (v *AviTLSKeyCertNode) CalculateCheckSum() {
 	// A sum of fields for this SSL cert.
 	checksum := lib.SSLKeyCertChecksum(v.Name, string(v.Cert), v.CACert)
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -898,8 +905,11 @@ func (v *AviVSVIPNode) GetCheckSum() uint32 {
 }
 
 func (v *AviVSVIPNode) CalculateCheckSum() {
+
 	checksum := lib.VSVipChecksum(v.FQDNs, v.IPAddress, v.NetworkNames)
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -942,7 +952,9 @@ func (v *AviPoolGroupNode) CalculateCheckSum() {
 		return *pgMembers[i].PoolRef < *pgMembers[j].PoolRef
 	})
 	checksum := utils.Hash(utils.Stringify(pgMembers))
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -995,8 +1007,10 @@ func (v *AviHTTPDataScriptNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
 	checksum := lib.DSChecksum(v.PoolGroupRefs)
 	if lib.GetEnableCtrl2014Features() {
-		checksum += lib.GetClusterLabelChecksum()
 		checksum += utils.Hash(v.Script)
+	}
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
 	}
 	v.CloudConfigCksum = checksum
 }
@@ -1049,7 +1063,9 @@ func (v *AviPkiProfileNode) GetCheckSum() uint32 {
 
 func (v *AviPkiProfileNode) CalculateCheckSum() {
 	checksum := lib.SSLKeyCertChecksum(v.Name, "", v.CACert)
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 
@@ -1118,8 +1134,9 @@ func (v *AviPoolNode) CalculateCheckSum() {
 	if v.ApplicationPersistence != "" {
 		checksum += utils.Hash(v.ApplicationPersistence)
 	}
-
-	checksum += lib.GetClusterLabelChecksum()
+	if lib.GetGRBACSupport() {
+		checksum += lib.GetClusterLabelChecksum()
+	}
 	v.CloudConfigCksum = checksum
 }
 

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	tenant_ref := "/api/tenant/?name=" + ds_meta.Tenant
 	cr := lib.AKOUser
 	vsdatascriptset := avimodels.VSDataScriptSet{CreatedBy: &cr, Datascript: datascriptlist, Name: &ds_meta.Name, TenantRef: &tenant_ref, PoolGroupRefs: poolgroupref}
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		vsdatascriptset.Labels = lib.GetLabels()
 	}
 	if len(ds_meta.ProtocolParsers) > 0 {

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -41,7 +41,7 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 	hps := avimodels.HTTPPolicySet{Name: &name, CloudConfigCksum: &cksumString,
 		CreatedBy: &cr, TenantRef: &tenant, HTTPRequestPolicy: &http_req_pol}
 
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		hps.Labels = lib.GetLabels()
 	}
 	var idx int32

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -38,7 +38,7 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 
 	hps := avimodels.L4PolicySet{Name: &name,
 		CreatedBy: &cr, TenantRef: &tenant}
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		hps.Labels = lib.GetLabels()
 	}
 	var idx int32

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -92,7 +92,7 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		SslProfileRef:     &pool_meta.SslProfileRef,
 		PlacementNetworks: placementNetworks,
 	}
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		pool.Labels = lib.GetLabels()
 	}
 	if pool_meta.PkiProfile != nil {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -86,7 +86,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		}
 		tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
 		vs.TenantRef = &tenant
-		if lib.GetEnableCtrl2014Features() {
+		if lib.GetGRBACSupport() {
 			vs.Labels = lib.GetLabels()
 		}
 		if vs_meta.SNIParent {
@@ -224,7 +224,7 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	sniChild.VhDomainName = vs_meta.VHDomainNames
 	ignPool := false
 	sniChild.IgnPoolNetReach = &ignPool
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		sniChild.Labels = lib.GetLabels()
 	}
 	if vs_meta.DefaultPool != "" {

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -97,7 +97,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 
 		// Override the Vip in VsVip tto bring in updates, keeping everything else as is.
 
-		if lib.GetEnableCtrl2014Features() {
+		if lib.GetGRBACSupport() {
 			vsvip.Labels = lib.GetLabels()
 		}
 		rest_op = utils.RestOp{
@@ -199,7 +199,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			DNSInfo:           dns_info_arr,
 			Vip:               vips,
 		}
-		if lib.GetEnableCtrl2014Features() {
+		if lib.GetGRBACSupport() {
 			vsvip.Labels = lib.GetLabels()
 		}
 		vsvip.VsvipCloudConfigCksum = &cksumstr
@@ -239,7 +239,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			}
 			vsvip_avi.DNSInfo = dns_info_arr
 			vsvip_avi.VrfContextRef = &vrfContextRef
-			if lib.GetEnableCtrl2014Features() {
+			if lib.GetGRBACSupport() {
 				vsvip_avi.Labels = lib.GetLabels()
 			}
 			vsvip_avi.VsvipCloudConfigCksum = &cksumstr

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	pg := avimodels.PoolGroup{Name: &name, CloudConfigCksum: &cksumString,
 		CreatedBy: &cr, TenantRef: &tenant, Members: members, CloudRef: &cloudRef, ImplicitPriorityLabels: &pg_meta.ImplicitPriorityLabel}
 
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		pg.Labels = lib.GetLabels()
 	}
 

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -40,7 +40,7 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 		CreatedBy: &cr, TenantRef: &tenant, Certificate: &avimodels.SSLCertificate{Certificate: &certificate},
 		Key: &key, Type: &certType}
 
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		sslkeycert.Labels = lib.GetLabels()
 	}
 	if ssl_node.CACert != "" {
@@ -188,7 +188,7 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 			Certificate: &caCert,
 		}),
 	}
-	if lib.GetEnableCtrl2014Features() {
+	if lib.GetGRBACSupport() {
 		pkiobject.Labels = lib.GetLabels()
 	}
 


### PR DESCRIPTION
This commit introduces a knob called GRBAC in the configmap
to switch off granual RBAC feature optionally.

Once this flag is set to true, the feature is turned out.
The feature is only supported with Avi controller version
20.1.5 and will be depcrecated in 20.1.4