### PR TITLE
cherry-pick, Disable GRBAC if avi controller build is less than 20.1.5. (#362)

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -462,8 +462,8 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pki.Name, string(*pki.CaCerts[0].Certificate), "")
-		if lib.GetGRBACSupport() && pki.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(pki.Labels)
+		if lib.GetGRBACSupport() && pki.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(pki.Markers)
 		}
 		pkiCacheObj := AviPkiProfileCache{
 			Name:             *pki.Name,
@@ -794,8 +794,8 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 				checksum += utils.Hash(*ds.Datascript[0].Script)
 			}
 		}
-		if lib.GetGRBACSupport() && ds.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		if lib.GetGRBACSupport() && ds.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(ds.Markers)
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		*DsData = append(*DsData, dsCacheObj)
@@ -892,8 +892,8 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetGRBACSupport() && sslkey.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
+		if lib.GetGRBACSupport() && sslkey.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(sslkey.Markers)
 		}
 		sslCacheObj := AviSSLCache{
 			Name:             *sslkey.Name,
@@ -966,8 +966,8 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.SSLKeyCertChecksum(*sslkey.Name, *sslkey.Certificate.Certificate, cacert)
-		if lib.GetGRBACSupport() && sslkey.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(sslkey.Labels)
+		if lib.GetGRBACSupport() && sslkey.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(sslkey.Markers)
 		}
 		sslCacheObj := AviSSLCache{
 			Name:             *sslkey.Name,
@@ -1016,8 +1016,8 @@ func (c *AviObjCache) AviPopulateOnePKICache(client *clients.AviClient,
 			continue
 		}
 		checksum := lib.SSLKeyCertChecksum(*pkikey.Name, *pkikey.CaCerts[0].Certificate, "")
-		if lib.GetGRBACSupport() && pkikey.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(pkikey.Labels)
+		if lib.GetGRBACSupport() && pkikey.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(pkikey.Markers)
 		}
 		sslCacheObj := AviSSLCache{
 			Name:             *pkikey.Name,
@@ -1146,8 +1146,8 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 			PoolGroups: pgs,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups)
-		if lib.GetGRBACSupport() && ds.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(ds.Labels)
+		if lib.GetGRBACSupport() && ds.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(ds.Markers)
 		}
 		if lib.GetEnableCtrl2014Features() {
 			if len(ds.Datascript) == 1 {
@@ -1418,8 +1418,8 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 			}
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetGRBACSupport() && l4pol.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
+		if lib.GetGRBACSupport() && l4pol.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(l4pol.Markers)
 		}
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,
@@ -1637,8 +1637,8 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 			protocol = utils.UDP
 		}
 		checksum := lib.L4PolicyChecksum(ports, protocol)
