### PR TITLE
Introduce buildsettings.json that enforces a supportability matrix

### DIFF
--- a/Dockerfile.ako
+++ b/Dockerfile.ako
@@ -1,14 +1,20 @@
 ARG golang_src_repo=golang:latest
 ARG photon_src_repo=photon:latest
 FROM ${golang_src_repo} as build
+ARG AKO_LDFLAGS=
 ENV BUILD_PATH="github.com/vmware/load-balancer-and-ingress-services-for-kubernetes"
-ENV AKO_VERSION="v1.5.1"
 RUN mkdir -p $GOPATH/src/$BUILD_PATH
 
 COPY . $GOPATH/src/$BUILD_PATH
 WORKDIR $GOPATH/src/$BUILD_PATH
 
-RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o $GOPATH/bin/akc -ldflags="-X 'main.version=$AKO_VERSION'" -mod=vendor $BUILD_PATH/cmd/ako-main
+RUN GOARCH=amd64 \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    go build -o $GOPATH/bin/akc \
+    -ldflags "$AKO_LDFLAGS" \
+    -mod=vendor \
+    $BUILD_PATH/cmd/ako-main
 
 FROM ${photon_src_repo}
 RUN yum install -y tar.x86_64

--- a/buildsettings.json
+++ b/buildsettings.json
@@ -1,0 +1,11 @@
+{
+    "version": "1.5.1",
+    "avi": {
+        "maxVersion": "20.1.6",
+        "minVersion": "20.1.1"
+    },
+    "kubernetes": {
+        "maxVersion": "1.21",
+        "minVersion": "1.16"
+    }
+}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2795,12 +2795,12 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 
 	networkList, err := lib.GetVipNetworkList()
 	if err != nil {
-		utils.AviLog.Warnf("Error gettting Network name: %s, skipping fetching of the VRF setting from network", err.Error())
+		utils.AviLog.Warnf("Error getting Network name: %s, skipping fetching of the VRF setting from network", err.Error())
 		return true
 	}
 
 	if len(networkList) == 0 {
-		utils.AviLog.Warnf("Network name net specified, skipping fetching of the VRF setting from network")
+		utils.AviLog.Warnf("Network name not specified, skipping fetching of the VRF setting from network")
 		return true
 	}
 

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -76,7 +76,6 @@ const (
 	CertTypeVS                                 = "SSL_CERTIFICATE_TYPE_VIRTUALSERVICE"
 	CertTypeCA                                 = "SSL_CERTIFICATE_TYPE_CA"
 	VSVIPDELCTRLVER                            = "20.1.1"
-	Advl4ControllerVersion                     = "20.1.2"
 	ControllerVersion2014                      = "20.1.4"
 	ControllerVersion2015                      = "20.1.5"
 	HostRule                                   = "HostRule"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -105,7 +105,7 @@ func SetGRBACSupport(val string) {
 		gRBAC = boolVal
 	}
 	controllerVersion := utils.CtrlVersion
-	if gRBAC && CheckControllerVersionCompatibility(controllerVersion, "<", ControllerVersion2015) {
+	if gRBAC && CompareVersions(controllerVersion, "<", ControllerVersion2015) {
 		// GRBAC is supported from 20.1.5 and above
 		utils.AviLog.Infof("Disabling GRBAC as current controller version %s is less than %s.", controllerVersion, ControllerVersion2015)
 		gRBAC = false
@@ -138,7 +138,7 @@ func GetAKOUser() string {
 var enableCtrl2014Features bool
 
 func SetEnableCtrl2014Features(controllerVersion string) {
-	enableCtrl2014Features = CheckControllerVersionCompatibility(controllerVersion, ">=", ControllerVersion2014)
+	enableCtrl2014Features = CompareVersions(controllerVersion, ">=", ControllerVersion2014)
 }
 
 func GetEnableCtrl2014Features() bool {
@@ -557,8 +557,8 @@ func UseServicesAPI() bool {
 	return false
 }
 
-//Here v1 is compared against v2
-func CheckControllerVersionCompatibility(v1, cmpSign, v2 string) bool {
+// CompareVersions compares version v1 against version v2.
+func CompareVersions(v1, cmpSign, v2 string) bool {
 	if c, err := semver.NewConstraint(cmpSign + v2); err == nil {
 		if currentVersion, err := semver.NewVersion(v1); err == nil && c.Check(currentVersion) {
 			return true
@@ -1104,4 +1104,27 @@ func GetControllerPropertiesFromSecret(cs kubernetes.Interface) (map[string]stri
 		ctrlProps[utils.ENV_CTRL_AUTHTOKEN] = ""
 	}
 	return ctrlProps, nil
+}
+
+var (
+	aviMinVersion = ""
+	aviMaxVersion = ""
+	k8sMinVersion = ""
+	k8sMaxVersion = ""
+)
+
+func GetAviMinSupportedVersion() string {
+	return aviMinVersion
+}
+
+func GetAviMaxSupportedVersion() string {
+	return aviMaxVersion
+}
+
+func GetK8sMinSupportedVersion() string {
+	return k8sMinVersion
+}
+
+func GetK8sMaxSupportedVersion() string {
+	return k8sMaxVersion
 }


### PR DESCRIPTION
AKO is built using parameters present in buildsettings.json which publishes
the min/max Avi and k8s versions supported with a given version of AKO.
Post this commit maintainers must update the buildsettings.json file to
correctly reflect the supported Avi and k8s versions.
Misc: minor TestSecureRouteMultiNamespaceInNodePort related cleanup