### PR TITLE
Add/Remove HTTP redirect rules for gslb fqdn

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1096,7 +1096,7 @@ func RemoveEvhInModel(currentEvhNodeName string, modelEvhNodes []*AviEvhVsNode, 
 
 func FindAndReplaceRedirectHTTPPolicyInModelforEvh(vsNode *AviEvhVsNode, httpPolicy *AviHttpPolicySetNode, hostname, key string) bool {
 	for _, policy := range vsNode.HttpPolicyRefs {
-		if policy.Name == httpPolicy.Name && policy.CloudConfigCksum != httpPolicy.CloudConfigCksum {
+		if policy.Name == httpPolicy.Name {
 			if !utils.HasElem(policy.RedirectPorts[0].Hosts, hostname) {
 				policy.RedirectPorts[0].Hosts = append(policy.RedirectPorts[0].Hosts, hostname)
 				utils.AviLog.Infof("key: %s, msg: replaced host %s for policy %s in model", key, hostname, policy.Name)

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -402,10 +402,10 @@ func (o *AviObjectGraph) BuildPoolSecurity(poolNode *AviPoolNode, tlsData TlsSet
 	poolNode.PkiProfile = &pkiProfile
 }
 
-func (o *AviObjectGraph) BuildPolicyRedirectForVS(vsNode []*AviVsNode, hostname string, key string) {
+func (o *AviObjectGraph) BuildPolicyRedirectForVS(vsNode []*AviVsNode, hostnames []string, key string) {
 	policyname := lib.GetL7HttpRedirPolicy(vsNode[0].Name)
 	myHppMap := AviRedirectPort{
-		Hosts:        []string{hostname},
+		Hosts:        hostnames,
 		RedirectPort: 443,
 		StatusCode:   lib.STATUS_REDIRECT,
 		VsPort:       80,
@@ -417,7 +417,7 @@ func (o *AviObjectGraph) BuildPolicyRedirectForVS(vsNode []*AviVsNode, hostname 
 		RedirectPorts: []AviRedirectPort{myHppMap},
 	}
 
-	if policyFound := FindAndReplaceRedirectHTTPPolicyInModel(vsNode[0], redirectPolicy, hostname, key); !policyFound {
+	if policyFound := FindAndReplaceRedirectHTTPPolicyInModel(vsNode[0], redirectPolicy, hostnames, key); !policyFound {
 		redirectPolicy.CalculateCheckSum()
 		vsNode[0].HttpPolicyRefs = append(vsNode[0].HttpPolicyRefs, redirectPolicy)
 	}
@@ -443,14 +443,17 @@ func (o *AviObjectGraph) BuildHeaderRewrite(vsNode []*AviVsNode, gslbHost, local
 
 }
 
-func FindAndReplaceRedirectHTTPPolicyInModel(vsNode *AviVsNode, httpPolicy *AviHttpPolicySetNode, hostname, key string) bool {
-	for _, policy := range vsNode.HttpPolicyRefs {
-		if policy.Name == httpPolicy.Name && policy.CloudConfigCksum != httpPolicy.CloudConfigCksum {
-			if !utils.HasElem(policy.RedirectPorts[0].Hosts, hostname) {
-				policy.RedirectPorts[0].Hosts = append(policy.RedirectPorts[0].Hosts, hostname)
-				utils.AviLog.Infof("key: %s, msg: replaced host %s for policy %s in model", key, hostname, policy.Name)
+func FindAndReplaceRedirectHTTPPolicyInModel(vsNode *AviVsNode, httpPolicy *AviHttpPolicySetNode, hostnames []string, key string) bool {
+	// The hostnames slice can at max have 2 elements.
+	for _, hostname := range hostnames {
+		for _, policy := range vsNode.HttpPolicyRefs {
+			if policy.Name == httpPolicy.Name && policy.CloudConfigCksum != httpPolicy.CloudConfigCksum {
+				if !utils.HasElem(policy.RedirectPorts[0].Hosts, hostname) {
+					policy.RedirectPorts[0].Hosts = append(policy.RedirectPorts[0].Hosts, hostname)
+					utils.AviLog.Infof("key: %s, msg: replaced host %s for policy %s in model", key, hostname, policy.Name)
+				}
+				return true
 			}
-			return true
 		}
 	}
 	return false
@@ -484,21 +487,23 @@ func RemoveHeaderRewriteHTTPPolicyInModel(vsNode *AviVsNode, hostname, key strin
 	}
 }
 
-func RemoveRedirectHTTPPolicyInModel(vsNode *AviVsNode, hostname, key string) {
+func RemoveRedirectHTTPPolicyInModel(vsNode *AviVsNode, hostnames []string, key string) {
 	policyName := lib.GetL7HttpRedirPolicy(vsNode.Name)
 	deletePolicy := false
-	for i, policy := range vsNode.HttpPolicyRefs {
-		if policy.Name == policyName {
-			// one redirect policy per shard vs
-			policy.RedirectPorts[0].Hosts = utils.Remove(policy.RedirectPorts[0].Hosts, hostname)
-			utils.AviLog.Infof("key: %s, msg: removed host %s from policy %s in model %v", key, hostname, policy.Name, policy.RedirectPorts[0].Hosts)
-			if len(policy.RedirectPorts[0].Hosts) == 0 {
-				deletePolicy = true
-			}
+	for _, hostname := range hostnames {
+		for i, policy := range vsNode.HttpPolicyRefs {
+			if policy.Name == policyName {
+				// one redirect policy per shard vs
+				policy.RedirectPorts[0].Hosts = utils.Remove(policy.RedirectPorts[0].Hosts, hostname)
+				utils.AviLog.Infof("key: %s, msg: removed host %s from policy %s in model %v", key, hostname, policy.Name, policy.RedirectPorts[0].Hosts)
+				if len(policy.RedirectPorts[0].Hosts) == 0 {
+					deletePolicy = true
+				}
 
-			if deletePolicy {
-				vsNode.HttpPolicyRefs = append(vsNode.HttpPolicyRefs[:i], vsNode.HttpPolicyRefs[i+1:]...)
-				utils.AviLog.Infof("key: %s, msg: removed policy %s in model", key, policy.Name)
+				if deletePolicy {
+					vsNode.HttpPolicyRefs = append(vsNode.HttpPolicyRefs[:i], vsNode.HttpPolicyRefs[i+1:]...)
+					utils.AviLog.Infof("key: %s, msg: removed policy %s in model", key, policy.Name)
+				}
 			}
 		}
 	}

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -176,10 +176,11 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 	if len(secureSharedVS.PassthroughChildNodes) > 0 {
 		passChildVS = secureSharedVS.PassthroughChildNodes[0]
 	}
-
+	var hostnameSlice []string
+	hostnameSlice = append(hostnameSlice, hostname)
 	if !redirect {
 		if passChildVS != nil {
-			RemoveRedirectHTTPPolicyInModel(passChildVS, hostname, key)
+			RemoveRedirectHTTPPolicyInModel(passChildVS, hostnameSlice, key)
 		}
 		return
 	}
@@ -202,8 +203,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 		passChildVS.ServiceMetadata.PassthroughParentRef = secureSharedVS.Name
 		secureSharedVS.ServiceMetadata.PassthroughChildRef = passChildVS.Name
 	}
-
-	o.BuildPolicyRedirectForVS([]*AviVsNode{passChildVS}, hostname, key)
+	o.BuildPolicyRedirectForVS([]*AviVsNode{passChildVS}, hostnameSlice, key)
 }
 
 func (o *AviObjectGraph) ConstructL4DataScript(vsName string, key string, vsNode *AviVsNode) *AviHTTPDataScriptNode {
@@ -262,7 +262,9 @@ func (o *AviObjectGraph) DeleteObjectsForPassthroughHost(vsName, hostname string
 		if len(vsNode[0].PassthroughChildNodes) > 0 {
 			passChild := vsNode[0].PassthroughChildNodes[0]
 			utils.AviLog.Infof("key: %s, msg: Removing redierct policy for %s from passthrough VS %s", key, hostname, passChild.Name)
-			RemoveRedirectHTTPPolicyInModel(passChild, hostname, key)
+			var hostnameSlice []string
+			hostnameSlice = append(hostnameSlice, hostname)
+			RemoveRedirectHTTPPolicyInModel(passChild, hostnameSlice, key)
 		}
 	}
 


### PR DESCRIPTION
When a hostrule is detected with a GSLB FQDN and it is for a secure
FQDN, a re-direct rule is attached on the shared VS for the GS FQDN.

The same is removed if:

 - The hostrule is removed.
 - If the ingress is deleted.
 - If the gs fqdn is dynamically changed in the hostrule.