### PR TITLE
Add public ip support for public cloud

### DIFF
--- a/helm/ako/crds/ako.vmware.com_aviinfrasettings.yaml
+++ b/helm/ako/crds/ako.vmware.com_aviinfrasettings.yaml
@@ -35,6 +35,8 @@ spec:
                     type: array
                   enableRhi:
                     type: boolean
+                  enablePublicIP:
+                    type: boolean
                   bgpPeerLabels:
                     items:
                       type: string

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -120,7 +120,6 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
 			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
 		}
-
 		avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
 		return avi_vs_meta
 	}

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1600,8 +1600,13 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
+		enablePublicIP := false
+		if infraSetting.Spec.Network.EnablePublicIP != nil {
+			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
+		}
+		vsvip.EnablePublicIP = enablePublicIP
+		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
 	}
-	utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
 }
 
 func manipulateEvhNodeForSSL(vsNode *AviEvhVsNode, evhNode *AviEvhVsNode) {

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1601,7 +1601,7 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
 		enablePublicIP := false
-		if infraSetting.Spec.Network.EnablePublicIP != nil {
+		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
 			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
 		}
 		vsvip.EnablePublicIP = enablePublicIP

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1600,11 +1600,9 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
-		enablePublicIP := false
 		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
-			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
+			vsvip.EnablePublicIP = infraSetting.Spec.Network.EnablePublicIP
 		}
-		vsvip.EnablePublicIP = enablePublicIP
 		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
 	}
 }

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -546,7 +546,7 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
 		enablePublicIP := false
-		if infraSetting.Spec.Network.EnablePublicIP != nil {
+		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
 			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
 		}
 		vsvip.EnablePublicIP = enablePublicIP

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -545,6 +545,12 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
+		enablePublicIP := false
+		if infraSetting.Spec.Network.EnablePublicIP != nil {
+			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
+		}
+		vsvip.EnablePublicIP = enablePublicIP
+		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
 	}
-	utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
+
 }

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -545,11 +545,9 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
-		enablePublicIP := false
 		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
-			enablePublicIP = *infraSetting.Spec.Network.EnablePublicIP
+			vsvip.EnablePublicIP = infraSetting.Spec.Network.EnablePublicIP
 		}
