### PR TITLE
keep EnableRhi nil if not set to true

### DIFF
--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -255,7 +255,9 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		} else {
 			enableRhi = lib.GetEnableRHI()
 		}
-		vs.EnableRhi = &enableRhi
+		if enableRhi {
+			vs.EnableRhi = &enableRhi
+		}
 
 		if vs_meta.DefaultPoolGroup != "" {
 			pool_ref := "/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -69,7 +69,9 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		} else {
 			enableRhi = lib.GetEnableRHI()
 		}
-		vs.EnableRhi = &enableRhi
+		if enableRhi {
+			vs.EnableRhi = &enableRhi
+		}
 
 		if lib.GetAdvancedL4() {
 			ignPool := true


### PR DESCRIPTION
Required for Avi Essentials and Basic licensing where setting the value
to False is not allowed by the Avi Controller.