### PR TITLE
Openshift EVH changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ namespacesynctests:
 	sudo docker run \
 	-w=/go/src/$(PACKAGE_PATH_AKO) \
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
-	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/namespacesynctests -failfast
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/namespacesynctests -failfast -timeout 0
 
 .PHONY: misc 
 temp:

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -53,6 +53,8 @@ const (
 	FAST_RETRY_LAYER                           = "FastRetryLayer"
 	NOT_FOUND                                  = "HTTP code: 404"
 	STATUS_REDIRECT                            = "HTTP_REDIRECT_STATUS_CODE_302"
+	CLOSE_CONNECTION                           = "HTTP_SECURITY_ACTION_CLOSE_CONN"
+	IS_IN                                      = "IS_IN"
 	SLOW_SYNC_TIME                             = 90 // seconds
 	LOG_LEVEL                                  = "logLevel"
 	LAYER7_ONLY                                = "layer7Only"
@@ -172,6 +174,7 @@ const (
 	AviSettingRouteIndex = "aviSettingRoute"
 )
 
+//Passthrough deployment same in EVH and SNI. Not changing log messages.
 const (
 	PassthroughDatascript = `local avi_tls = require "Default-TLS"
 	buffered = avi.l4.collect(20)

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -104,7 +104,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 	dsNode := datascriptList[0]
 
 	// Get Poolgroup Node, create if not present
-	pgName := lib.GetClusterName() + "--" + hostname
+	pgName := lib.Encode(lib.GetClusterName() + "--" + hostname)
 	pgNode := o.GetPoolGroupByName(pgName)
 	if pgNode == nil {
 		pgNode = &AviPoolGroupNode{Name: pgName, Tenant: lib.GetTenant()}
@@ -129,7 +129,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 	// store the Pools in the a temoprary list to be used for populating PG members
 	tmpPoolList := []*AviPoolNode{}
 	for _, obj := range svclist {
-		poolName := lib.GetClusterName() + "--" + hostname + "-" + obj.ServiceName
+		poolName := lib.Encode(lib.GetClusterName() + "--" + hostname + "-" + obj.ServiceName)
 		poolNode := o.GetAviPoolNodeByName(poolName)
 		if poolNode == nil {
 			poolNode = &AviPoolNode{

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -430,6 +430,8 @@ func (v *Validator) ParseHostPathForRoute(ns string, routeName string, routeSpec
 				tls.cacert = routeSpec.TLS.CACertificate
 				if routeSpec.TLS.InsecureEdgeTerminationPolicy == routev1.InsecureEdgeTerminationPolicyRedirect {
 					tls.redirect = true
+				} else if routeSpec.TLS.InsecureEdgeTerminationPolicy == routev1.InsecureEdgeTerminationPolicyNone {
+					tls.blockHTTPTraffic = true
 				}
 			}
 

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -425,6 +425,16 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		evhChild.PoolRef = &pool_ref
 	}
 
+	//DS from hostrule
+	var datascriptCollection []*avimodels.VSDataScripts
+	for i, script := range vs_meta.VsDatascriptRefs {
+		j := int32(i)
+		datascript := script
+		datascripts := &avimodels.VSDataScripts{VsDatascriptSetRef: &datascript, Index: &j}
+		datascriptCollection = append(datascriptCollection, datascripts)
+	}
+	evhChild.VsDatascripts = datascriptCollection
+
 	// No need of HTTP rules for TLS passthrough.
 	if vs_meta.TLSType != utils.TLS_PASSTHROUGH {
 		// this overwrites the sslkeycert created from the Secret object, with the one mentioned in HostRule.TLS

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -153,9 +153,21 @@ func UpdateNamespace(nsName string, labels map[string]string) error {
 	_, err := KubeClient.CoreV1().Namespaces().Update(context.TODO(), nsMetaOptions, metav1.UpdateOptions{})
 	return err
 }
+func WaitTillNamespaceDelete(nsName string, retry_count int) {
+	_, err := KubeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+	if err == nil {
+		//NS still exists
+		if retry_count > 0 {
+			time.Sleep(time.Second * 1)
+			WaitTillNamespaceDelete(nsName, retry_count-1)
+		}
+	}
 
+}
 func DeleteNamespace(nsName string) {
 	KubeClient.CoreV1().Namespaces().Delete(context.TODO(), nsName, metav1.DeleteOptions{})
+	//create delay of max 10 sec
+	WaitTillNamespaceDelete(nsName, 10)
 }
 
 // Fake Secret


### PR DESCRIPTION
This PR handles:
1. Openshift EVH changes.
2. Fixed: Datascript, from host rule, not attached to VS in EVH mode. (Attaching DS to child node)
2. Issue in cksum calculation for passthrough vs.

Note: For passthrough route with redirect allow, we are not encoding suffix (-indirect) of redirect VS created as AKO code base has logic based on that. 