### PR TITLE
match portname for multi port service while populating servers for NPL

### DIFF
--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -232,13 +232,15 @@ func PopulateServersForNPL(poolNode *AviPoolNode, ns string, serviceName string,
 			} else {
 				atype = "V6"
 			}
-			server := AviPoolMetaServer{
-				Port: int32(a.NodePort),
-				Ip: models.IPAddr{
-					Addr: &a.NodeIP,
-					Type: &atype,
-				}}
-			poolMeta = append(poolMeta, server)
+			if _, ok := targetPorts[a.PodPort]; ok {
+				server := AviPoolMetaServer{
+					Port: int32(a.NodePort),
+					Ip: models.IPAddr{
+						Addr: &a.NodeIP,
+						Type: &atype,
+					}}
+				poolMeta = append(poolMeta, server)
+			}
 		}
 	}
 	utils.AviLog.Infof("key: %s, msg: servers for port: %v, are: %v", key, poolNode.Port, utils.Stringify(poolMeta))

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -75,7 +75,7 @@ func SetUpTestForIngress(t *testing.T, modelName string) {
 func createPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":80,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
 	testPod.Annotations = ann
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
@@ -83,7 +83,7 @@ func createPodWithNPLAnnotation(labels map[string]string) {
 func updatePodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":80,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
 	testPod.Annotations = ann
 	testPod.ResourceVersion = "2"
 	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})


### PR DESCRIPTION
If an ingress is referring a multi port service then we must check if portname
mentioned in the ingress spec matches with the service port

(cherry picked from commit 2e7d2b2d1d37bd6d30155a0ac8d3fabf4fb4c648)