-		vsvip.EnablePublicIP = enablePublicIP
 		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)
 	}
 

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -985,6 +985,7 @@ type AviVSVIPNode struct {
 	VrfContext              string
 	IPAddress               string
 	VipNetworks             []akov1alpha1.AviInfraSettingVipNetwork
+	EnablePublicIP          bool
 	BGPPeerLabels           []string
 	SecurePassthroughNode   *AviVsNode
 	InsecurePassthroughNode *AviVsNode
@@ -1016,6 +1017,7 @@ func (v *AviVSVIPNode) CalculateCheckSum() {
 		sort.Strings(vipNetworkStringList)
 		checksum += utils.Hash(utils.Stringify(vipNetworkStringList))
 	}
+	checksum += utils.Hash(strconv.FormatBool(v.EnablePublicIP))
 
 	if lib.GetGRBACSupport() {
 		checksum += lib.GetClusterLabelChecksum()

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -777,6 +777,9 @@ func (v *AviVsNode) CalculateCheckSum() {
 	if v.EnableRhi != nil {
 		checksum += utils.Hash(utils.Stringify(*v.EnableRhi))
 	}
+	for _, vsvipref := range v.VSVIPRefs {
+		checksum += utils.Hash(utils.Stringify(vsvipref.EnablePublicIP))
+	}
 
 	v.CloudConfigCksum = checksum
 }

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -777,9 +777,6 @@ func (v *AviVsNode) CalculateCheckSum() {
 	if v.EnableRhi != nil {
 		checksum += utils.Hash(utils.Stringify(*v.EnableRhi))
 	}
-	for _, vsvipref := range v.VSVIPRefs {
-		checksum += utils.Hash(utils.Stringify(vsvipref.EnablePublicIP))
-	}
 
 	v.CloudConfigCksum = checksum
 }
@@ -988,7 +985,7 @@ type AviVSVIPNode struct {
 	VrfContext              string
 	IPAddress               string
 	VipNetworks             []akov1alpha1.AviInfraSettingVipNetwork
-	EnablePublicIP          bool
+	EnablePublicIP          *bool
 	BGPPeerLabels           []string
 	SecurePassthroughNode   *AviVsNode
 	InsecurePassthroughNode *AviVsNode
@@ -1020,7 +1017,9 @@ func (v *AviVSVIPNode) CalculateCheckSum() {
 		sort.Strings(vipNetworkStringList)
 		checksum += utils.Hash(utils.Stringify(vipNetworkStringList))
 	}
-	checksum += utils.Hash(strconv.FormatBool(v.EnablePublicIP))
+	if v.EnablePublicIP != nil {
+		checksum += utils.Hash(utils.Stringify(*v.EnablePublicIP))
+	}
 
 	if lib.GetGRBACSupport() {
 		checksum += lib.GetClusterLabelChecksum()

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -79,7 +79,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 		vip := &avimodels.Vip{
 			VipID:                  &vipId,
 			AutoAllocateIP:         &autoAllocate,
-			AutoAllocateFloatingIP: &vsvip_meta.EnablePublicIP,
+			AutoAllocateFloatingIP: vsvip_meta.EnablePublicIP,
 		}
 
 		// This would throw an error for advl4 the error is propagated to the gateway status.
@@ -133,7 +133,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 		vip := avimodels.Vip{
 			VipID:                  &vipId,
 			AutoAllocateIP:         &autoAllocate,
-			AutoAllocateFloatingIP: &vsvip_meta.EnablePublicIP,
+			AutoAllocateFloatingIP: vsvip_meta.EnablePublicIP,
 		}
 
 		// configuring static IP, from gateway.Addresses (advl4, svcapi) and service.loadBalancerIP (l4)
@@ -526,7 +526,7 @@ func (rest *RestOperations) AviVsVipCacheDel(rest_op *utils.RestOp, vsKey avicac
 	return nil
 }
 
-func networkNamesToVips(vipNetworks []akov1alpha1.AviInfraSettingVipNetwork, enablePublicIP bool) []*avimodels.Vip {
+func networkNamesToVips(vipNetworks []akov1alpha1.AviInfraSettingVipNetwork, enablePublicIP *bool) []*avimodels.Vip {
 	var vipList []*avimodels.Vip
 	autoAllocate := true
 	for vipIDInt, vipNetwork := range vipNetworks {
@@ -534,7 +534,7 @@ func networkNamesToVips(vipNetworks []akov1alpha1.AviInfraSettingVipNetwork, ena
 		newVip := &avimodels.Vip{
 			VipID:                  &vipID,
 			AutoAllocateIP:         &autoAllocate,
-			AutoAllocateFloatingIP: &enablePublicIP,
+			AutoAllocateFloatingIP: enablePublicIP,
 		}
 		newVip.SubnetUUID = proto.String(vipNetwork.NetworkName)
 		vipList = append(vipList, newVip)

--- a/pkg/apis/ako/v1alpha1/aviinfrasetting.go
+++ b/pkg/apis/ako/v1alpha1/aviinfrasetting.go
@@ -40,9 +40,10 @@ type AviInfraSettingSpec struct {
 }
 
 type AviInfraSettingNetwork struct {
-	VipNetworks   []AviInfraSettingVipNetwork `json:"vipNetworks,omitempty"`
-	EnableRhi     *bool                       `json:"enableRhi,omitempty"`
-	BgpPeerLabels []string                    `json:"bgpPeerLabels,omitempty"`
+	VipNetworks    []AviInfraSettingVipNetwork `json:"vipNetworks,omitempty"`
+	EnableRhi      *bool                       `json:"enableRhi,omitempty"`
+	EnablePublicIP *bool                       `json:"enablePublicIP,omitempty"`
+	BgpPeerLabels  []string                    `json:"bgpPeerLabels,omitempty"`
 }
 
 type AviInfraSettingVipNetwork struct {

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -736,7 +736,6 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 		}
 		return false
 	}, 40*time.Second).Should(gomega.Equal(true))
-
 	settingUpdate := (integrationtest.FakeAviInfraSetting{
 		Name:        settingName,
 		SeGroupName: "thisisaviref-seGroup",
@@ -752,7 +751,6 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 		setting, _ := lib.GetCRDClientset().AkoV1alpha1().AviInfraSettings().Get(context.TODO(), settingName, metav1.GetOptions{})
 		return setting.Status.Status
 	}, 40*time.Second).Should(gomega.Equal("Accepted"))
-
 	g.Eventually(func() bool {
 		if found, aviModel := objects.SharedAviGraphLister().Get(settingModelName); found && aviModel != nil {
 			if nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS(); len(nodes) > 0 {
@@ -764,7 +762,6 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 		}
 		return false
 	}, 45*time.Second).Should(gomega.Equal(true))
-
 	settingUpdate = (integrationtest.FakeAviInfraSetting{
 		Name:        settingName,
 		SeGroupName: "thisisaviref-seGroup",

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -744,7 +744,6 @@ func TestWithInfraSettingStatusUpdates(t *testing.T) {
 		}
 		return false
 	}, 40*time.Second).Should(gomega.Equal(true))
-
 	settingUpdate := (FakeAviInfraSetting{
 		Name:        settingName,
 		SeGroupName: "thisisaviref-seGroup",

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1395,12 +1395,13 @@ func VerifyMetadataHTTPRule(g *gomega.WithT, poolKey cache.NamespaceName, rrnsna
 }
 
 type FakeAviInfraSetting struct {
-	Name          string
-	SeGroupName   string
-	Networks      []string
-	EnableRhi     bool
-	ShardSize     string
-	BGPPeerLabels []string
+	Name           string
+	SeGroupName    string
+	Networks       []string
+	EnableRhi      bool
+	EnablePublicIP bool
+	ShardSize      string
+	BGPPeerLabels  []string
 }
 
 func (infraSetting FakeAviInfraSetting) AviInfraSetting() *akov1alpha1.AviInfraSetting {
@@ -1413,8 +1414,9 @@ func (infraSetting FakeAviInfraSetting) AviInfraSetting() *akov1alpha1.AviInfraS
 				Name: infraSetting.SeGroupName,
 			},
 			Network: akov1alpha1.AviInfraSettingNetwork{
-				EnableRhi:     &infraSetting.EnableRhi,
-				BgpPeerLabels: infraSetting.BGPPeerLabels,
+				EnableRhi:      &infraSetting.EnableRhi,
+				BgpPeerLabels:  infraSetting.BGPPeerLabels,
+				EnablePublicIP: &infraSetting.EnablePublicIP,
 			},
 		},
 	}


### PR DESCRIPTION
Tests done:
create ingress/ lb service with public ip enabled
disabling public ip from aviinfrasetting deletes public ip
enabling public ip on existing aviinfrasetting adds public ip
removing annotation from lb service removes public ip
