### PR TITLE
Upgrade AKO Operator's SDK version to 3 from 3-alpha

### DIFF
--- a/Dockerfile.ako-operator
+++ b/Dockerfile.ako-operator
@@ -20,10 +20,12 @@ FROM ${ubi_src_repo}
 
 LABEL name="ako-operator"
 LABEL summary="An AKO operator to deploy AKO controller"
+LABEL io.openshift.tags="ako,ako-operator,avi,ingress-controller,kubernetes,ingress,controller,openshift"
+LABEL maintainer="VMware <https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes>"
 LABEL version="v1.4.2"
 LABEL release="1"
 LABEL description="Manage configmap, statefulset and other artifacts for deploying AKO controller"
-LABEL vendor="VMware"
+LABEL vendor="VMware <https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes>"
 
 WORKDIR /
 COPY LICENSE /licenses/

--- a/ako-operator/PROJECT
+++ b/ako-operator/PROJECT
@@ -3,9 +3,11 @@ layout: go.kubebuilder.io/v2
 projectName: ako-operator
 repo: github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator
 resources:
-- group: ako
+- domain: vmware.com
+  group: ako
   kind: AKOConfig
+  path: github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-operator/api/v1alpha1
   version: v1alpha1
-version: 3-alpha
+version: "3"
 plugins:
   go.sdk.operatorframework.io/v2-alpha: {}

--- a/ako-operator/config/default/kustomization.yaml
+++ b/ako-operator/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+#- manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/ako-operator/config/manager/manager.yaml
+++ b/ako-operator/config/manager/manager.yaml
@@ -24,9 +24,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
-        args:
-        - --enable-leader-election
+        - /ako-operator
         image: controller:latest
         name: manager
         resources:

--- a/ako-operator/config/samples/ako_v1alpha1_akoconfig.yaml
+++ b/ako-operator/config/samples/ako_v1alpha1_akoconfig.yaml
@@ -6,10 +6,10 @@ metadata:
   name: ako-sample
   namespace: avi-system
 spec:
-  imageRepository: "10.79.172.11:5000/avi-buildops/ako"
+  imageRepository: "projects.registry.vmware.com/ako/ako:1.4.2"
   imagePullPolicy: "IfNotPresent"
   akoSettings:
-    logLevel: "WARN"   #enum
+    logLevel: "INFO"   #enum
     fullSyncFrequency: "1800"
     apiServerPort: 8080
     deleteConfig: false
@@ -40,7 +40,7 @@ spec:
 
   controllerSettings:
     serviceEngineGroupName: "Default-Group"
-    controllerVersion: "20.1.1"
+    controllerVersion: "20.1.5"
     cloudName: "Default-Cloud"
     controllerIP: ""
 
@@ -67,3 +67,6 @@ spec:
 
   mountPath: "/log"
   logFile: "avi.log"
+
+status:
+  state: "Reconciled all artifacts"

--- a/ako-operator/controllers/utils.go
+++ b/ako-operator/controllers/utils.go
@@ -18,6 +18,7 @@ const (
 	CleanupErrMsg            = "Error in cleaning up artifacts: "
 	FinalizerRemoveErrMsg    = "Error in removing finalizer: "
 	ArtifactsReconcileErrMsg = "Error in reconciling: "
+	ReconcilingArtifacts     = "Reconciling all artifacts"
 )
 
 // properties used for naming the dependent artifacts


### PR DESCRIPTION
Also, AKO Operator would now update the status of AKOConfig as soon as
it boots up (this is to make sure that the scorecard test of checking
the status update before the 60s timeout works). For this, we also
need to make sure that the AKOConfig status update doesn't prompt a
reconcile request and hence, we now use a predicate to avoid such
calls.

And, this also removes a spurious log.