-		if lib.GetGRBACSupport() && l4pol.Labels != nil {
-			checksum += lib.ObjectLabelChecksum(l4pol.Labels)
+		if lib.GetGRBACSupport() && l4pol.Markers != nil {
+			checksum += lib.ObjectLabelChecksum(l4pol.Markers)
 		}
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -79,6 +79,7 @@ const (
 	VSVIPDELCTRLVER                            = "20.1.1"
 	Advl4ControllerVersion                     = "20.1.2"
 	ControllerVersion2014                      = "20.1.4"
+	ControllerVersion2015                      = "20.1.5"
 	HostRule                                   = "HostRule"
 	HTTPRule                                   = "HTTPRule"
 	AviInfraSetting                            = "AviInfraSetting"

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -41,7 +41,7 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	cr := lib.AKOUser
 	vsdatascriptset := avimodels.VSDataScriptSet{CreatedBy: &cr, Datascript: datascriptlist, Name: &ds_meta.Name, TenantRef: &tenant_ref, PoolGroupRefs: poolgroupref}
 	if lib.GetGRBACSupport() {
-		vsdatascriptset.Labels = lib.GetLabels()
+		vsdatascriptset.Markers = lib.GetMarkers()
 	}
 	if len(ds_meta.ProtocolParsers) > 0 {
 		vsdatascriptset.ProtocolParserRefs = ds_meta.ProtocolParsers

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -42,7 +42,7 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 		CreatedBy: &cr, TenantRef: &tenant, HTTPRequestPolicy: &http_req_pol}
 
 	if lib.GetGRBACSupport() {
-		hps.Labels = lib.GetLabels()
+		hps.Markers = lib.GetMarkers()
 	}
 	var idx int32
 	idx = 0

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -39,7 +39,7 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 	hps := avimodels.L4PolicySet{Name: &name,
 		CreatedBy: &cr, TenantRef: &tenant}
 	if lib.GetGRBACSupport() {
-		hps.Labels = lib.GetLabels()
+		hps.Markers = lib.GetMarkers()
 	}
 	var idx int32
 	idx = 0

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -93,7 +93,7 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		PlacementNetworks: placementNetworks,
 	}
 	if lib.GetGRBACSupport() {
-		pool.Labels = lib.GetLabels()
+		pool.Markers = lib.GetMarkers()
 	}
 	if pool_meta.PkiProfile != nil {
 		pkiProfileName := "/api/pkiprofile?name=" + pool_meta.PkiProfile.Name

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -87,7 +87,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
 		vs.TenantRef = &tenant
 		if lib.GetGRBACSupport() {
-			vs.Labels = lib.GetLabels()
+			vs.Markers = lib.GetMarkers()
 		}
 		if vs_meta.SNIParent {
 			// This is a SNI parent
@@ -225,7 +225,7 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	ignPool := false
 	sniChild.IgnPoolNetReach = &ignPool
 	if lib.GetGRBACSupport() {
-		sniChild.Labels = lib.GetLabels()
+		sniChild.Markers = lib.GetMarkers()
 	}
 	if vs_meta.DefaultPool != "" {
 		pool_ref := "/api/pool/?name=" + vs_meta.DefaultPool

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -98,7 +98,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		// Override the Vip in VsVip tto bring in updates, keeping everything else as is.
 
 		if lib.GetGRBACSupport() {
-			vsvip.Labels = lib.GetLabels()
+			vsvip.Markers = lib.GetMarkers()
 		}
 		rest_op = utils.RestOp{
 			ObjName: name,
@@ -202,7 +202,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 		}
 
 		if lib.GetGRBACSupport() {
-			vsvip.Labels = lib.GetLabels()
+			vsvip.Markers = lib.GetMarkers()
 		}
 
 		path = "/api/vsvip"
@@ -242,7 +242,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, cache_
 			vsvip_avi.DNSInfo = dns_info_arr
 			vsvip_avi.VrfContextRef = &vrfContextRef
 			if lib.GetGRBACSupport() {
-				vsvip_avi.Labels = lib.GetLabels()
+				vsvip_avi.Markers = lib.GetMarkers()
 			}
 			vsvip_avi.VsvipCloudConfigCksum = &cksumstr
 			path = "/api/vsvip/" + vsvip_cache_obj.Uuid

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -41,7 +41,7 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 		CreatedBy: &cr, TenantRef: &tenant, Members: members, CloudRef: &cloudRef, ImplicitPriorityLabels: &pg_meta.ImplicitPriorityLabel}
 
 	if lib.GetGRBACSupport() {
-		pg.Labels = lib.GetLabels()
+		pg.Markers = lib.GetMarkers()
 	}
 
 	var path string

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -41,7 +41,7 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 		Key: &key, Type: &certType}
 
 	if lib.GetGRBACSupport() {
-		sslkeycert.Labels = lib.GetLabels()
+		sslkeycert.Markers = lib.GetMarkers()
 	}
 	if ssl_node.CACert != "" {
 		cacertRef := "/api/sslkeyandcertificate/?name=" + ssl_node.CACert
@@ -189,7 +189,7 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 		}),
 	}
 	if lib.GetGRBACSupport() {
-		pkiobject.Labels = lib.GetLabels()
+		pkiobject.Markers = lib.GetMarkers()
 	}
 
 	var path string


### PR DESCRIPTION
Changes in rest layer to use Markers instead of Labels.