### PR TITLE
AKO Operator clusterrole change, Changing Update call to Patch in Reconcile

### DIFF
--- a/ako-operator/controllers/akoconfig_controller.go
+++ b/ako-operator/controllers/akoconfig_controller.go
@@ -109,8 +109,10 @@ func (r *AKOConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			if err := r.CleanupArtifacts(ctx, log); err != nil {
 				return ctrl.Result{}, err
 			}
+
+			patch := client.MergeFrom(ako.DeepCopy())
 			ako.Finalizers = removeFinalizer(ako.Finalizers, CleanupFinalizer)
-			if err := r.Update(ctx, &ako); err != nil {
+			if err := r.Patch(context.TODO(), &ako, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/ako-operator/controllers/role.go
+++ b/ako-operator/controllers/role.go
@@ -65,6 +65,7 @@ func createOrUpdateClusterRole(ctx context.Context, ako akov1alpha1.AKOConfig, l
 	err := r.Get(ctx, getCRName(), &newCR)
 	if err != nil {
 		log.V(0).Info("error getting a clusterrole with name", "name", getCRName().Name, "err", err)
+		return err
 	}
 	// update this object in the global list
 	objList := getObjectList()
@@ -119,7 +120,7 @@ func BuildClusterrole(ako akov1alpha1.AKOConfig, r *AKOConfigReconciler, log log
 			},
 			{
 				APIGroups: []string{"ako.vmware.com"},
-				Resources: []string{"hostrules", "hostrules/status", "httprules", "httprules/status"},
+				Resources: []string{"hostrules", "hostrules/status", "httprules", "httprules/status", "aviinfrasettings", "aviinfrasettings/status"},
 				Verbs:     []string{"get", "watch", "list", "patch", "update"},
 			},
 			{

--- a/ako-operator/helm/ako-operator/templates/ako-operator-manager-role.yaml
+++ b/ako-operator/helm/ako-operator/templates/ako-operator-manager-role.yaml
@@ -37,7 +37,7 @@ rules:
   resources: ["routes", "routes/status"]
   verbs: ["get", "watch", "list", "patch", "update"]
 - apiGroups: ["ako.vmware.com"]
-  resources: ["hostrules", "hostrules/status", "httprules", "httprules/status"]
+  resources: ["hostrules", "hostrules/status", "httprules", "httprules/status", "aviinfrasettings", "aviinfrasettings/status"]
   verbs: ["get","watch","list","patch", "update"]
 - apiGroups: ["networking.x-k8s.io"]
   resources: ["gateways", "gateways/status", "gatewayclasses", "gatewayclasses/status"]


### PR DESCRIPTION
AKO Operator changes : 

- Added aviinfrasettings permissions to ako-cr and ako-operator-manager-role clusterrole 
- Updated Reconcile function to avoid stale objects for FT verifications. 