### PR TITLE
Use kubeclient instead of informer to fetch ingress class for status update during bootup

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -955,3 +955,19 @@ func IsAviLBDefaultIngressClass() (string, bool) {
 	utils.AviLog.Debugf("IngressClass with controller ako.vmware.com/avi-lb not found in the cluster")
 	return "", false
 }
+
+func IsAviLBDefaultIngressClassWithClient(kc kubernetes.Interface) (string, bool) {
+	ingClassObjs, _ := kc.NetworkingV1().IngressClasses().List(context.TODO(), metav1.ListOptions{})
+	for _, ingClass := range ingClassObjs.Items {
+		if ingClass.Spec.Controller == AviIngressController {
+			annotations := ingClass.GetAnnotations()
+			isDefaultClass, ok := annotations[DefaultIngressClassAnnotation]
+			if ok && isDefaultClass == "true" {
+				return ingClass.Name, true
+			}
+		}
+	}
+
+	utils.AviLog.Debugf("IngressClass with controller ako.vmware.com/avi-lb not found in the cluster")
+	return "", false
+}

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -517,7 +517,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 					if _, ok := aviIngClasses[*ingressList.Items[i].Spec.IngressClassName]; ok {
 						returnIng = true
 					}
-				} else if _, ok := lib.IsAviLBDefaultIngressClass(); ok {
+				} else if _, ok := lib.IsAviLBDefaultIngressClassWithClient(mClient); ok {
 					returnIng = true
 				}
 			} else {


### PR DESCRIPTION
In this time, the informers are not initialized yet.

(cherry picked from commit 07a6c7dc857865842854d261f708f7fb0be16189)