### PR TITLE
fix wrong script addition for checksum calculation

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -787,7 +787,7 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups, ds.Markers, true)
 		if lib.GetEnableCtrl2014Features() && len(ds.Datascript) == 1 {
-			checksum = utils.Hash(string(checksum) + *ds.Datascript[0].Script)
+			checksum = utils.Hash(fmt.Sprint(checksum) + utils.HTTP_DS_SCRIPT_MODIFIED)
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		*DsData = append(*DsData, dsCacheObj)
@@ -1132,7 +1132,7 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 		}
 		checksum := lib.DSChecksum(dsCacheObj.PoolGroups, ds.Markers, true)
 		if lib.GetEnableCtrl2014Features() && len(ds.Datascript) == 1 {
-			checksum = utils.Hash(string(checksum) + *ds.Datascript[0].Script)
+			checksum = utils.Hash(fmt.Sprint(checksum) + utils.HTTP_DS_SCRIPT_MODIFIED)
 		}
 		dsCacheObj.CloudConfigCksum = checksum
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *ds.Name}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1016,7 +1016,7 @@ func (v *AviHTTPDataScriptNode) CalculateCheckSum() {
 	// A sum of fields for this VS.
 	checksum := lib.DSChecksum(v.PoolGroupRefs, nil, false)
 	if lib.GetEnableCtrl2014Features() {
-		checksum = utils.Hash(string(checksum) + v.Script)
+		checksum = utils.Hash(fmt.Sprint(checksum) + utils.HTTP_DS_SCRIPT_MODIFIED)
 	}
 	v.CloudConfigCksum = checksum
 }

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -16,6 +16,7 @@ package rest
 
 import (
 	"errors"
+	"fmt"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -39,7 +40,13 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	datascriptlist = append(datascriptlist, &datascript)
 	tenant_ref := "/api/tenant/?name=" + ds_meta.Tenant
 	cr := lib.AKOUser
-	vsdatascriptset := avimodels.VSDataScriptSet{CreatedBy: &cr, Datascript: datascriptlist, Name: &ds_meta.Name, TenantRef: &tenant_ref, PoolGroupRefs: poolgroupref}
+	vsdatascriptset := avimodels.VSDataScriptSet{
+		CreatedBy:     &cr,
+		Datascript:    datascriptlist,
+		Name:          &ds_meta.Name,
+		TenantRef:     &tenant_ref,
+		PoolGroupRefs: poolgroupref,
+	}
 	if lib.GetGRBACSupport() {
 		vsdatascriptset.Markers = lib.GetMarkers()
 	}
@@ -108,7 +115,6 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 			utils.AviLog.Warnf("key: %s, msg: DS Uuid not present in response %v", key, resp)
 			continue
 		}
-		// Datascript should not have a checksum
 
 		var poolgroups []string
 		if resp["pool_group_refs"] != nil {
@@ -124,9 +130,10 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		ds_cache_obj := avicache.AviDSCache{Name: name, Tenant: rest_op.Tenant,
 			Uuid: uuid, PoolGroups: poolgroups}
 
+		// Datascript should not have a checksum
 		checksum := lib.DSChecksum(ds_cache_obj.PoolGroups, nil, false)
 		if lib.GetEnableCtrl2014Features() {
-			checksum = utils.Hash(string(checksum) + utils.HTTP_DS_SCRIPT_MODIFIED)
+			checksum = utils.Hash(fmt.Sprint(checksum) + utils.HTTP_DS_SCRIPT_MODIFIED)
 		}
 		ds_cache_obj.CloudConfigCksum = checksum
 


### PR DESCRIPTION
The vsdatascriptset checksum calculation was inconsistent for graph nodes and the rest cache layer, 
that lead to multiple PUT calls. The rest layer checksum calculation did not involve replacing the datascript
string with the proper pool group name (in place constant POOLGROUP) that lead to different checksums.
