### PR TITLE
skip other operations if sni child deletion fails

### DIFF
--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -228,7 +228,7 @@ func removeObjRefFromRestOps(restOps []*utils.RestOp, objName, objType string) b
 
 func isErrorRetryable(statusCode int) bool {
 	// List of status codes for which we support retry
-	if (statusCode >= 500 && statusCode < 599) || statusCode == 404 || statusCode == 408 || statusCode == 409 {
+	if (statusCode >= 500 && statusCode < 599) || statusCode == 401 || statusCode == 404 || statusCode == 408 || statusCode == 409 {
 		return true
 	}
 	return false


### PR DESCRIPTION
This fixes a problem where objects belonging to the parent VS could not be deleted,
when deleteConfig flag was set to true.