### PR TITLE
Slow retry forever on error - No available free IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ npltests:
 
 .PHONY: int_test
 int_test:
-	make -j k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc
+	make -j 1 k8stest integrationtest hostnameshardtests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc
 
 .PHONY: scale_test
 scale_test:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -112,6 +112,7 @@ const (
 	DeleteStatus                               = "DeleteStatus"
 	NPLService                                 = "NPLService"
 	SyncStatusKey                              = "syncstatus"
+	NoFreeIPError                              = "No available free IPs"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -429,8 +429,10 @@ func TestAdvL4WrongControllerGWClass(t *testing.T) {
 		gw, _ := AdvL4Client.NetworkingV1alpha1pre1().Gateways(ns).Get(context.TODO(), gatewayName, metav1.GetOptions{})
 		return len(gw.Status.Addresses)
 	}, 10*time.Second).Should(gomega.Equal(0))
-	svc, _ := KubeClient.CoreV1().Services(ns).Get(context.TODO(), "svc", metav1.GetOptions{})
-	g.Expect(svc.Status.LoadBalancer.Ingress).To(gomega.HaveLen(0))
+	g.Eventually(func() int {
+		svc, _ := KubeClient.CoreV1().Services(ns).Get(context.TODO(), "svc", metav1.GetOptions{})
+		return len(svc.Status.LoadBalancer.Ingress)
+	}, 10*time.Second).Should(gomega.Equal(0))
 
 	TeardownAdvLBService(t, "svc", ns)
 	TeardownGateway(t, gatewayName, ns)

--- a/tests/oshiftroutetests/oshift_route_passthrough_test.go
+++ b/tests/oshiftroutetests/oshift_route_passthrough_test.go
@@ -195,6 +195,14 @@ func TestPassthroughRemoveRedirectRoute(t *testing.T) {
 	vs := graph.GetAviVS()[0]
 
 	VerifyOnePasthrough(t, g, vs)
+
+	g.Eventually(func() int {
+		aviModel := ValidatePassthroughModel(t, g, DefaultPassthroughModel)
+		graph := aviModel.(*avinodes.AviObjectGraph)
+		vs := graph.GetAviVS()[0]
+		return len(vs.PassthroughChildNodes)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
 	g.Expect(vs.PassthroughChildNodes).To(gomega.HaveLen(0))
 
 	VerifyPassthroughRouteDeletion(t, g, DefaultPassthroughModel, 0, 0)


### PR DESCRIPTION
If we get an error in rest layer when no free IP is avialable, then
retry forever until a free IP is avialable. Usually users can increase
avialable IP range and then after sometime the VsVip would get a free IP automatically.