### PR TITLE
Fix problem with default secret annotation in Ingress

### DIFF
--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -271,8 +271,9 @@ func (v *Validator) ParseHostPathForIngress(ns string, ingName string, ingSpec n
 			defaultTLS.redirect = true
 			tlsConfigs = append(tlsConfigs, defaultTLS)
 			if ok, _ := objects.SharedSvcLister().IngressMappings(ns).GetIngToSecret(ingName); !ok {
-				objects.SharedSvcLister().IngressMappings(ns).AddIngressToSecretsMappings(ns, ingName, defaultTLS.SecretName)
-				objects.SharedSvcLister().IngressMappings(ns).AddSecretsToIngressMappings(ns, ingName, defaultTLS.SecretName)
+				akoNS := utils.GetAKONamespace()
+				objects.SharedSvcLister().IngressMappings(ns).AddIngressToSecretsMappings(akoNS, ingName, defaultTLS.SecretName)
+				objects.SharedSvcLister().IngressMappings(akoNS).AddSecretsToIngressMappings(ns, ingName, defaultTLS.SecretName)
 			}
 		} else {
 			hostMap[hostName] = hostPathMapSvcList

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -415,7 +415,7 @@ func TestAdvL4WrongControllerGWClass(t *testing.T) {
 			return gw.Status.Addresses[0].Value
 		}
 		return ""
-	}, 20*time.Second).Should(gomega.Equal("10.250.250.250"))
+	}, 40*time.Second).Should(gomega.Equal("10.250.250.250"))
 
 	gwclassUpdate := FakeGWClass{
 		Name:       gwClassName,

--- a/tests/ingresstests/ingress_annotation_test.go
+++ b/tests/ingresstests/ingress_annotation_test.go
@@ -581,3 +581,65 @@ func TestAddIngressDefaultCertAddAnnotation(t *testing.T) {
 	}
 	TearDownTestForIngress(t, modelName)
 }
+
+// TestIngressAnnotationAddDefaultCert first adds an Ingress with default secret annotation, then adds the secret and verifies the model graph.
+func TestIngressAnnotationAddDefaultCert(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-0"
+	SetUpTestForIngress(t, modelName)
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	ann := make(map[string]string)
+	ann[lib.DefaultSecretEnabled] = "true"
+	ingrFake.SetAnnotations(ann)
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	integrationtest.AddSecret(lib.DefaultRouteCert, utils.GetAKONamespace(), "tlsCert", "tlsKey")
+
+	var aviModel interface{}
+	var nodes []*avinodes.AviVsNode
+	var found bool
+	g.Eventually(func() bool {
+		found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return false
+		}
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		if len(nodes) != 1 {
+			return false
+		}
+		if len(nodes[0].SniNodes) != 1 {
+			return false
+		}
+		return true
+	}, 40*time.Second).Should(gomega.Equal(true))
+
+	g.Expect(nodes[0].SniNodes[0].Name).To(gomega.Equal("cluster--foo.com"))
+	g.Expect(nodes[0].SniNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].SSLKeyCertRefs[0].Name).To(gomega.Equal("cluster--foo.com"))
+	g.Expect(nodes[0].SniNodes[0].HttpPolicyRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+
+	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't Delete the Ingress %v", err)
+	}
+	err = KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), lib.DefaultRouteCert, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't Delete the secret %v", err)
+	}
+	TearDownTestForIngress(t, modelName)
+}

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -127,12 +127,12 @@ func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 20*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 
 	ingressUpdate := (integrationtest.FakeIngress{
 		Name:        ingressName,
@@ -155,7 +155,7 @@ func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 20*time.Second).Should(gomega.Equal(0))
+	}, 40*time.Second).Should(gomega.Equal(0))
 
 	ingressUpdate2 := (integrationtest.FakeIngress{
 		Name:        ingressName,
@@ -179,7 +179,7 @@ func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 25*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 
 	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
@@ -228,7 +228,7 @@ func TestDefaultIngressClassChange(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 25*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 
 	ingClass.Annotations = map[string]string{lib.DefaultIngressClassAnnotation: "false"}
 	ingClass.ResourceVersion = "2"
@@ -240,7 +240,7 @@ func TestDefaultIngressClassChange(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 35*time.Second).Should(gomega.Equal(0))
+	}, 40*time.Second).Should(gomega.Equal(0))
 
 	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
@@ -360,7 +360,7 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 			}
 		}
 		return false
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
 	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
