### PR TITLE
add child node checksum to vs checksum calculation

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -437,11 +437,6 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 		checksumStringSlice = append(checksumStringSlice, "VSVIP"+vsvipref.Name)
 	}
 
-	//Required to capture changes in evh child nodes.
-	for _, EVHNode := range v.EvhNodes {
-		checksumStringSlice = append(checksumStringSlice, "EVHChildNode"+EVHNode.Name)
-	}
-
 	// Note: Changing the order of strings being appended, while computing vsRefs and checksum,
 	// will change the eventual checksum Hash.
 
@@ -470,6 +465,10 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 		v.NetworkProfile +
 		utils.Stringify(portproto) +
 		v.EvhHostName)
+
+	for _, evhnode := range v.EvhNodes {
+		checksum += evhnode.GetCheckSum()
+	}
 
 	if vsRefs != "" {
 		checksum += utils.Hash(vsRefs)

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -682,6 +682,10 @@ func (v *AviVsNode) CalculateCheckSum() {
 		v.NetworkProfile +
 		utils.Stringify(portproto))
 
+	for _, sninode := range v.SniNodes {
+		checksum += sninode.GetCheckSum()
+	}
+
 	if vsRefs != "" {
 		checksum += utils.Hash(vsRefs)
 	}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -384,7 +384,7 @@ func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, st
 
 func saveAviModel(model_name string, aviGraph *AviObjectGraph, key string) bool {
 	utils.AviLog.Debugf("key: %s, msg: Evaluating model :%s", key, model_name)
-	if lib.DisableSync == true {
+	if lib.DisableSync {
 		// Note: This is not thread safe, however locking is expensive and the condition for locking should happen rarely
 		utils.AviLog.Infof("key: %s, msg: Disable Sync is True, model %s can not be saved", key, model_name)
 		return false

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -357,7 +357,7 @@ func updateRouteAnnotations(mRoute *routev1.Route, updateOption UpdateOptions, o
 		}
 	}
 
-	// compare the VirtualService annotations for this ingress object
+	// compare the VirtualService annotations for this Route object
 	if req := isAnnotationsUpdateRequired(mRoute.Annotations, vsAnnotations); req {
 		if err := patchRouteAnnotations(mRoute, vsAnnotations); err != nil && k8serrors.IsNotFound(err) {
 			utils.AviLog.Errorf("key: %s, msg: error in updating the route annotations: %v", key, err)
@@ -466,7 +466,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 	mRoute, err := utils.GetInformers().RouteInformer.Lister().Routes(svc_mdata_obj.Namespace).Get(svc_mdata_obj.IngressName)
 
 	if err != nil {
-		utils.AviLog.Warnf("key: %s, msg: Could not get the ingress object for DeleteStatus: %s", key, err)
+		utils.AviLog.Warnf("key: %s, msg: Could not get the Route object for DeleteStatus: %s", key, err)
 		return err
 	}
 
@@ -497,7 +497,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 	var updatedRoute *routev1.Route
 	sameStatus := compareRouteStatus(oldRouteStatus.Ingress, mRoute.Status.Ingress)
 	if sameStatus {
-		utils.AviLog.Debugf("key: %s, msg: No changes detected in ingress status. old: %+v new: %+v",
+		utils.AviLog.Debugf("key: %s, msg: No changes detected in Route status. old: %+v new: %+v",
 			key, oldRouteStatus.Ingress, mRoute.Status.Ingress)
 	} else {
 		patchPayload, _ := json.Marshal(map[string]interface{}{
@@ -510,7 +510,7 @@ func deleteRouteObject(svc_mdata_obj avicache.ServiceMetadataObj, key string, is
 		}
 		updatedRoute, err = utils.GetInformers().OshiftClient.RouteV1().Routes(svc_mdata_obj.Namespace).Patch(context.TODO(), mRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 		if err != nil {
-			utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the ingress status: %v", key, err)
+			utils.AviLog.Errorf("key: %s, msg: there was an error in deleting the Route status: %v", key, err)
 			return deleteObject(svc_mdata_obj, key, isVSDelete, retry+1)
 		}
 


### PR DESCRIPTION
add UT corresponding to it that creates separate routes (reproducible
in case of ingresses too), with same host but differrent paths, and
then deletes one of the routes forcing a SNI pool delete. AKO does not
let graph nodes proceed to rest layer, unless the graph checksum changes,
(see saveAviModel) so for any changes whatsoever, the graph checksum must
change. This would lead to irrelevant PUT calls on the parent VS.
Fixes AV-116457