### PR TITLE
fix status sync for status removal during reboot

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -392,7 +392,7 @@ func (c *AviController) FullSyncK8s() error {
 		}
 	}
 
-	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services("").List(labels.Set(nil).AsSelector())
+	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 	if err != nil {
 		utils.AviLog.Errorf("Unable to retrieve the services during full sync: %s", err)
 		return err
@@ -435,7 +435,7 @@ func (c *AviController) FullSyncK8s() error {
 	}
 
 	if !lib.GetAdvancedL4() {
-		hostRuleObjs, err := lib.GetCRDInformers().HostRuleInformer.Lister().HostRules("").List(labels.Set(nil).AsSelector())
+		hostRuleObjs, err := lib.GetCRDInformers().HostRuleInformer.Lister().HostRules(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the hostrules during full sync: %s", err)
 		} else {
@@ -445,7 +445,7 @@ func (c *AviController) FullSyncK8s() error {
 			}
 		}
 
-		httpRuleObjs, err := lib.GetCRDInformers().HTTPRuleInformer.Lister().HTTPRules("").List(labels.Set(nil).AsSelector())
+		httpRuleObjs, err := lib.GetCRDInformers().HTTPRuleInformer.Lister().HTTPRules(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the httprules during full sync: %s", err)
 		} else {
@@ -467,7 +467,7 @@ func (c *AviController) FullSyncK8s() error {
 
 		// Ingress Section
 		if utils.GetInformers().IngressInformer != nil {
-			ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses("").List(labels.Set(nil).AsSelector())
+			ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 			if err != nil {
 				utils.AviLog.Errorf("Unable to retrieve the ingresses during full sync: %s", err)
 			} else {
@@ -502,7 +502,7 @@ func (c *AviController) FullSyncK8s() error {
 			}
 		}
 		if lib.UseServicesAPI() {
-			gatewayObjs, err := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways("").List(labels.Set(nil).AsSelector())
+			gatewayObjs, err := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 			if err != nil {
 				utils.AviLog.Errorf("Unable to retrieve the gateways during full sync: %s", err)
 				return err
@@ -530,7 +530,7 @@ func (c *AviController) FullSyncK8s() error {
 	} else {
 		//Gateway Section
 
-		gatewayObjs, err := lib.GetAdvL4Informers().GatewayInformer.Lister().Gateways("").List(labels.Set(nil).AsSelector())
+		gatewayObjs, err := lib.GetAdvL4Informers().GatewayInformer.Lister().Gateways(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the gateways during full sync: %s", err)
 			return err

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -111,6 +111,7 @@ const (
 	UpdateStatus                               = "UpdateStatus"
 	DeleteStatus                               = "DeleteStatus"
 	NPLService                                 = "NPLService"
+	SyncStatusKey                              = "syncstatus"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -704,11 +704,11 @@ func InformersToRegister(oclient *oshiftclient.Clientset, kclient *kubernetes.Cl
 		allInformers = append(allInformers, utils.NodeInformer)
 
 		informerTimeout := int64(120)
-		_, err := kclient.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
+		_, err := kclient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
 		if err != nil {
 			return allInformers, errors.New("Error in fetching services: " + err.Error())
 		}
-		_, err = oclient.RouteV1().Routes("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
+		_, err = oclient.RouteV1().Routes(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &informerTimeout})
 		if err == nil {
 			// Openshift cluster with route support, we will just add route informer
 			allInformers = append(allInformers, utils.RouteInformer)

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -68,7 +69,7 @@ func IsServiceClusterIPType(svcObj *corev1.Service) bool {
 func GetSvcKeysForNodeCRUD() (svcl4Keys []string, svcl7Keys []string) {
 	// For NodePort if the node matches the  selector update all L4 services.
 
-	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services("").List(labels.Set(nil).AsSelector())
+	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 	if err != nil {
 		utils.AviLog.Errorf("Unable to retrieve the services : %s", err)
 		return

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -843,7 +843,7 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 			// TODO (sudswas): if error code 400 happens, it means layer 2's model has issue - can re-trigger a model eval in that case?
 			// If it's 409 it refers to a conflict. That means the cache should be refreshed for the particular object.
 
-			utils.AviLog.Infof("key: %s, msg: Confict for object: %s of type :%s", key, rest_op.ObjName, rest_op.Model)
+			utils.AviLog.Infof("key: %s, msg: Conflict for object: %s of type :%s", key, rest_op.ObjName, rest_op.Model)
 			switch rest_op.Model {
 			case "Pool":
 				var poolObjName string

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -74,6 +74,16 @@ func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 				Status: corev1.ConditionTrue,
 			})
 			UpdateGatewayStatusObject(option.Key, gw, gwStatus)
+			delete(gatewayMap, option.IngSvc)
+		}
+	}
+
+	// reset IPAddress and finalizer from Gateways that do not have a corresponding VS in cache
+	if bulk {
+		for gwNSName := range gatewayMap {
+			DeleteGatewayStatusAddress(avicache.ServiceMetadataObj{
+				Gateway: gwNSName,
+			}, lib.SyncStatusKey)
 		}
 	}
 
@@ -325,19 +335,44 @@ func getGateways(gwNSNames []string, bulk bool, retryNum ...int) map[string]*adv
 	}
 
 	if bulk {
-		gwList, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().Gateways("").List(context.TODO(), metav1.ListOptions{})
+		// Get GatewayClasses with Avi set as the controller, get corresponding Gateways,
+		// to return all AKO ingestable Gateways.
+		aviGWClasses := make(map[string]bool)
+		gwClassList, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().GatewayClasses().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			utils.AviLog.Warnf("Could not get the gateway object for UpdateStatus: %s", err)
+			utils.AviLog.Warnf("Could not get the GatewayClass object for UpdateStatus: %s", err)
 			// retry get if request timeout
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
 				return getGateways(gwNSNames, bulk, retry+1)
 			}
-		} else {
-			for i := range gwList.Items {
+		}
+
+		if len(gwClassList.Items) == 0 {
+			return gwMap
+		}
+
+		for i := range gwClassList.Items {
+			if gwClassList.Items[i].Spec.Controller == lib.AviGatewayController {
+				aviGWClasses[gwClassList.Items[i].Name] = true
+			}
+		}
+
+		gwList, err := lib.GetAdvL4Clientset().NetworkingV1alpha1pre1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			utils.AviLog.Warnf("Could not get the Gateway object for UpdateStatus: %s", err)
+			// retry get if request timeout
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+				return getGateways(gwNSNames, bulk, retry+1)
+			}
+		}
+
+		for i := range gwList.Items {
+			if _, ok := aviGWClasses[gwList.Items[i].Spec.Class]; ok {
 				ing := gwList.Items[i]
 				gwMap[ing.Namespace+"/"+ing.Name] = &ing
 			}
 		}
+
 		return gwMap
 	}
 

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -63,6 +63,23 @@ func UpdateIngressStatus(options []UpdateOptions, bulk bool) {
 			if err = updateObject(ingress, option); err != nil {
 				utils.AviLog.Error("key: %s, msg: updating Ingress object failed: %v", option.Key, err)
 			}
+			delete(ingressMap, option.IngSvc)
+		}
+	}
+
+	// reset IPAddress and finalizer from Gateways that do not have a corresponding VS in cache
+	if bulk {
+		for ingNSName, ing := range ingressMap {
+			var hostnames []string
+			for _, rule := range ing.Spec.Rules {
+				hostnames = append(hostnames, rule.Host)
+			}
+			DeleteIngressStatus([]UpdateOptions{{
+				ServiceMetadata: avicache.ServiceMetadataObj{
+					NamespaceIngressName: []string{ingNSName},
+					HostNames:            hostnames,
+				},
+			}}, true, lib.SyncStatusKey)
 		}
 	}
 
@@ -451,7 +468,30 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 	}
 
 	if bulk {
-		ingressList, err := mClient.NetworkingV1beta1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
+		// Get IngressClasses with Avi set as the controller, get corresponding Ingresses,
+		// to return all AKO ingestable Ingresses.
+		aviIngClasses := make(map[string]bool)
+		ingClassList, err := mClient.NetworkingV1beta1().IngressClasses().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			utils.AviLog.Warnf("Could not get the IngressClass object for UpdateStatus: %s", err)
+			// retry get if request timeout
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+				return getIngresses(ingressNSNames, bulk, retry+1)
+			}
+			return ingressMap
+		}
+
+		if len(ingClassList.Items) == 0 {
+			return ingressMap
+		}
+
+		for i := range ingClassList.Items {
+			if ingClassList.Items[i].Spec.Controller == lib.SvcApiAviGatewayController {
+				aviIngClasses[ingClassList.Items[i].Name] = true
+			}
+		}
+
+		ingressList, err := mClient.NetworkingV1beta1().Ingresses(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the ingress object for UpdateStatus: %v", err)
 			// retry get if request timeout
@@ -459,9 +499,12 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
 		}
+
 		for i := range ingressList.Items {
-			ing := ingressList.Items[i]
-			ingressMap[ing.Namespace+"/"+ing.Name] = &ing
+			if _, ok := aviIngClasses[*ingressList.Items[i].Spec.IngressClassName]; ok {
+				ing := ingressList.Items[i]
+				ingressMap[ing.Namespace+"/"+ing.Name] = &ing
+			}
 		}
 
 		return ingressMap

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -92,6 +92,15 @@ func UpdateL4LBStatus(options []UpdateOptions, bulk bool) {
 				continue
 			}
 		}
+		delete(serviceMap, option.IngSvc)
+	}
+
+	if bulk {
+		for svcNSName := range serviceMap {
+			DeleteL4LBStatus(avicache.ServiceMetadataObj{
+				NamespaceServiceName: []string{svcNSName},
+			}, lib.SyncStatusKey)
+		}
 	}
 
 	return
@@ -196,7 +205,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 	}
 
 	if bulk {
-		serviceLBList, err := mClient.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
+		serviceLBList, err := mClient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
 			// retry get if request timeout


### PR DESCRIPTION
This PR addresses the issue wherein AKO reboots right after
virtualservices are deleted from Avi, during object deletes,
leaving status updates incomplete. During such scenarios, AKO
should correctly remove the status (IPaddress/finalizers/annotations)
from objects whose corressponding VSes have been deleted from Avi.