### PR TITLE
Allow vipNetworkList to be empty in case of advancedL4

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -192,7 +192,7 @@ func AddRoutesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namesp
 
 }
 func AddServicesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
-	// For Advancd L4 and service api , do not handle. services already been taken care
+	// For Advanced L4 and service api , do not handle. services already been taken care
 	// in service handler
 	if lib.GetAdvancedL4() {
 		return

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -438,6 +438,11 @@ func GetSubnetPrefixInt() int32 {
 
 func GetVipNetworkList() ([]string, error) {
 	var vipNetworkList []string
+	if GetAdvancedL4() {
+		// do not return error in case of advancedL4 (wcp)
+		return vipNetworkList, nil
+	}
+
 	type Row struct {
 		NetworkName string `json:"networkName"`
 	}


### PR DESCRIPTION
After the migration from networkName to vipNetworkList, it was made
mandatory. In WCP environments networkName is not provided. This
extends the same behaviour with vipNetworkList.