### PR TITLE
unblock AKO run if CRDs are not installed in cluster

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1109,25 +1109,33 @@ func (c *AviController) Start(stopCh <-chan struct{}) {
 		go c.informers.NodeInformer.Informer().Run(stopCh)
 		informersList = append(informersList, c.informers.NodeInformer.Informer().HasSynced)
 
-		go lib.GetCRDInformers().HostRuleInformer.Informer().Run(stopCh)
-		go lib.GetCRDInformers().HTTPRuleInformer.Informer().Run(stopCh)
-		go lib.GetCRDInformers().AviInfraSettingInformer.Informer().Run(stopCh)
-		if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().AviInfraSettingInformer.Informer().HasSynced) {
-			runtime.HandleError(fmt.Errorf("Timed out waiting for AviInfraSettingInformer caches to sync"))
+		if lib.GetAviInfraSettingEnabled() {
+			go lib.GetCRDInformers().AviInfraSettingInformer.Informer().Run(stopCh)
+			if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().AviInfraSettingInformer.Informer().HasSynced) {
+				runtime.HandleError(fmt.Errorf("timed out waiting for AviInfraSettingInformer caches to sync"))
+			}
 		}
+
 		// separate wait steps to try getting hostrules synced first,
 		// since httprule has a key relation to hostrules.
-		if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().HostRuleInformer.Informer().HasSynced) {
-			runtime.HandleError(fmt.Errorf("Timed out waiting for HostRule caches to sync"))
+		if lib.GetHostRuleEnabled() {
+			go lib.GetCRDInformers().HostRuleInformer.Informer().Run(stopCh)
+			if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().HostRuleInformer.Informer().HasSynced) {
+				runtime.HandleError(fmt.Errorf("timed out waiting for HostRule caches to sync"))
+			}
 		}
-		if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().HTTPRuleInformer.Informer().HasSynced) {
-			runtime.HandleError(fmt.Errorf("Timed out waiting for HTTPRule caches to sync"))
+
+		if lib.GetHttpRuleEnabled() {
+			go lib.GetCRDInformers().HTTPRuleInformer.Informer().Run(stopCh)
+			if !cache.WaitForCacheSync(stopCh, lib.GetCRDInformers().HTTPRuleInformer.Informer().HasSynced) {
+				runtime.HandleError(fmt.Errorf("timed out waiting for HTTPRule caches to sync"))
+			}
 		}
 		utils.AviLog.Info("CRD caches synced")
 	}
 
 	if !cache.WaitForCacheSync(stopCh, informersList...) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 	} else {
 		utils.AviLog.Info("Caches synced")
 	}

--- a/internal/lib/crd.go
+++ b/internal/lib/crd.go
@@ -24,59 +24,50 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-var aviInfraSettingEnabled *bool
-var hostRuleEnabled *bool
-var httpRuleEnabled *bool
+var aviInfraSettingEnabled bool
+var hostRuleEnabled bool
+var httpRuleEnabled bool
 
 func SetCRDEnabledParams(cs akocrd.Interface) {
-	if aviInfraSettingEnabled != nil {
-		return
-	}
-
-	var isAviInfraSettingPresent, isHostRulePresent, isHttpRulePresent bool
 	timeout := int64(120)
 	_, aviInfraError := cs.AkoV1alpha1().AviInfraSettings().List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeout})
 	if aviInfraError != nil {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/AviInfraSetting not found/enabled on cluster: %v", aviInfraError)
-		isAviInfraSettingPresent = false
+		aviInfraSettingEnabled = false
 	} else {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/AviInfraSetting enabled on cluster")
-		isAviInfraSettingPresent = true
+		aviInfraSettingEnabled = true
 	}
 
 	_, hostRulesError := cs.AkoV1alpha1().HostRules(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeout})
 	if hostRulesError != nil {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/HostRule not found/enabled on cluster: %v", hostRulesError)
-		isHostRulePresent = false
+		hostRuleEnabled = false
 	} else {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/HostRule enabled on cluster")
-		isHostRulePresent = true
+		hostRuleEnabled = true
 	}
 
 	_, httpRulesError := cs.AkoV1alpha1().HTTPRules(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeout})
 	if httpRulesError != nil {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/HTTPRule not found/enabled on cluster: %v", httpRulesError)
-		isHttpRulePresent = false
+		httpRuleEnabled = false
 	} else {
 		utils.AviLog.Infof("ako.vmware.com/v1alpha1/HTTPRule enabled on cluster")
-		isHttpRulePresent = true
+		httpRuleEnabled = true
 	}
-
-	aviInfraSettingEnabled = &isAviInfraSettingPresent
-	hostRuleEnabled = &isHostRulePresent
-	httpRuleEnabled = &isHttpRulePresent
 }
 
 func GetAviInfraSettingEnabled() bool {
-	return *aviInfraSettingEnabled
+	return aviInfraSettingEnabled
 }
 
 func GetHostRuleEnabled() bool {
-	return *hostRuleEnabled
+	return hostRuleEnabled
 }
 
 func GetHttpRuleEnabled() bool {
-	return *httpRuleEnabled
+	return httpRuleEnabled
 }
 
 var CRDClientset akocrd.Interface


### PR DESCRIPTION
This allows AKO to not get stuck while trying to initialize informers
for the CRDs, in case the CRDs are not installed on the cluster
Fixes #456