### PR TITLE
Support NSX-T cloud in AKO

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
   enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
+  nsxt1LR: {{ .Values.NetworkSettings.nsxt1LR | quote }}
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
   subnetIP: {{ .Values.NetworkSettings.subnetIP | quote }}
   enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   subnetPrefix: {{ .Values.NetworkSettings.subnetPrefix | quote }}
-  nsxt1LR: {{ .Values.NetworkSettings.nsxt1LR | quote }}
+  nsxtT1LR: {{ .Values.NetworkSettings.nsxtT1LR | quote }}
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -144,6 +144,13 @@ spec:
                 name: avi-k8s-config
                 key: syncNamespace
           {{ end }}
+           {{ if .Values.NetworkSettings.nsxt1LR }}
+          - name: NSXT_T1_LR
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: nsxt1LR
+          {{ end }}
           - name: NAMESPACE_SYNC_LABEL_KEY
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -149,7 +149,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: avi-k8s-config
-                key: nsxt1LR
+                key: nsxtT1LR
           {{ end }}
           - name: NAMESPACE_SYNC_LABEL_KEY
             valueFrom:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -41,7 +41,7 @@ NetworkSettings:
   subnetIP: "" # Subnet IP of the vip network
   subnetPrefix: "" # Subnet Prefix of the vip network
   enableRHI: false # This is a cluster wide setting for BGP peering.
-  nsxT1LR: "" # T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
+  nsxtT1LR: "" # T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
   bgpPeerLabels: [] # Select BGP peers using bgpPeerLabels, for selective VsVip advertisement.
   # bgpPeerLabels:
   #   - peer1

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -41,6 +41,7 @@ NetworkSettings:
   subnetIP: "" # Subnet IP of the vip network
   subnetPrefix: "" # Subnet Prefix of the vip network
   enableRHI: false # This is a cluster wide setting for BGP peering.
+  nsxT1LR: "" # T1 Logical Segment mapping for backend network. Only applies to NSX-T cloud.
   bgpPeerLabels: [] # Select BGP peers using bgpPeerLabels, for selective VsVip advertisement.
   # bgpPeerLabels:
   #   - peer1

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2703,6 +2703,17 @@ func checkAndSetCloudType(client *clients.AviClient) bool {
 		utils.AviLog.Errorf("Cloud does not have a ipam_provider_ref configured")
 		return false
 	}
+	// If an NSX-T cloud is configured without a T1LR param, we will disable sync.
+	if vType == "CLOUD_NSXT" {
+		if lib.GetT1LRPath() == "" {
+			utils.AviLog.Errorf("Cloud is configured as NSX-T but the T1 LR mapping is not provided")
+			return false
+		}
+	} else if lib.GetT1LRPath() != "" {
+		// If the cloud type is not NSX-T and yet the T1 LR is set then too disable sync
+		utils.AviLog.Errorf("Cloud is not configured as NSX-T but the T1 LR mapping is  provided")
+		return false
+	}
 
 	return true
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -457,6 +457,15 @@ func GetGlobalBgpPeerLabels() []string {
 	return bgpPeerLabels
 }
 
