### PR TITLE
Changing the make to execute many recipes simultaneously.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ npltests:
 
 .PHONY: int_test
 int_test:
-	make -j 1 k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc
+	make -j k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc
 
 .PHONY: scale_test
 scale_test:


### PR DESCRIPTION
 int_test target is changed to run all the UTs simultaneously.
This is reducing the PR builder time from 37 min to 20 min.