### PR TITLE
Use VHDomainNames for VS checksum calculation

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -436,6 +436,9 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 	for _, vsvipref := range v.VSVIPRefs {
 		checksumStringSlice = append(checksumStringSlice, "VSVIP"+vsvipref.Name)
 	}
+	for _, vhdomain := range v.VHDomainNames {
+		checksumStringSlice = append(checksumStringSlice, "VHDomain"+vhdomain)
+	}
 
 	// Note: Changing the order of strings being appended, while computing vsRefs and checksum,
 	// will change the eventual checksum Hash.

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -645,6 +645,10 @@ func (v *AviVsNode) CalculateCheckSum() {
 		checksumStringSlice = append(checksumStringSlice, "L4Policy"+l4policy.Name)
 	}
 
+	for _, vhdomain := range v.VHDomainNames {
+		checksumStringSlice = append(checksumStringSlice, "VHDomain"+vhdomain)
+	}
+
 	// Note: Changing the order of strings being appended, while computing vsRefs and checksum,
 	// will change the eventual checksum Hash.
 

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -581,7 +581,7 @@ func TestUpdateAndDeleteServiceLBCacheSync(t *testing.T) {
 }
 
 //TestScaleUpAndDownServiceLBCacheSync tests the avi node graph and rest layer functionality when the
-//multiport serviceLB is increased from 1 to 30 and then decreased back to 1
+//multiport serviceLB is increased from 1 to 5 and then decreased back to 1
 func TestScaleUpAndDownServiceLBCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var model, service string
@@ -595,8 +595,8 @@ func TestScaleUpAndDownServiceLBCacheSync(t *testing.T) {
 
 	SetUpTestForSvcLB(t)
 
-	// create 30 more multiport service of type loadbalancer
-	numScale := 20
+	// create numScale more multiport service of type loadbalancer
+	numScale := 5
 	for i := 0; i < numScale; i++ {
 		service = fmt.Sprintf("%s%d", MULTIPORTSVC, i)
 		model = strings.Replace(MULTIPORTMODEL, MULTIPORTSVC, service, 1)
@@ -606,7 +606,7 @@ func TestScaleUpAndDownServiceLBCacheSync(t *testing.T) {
 		CreateEP(t, NAMESPACE, service, true, true, "1.1.1")
 	}
 
-	// verify that 30 services are created on the graph and corresponding cache objects
+	// verify that numScale services are created on the graph and corresponding cache objects
 	var found bool
 	var vsKey cache.NamespaceName
 	var aviModel interface{}
@@ -628,7 +628,7 @@ func TestScaleUpAndDownServiceLBCacheSync(t *testing.T) {
 		}, 15*time.Second).Should(gomega.Equal(true))
 	}
 
-	// delete the 30 services
+	// delete the numScale services
 	for i := 0; i < numScale; i++ {
 		service = fmt.Sprintf("%s%d", MULTIPORTSVC, i)
 		model = strings.Replace(MULTIPORTMODEL, MULTIPORTSVC, service, 1)
@@ -637,7 +637,7 @@ func TestScaleUpAndDownServiceLBCacheSync(t *testing.T) {
 		DelEP(t, NAMESPACE, service)
 	}
 
-	// verify that the graph nodes and corresponding cache are deleted for the 30 services
+	// verify that the graph nodes and corresponding cache are deleted for the numScale services
 	for i := 0; i < numScale; i++ {
 		service = fmt.Sprintf("%s%d", MULTIPORTSVC, i)
 		model = strings.Replace(MULTIPORTMODEL, MULTIPORTSVC, service, 1)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -134,11 +134,16 @@ func AddNamespace(nsName string, labels map[string]string) error {
 		Labels: labels,
 	}).Namespace()
 	nsMetaOptions.ResourceVersion = "1"
-	_, err := KubeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+	ns, err := KubeClient.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 	if err != nil {
 		_, err = KubeClient.CoreV1().Namespaces().Create(context.TODO(), nsMetaOptions, metav1.CreateOptions{})
 		if err != nil {
 			utils.AviLog.Errorf("Error occurred while Adding namespace : %v", err)
+		}
+	} else {
+		nsLabels := ns.GetLabels()
+		if len(nsLabels) == 0 {
+			err = UpdateNamespace(nsName, labels)
 		}
 	}
 	return err

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -185,7 +185,7 @@ func TestMain(m *testing.M) {
 	integrationtest.AddDefaultIngressClass()
 	defaultKey = "app"
 	defaultValue = "migrate"
-	SetupRouteNamespaceSync(defaultKey, defaultValue, "")
+	SetupRouteNamespaceSync(defaultKey, defaultValue)
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 

--- a/tests/oshiftroutetests/oshift_route_namespace_sync_test.go
+++ b/tests/oshiftroutetests/oshift_route_namespace_sync_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 )
 
-func SetupRouteNamespaceSync(key, value, shardScheme string) {
+func SetupRouteNamespaceSync(key, value string) {
 	os.Setenv("NAMESPACE_SYNC_LABEL_KEY", key)
 	os.Setenv("NAMESPACE_SYNC_LABEL_VALUE", value)
 	ctrl.InitializeNamespaceSync()


### PR DESCRIPTION
Without this fix, gslb host doesn't get added to SNI VS VHDomainNames