### PR TITLE
fix configmap key reference for bgpPeerLabels

### DIFF
--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -86,7 +86,7 @@ type NetworkSettings struct {
 	SubnetPrefix string `json:"subnetPrefix,omitempty"`
 	// EnableRHI is a cluster wide setting for BGP peering
 	EnableRHI bool `json:"enableRHI,omitempty"`
-	// BGPPeerLabels enables selection of BGP peers, for selective VsVip advertisement.
+	// BGPPeerLabels enable selection of BGP peers, for selective VsVip advertisement.
 	BGPPeerLabels []string `json:"bgpPeerLabels,omitempty"`
 	// VipNetworkList holds the names of networks as specified in Avi
 	VipNetworkList []VipNetwork `json:"vipNetworkList,omitempty"`

--- a/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
@@ -185,8 +185,8 @@ spec:
                 the AKO controller
               properties:
                 bgpPeerLabels:
-                  description: BGPPeerLabels enables selection of BGP peers, for selective VsVip
-                    advertisement.
+                  description: BGPPeerLabels enable selection of BGP peers, for selective
+                    VsVip advertisement.
                   items:
                     type: string
                   type: array

--- a/ako-operator/helm/ako-operator/templates/akoconfig.yaml
+++ b/ako-operator/helm/ako-operator/templates/akoconfig.yaml
@@ -27,6 +27,10 @@ spec:
     subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
     subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
     enableRHI: {{ .Values.NetworkSettings.enableRHI }}
+{{- with .Values.NetworkSettings.bgpPeerLabels }}
+    bgpPeerLabels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 {{- with .Values.NetworkSettings.vipNetworkList }}
     vipNetworkList:
 {{- toYaml . | nindent 4 }}
@@ -35,6 +39,7 @@ spec:
     nodeNetworkList:
 {{- toYaml . | nindent 4 }}
 {{- end }}
+
   l7Settings:
     defaultIngController: {{ .Values.L7Settings.defaultIngController }}
     serviceType: {{ .Values.L7Settings.serviceType }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: avi-k8s-config
-                key: bgpPeerList
+                key: bgpPeerLabels
           - name: NODE_NETWORK_LIST
             valueFrom:
               configMapKeyRef:

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -185,7 +185,7 @@ func TestL7Model(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
-	}, 30*time.Second).Should(gomega.Equal(true))
+	}, 50*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(len(nodes)).To(gomega.Equal(1))


### PR DESCRIPTION
This was incorrectly set as bgpPeerList