### PR TITLE
remove networkName and use vipNetworkList for all clouds

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -142,6 +142,10 @@ func InitializeAKC() {
 		}
 	}
 
+	if _, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		utils.AviLog.Fatalf("Error in getting VIP network %s, shutting down AKO", err)
+	}
+
 	aviObjCache := avicache.SharedAviObjCache()
 	aviRestClientPool := avicache.SharedAVIClients()
 	if !aviObjCache.IsAviClusterActive(aviRestClientPool.AviClient[0]) {

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -142,7 +142,7 @@ func InitializeAKC() {
 		}
 	}
 
-	if _, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+	if _, err := lib.GetVipNetworkList(); err != nil {
 		utils.AviLog.Fatalf("Error in getting VIP network %s, shutting down AKO", err)
 	}
 

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -25,7 +25,6 @@ data:
   subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
   enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
-  networkName: {{ .Values.NetworkSettings.networkName | quote }}
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -169,11 +169,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: defaultIngController
-          - name: NETWORK_NAME
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: networkName
           - name: SEG_NAME
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -40,11 +40,10 @@ NetworkSettings:
   #       - 11.0.0.1/24
   subnetIP: "" # Subnet IP of the vip network
   subnetPrefix: "" # Subnet Prefix of the vip network
-  networkName: "" # Network Name of the vip network
   enableRHI: false # This is a cluster wide setting for BGP peering.
