### PR TITLE
Remove cache entry only when rest method is DELETE

### DIFF
--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -261,7 +261,7 @@ func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode 
 		if len(tlsNode.SSLKeyCertRefs) == 1 {
 			// Overwrite if the secrets are different.
 			tlsNode.SSLKeyCertRefs[0] = certNode
-			utils.AviLog.Warnf("key: %s, msg: Duplicate secrets detected for the same hostname, overwrote the secret for hostname %s, with contents of secret :%s in ns: %s", key, sniHost[0], secretName, namespace)
+			utils.AviLog.Warnf("key: %s, msg: Duplicate secrets detected for the same hostname, overwrote the secret for hostname %s, with contents of secret :%s in ns: %s", key, sniHost, secretName, namespace)
 		} else {
 			tlsNode.ReplaceSniSSLRefInSNINode(certNode, key)
 		}
@@ -406,7 +406,7 @@ func (o *AviObjectGraph) BuildPoolSecurity(poolNode *AviPoolNode, tlsData TlsSet
 	poolNode.SniEnabled = true
 	poolNode.SslProfileRef = fmt.Sprintf("/api/sslprofile?name=%s", lib.DefaultPoolSSLProfile)
 
-	utils.AviLog.Infof("key: %s, Added ssl profile for pool %s", poolNode.Name)
+	utils.AviLog.Infof("key: %s, Added ssl profile for pool %s", key, poolNode.Name)
 	if tlsData.destCA == "" {
 		return
 	}

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -631,7 +631,7 @@ func (rest *RestOperations) PopulateOneCache(rest_op *utils.RestOp, aviObjKey av
 			rest.AviVsVipCacheAdd(rest_op, aviObjKey, key)
 		}
 
-	} else {
+	} else if rest_op.Err == nil && rest_op.Method == utils.RestDelete {
 		utils.AviLog.Infof("key: %s, msg: deleting %s cache", key, rest_op.Model)
 		if rest_op.Model == "PKIprofile" {
 			rest.AviPkiProfileCacheDel(rest_op, aviObjKey, key)


### PR DESCRIPTION
This PR works on:
1. Fixing : Delete cache entry only when Rest Method is DELETE. In case of non-retryable exception, AKO delete cache entry even if rest method is POST /PUT. This PR fixes that. 
2. Few log printing related issues. 