### PR TITLE
Fix for race conditons for updating avi model in graph layer

### DIFF
--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -126,6 +126,8 @@ func (v *AviObjectGraph) DecrementRetryCounter() {
 }
 
 func (v *AviObjectGraph) CalculateCheckSum() {
+	v.Lock.Lock()
+	defer v.Lock.Unlock()
 	// A sum of fields for this model.
 	v.GraphChecksum = 0
 	for _, model := range v.modelNodes {


### PR DESCRIPTION
In the rest layer we take lock and get a copy of the model.
But in layer2 we were not always taking a lock before updating the models.
This was figured out by using -race flag while building the binary object.

To fix this, added a lock in calculateChecksum and sniNodeHostName function.

(cherry picked from commit a8db7ad551c0e4b296a8185d01ee1f85c0d22998)