-  vipNetworkList: []
-  # vipNetworkList: []
-  #  - networkName: subnet-xxxxxxx
+  vipNetworkList: [] # Network Name of the VIP network, multiple networks allowed only for AWS Cloud.
+  # vipNetworkList:
+  #  - networkName: net1
 
 ### This section outlines all the knobs  used to control Layer 7 loadbalancing settings in AKO.
 L7Settings:

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2700,15 +2700,12 @@ func checkAndSetCloudType(client *clients.AviClient) bool {
 func checkPublicCloud(client *clients.AviClient) bool {
 	if lib.IsPublicCloud() {
 		// Handle all public cloud validations here
-		if lib.GetCloudType() != lib.CLOUD_GCP {
-			vipNetworkList, err := lib.GetVipNetworkList()
-			if err == nil && len(vipNetworkList) != 0 {
-				return true
-			}
+		vipNetworkList, err := lib.GetVipNetworkList()
+		if err != nil {
+			utils.AviLog.Errorf("Got error while fetching VIP network list: %s", err.Error())
+			return false
+		} else if len(vipNetworkList) == 0 {
 			utils.AviLog.Errorf("vipNetworkList not specified, syncing will be disabled.")
-			if err != nil {
-				utils.AviLog.Errorf("%s", err.Error())
-			}
 			return false
 		}
 	}
@@ -2785,6 +2782,12 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 		utils.AviLog.Warnf("Network name net specified, skipping fetching of the VRF setting from network")
 		return true
 	}
+
+	if !validateNetworkNames(client, networkList) {
+		utils.AviLog.Warnf("Failed to validate Network Names specified in VIP Network List")
+		return false
+	}
+
 	networkName := networkList[0]
 
 	uri := "/api/network/?include_name&name=" + networkName + "&cloud_ref.name=" + utils.CloudName
@@ -2821,6 +2824,29 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 	vrfName := strings.Split(vrfRef, "#")[1]
 	utils.AviLog.Infof("Setting VRF %s found from network %s", vrfName, networkName)
 	lib.SetVrf(vrfName)
+	return true
+}
+
+func validateNetworkNames(client *clients.AviClient, networkList []string) bool {
+	for _, networkName := range networkList {
+		uri := "/api/network/?include_name&name=" + networkName + "&cloud_ref.name=" + utils.CloudName
+		result, err := lib.AviGetCollectionRaw(client, uri)
+		if err != nil {
+			utils.AviLog.Warnf("Get uri %v returned err %v", uri, err)
+			return false
+		}
+		elems := make([]json.RawMessage, result.Count)
+		err = json.Unmarshal(result.Results, &elems)
+		if err != nil {
+			utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
+			return false
+		}
+
+		if result.Count == 0 {
+			utils.AviLog.Warnf("No networks found for networkName: %s", networkName)
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2700,25 +2700,15 @@ func checkAndSetCloudType(client *clients.AviClient) bool {
 func checkPublicCloud(client *clients.AviClient) bool {
 	if lib.IsPublicCloud() {
 		// Handle all public cloud validations here
-		networkName := lib.GetNetworkName()
-		if networkName == "" && lib.GetCloudType() != lib.CLOUD_GCP {
-			if lib.GetCloudType() == lib.CLOUD_AWS {
-				//check for vipNetworkList if networkName not present for AWS Clouds
-				utils.AviLog.Infof("networkName not specified, checking for vipNetworkList as cloud is AWS")
-				vipNetworkList, err := lib.GetVipNetworkList()
-				if err == nil && len(vipNetworkList) != 0 {
-					utils.AviLog.Infof("Proceeding as multi-vip enabled")
-					return true
-				} else {
-					utils.AviLog.Errorf("vipNetworkList not specified, syncing will be disabled.")
-					if err != nil {
-						utils.AviLog.Errorf("%s", err.Error())
-					}
-					return false
-				}
+		if lib.GetCloudType() != lib.CLOUD_GCP {
+			vipNetworkList, err := lib.GetVipNetworkList()
+			if err == nil && len(vipNetworkList) != 0 {
+				return true
 			}
-			// networkName is required param for Azure Clouds
-			utils.AviLog.Errorf("Required param networkName not specified, syncing will be disabled.")
+			utils.AviLog.Errorf("vipNetworkList not specified, syncing will be disabled.")
+			if err != nil {
+				utils.AviLog.Errorf("%s", err.Error())
+			}
 			return false
 		}
 	}
@@ -2785,11 +2775,17 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 		return true
 	}
 
-	networkName := lib.GetNetworkName()
-	if networkName == "" {
-		utils.AviLog.Warnf("Param networkName not specified, skipping fetching of the VRF setting from network")
+	networkList, err := lib.GetVipNetworkList()
+	if err != nil {
+		utils.AviLog.Warnf("Error gettting Network name: %s, skipping fetching of the VRF setting from network", err.Error())
 		return true
 	}
+
+	if len(networkList) == 0 {
+		utils.AviLog.Warnf("Network name net specified, skipping fetching of the VRF setting from network")
+		return true
+	}
+	networkName := networkList[0]
 
 	uri := "/api/network/?include_name&name=" + networkName + "&cloud_ref.name=" + utils.CloudName
 	result, err := lib.AviGetCollectionRaw(client, uri)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -418,20 +418,6 @@ func GetSubnetPrefixInt() int32 {
 	return int32(intCidr)
 }
 
-func GetNetworkNamesForVsVipNode() ([]string, error) {
-	vipNetworkList, err := GetVipNetworkList()
-	if err != nil {
-		return nil, err
-	}
-	if len(vipNetworkList) > 1 {
-		// Only AWS cloud supports multiple VIP networks
-		if !(IsPublicCloud() && GetCloudType() != CLOUD_AWS) {
-			return nil, fmt.Errorf("More than one network specified in VIP Network List and Cloud type is not AWS")
-		}
-	}
-	return vipNetworkList, nil
-}
-
 func GetVipNetworkList() ([]string, error) {
 	var vipNetworkList []string
 	type Row struct {
@@ -451,6 +437,12 @@ func GetVipNetworkList() ([]string, error) {
 	}
 	for _, subnet := range vipNetworkListObj {
 		vipNetworkList = append(vipNetworkList, subnet.NetworkName)
+	}
+	if len(vipNetworkList) > 1 {
+		// Only AWS cloud supports multiple VIP networks
+		if !(IsPublicCloud() && GetCloudType() != CLOUD_AWS) {
+			return nil, fmt.Errorf("More than one network specified in VIP Network List and Cloud type is not AWS")
+		}
 	}
 	return vipNetworkList, nil
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -419,26 +419,17 @@ func GetSubnetPrefixInt() int32 {
 }
 
 func GetNetworkNamesForVsVipNode() ([]string, error) {
-	if networkName := GetNetworkName(); networkName != "" {
-		return []string{networkName}, nil
-	} else if IsPublicCloud() && GetCloudType() == CLOUD_AWS {
-		vipNetworkList, err := GetVipNetworkList()
-		if err != nil {
-			return nil, err
-		}
-		if len(vipNetworkList) != 0 {
-			return vipNetworkList, nil
+	vipNetworkList, err := GetVipNetworkList()
+	if err != nil {
+		return nil, err
+	}
+	if len(vipNetworkList) > 1 {
+		// Only AWS cloud supports multiple VIP networks
+		if !(IsPublicCloud() && GetCloudType() != CLOUD_AWS) {
+			return nil, fmt.Errorf("More than one network specified in VIP Network List and Cloud type is not AWS")
 		}
 	}
-	return []string{}, nil
-}
-
-func GetNetworkName() string {
-	networkName := os.Getenv(NETWORK_NAME)
-	if networkName != "" {
-		return networkName
-	}
-	return ""
+	return vipNetworkList, nil
 }
 
 func GetVipNetworkList() ([]string, error) {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -111,9 +111,8 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 			vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 		}
 
-		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		if networkNames, err := lib.GetVipNetworkList(); err != nil {
 			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
-			//return nil
 		} else {
 			vsVipNode.NetworkNames = networkNames
 		}
@@ -192,7 +191,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 		}
 
-		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+		if networkNames, err := lib.GetVipNetworkList(); err != nil {
 			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %v", key, err.Error())
 		} else {
 			vsVipNode.NetworkNames = networkNames

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -112,8 +112,8 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		}
 
 		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-			return nil
+			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
+			//return nil
 		} else {
 			vsVipNode.NetworkNames = networkNames
 		}
@@ -193,8 +193,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		}
 
 		if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-			return nil
+			utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %v", key, err.Error())
 		} else {
 			vsVipNode.NetworkNames = networkNames
 		}

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -578,7 +578,6 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName, key string, ro
 
 	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
 		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-		return nil
 	} else {
 		vsVipNode.NetworkNames = networkNames
 	}
@@ -1501,8 +1500,7 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 			vsvip.SubnetIP = ""
 		} else {
 			if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-				return
+				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 			} else {
 				vsvip.NetworkNames = networkNames
 			}

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -576,7 +576,7 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName, key string, ro
 		vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 	}
 
-	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+	if networkNames, err := lib.GetVipNetworkList(); err != nil {
 		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
 	} else {
 		vsVipNode.NetworkNames = networkNames
@@ -1499,7 +1499,7 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 			vsvip.NetworkNames = infraSetting.Spec.Network.Names
 			vsvip.SubnetIP = ""
 		} else {
-			if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+			if networkNames, err := lib.GetVipNetworkList(); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 			} else {
 				vsvip.NetworkNames = networkNames

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -116,7 +116,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 	}
 
-	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+	if networkNames, err := lib.GetVipNetworkList(); err != nil {
 		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -117,8 +117,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	}
 
 	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-		return nil
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames
 	}

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -120,7 +120,7 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 		vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 	}
 
-	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+	if networkNames, err := lib.GetVipNetworkList(); err != nil {
 		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames
@@ -524,7 +524,7 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 			vsvip.NetworkNames = infraSetting.Spec.Network.Names
 			vsvip.SubnetIP = ""
 		} else {
-			if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+			if networkNames, err := lib.GetVipNetworkList(); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err)
 			} else {
 				vsvip.NetworkNames = networkNames

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -121,8 +121,7 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 	}
 
 	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-		return nil
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames
 	}
@@ -526,8 +525,7 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 			vsvip.SubnetIP = ""
 		} else {
 			if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-				return
+				utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err)
 			} else {
 				vsvip.NetworkNames = networkNames
 			}

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -70,7 +70,7 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 		vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
 	}
 
