### PR TITLE
Fixing Continuous POST calls for sslkeyandcertificate in 409 error and DELETE calls for other AVI objects in 404 error

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -724,7 +724,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.Pool:
 					poolObjName = *rest_op.Obj.(avimodels.Pool).Name
 				}
-				rest_op.ObjName = poolObjName
+				if poolObjName != "" {
+					rest_op.ObjName = poolObjName
+				}
 				rest.AviPoolCacheDel(rest_op, aviObjKey, key)
 			case "PoolGroup":
 				var pgObjName string
@@ -734,7 +736,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.PoolGroup:
 					pgObjName = *rest_op.Obj.(avimodels.PoolGroup).Name
 				}
-				rest_op.ObjName = pgObjName
+				if pgObjName != "" {
+					rest_op.ObjName = pgObjName
+				}
 				if strings.Contains(errorStr, "Pool object not found!") {
 					// PG error with pool object not found.
 					aviObjCache.AviPopulateOnePGCache(c, utils.CloudName, pgObjName)
@@ -793,7 +797,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.VsVip:
 					VsVip = *rest_op.Obj.(avimodels.VsVip).Name
 				}
-				rest_op.ObjName = VsVip
+				if VsVip != "" {
+					rest_op.ObjName = VsVip
+				}
 				rest.AviVsVipCacheDel(rest_op, aviObjKey, key)
 			case "HTTPPolicySet":
 				var HTTPPolicySet string
@@ -803,7 +809,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.HTTPPolicySet:
 					HTTPPolicySet = *rest_op.Obj.(avimodels.HTTPPolicySet).Name
 				}
-				rest_op.ObjName = HTTPPolicySet
+				if HTTPPolicySet != "" {
+					rest_op.ObjName = HTTPPolicySet
+				}
 				rest.AviHTTPPolicyCacheDel(rest_op, aviObjKey, key)
 			case "L4PolicySet":
 				var L4PolicySet string
@@ -813,7 +821,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.L4PolicySet:
 					L4PolicySet = *rest_op.Obj.(avimodels.L4PolicySet).Name
 				}
-				rest_op.ObjName = L4PolicySet
+				if L4PolicySet != "" {
+					rest_op.ObjName = L4PolicySet
+				}
 				rest.AviL4PolicyCacheDel(rest_op, aviObjKey, key)
 			case "SSLKeyAndCertificate":
 				var SSLKeyAndCertificate string
@@ -823,7 +833,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.SSLKeyAndCertificate:
 					SSLKeyAndCertificate = *rest_op.Obj.(avimodels.SSLKeyAndCertificate).Name
 				}
-				rest_op.ObjName = SSLKeyAndCertificate
+				if SSLKeyAndCertificate != "" {
+					rest_op.ObjName = SSLKeyAndCertificate
+				}
 				rest.AviSSLCacheDel(rest_op, aviObjKey, key)
 			case "PKIprofile":
 				var PKIprofile string
@@ -833,7 +845,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.PKIprofile:
 					PKIprofile = *rest_op.Obj.(avimodels.PKIprofile).Name
 				}
-				rest_op.ObjName = PKIprofile
+				if PKIprofile != "" {
+					rest_op.ObjName = PKIprofile
+				}
 				rest.AviPkiProfileCacheDel(rest_op, aviObjKey, key)
 			case "VirtualService":
 				rest.AviVsCacheDel(rest_op, aviObjKey, key)
@@ -845,7 +859,9 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				case avimodels.VSDataScriptSet:
 					VSDataScriptSet = *rest_op.Obj.(avimodels.VSDataScriptSet).Name
 				}
-				rest_op.ObjName = VSDataScriptSet
+				if VSDataScriptSet != "" {
+					rest_op.ObjName = VSDataScriptSet
+				}
 				rest.AviDSCacheDel(rest_op, aviObjKey, key)
 			}
 		} else if statuscode == 409 {

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -66,9 +66,18 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 			Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
 		rest_op.ObjName = name
 	} else {
-		path = "/api/sslkeyandcertificate"
-		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: sslkeycert,
-			Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+		ssl_key := avicache.NamespaceName{Namespace: ssl_node.Tenant, Name: name}
+		ssl_cache, ok := rest.cache.SSLKeyCache.AviCacheGet(ssl_key)
+		if ok {
+			ssl_cache_obj, _ := ssl_cache.(*avicache.AviSSLCache)
+			path = "/api/sslkeyandcertificate/" + ssl_cache_obj.Uuid
+			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: sslkeycert,
+				Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+		} else {
+			path = "/api/sslkeyandcertificate"
+			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: sslkeycert,
+				Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+		}
 	}
 	return &rest_op
 }


### PR DESCRIPTION
This PR fixes
1. Continuous  post for SSLkeyandcertificate even continuous 409 errors are there in retry layer for that sslkeyandcertificate 
2. Continuous delete call for AVI Objects even 404 error are there in retry layer.

This fixes S1 issue AKO: AKO continuously does POST for sslkeyandcertificate and fails to configure all VS. 