### PR TITLE
cherry-pick: remove AKO annotations completely from ingress/routes if present with stale values

### DIFF
--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -170,13 +170,12 @@ func DeleteL4LBStatus(svc_mdata_obj avicache.ServiceMetadataObj, key string) err
 }
 
 func deleteSvcAnnotation(svc *corev1.Service) error {
-	payloadValue := make(map[string]*string)
-	payloadValue[VSAnnotation] = nil
-	payloadValue[ControllerAnnotation] = nil
-
 	payloadData := map[string]interface{}{
 		"metadata": map[string]map[string]*string{
-			"annotations": payloadValue,
+			"annotations": {
+				VSAnnotation:         nil,
+				ControllerAnnotation: nil,
+			},
 		},
 	}
 


### PR DESCRIPTION
(#388)

This PR ensures that AKO annotations are completely removed
in case when deleteConfig is set to `true` or in cases when the
no hosts in ingress/routes have a corresponding VS in Avi.