### PR TITLE
Remove SE group labels on deleteConfig

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -172,6 +172,9 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			if isValidUserInput {
 				if delConfigFromData(cm.Data) {
 					c.DeleteModels()
+					if lib.GetServiceType() == "ClusterIP" {
+						avicache.DeConfigureSeGroupLabels()
+					}
 				} else {
 					status.ResetStatefulSetStatus()
 					quickSyncCh <- struct{}{}


### PR DESCRIPTION
This commit removes the SE group labels configured for the AKO cluster.
This operation is carried out if `deleteConfig` is set to `true`.

The operation is only done for the label added for the cluster.

In order for this change to take effect, the existing SEs have to
be rebooted or new SEs have to be created within the SE group.