### PR TITLE
Allow listening to endpoint updates in NodePort mode

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -469,10 +469,6 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if c.DisableSync {
 				return
 			}
-			if lib.IsNodePortMode() {
-				utils.AviLog.Debugf("skipping endpoint for nodeport mode")
-				return
-			}
 			ep := obj.(*corev1.Endpoints)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ep))
 			key := utils.Endpoints + "/" + utils.ObjKey(ep)
@@ -482,10 +478,6 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 		},
 		DeleteFunc: func(obj interface{}) {
 			if c.DisableSync {
-				return
-			}
-			if lib.IsNodePortMode() {
-				utils.AviLog.Debugf("skipping endpoint for nodeport mode")
 				return
 			}
 			ep, ok := obj.(*corev1.Endpoints)
@@ -515,10 +507,6 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			oep := old.(*corev1.Endpoints)
 			cep := cur.(*corev1.Endpoints)
 			if !reflect.DeepEqual(cep.Subsets, oep.Subsets) {
-				if lib.IsNodePortMode() {
-					utils.AviLog.Debugf("skipping endpoint for nodeport mode")
-					return
-				}
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(cep))
 				key := utils.Endpoints + "/" + utils.ObjKey(cep)
 				bkt := utils.Bkt(namespace, numWorkers)


### PR DESCRIPTION
This commit would allow AKO to listen on endpoint updates even in
nodeport mode. This is needed because if someone uses the skipnodeport
annotation and update endpoints, we need to read those endpoint
object updates and accordingly update the pool servers.