### PR TITLE
sync CRD files from ako helm directory to ako-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,14 +47,21 @@ endif
 .PHONY: all
 all: build docker
 
+.PHONY: sync-crd-files
+sync-crd-files:
+		cp ./helm/ako/crds/* ./ako-operator/helm/ako-operator/crds/
+
+.PHONY: pre-build
+pre-build: sync-crd-files
+
 # builds
 .PHONY: build
-build: glob-vars
+build: pre-build glob-vars
 		sudo docker run -w=/go/src/$(PACKAGE_PATH_AKO) -v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
 		$(GOBUILD) -o /go/src/$(PACKAGE_PATH_AKO)/bin/$(BINARY_NAME_AKO) -ldflags="-X 'main.version=$(AKO_VERSION)'" -mod=vendor /go/src/$(REL_PATH_AKO)
 
 .PHONY: build-local
-build-local:
+build-local: pre-build
 		$(GOBUILD) -o bin/$(BINARY_NAME_AKO) -ldflags="-X 'main.version=$(AKO_VERSION)'" -mod=vendor ./cmd/ako-main
 
 .PHONY: clean

--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -24,10 +24,20 @@ spec:
             properties:
               virtualhost:
                 properties:
+                  analyticsProfile:
+                    type: string
                   applicationProfile:
+                    type: string
+                  enableVirtualHost:
+                    type: boolean
+                  errorPageProfile:
                     type: string
                   fqdn:
                     type: string
+                  datascripts:
+                    items:
+                      type: string
+                    type: array
                   httpPolicy:
                     properties:
                       overwrite:
@@ -37,10 +47,15 @@ spec:
                           type: string
                         type: array
                     type: object
-                  networkSecurityPolicy:
-                    type: string
+                  gslb:
+                    properties:
+                      fqdn:
+                        type: string
+                    type: object
                   tls:
                     properties:
+                      sslProfile:
+                        type: string
                       sslKeyCertificate:
                         properties:
                           name:

--- a/internal/status/crd_status.go
+++ b/internal/status/crd_status.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -23,6 +24,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // UpdateCRDStatusOptions CRD Status Update Options
@@ -42,10 +44,11 @@ func UpdateHostRuleStatus(key string, hr *akov1alpha1.HostRule, updateStatus Upd
 		}
 	}
 
-	hr.Status.Status = updateStatus.Status
-	hr.Status.Error = updateStatus.Error
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": updateStatus,
+	})
 
-	_, err := lib.GetCRDClientset().AkoV1alpha1().HostRules(hr.Namespace).UpdateStatus(context.TODO(), hr, metav1.UpdateOptions{})
+	_, err := lib.GetCRDClientset().AkoV1alpha1().HostRules(hr.Namespace).Patch(context.TODO(), hr.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 	if err != nil {
 		utils.AviLog.Errorf("key: %s, msg: there was an error in updating the hostrule status: %+v", key, err)
 		updatedHr, err := lib.GetCRDClientset().AkoV1alpha1().HostRules(hr.Namespace).Get(context.TODO(), hr.Name, metav1.GetOptions{})
@@ -60,7 +63,6 @@ func UpdateHostRuleStatus(key string, hr *akov1alpha1.HostRule, updateStatus Upd
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Successfully updated the hostrule %s/%s status %+v", key, hr.Namespace, hr.Name, utils.Stringify(updateStatus))
-	return
 }
 
 // UpdateHTTPRuleStatus HttpRule status updates
@@ -74,10 +76,11 @@ func UpdateHTTPRuleStatus(key string, rr *akov1alpha1.HTTPRule, updateStatus Upd
 		}
 	}
 
-	rr.Status.Status = updateStatus.Status
-	rr.Status.Error = updateStatus.Error
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": updateStatus,
+	})
 
-	_, err := lib.GetCRDClientset().AkoV1alpha1().HTTPRules(rr.Namespace).UpdateStatus(context.TODO(), rr, metav1.UpdateOptions{})
+	_, err := lib.GetCRDClientset().AkoV1alpha1().HTTPRules(rr.Namespace).Patch(context.TODO(), rr.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 	if err != nil {
 		utils.AviLog.Errorf("key: %s, msg: %d there was an error in updating the httprule status: %+v", key, retry, err)
 		updatedRr, err := lib.GetCRDClientset().AkoV1alpha1().HTTPRules(rr.Namespace).Get(context.TODO(), rr.Name, metav1.GetOptions{})
@@ -92,7 +95,6 @@ func UpdateHTTPRuleStatus(key string, rr *akov1alpha1.HTTPRule, updateStatus Upd
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Successfully updated the httprule %s/%s status %+v", key, rr.Namespace, rr.Name, utils.Stringify(updateStatus))
-	return
 }
 
 // UpdateAviInfraSettingStatus AviInfraSetting status updates
@@ -106,10 +108,11 @@ func UpdateAviInfraSettingStatus(key string, infraSetting *akov1alpha1.AviInfraS
 		}
 	}
 
-	infraSetting.Status.Status = updateStatus.Status
-	infraSetting.Status.Error = updateStatus.Error
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": updateStatus,
+	})
 
-	_, err := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().UpdateStatus(context.TODO(), infraSetting, metav1.UpdateOptions{})
+	_, err := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Patch(context.TODO(), infraSetting.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 	if err != nil {
 		utils.AviLog.Errorf("key: %s, msg: %d there was an error in updating the aviinfrasetting status: %+v", key, retry, err)
 		updatedInfraSetting, err := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), infraSetting.Name, metav1.GetOptions{})
@@ -124,5 +127,4 @@ func UpdateAviInfraSettingStatus(key string, infraSetting *akov1alpha1.AviInfraS
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Successfully updated the aviinfrasetting %s status %+v", key, infraSetting.Name, utils.Stringify(updateStatus))
-	return
 }


### PR DESCRIPTION
This also adds a pre-build sync-crd-files target in the Makefile
that should run before the build target and sync the CRD files to
the ako-operator helm directory.

Note: The expectation is that whenever someone changes the crd schema in AKO, 
the `build`/`build-local` targets should be executed which would automatically sync the 
changed CRD schemas to ako-operator. The source of truth would be the schemas 
defined in AKO and not AKO-operator, hence the new `pre-build` target is for AKO only.