### PR TITLE
Retry rest operations if avi controller upgrade is in progress

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -113,6 +113,7 @@ const (
 	NPLService                                 = "NPLService"
 	SyncStatusKey                              = "syncstatus"
 	NoFreeIPError                              = "No available free IPs"
+	ConfigDisallowedDuringUpgradeError         = "Configuration is disallowed during upgrade"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -235,6 +235,9 @@ func isErrorRetryable(statusCode int, errMsg string) bool {
 	if statusCode == 400 && strings.Contains(errMsg, lib.NoFreeIPError) {
 		return true
 	}
+	if statusCode == 403 && strings.Contains(errMsg, lib.ConfigDisallowedDuringUpgradeError) {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
If avi controller upgrade is is progress we would get 403 error.
Currently we don't retry on these errors, which would create a problem
if some kubernetes objects are modified while controller upgrade is in progress.

Enabling retry for these errors to handle this issue.