-	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
+	if networkNames, err := lib.GetVipNetworkList(); err != nil {
 		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -71,8 +71,7 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 	}
 
 	if networkNames, err := lib.GetNetworkNamesForVsVipNode(); err != nil {
-		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: ", key, err)
-		return nil
+		utils.AviLog.Warnf("key: %s, msg: error when getting vipNetworkList: %s", key, err.Error())
 	} else {
 		vsVipNode.NetworkNames = networkNames
 	}

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -30,7 +30,7 @@ const invalidFilePath = "invalidmock1"
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/hostnameshardtests/l7_hostname_shard_test.go
+++ b/tests/hostnameshardtests/l7_hostname_shard_test.go
@@ -49,7 +49,7 @@ var akoApiServer *api.FakeApiServer
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -79,7 +79,7 @@ func TearDownTestForSvcLBMultiport(t *testing.T, g *gomega.GomegaWithT) {
 }
 
 func TestMain(m *testing.M) {
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")
@@ -732,7 +732,8 @@ func TestWithInfraSettingStatusUpdates(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(lib.GetSEGName()))
 	_, aviModel := objects.SharedAviGraphLister().Get(SINGLEPORTMODEL)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(lib.GetNetworkName()))
+	netList, _ := lib.GetVipNetworkList()
+	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(netList[0]))
 	g.Expect(nodes[0].EnableRhi).Should(gomega.BeNil())
 
 	settingUpdate := (FakeAviInfraSetting{
@@ -789,7 +790,7 @@ func TestWithInfraSettingStatusUpdates(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(lib.GetSEGName()))
 	_, aviModel = objects.SharedAviGraphLister().Get(SINGLEPORTMODEL)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(lib.GetNetworkName()))
+	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(netList[0]))
 	g.Expect(nodes[0].EnableRhi).Should(gomega.BeNil())
 
 	settingUpdate = (FakeAviInfraSetting{
@@ -878,7 +879,8 @@ func TestInfraSettingDelete(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(lib.GetSEGName()))
 	_, aviModel = objects.SharedAviGraphLister().Get(SINGLEPORTMODEL)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(lib.GetNetworkName()))
+	netList, _ := lib.GetVipNetworkList()
+	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(netList[0]))
 	g.Expect(nodes[0].EnableRhi).Should(gomega.BeNil())
 
 	TearDownTestForSvcLB(t, g)

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -96,7 +96,7 @@ func addConfigMap() {
 func TestMain(m *testing.M) {
 	kubeClient = k8sfake.NewSimpleClientset()
 	dynamicClient = dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -235,7 +235,7 @@ func injectMWForCloud() {
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("SEG_NAME", "Default-Group")
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
@@ -288,15 +288,15 @@ func TestAWSCloudValidation(t *testing.T) {
 	os.Setenv("CLOUD_NAME", "CLOUD_AWS")
 	utils.SetCloudName("CLOUD_AWS")
 	os.Setenv("SERVICE_TYPE", "NodePort")
-	os.Setenv("NETWORK_NAME", "")
+	os.Setenv("VIP_NETWORK_LIST", `[]`)
 
 	AddConfigMap(t)
 
 	if !ctrl.DisableSync {
-		t.Fatalf("CLOUD_AWS should not be allowed if NETWORK_NAME is empty")
+		t.Fatalf("CLOUD_AWS should not be allowed if VIP_NETWORK_LIST is empty")
 	}
 	DeleteConfigMap(t)
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 }
 
 // TestAzureCloudValidation tests validation in place for public clouds
@@ -304,15 +304,15 @@ func TestAzureCloudValidation(t *testing.T) {
 	os.Setenv("CLOUD_NAME", "CLOUD_AZURE")
 	utils.SetCloudName("CLOUD_AZURE")
 	os.Setenv("SERVICE_TYPE", "NodePort")
-	os.Setenv("NETWORK_NAME", "")
+	os.Setenv("VIP_NETWORK_LIST", `[]`)
 
 	AddConfigMap(t)
 
 	if !ctrl.DisableSync {
-		t.Fatalf("CLOUD_AZURE should not be allowed if NETWORK_NAME is empty")
+		t.Fatalf("CLOUD_AZURE should not be allowed if VIP_NETWORK_LIST is empty")
 	}
 	DeleteConfigMap(t)
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 }
 
 // TestAWSCloudInClusterIPMode tests case where AWS CLOUD is configured in ClousterIP mode. Sync should be allowed.

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -44,7 +44,7 @@ var CRDClient *crdfake.Clientset
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -168,7 +168,7 @@ func getTestPod(labels map[string]string) corev1.Pod {
 func TestMain(m *testing.M) {
 	os.Setenv("SERVICE_TYPE", "NodePortLocal")
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -116,7 +116,7 @@ func (rt FakeRoute) ABRoute(ratio ...int) *routev1.Route {
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -47,7 +47,7 @@ var CRDClient *crdfake.Clientset
 func TestMain(m *testing.M) {
 	os.Setenv("SERVICES_API", "true")
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")
@@ -1082,7 +1082,8 @@ func TestServicesAPIWithInfraSettingStatusUpdates(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(lib.GetSEGName()))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(lib.GetNetworkName()))
+	netList, _ := lib.GetVipNetworkList()
+	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(netList[0]))
 	g.Expect(nodes[0].EnableRhi).Should(gomega.BeNil())
 
 	settingUpdate := (integrationtest.FakeAviInfraSetting{
@@ -1177,7 +1178,8 @@ func TestServicesAPIInfraSettingDelete(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(lib.GetSEGName()))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(lib.GetNetworkName()))
+	netList, _ := lib.GetVipNetworkList()
+	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal(netList[0]))
 	g.Expect(nodes[0].EnableRhi).Should(gomega.BeNil())
 
 	TeardownAdvLBService(t, "svc", ns)

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -48,7 +48,7 @@ var akoApiServer *api.FakeApiServer
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
-	os.Setenv("NETWORK_NAME", "net123")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"net123"}]`)
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")


### PR DESCRIPTION
Currently there are two ways to specify vip network - vipNetworkList for AWS and
networkName for others. Removing networkName to use vipNetworkList for all cases.
But vipNetworkList can contain multiple entries only for AWS.