+func GetT1LRPath() string {
+	t1LrPath := os.Getenv("NSXT_T1_LR")
+	if t1LrPath == "" {
+		utils.AviLog.Error("Required param nsxt1LR, missing from the configuration")
+		return ""
+	}
+	return t1LrPath
+}
+
 func GetSEGName() string {
 	segName := os.Getenv(SEG_NAME)
 	if segName != "" {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -459,10 +459,6 @@ func GetGlobalBgpPeerLabels() []string {
 
 func GetT1LRPath() string {
 	t1LrPath := os.Getenv("NSXT_T1_LR")
-	if t1LrPath == "" {
-		utils.AviLog.Error("Required param nsxt1LR, missing from the configuration")
-		return ""
-	}
 	return t1LrPath
 }
 

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -86,7 +86,11 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	avi_vs_meta.EnableRhi = &enableRhi
 
 	vrfcontext := lib.GetVrf()
-	avi_vs_meta.VrfContext = vrfcontext
+	if lib.GetT1LRPath() != "" {
+		vrfcontext = ""
+	} else {
+		avi_vs_meta.VrfContext = vrfcontext
+	}
 
 	isTCP := false
 	var portProtocols []AviPortHostProtocol
@@ -113,6 +117,9 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		FQDNs:      fqdns,
 		EastWest:   false,
 		VrfContext: vrfcontext,
+	}
+	if lib.GetT1LRPath() != "" {
+		vsVipNode.T1Lr = lib.GetT1LRPath()
 	}
 
 	if lib.GetSubnetIP() != "" {
@@ -155,7 +162,11 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 			PortName:   portProto.Name,
 			VrfContext: lib.GetVrf(),
 		}
-
+		if lib.GetT1LRPath() != "" {
+			poolNode.T1Lr = lib.GetT1LRPath()
+			// Unset the poolnode's vrfcontext.
+			poolNode.VrfContext = ""
+		}
 		serviceType := lib.GetServiceType()
 		if serviceType == lib.NodePortLocal {
 			if svcObj.Spec.Type == "NodePort" {

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -106,7 +106,11 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 				},
 				VrfContext: lib.GetVrf(),
 			}
-
+			if lib.GetT1LRPath() != "" {
+				poolNode.T1Lr = lib.GetT1LRPath()
+				// Unset the poolnode's vrfcontext.
+				poolNode.VrfContext = ""
+			}
 			serviceType := lib.GetServiceType()
 			if serviceType == lib.NodePortLocal {
 				if servers := PopulateServersForNPL(poolNode, namespace, obj.ServiceName, true, key); servers != nil {

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -92,6 +92,7 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 
 	// Hard coded ports for the shared VS
 	var portProtocols []AviPortHostProtocol
+	var vrfcontext string
 	httpPort := AviPortHostProtocol{Port: 80, Protocol: utils.HTTP}
 	httpsPort := AviPortHostProtocol{Port: 443, Protocol: utils.HTTP, EnableSSL: true}
 	portProtocols = append(portProtocols, httpPort)
@@ -101,9 +102,12 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L7_APP_PROFILE
 	avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
 	avi_vs_meta.SNIParent = true
-
-	vrfcontext := lib.GetVrf()
-	avi_vs_meta.VrfContext = vrfcontext
+	if lib.GetT1LRPath() != "" {
+		vrfcontext = ""
+	} else {
+		vrfcontext = lib.GetVrf()
+		avi_vs_meta.VrfContext = vrfcontext
+	}
 
 	o.AddModelNode(avi_vs_meta)
 	o.ConstructShardVsPGNode(vsName, key, avi_vs_meta)
@@ -117,7 +121,9 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 		EastWest:   false,
 		VrfContext: vrfcontext,
 	}
-
+	if lib.GetT1LRPath() != "" {
+		vsVipNode.T1Lr = lib.GetT1LRPath()
+	}
 	if lib.GetSubnetIP() != "" {
 		vsVipNode.SubnetIP = lib.GetSubnetIP()
 		vsVipNode.SubnetPrefix = lib.GetSubnetPrefixInt()
@@ -343,7 +349,11 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 					HostNames:   hostSlice,
 				},
 			}
-
+			if lib.GetT1LRPath() != "" {
+				poolNode.T1Lr = lib.GetT1LRPath()
+				// Unset the poolnode's vrfcontext.
+				poolNode.VrfContext = ""
+			}
 			if hostpath.reencrypt == true {
 				o.BuildPoolSecurity(poolNode, hostpath, key)
 			}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -901,6 +901,7 @@ type AviVSVIPNode struct {
 	BGPPeerLabels           []string
 	SecurePassthroughNode   *AviVsNode
 	InsecurePassthroughNode *AviVsNode
+	T1Lr                    string
 }
 
 func (v *AviVSVIPNode) GetCheckSum() uint32 {
@@ -931,6 +932,9 @@ func (v *AviVSVIPNode) CalculateCheckSum() {
 	if len(v.BGPPeerLabels) > 0 {
 		sort.Strings(v.BGPPeerLabels)
 		checksum += utils.Hash(utils.Stringify(v.BGPPeerLabels))
+	}
+	if v.T1Lr != "" {
+		checksum += utils.Hash(v.T1Lr)
 	}
 	v.CloudConfigCksum = checksum
 }
@@ -1106,6 +1110,7 @@ type AviPoolNode struct {
 	HealthMonitors         []string
 	ApplicationPersistence string
 	VrfContext             string
+	T1Lr                   string // Only applicable to NSX-T cloud, if this value is set, we automatically should unset the VRF context value.
 }
 
 func (v *AviPoolNode) GetCheckSum() uint32 {
@@ -1153,6 +1158,9 @@ func (v *AviPoolNode) CalculateCheckSum() {
 
 	if lib.GetGRBACSupport() {
 		checksum += lib.GetClusterLabelChecksum()
+	}
+	if v.T1Lr != "" {
+		checksum += utils.Hash(v.T1Lr)
 	}
 
 	v.CloudConfigCksum = checksum

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -137,7 +137,11 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 				Tenant:     lib.GetTenant(),
 				VrfContext: lib.GetVrf(),
 			}
-
+			if lib.GetT1LRPath() != "" {
+				poolNode.T1Lr = lib.GetT1LRPath()
+				// Unset the poolnode's vrfcontext.
+				poolNode.VrfContext = ""
+			}
 			o.AddModelNode(poolNode)
 		}
 		poolNode.IngressName = objName

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -235,7 +235,9 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		cloudRef := "/api/cloud?name=" + utils.CloudName
 		svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 		svc_mdata := string(svc_mdata_json)
+
 		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
+
 		seGroupRef := "/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup
 		vs := avimodels.VirtualService{
 			Name:                  &name,
@@ -246,8 +248,10 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 			CloudRef:              &cloudRef,
 			ServiceMetadata:       &svc_mdata,
 			SeGroupRef:            &seGroupRef,
-			VrfContextRef:         &vrfContextRef,
 			VhType:                proto.String(utils.VS_TYPE_VH_ENHANCED),
+		}
+		if lib.GetT1LRPath() == "" {
+			vs.VrfContextRef = &vrfContextRef
 		}
 		var enableRhi bool
 		if vs_meta.EnableRhi != nil {
@@ -375,7 +379,6 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		ApplicationProfileRef: &app_prof,
 		EastWestPlacement:     &east_west,
 		CloudRef:              &cloudRef,
-		VrfContextRef:         &vrfContextRef,
 		SeGroupRef:            &seGroupRef,
 		ServiceMetadata:       &svc_mdata,
 		WafPolicyRef:          &vs_meta.WafPolicyRef,
@@ -385,7 +388,9 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		Enabled:               vs_meta.Enabled,
 		VhType:                proto.String(utils.VS_TYPE_VH_ENHANCED),
 	}
-
+	if lib.GetT1LRPath() == "" {
+		evhChild.VrfContextRef = &vrfContextRef
+	}
 	//This VS has a TLSKeyCert associated, we need to mark 'type': 'VS_TYPE_VH_PARENT'
 	vh_type := utils.VS_TYPE_VH_CHILD
 	evhChild.Type = &vh_type

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -41,7 +41,6 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 	svc_mdata_json, _ := json.Marshal(&pool_meta.ServiceMetadata)
 	svc_mdata := string(svc_mdata_json)
 	cloudRef := "/api/cloud?name=" + utils.CloudName
-	vrfContextRef := "/api/vrfcontext?name=" + pool_meta.VrfContext
 	placementNetworks := []*avimodels.PlacementNetwork{}
 	nodeNetworkMap, _ := lib.GetNodeNetworkMap()
 
@@ -85,10 +84,17 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		TenantRef:         &tenant,
 		CloudRef:          &cloudRef,
 		ServiceMetadata:   &svc_mdata,
-		VrfRef:            &vrfContextRef,
 		SniEnabled:        &pool_meta.SniEnabled,
 		SslProfileRef:     &pool_meta.SslProfileRef,
 		PlacementNetworks: placementNetworks,
+	}
+	var vrfContextRef string
+	if pool_meta.VrfContext != "" {
+		vrfContextRef = "/api/vrfcontext?name=" + pool_meta.VrfContext
+		pool.VrfRef = &vrfContextRef
+	}
+	if pool_meta.T1Lr != "" {
+		pool.Tier1Lr = &pool_meta.T1Lr
 	}
 	if lib.GetGRBACSupport() {
 		pool.Markers = lib.GetMarkers()

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -62,7 +62,10 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			SeGroupRef:            &seGroupRef,
 			VrfContextRef:         &vrfContextRef,
 		}
-
+		if lib.GetT1LRPath() != "" {
+			// Clear the vrfContextRef
+			vs.VrfContextRef = nil
+		}
 		var enableRhi bool
 		if vs_meta.EnableRhi != nil {
 			enableRhi = *vs_meta.EnableRhi
@@ -218,7 +221,10 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 		ErrorPageProfileRef:   &vs_meta.ErrorPageProfileRef,
 		Enabled:               vs_meta.Enabled,
 	}
-
+	if lib.GetT1LRPath() != "" {
+		// Clear the vrfContextRef
+		sniChild.VrfContextRef = nil
+	}
 	//This VS has a TLSKeyCert associated, we need to mark 'type': 'VS_TYPE_VH_PARENT'
 	vh_type := utils.VS_TYPE_VH_CHILD
 	sniChild.Type = &vh_type

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -198,19 +198,23 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 				dns_info_arr = append(dns_info_arr, &dns_info)
 			}
 		}
-
-		vrfContextRef := "/api/vrfcontext?name=" + vsvip_meta.VrfContext
+		var vrfContextRef string
 		vsvip := avimodels.VsVip{
 			Name:                  &name,
 			TenantRef:             &tenant,
 			CloudRef:              &cloudRef,
 			EastWestPlacement:     &east_west,
-			VrfContextRef:         &vrfContextRef,
 			DNSInfo:               dns_info_arr,
 			Vip:                   vips,
 			VsvipCloudConfigCksum: &cksumstr,
 		}
-
+		if vsvip_meta.VrfContext != "" {
+			vrfContextRef = "/api/vrfcontext?name=" + vsvip_meta.VrfContext
+			vsvip.VrfContextRef = &vrfContextRef
+		}
+		if vsvip_meta.T1Lr != "" {
+			vsvip.Tier1Lr = &vsvip_meta.T1Lr
+		}
 		if len(vsvip_meta.BGPPeerLabels) > 0 {
 			vsvip.BgpPeerLabels = vsvip_meta.BGPPeerLabels
 		}


### PR DESCRIPTION
This PR adds supports for the NSX-T cloud in AKO.

The user needs to specify the backend network's T1Lr mapping as a
config option in the values.yaml on which the Service Engine would
create the backend network.