### PR TITLE
Add session timeouts into retryable errors

### DIFF
--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -228,7 +228,7 @@ func removeObjRefFromRestOps(restOps []*utils.RestOp, objName, objType string) b
 
 func isErrorRetryable(statusCode int) bool {
 	// List of status codes for which we support retry
-	if (statusCode >= 500 && statusCode < 599) || statusCode == 404 || statusCode == 408 || statusCode == 409 {
+	if (statusCode >= 500 && statusCode < 599) || statusCode == 404 || statusCode == 401 || statusCode == 408 || statusCode == 409 {
 		return true
 	}
 	return false


### PR DESCRIPTION
This commit includes 401 into the retryable errors. One may hit
this error when the sessions become stale. Hence we need to re-enqueue.