### PR TITLE
Fix for ako artifacts cleanup issue and a cherry-pick

### DIFF
--- a/Dockerfile.ako-operator
+++ b/Dockerfile.ako-operator
@@ -20,7 +20,7 @@ FROM ${ubi_src_repo}
 
 LABEL name="ako-operator"
 LABEL summary="An AKO operator to deploy AKO controller"
-LABEL version="v1.3.1"
+LABEL version="v1.4.2"
 LABEL release="1"
 LABEL description="Manage configmap, statefulset and other artifacts for deploying AKO controller"
 LABEL vendor="VMware"

--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -57,7 +57,7 @@ type AKOSettings struct {
 	NSSelector NamespaceSelector `json:"namespaceSelector,omitempty"`
 	// EnableEVH enables the Enhanced Virtual Hosting Model in Avi Controller for the Virtual Services
 	EnableEVH bool `json:"enableEVH,omitempty"`
-	// Layer7Only enables AKO to do Layer 7 loadbalancing only
+	// Layer7Only flag, if set to true, then AKO controller will only do layer 7 loadbalancing
 	Layer7Only bool `json:"layer7Only,omitempty"`
 	// ServicesAPI enables AKO to do Layer 4 loadbalancing using Services API
 	ServicesAPI bool `json:"servicesAPI,omitempty"`

--- a/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
@@ -65,8 +65,8 @@ spec:
                     sync is carried out by the AKO controller
                   type: string
                 layer7Only:
-                  description: Layer7Only enables AKO to do Layer 7 loadbalancing
-                    only
+                  description: Layer7Only flag, if set to true, then AKO controller
+                    will only do layer 7 loadbalancing
                   type: boolean
                 logLevel:
                   description: LogLevel defines the log level to be used by the AKO

--- a/ako-operator/controllers/akoconfig_controller.go
+++ b/ako-operator/controllers/akoconfig_controller.go
@@ -173,51 +173,57 @@ func (r *AKOConfigReconciler) ReconcileAllArtifacts(ctx context.Context, ako ako
 
 func (r *AKOConfigReconciler) CleanupArtifacts(ctx context.Context, log logr.Logger) error {
 	log.V(0).Info("cleaning up all the artifacts")
-	objList := getObjectList()
-	if len(objList) == 0 {
-		// AKOConfig was deleted, but during the same time, the operator was restarted
-		var cm corev1.ConfigMap
-		if err := r.Get(ctx, getConfigMapName(), &cm); err != nil {
-			log.V(0).Info("error getting configmap", "error", err)
-		} else {
-			objList[getConfigMapName()] = &cm
-		}
-		var sf appsv1.StatefulSet
-		if err := r.Get(ctx, getSFNamespacedName(), &sf); err != nil {
-			log.V(0).Info("error getting statefulset", "error", err)
-		} else {
-			objList[getSFNamespacedName()] = &sf
-		}
-		var cr rbacv1.ClusterRole
-		if err := r.Get(ctx, getCRName(), &cr); err != nil {
-			log.V(0).Info("error getting clusterrole", "error", err)
-		} else {
-			objList[getCRName()] = &cr
-		}
-		var crb rbacv1.ClusterRoleBinding
-		if err := r.Get(ctx, getCRBName(), &crb); err != nil {
-			log.V(0).Info("error getting clusterrolebinding", "error", err)
-		} else {
-			objList[getCRBName()] = &crb
-		}
-		var sa v1.ServiceAccount
-		if err := r.Get(ctx, getSAName(), &sa); err != nil {
-			log.V(0).Info("error getting serviceaccount", "error", err)
-		} else {
-			objList[getSAName()] = &sa
-		}
-		var psp policyv1beta1.PodSecurityPolicy
-		if err := r.Get(ctx, getPSPName(), &psp); err != nil {
-			log.V(0).Info("error getting podsecuritypolicy", "error", err)
-		} else {
-			objList[getPSPName()] = &psp
-		}
+	objList := make(map[types.NamespacedName]runtime.Object)
+
+	// Fetch all artifacts and delete them
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, getConfigMapName(), &cm); err != nil {
+		log.V(0).Info("error getting configmap", "error", err)
+	} else {
+		log.V(0).Info("will cleanup configmap", "configmap", getConfigMapName())
+		objList[getConfigMapName()] = &cm
+	}
+	var sf appsv1.StatefulSet
+	if err := r.Get(ctx, getSFNamespacedName(), &sf); err != nil {
+		log.V(0).Info("error getting statefulset", "error", err)
+	} else {
+		log.V(0).Info("will cleanup statefulset", "statefulset", getSFNamespacedName())
+		objList[getSFNamespacedName()] = &sf
+	}
+	var cr rbacv1.ClusterRole
+	if err := r.Get(ctx, getCRName(), &cr); err != nil {
+		log.V(0).Info("error getting clusterrole", "error", err)
+	} else {
+		log.V(0).Info("will delete clusterrole", "clusterrole", getCRName())
+		objList[getCRName()] = &cr
+	}
+	var crb rbacv1.ClusterRoleBinding
+	if err := r.Get(ctx, getCRBName(), &crb); err != nil {
+		log.V(0).Info("error getting clusterrolebinding", "error", err)
+	} else {
+		log.V(0).Info("will delete clusterrolebinding", "clusterrolebinding", getCRBName())
+		objList[getCRBName()] = &crb
+	}
+	var sa v1.ServiceAccount
+	if err := r.Get(ctx, getSAName(), &sa); err != nil {
+		log.V(0).Info("error getting serviceaccount", "error", err)
+	} else {
+		log.V(0).Info("will delete serviceaccount", "serviceaccount", getSAName())
+		objList[getSAName()] = &sa
+	}
+	var psp policyv1beta1.PodSecurityPolicy
+	if err := r.Get(ctx, getPSPName(), &psp); err != nil {
+		log.V(0).Info("error getting podsecuritypolicy", "error", err)
+	} else {
+		log.V(0).Info("will delete pod security policy", "podsecuritypolicy", getPSPName())
+		objList[getPSPName()] = &psp
 	}
 	for objName, obj := range objList {
 		if err := r.deleteIfExists(ctx, objName, obj); err != nil {
 			log.Error(err, "error while deleting object")
 			return err
 		}
+		log.V(0).Info("deleted object", "object", objName)
 	}
 	return nil
 }

--- a/ako-operator/controllers/akoconfig_controller.go
+++ b/ako-operator/controllers/akoconfig_controller.go
@@ -134,13 +134,15 @@ func (r *AKOConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *AKOConfigReconciler) UpdateAKOConfigStatus(ctx context.Context, state string,
 	akoConfig *akov1alpha1.AKOConfig, log logr.Logger) error {
 
-	log.V(0).Info("updating ako config status", "status message", state)
-	akoConfig.Status.State = state
 	patch := client.MergeFrom(akoConfig.DeepCopy())
-	err := r.Client.Patch(ctx, akoConfig, patch)
+	akoConfig.Status.State = state
+	log.V(0).Info("patch data", "patch", patch)
+	err := r.Status().Patch(ctx, akoConfig, patch)
 	if err != nil {
 		return err
 	}
+
+	log.V(1).Info("updated status of AKOConfig", "state", state)
 	return nil
 }
 

--- a/ako-operator/controllers/configmap.go
+++ b/ako-operator/controllers/configmap.go
@@ -144,39 +144,11 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 	cm.Data[CloudName] = ako.Spec.ControllerSettings.CloudName
 	cm.Data[ClusterName] = ako.Spec.AKOSettings.ClusterName
 	cm.Data[DefaultDomain] = ako.Spec.L4Settings.DefaultDomain
-	disableStaticRouteSync := "false"
-	if ako.Spec.AKOSettings.DisableStaticRouteSync {
-		disableStaticRouteSync = "true"
-	}
-	cm.Data[DisableStaticRouteSync] = disableStaticRouteSync
-
-	defaultIngController := "false"
-	if ako.Spec.L7Settings.DefaultIngController {
-		defaultIngController = "true"
-	}
-	cm.Data[DefaultIngController] = defaultIngController
-
+	cm.Data[DisableStaticRouteSync] = strconv.FormatBool(ako.Spec.AKOSettings.DisableStaticRouteSync)
+	cm.Data[DefaultIngController] = strconv.FormatBool(ako.Spec.L7Settings.DefaultIngController)
 	cm.Data[SubnetIP] = ako.Spec.NetworkSettings.SubnetIP
 	cm.Data[SubnetPrefix] = ako.Spec.NetworkSettings.SubnetPrefix
 	cm.Data[LogLevel] = string(ako.Spec.LogLevel)
-
-	deleteConfig := "false"
-	if ako.Spec.AKOSettings.DeleteConfig {
-		deleteConfig = "true"
-	}
-	cm.Data[DeleteConfig] = deleteConfig
-
-	advancedL4 := "false"
-	if ako.Spec.L4Settings.AdvancedL4 {
-		advancedL4 = "true"
-	}
-	cm.Data[AdvancedL4] = advancedL4
-
-	enableRHI := "false"
-	if ako.Spec.NetworkSettings.EnableRHI {
-		enableRHI = "true"
-	}
-	cm.Data[EnableRHI] = enableRHI
 
 	var err error
 	vipListBytes, err := json.Marshal(ako.Spec.NetworkSettings.VipNetworkList)
@@ -184,11 +156,14 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 		return cm, err
 	}
 	cm.Data[VipNetworkList] = string(vipListBytes)
-
+	cm.Data[DeleteConfig] = strconv.FormatBool(ako.Spec.AKOSettings.DeleteConfig)
+	cm.Data[AdvancedL4] = strconv.FormatBool(ako.Spec.L4Settings.AdvancedL4)
+	cm.Data[EnableRHI] = strconv.FormatBool(ako.Spec.NetworkSettings.EnableRHI)
 	cm.Data[ServiceType] = string(ako.Spec.L7Settings.ServiceType)
 	cm.Data[NodeKey] = ako.Spec.NodePortSelector.Key
 	cm.Data[NodeValue] = ako.Spec.NodePortSelector.Value
 	cm.Data[ServiceEngineGroupName] = ako.Spec.ControllerSettings.ServiceEngineGroupName
+
 	apiServerPort := ako.Spec.AKOSettings.APIServerPort
 	if apiServerPort > 0 {
 		cm.Data[APIServerPort] = strconv.Itoa(apiServerPort)
@@ -227,13 +202,9 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 	cm.Data[NSSyncLabelKey] = ako.Spec.AKOSettings.NSSelector.LabelKey
 	cm.Data[NSSyncLabelValue] = ako.Spec.AKOSettings.NSSelector.LabelValue
 
-	tenantsPerCluster := "false"
-	if ako.Spec.ControllerSettings.TenantsPerCluster {
-		tenantsPerCluster = "true"
-	}
-	cm.Data[TenantsPerCluster] = tenantsPerCluster
+	cm.Data[TenantsPerCluster] = strconv.FormatBool(ako.Spec.ControllerSettings.TenantsPerCluster)
 	cm.Data[TenantName] = ako.Spec.ControllerSettings.TenantName
 	cm.Data[AutoFQDN] = ako.Spec.L4Settings.AutoFQDN
-
+	cm.Data[Layer7Only] = strconv.FormatBool(ako.Spec.Layer7Only)
 	return cm, nil
 }

--- a/ako-operator/controllers/utils.go
+++ b/ako-operator/controllers/utils.go
@@ -12,6 +12,14 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
+// Status messages
+const (
+	SuccessfullyDeployedMsg  = "Reconciled all artifacts"
+	CleanupErrMsg            = "Error in cleaning up artifacts: "
+	FinalizerRemoveErrMsg    = "Error in removing finalizer: "
+	ArtifactsReconcileErrMsg = "Error in reconciling: "
+)
+
 // properties used for naming the dependent artifacts
 const (
 	StatefulSetName    = "ako"


### PR DESCRIPTION
Instead of relying on the in-memory object map, just fetch all the
related artifacts and delete them.

Also includes a cherry-pick for status updates of `AKOConfig` object.