### PR TITLE
Do not perform bulk status update on resources of un-accepted namespaces when namespace sync feature is enabled.

### DIFF
--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -368,8 +368,10 @@ func getGateways(gwNSNames []string, bulk bool, retryNum ...int) map[string]*adv
 
 		for i := range gwList.Items {
 			if _, ok := aviGWClasses[gwList.Items[i].Spec.Class]; ok {
-				ing := gwList.Items[i]
-				gwMap[ing.Namespace+"/"+ing.Name] = &ing
+				gw := gwList.Items[i]
+				if utils.CheckIfNamespaceAccepted(gw.Namespace) {
+					gwMap[gw.Namespace+"/"+gw.Name] = &gw
+				}
 			}
 		}
 

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -478,7 +478,6 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		// to return all AKO ingestable Ingresses.
 		aviIngClasses := make(map[string]bool)
 		if utils.GetIngressClassEnabled() {
-			//It seems v1bet1/ingressclass deprecated in 1.19+. Should we use networking/v1 ingress class ?
 			ingClassList, err := mClient.NetworkingV1beta1().IngressClasses().List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				utils.AviLog.Warnf("Could not get the IngressClass object for UpdateStatus: %s", err)

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -478,6 +478,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		// to return all AKO ingestable Ingresses.
 		aviIngClasses := make(map[string]bool)
 		if utils.GetIngressClassEnabled() {
+			//It seems v1bet1/ingressclass deprecated in 1.19+. Should we use networking/v1 ingress class ?
 			ingClassList, err := mClient.NetworkingV1beta1().IngressClasses().List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				utils.AviLog.Warnf("Could not get the IngressClass object for UpdateStatus: %s", err)
@@ -525,7 +526,9 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 			}
 			if returnIng {
 				ing := ingressList.Items[i]
-				ingressMap[ing.Namespace+"/"+ing.Name] = &ing
+				if utils.CheckIfNamespaceAccepted(ing.Namespace) {
+					ingressMap[ing.Namespace+"/"+ing.Name] = &ing
+				}
 			}
 		}
 

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -142,7 +142,9 @@ func getRoutes(routeNSNames []string, bulk bool, retryNum ...int) map[string]*ro
 		}
 		for i := range routeList.Items {
 			route := routeList.Items[i]
-			routeMap[route.Namespace+"/"+route.Name] = &route
+			if utils.CheckIfNamespaceAccepted(route.Namespace) {
+				routeMap[route.Namespace+"/"+route.Name] = &route
+			}
 		}
 
 		return routeMap

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -210,8 +210,11 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 			}
 		}
 		for i := range serviceLBList.Items {
-			ing := serviceLBList.Items[i]
-			serviceMap[ing.Namespace+"/"+ing.Name] = &ing
+			svc := serviceLBList.Items[i]
+			//Do not perform status update on service if namespace is not accepted.
+			if utils.CheckIfNamespaceAccepted(svc.Namespace) {
+				serviceMap[svc.Namespace+"/"+svc.Name] = &svc
+			}
 		}
 
 		return serviceMap

--- a/internal/status/svcapi_status.go
+++ b/internal/status/svcapi_status.go
@@ -137,8 +137,10 @@ func getSvcApiGateways(gwNSNames []string, bulk bool, retryNum ...int) map[strin
 
 		for i := range gwList.Items {
 			if _, ok := aviGWClasses[gwList.Items[i].Spec.GatewayClassName]; ok {
-				ing := gwList.Items[i]
-				gwMap[ing.Namespace+"/"+ing.Name] = &ing
+				gw := gwList.Items[i]
+				if utils.CheckIfNamespaceAccepted(gw.Namespace) {
+					gwMap[gw.Namespace+"/"+gw.Name] = &gw
+				}
 			}
 		}
 


### PR DESCRIPTION

This PR handles following objects:
1. Ingress
2. Routes
3. Gateway
4. LB Service
5. Advance LB service

For services and routes, we do not have gated condition other than namespace sync feature to use.
So if namespace sync feature is disabled, we will reset status of all services and routes, irrespective whether it is handled by AKO or not.
That is not case with Ingress, gateways, as it has specific class which is only handled by AKO. 