### PR TITLE
Fix issue related with ordering of httppolicysets of VS having same host with different Paths for Openshift route, K8 ingress

### DIFF
--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -432,7 +432,7 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		var httpsWithHppMap []*nodes.AviHttpPolicySetNode
 		var httpsNoHppMap []*nodes.AviHttpPolicySetNode
 		for _, http := range vs_meta.HttpPolicyRefs {
-			if http.HppMap != nil {
+			if http.HppMap != nil && http.HppMap[0].Path != nil {
 				httpsWithHppMap = append(httpsWithHppMap, http)
 			} else {
 				httpsNoHppMap = append(httpsNoHppMap, http)
@@ -443,16 +443,21 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 			return httpsWithHppMap[i].HppMap[0].Path[0] < httpsWithHppMap[j].HppMap[0].Path[0]
 		})
 		var j int32
-		for i, http := range httpsWithHppMap {
+		for i, http := range httpsNoHppMap {
 			j = int32(i) + internalPolicyIndexBuffer
 			k := j
 			httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
 			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
 			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
 		}
-		for _, http := range httpsNoHppMap {
+		if len(httpsNoHppMap) == 0 {
+			j = internalPolicyIndexBuffer
+		} else {
 			j = j + 1
+		}
+		for _, http := range httpsWithHppMap {
 			k := j
+			j = j + 1
 			httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
 			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
 			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
@@ -461,6 +466,7 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		// from hostrule CRD
 		bufferLen := int32(len(httpPolicyCollection)) + internalPolicyIndexBuffer + 5
 		for i, policy := range vs_meta.HttpPolicySetRefs {
+			var j int32
 			j = int32(i) + bufferLen
 			httpPolicy := policy
 			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -255,6 +256,11 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 
 		var httpPolicyCollection []*avimodels.HTTPPolicies
 		internalPolicyIndexBuffer := int32(11)
+
+		sort.Slice(vs_meta.HttpPolicyRefs, func(i, j int) bool {
+			return vs_meta.HttpPolicyRefs[i].HppMap[0].Path[0] < vs_meta.HttpPolicyRefs[j].HppMap[0].Path[0]
+		})
+
 		for i, http := range vs_meta.HttpPolicyRefs {
 			// Update them on the VS object
 			var j int32

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -253,56 +253,7 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 				sniChild.SslKeyAndCertificateRefs = append(sniChild.SslKeyAndCertificateRefs, certName)
 			}
 		}
-
-		var httpPolicyCollection []*avimodels.HTTPPolicies
-		internalPolicyIndexBuffer := int32(11)
-
-		var httpsWithHppMap []*nodes.AviHttpPolicySetNode
-		var httpsNoHppMap []*nodes.AviHttpPolicySetNode
-		for _, http := range vs_meta.HttpPolicyRefs {
-			if http.HppMap != nil && http.HppMap[0].Path != nil {
-				httpsWithHppMap = append(httpsWithHppMap, http)
-			} else {
-				httpsNoHppMap = append(httpsNoHppMap, http)
-			}
-		}
-
-		sort.Slice(httpsWithHppMap, func(i, j int) bool {
-			return httpsWithHppMap[i].HppMap[0].Path[0] < httpsWithHppMap[j].HppMap[0].Path[0]
-		})
-
-		var j int32
-		for i, http := range httpsNoHppMap {
-			j = int32(i) + internalPolicyIndexBuffer
-			k := j
-			httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
-			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
-			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
-		}
-		if len(httpsNoHppMap) == 0 {
-			j = internalPolicyIndexBuffer
-		} else {
-			j = j + 1
-		}
-		for _, http := range httpsWithHppMap {
-			k := j
-			j = j + 1
-			httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
-			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
-			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
-		}
-
-		// from hostrule CRD
-		bufferLen := int32(len(httpPolicyCollection)) + internalPolicyIndexBuffer + 5
-		for i, policy := range vs_meta.HttpPolicySetRefs {
-			var j int32
-			j = int32(i) + bufferLen
-			httpPolicy := policy
-			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}
-			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
-		}
-
-		sniChild.HTTPPolicies = httpPolicyCollection
+		sniChild.HTTPPolicies = AviVsHttpPSAdd(vs_meta, false)
 	}
 
 	var rest_ops []*utils.RestOp
@@ -323,6 +274,69 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	}
 
 	return rest_ops
+}
+func AviVsHttpPSAdd(vs_meta interface{}, isEVH bool) []*avimodels.HTTPPolicies {
+	var httpPolicyRef []*nodes.AviHttpPolicySetNode
+	var httpPSRef []string
+	var httpPolicyCollection []*avimodels.HTTPPolicies
+	if isEVH {
+		vsMeta := vs_meta.(*nodes.AviEvhVsNode)
+		httpPolicyRef = vsMeta.HttpPolicyRefs
+		httpPSRef = vsMeta.HttpPolicySetRefs
+	} else {
+		vsMeta := vs_meta.(*nodes.AviVsNode)
+		httpPolicyRef = vsMeta.HttpPolicyRefs
+		httpPSRef = vsMeta.HttpPolicySetRefs
+	}
+
+	internalPolicyIndexBuffer := int32(11)
+
+	var httpsWithHppMap []*nodes.AviHttpPolicySetNode
+	var httpsNoHppMap []*nodes.AviHttpPolicySetNode
+	for _, http := range httpPolicyRef {
+		if http.HppMap != nil && http.HppMap[0].Path != nil {
+			httpsWithHppMap = append(httpsWithHppMap, http)
+		} else {
+			httpsNoHppMap = append(httpsNoHppMap, http)
+		}
+	}
+
+	sort.Slice(httpsWithHppMap, func(i, j int) bool {
+		return httpsWithHppMap[i].HppMap[0].Path[0] < httpsWithHppMap[j].HppMap[0].Path[0]
+	})
+
+	var j int32
+	for i, http := range httpsNoHppMap {
+		j = int32(i) + internalPolicyIndexBuffer
+		k := j
+		httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
+		httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
+		httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
+	}
+	if len(httpsNoHppMap) == 0 {
+		j = internalPolicyIndexBuffer
+	} else {
+		j = j + 1
+	}
+	for _, http := range httpsWithHppMap {
+		k := j
+		j = j + 1
+		httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
+		httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &k}
+		httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
+	}
+
+	// from hostrule CRD
+	bufferLen := int32(len(httpPolicyCollection)) + internalPolicyIndexBuffer + 5
+	for i, policy := range httpPSRef {
+		var j int32
+		j = int32(i) + bufferLen
+		httpPolicy := policy
+		httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}
+		httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
+	}
+
+	return httpPolicyCollection
 }
 
 func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) error {


### PR DESCRIPTION
As part of this PR, httppolicysets of same VS are sorted in ascending order of path.
Changes has been done for SNI and EVH models.