@@ -384,7 +384,7 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 			}
 		}
 		return false
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
@@ -393,13 +393,13 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 		settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(settingNodes[0].SniNodes)
-	}, 25*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal("cluster--my-infrasetting-baz.com"))
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs)
-	}, 25*time.Second).Should(gomega.Equal(0))
+	}, 40*time.Second).Should(gomega.Equal(0))
 
 	ingClassUpdate = (FakeIngressClass{
 		Name:       ingClassName,
@@ -465,7 +465,7 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 			}
 		}
 		return ""
-	}, 25*time.Second).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	}, 40*time.Second).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
 
 	ingClassUpdate := (FakeIngressClass{
 		Name:            ingClassName,
@@ -486,7 +486,7 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 			}
 		}
 		return 0
-	}, 35*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName2)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting2-bar.com_foo-default-foo-with-class"))
@@ -553,7 +553,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
 		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() int {
 		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
@@ -562,7 +562,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 			}
 		}
 		return 0
-	}, 25*time.Second).Should(gomega.Equal(1))
+	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
@@ -579,7 +579,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 			return len(nodes[0].PoolRefs)
 		}
 		return -1
-	}, 35*time.Second).Should(gomega.Equal(0))
+	}, 40*time.Second).Should(gomega.Equal(0))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	g.Expect(aviModel).Should(gomega.BeNil())
 
@@ -631,7 +631,7 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(settingModelName1)
 		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 	_, aviSettingModel1 := objects.SharedAviGraphLister().Get(settingModelName1)
 	settingNodes1 := aviSettingModel1.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes1[0].PoolRefs).Should(gomega.HaveLen(1))
@@ -657,7 +657,7 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(settingModelName2)
 		return found
-	}, 25*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 	_, aviSettingModel2 := objects.SharedAviGraphLister().Get(settingModelName2)
 	settingNodes2 := aviSettingModel2.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes2[0].PoolRefs).Should(gomega.HaveLen(1))
@@ -729,13 +729,13 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := CRDClient.AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 15*time.Second).Should(gomega.Equal("Rejected"))
+	}, 40*time.Second).Should(gomega.Equal("Rejected"))
 	g.Eventually(func() bool {
 		if found, _ := objects.SharedAviGraphLister().Get(modelName); !found {
 			return true
 		}
 		return false
-	}, 20*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 
 	settingUpdate := (integrationtest.FakeAviInfraSetting{
 		Name:        settingName,
@@ -751,7 +751,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 15*time.Second).Should(gomega.Equal("Accepted"))
+	}, 40*time.Second).Should(gomega.Equal("Accepted"))
 
 	g.Eventually(func() string {
 		if found, aviModel := objects.SharedAviGraphLister().Get(settingModelName); found && aviModel != nil {
@@ -760,7 +760,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 			}
 		}
 		return ""
-	}, 35*time.Second).Should(gomega.Equal("thisisaviref-seGroup"))
+	}, 40*time.Second).Should(gomega.Equal("thisisaviref-seGroup"))
 	_, aviModel := objects.SharedAviGraphLister().Get(settingModelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal("thisisaviref-networkName"))
@@ -780,7 +780,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 15*time.Second).Should(gomega.Equal("Accepted"))
+	}, 40*time.Second).Should(gomega.Equal("Accepted"))
 
 	g.Eventually(func() int {
 		if found, aviModel := objects.SharedAviGraphLister().Get(settingModelName); found && aviModel != nil {
@@ -789,7 +789,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 			}
 		}
 		return 0
-	}, 35*time.Second).Should(gomega.Equal(3))
+	}, 40*time.Second).Should(gomega.Equal(3))
 	_, aviModel = objects.SharedAviGraphLister().Get(settingModelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].VSVIPRefs[0].NetworkNames[0]).Should(gomega.Equal("multivip-network1"))
@@ -845,13 +845,13 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
 		return found
-	}, 15*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() string {
 		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 		settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return settingNodes[0].ServiceEngineGroup
-	}, 30*time.Second).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
+	}, 40*time.Second).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
@@ -876,7 +876,7 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
-	}, 15*time.Second).Should(gomega.Equal(true))
+	}, 40*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(1))
@@ -965,7 +965,7 @@ func TestBGPConfigurationWithInfraSetting(t *testing.T) {
 	g.Eventually(func() string {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
-	}, 15*time.Second).Should(gomega.Equal("Rejected"))
+	}, 40*time.Second).Should(gomega.Equal("Rejected"))
 
 	integrationtest.TeardownAviInfraSetting(t, settingName)
 	TeardownIngressClass(t, ingClassName)


### PR DESCRIPTION
While adding IngressMappings for the secret we were adding wrong Namespace.
Due to this problem, if the secret was added after adding Ingress, it was not getting processed.