### PR TITLE
Use index while accessing network from networkList in rest layer for AWS multiVip

### DIFF
--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -29,6 +29,7 @@ import (
 
 	avimodels "github.com/avinetworks/sdk/go/models"
 	"github.com/davecgh/go-spew/spew"
+	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -510,7 +511,7 @@ func networkNamesToVips(networkNames []string) []*avimodels.Vip {
 			VipID:          &vipID,
 			AutoAllocateIP: &autoAllocate,
 		}
-		newVip.SubnetUUID = &networkName
+		newVip.SubnetUUID = proto.String(networkName)
 		vipList = append(vipList, newVip)
 	}
 	return vipList


### PR DESCRIPTION

using networkName instead of index results in same network multiple times because we are using a pointer.