### PR TITLE
Process SwitchingAction in http policy rule only if it contains SwitchingAction

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1313,18 +1313,20 @@ func (c *AviObjCache) AviPopulateOneVsHttpPolCache(client *clients.AviClient,
 		var pools []string
 		if httppol.HTTPRequestPolicy != nil {
 			for _, rule := range httppol.HTTPRequestPolicy.Rules {
-				val := reflect.ValueOf(rule.SwitchingAction)
-				if !val.Elem().FieldByName("PoolGroupRef").IsNil() {
-					pgUuid := ExtractUuid(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
-					pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
-					if found {
-						poolGroups = append(poolGroups, pgName.(string))
-					}
-				} else if !val.Elem().FieldByName("PoolRef").IsNil() {
-					poolUuid := ExtractUuid(*rule.SwitchingAction.PoolRef, "pool-.*.#")
-					poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
-					if found {
-						pools = append(pools, poolName.(string))
+				if rule.SwitchingAction != nil {
+					val := reflect.ValueOf(rule.SwitchingAction)
+					if !val.Elem().FieldByName("PoolGroupRef").IsNil() {
+						pgUuid := ExtractUuid(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
+						pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
+						if found {
+							poolGroups = append(poolGroups, pgName.(string))
+						}
+					} else if !val.Elem().FieldByName("PoolRef").IsNil() {
+						poolUuid := ExtractUuid(*rule.SwitchingAction.PoolRef, "pool-.*.#")
+						poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
+						if found {
+							pools = append(pools, poolName.(string))
+						}
 					}
 				}
 			}


### PR DESCRIPTION

While populating http policy in cache we check for the ref type in SwitchingAction.
But not all rules contain SwitchingAction, for which we get a panic because we try to process a nil value.