### PR TITLE
Scale Test - Test case to check for any redundant/unwanted API calls to AVI on AKO reboot

### DIFF
--- a/tests/scaletest/lib/ingress.go
+++ b/tests/scaletest/lib/ingress.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"strconv"
 	"testing"
-	"time"
 
 	appsV1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
@@ -458,13 +457,13 @@ func DeletePod(podName string, namespace string) error {
 	return nil
 }
 
-func WaitForAKOPodReboot(t *testing.T, akoPodName string) {
+func WaitForAKOPodReboot(t *testing.T, akoPodName string) bool {
 	t.Logf("Waiting for AKO pod...")
 	pod, _ := coreV1Client.Pods(AVISYSTEM).Get(ctx, akoPodName, metaV1.GetOptions{})
 	if pod.Status.Phase != coreV1.PodRunning {
-		time.Sleep(5 * time.Second)
-		WaitForAKOPodReboot(t, akoPodName)
+		return false
 	}
+	return true
 }
 
 func KubeInit(kubeconfig string) {

--- a/tests/scaletest/lib/ingress.go
+++ b/tests/scaletest/lib/ingress.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"strconv"
 	"testing"
+	"time"
 
 	appsV1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
@@ -45,6 +46,7 @@ const SUBDOMAIN = ".avi.internal"
 const SECRETNAME = "ingress-host-tls"
 const INGRESSAPIVERSION = "networking.k8s.io/v1"
 const PATHTYPE = "Prefix"
+const AVISYSTEM = "avi-system"
 
 func CreateApp(appName string, namespace string, replica int) error {
 	deploymentSpec := &appsV1.Deployment{
@@ -454,6 +456,15 @@ func DeletePod(podName string, namespace string) error {
 		return err
 	}
 	return nil
+}
+
+func WaitForAKOPodReboot(t *testing.T, akoPodName string) {
+	t.Logf("Waiting for AKO pod...")
+	pod, _ := coreV1Client.Pods(AVISYSTEM).Get(ctx, akoPodName, metaV1.GetOptions{})
+	if pod.Status.Phase != coreV1.PodRunning {
+		time.Sleep(5 * time.Second)
+		WaitForAKOPodReboot(t, akoPodName)
+	}
 }
 
 func KubeInit(kubeconfig string) {

--- a/tests/scaletest/lib/utils.go
+++ b/tests/scaletest/lib/utils.go
@@ -17,7 +17,9 @@ package lib
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -244,7 +246,7 @@ func FetchVirtualServiceOperStatus(t *testing.T, AviClient *clients.AviClient) [
 	}
 	for result.Next != "" {
 		page_num = page_num + 1
-		uri := "/api/virtualservice-inventory??page=" + strconv.Itoa(page_num)
+		uri := "/api/virtualservice-inventory?page=" + strconv.Itoa(page_num)
 		result, err = AviClient.AviSession.GetCollectionRaw(uri)
 		if err != nil {
 			t.Errorf("Get uri %v returned err for VS %v", uri, err)
@@ -280,4 +282,188 @@ func FetchOPERDownVirtualService(t *testing.T, AviClient *clients.AviClient) []V
 		}
 	}
 	return OperDownVS
+}
+
+func CleanResourceData(data string) string {
+	data = strings.Replace(data, "\\", "", -1)
+	data = strings.Replace(data, " ", "", -1)
+	return data
+}
+
+func CompareVirtualServiceResources(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.VirtualService
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Logf("Error unmarshalling data into VS. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Logf("Error unmarshalling data into VS. Error : %v", err)
+	}
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old VS to LastModified of New VS to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New VS are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Check if all fields other than LastModified and CloudConfigCksum are equal
+	// Set the CloudConfigCksum field of Old VS to CloudConfigCksum of New VS to Mask the difference from DeepEqual
+	old.CloudConfigCksum = new.CloudConfigCksum
+	if reflect.DeepEqual(new, old) {
+		// Old and New VS are same. Only the LastModified and CloudConfigCksum field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of VS object
+	return true
+}
+
+func ComparePoolResources(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.Pool
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Logf("Error unmarshalling data into Pool. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Logf("Error unmarshalling data into Pool. Error : %v", err)
+	}
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old Pool to LastModified of New Pool to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New Pool are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Check if all fields other than LastModified and CloudConfigCksum are equal
+	// Set the CloudConfigCksum field of Old Pool to CloudConfigCksum of New Pool to Mask the difference from DeepEqual
+	old.CloudConfigCksum = new.CloudConfigCksum
+	if reflect.DeepEqual(new, old) {
+		// Old and New Pool are same. Only the LastModified and CloudConfigCksum field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of Pool object
+	return true
+}
+
+func ComparePoolGroupResources(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.PoolGroup
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Logf("Error unmarshalling data into PoolGroup. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Logf("Error unmarshalling data into PoolGroup. Error : %v", err)
+	}
+
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old PoolGroup to LastModified of New PoolGroup to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New PoolGroup are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Check if all fields other than LastModified and CloudConfigCksum are equal
+	// Set the CloudConfigCksum field of Old PoolGroup to CloudConfigCksum of New PoolGroup to Mask the difference from DeepEqual
+	old.CloudConfigCksum = new.CloudConfigCksum
+	if reflect.DeepEqual(new, old) {
+		// Old and New PoolGroup are same. Only the LastModified and CloudConfigCksum field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of PoolGroup object
+	return true
+}
+
+func CompareVsVipResources(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.VsVip
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Logf("Error unmarshalling data into VsVip. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Logf("Error unmarshalling data into VsVip. Error : %v", err)
+	}
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old VsVip to LastModified of New VsVip to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New VsVip are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of VsVip object
+	return true
+}
+
+func CheckForUnwantedAPICallsToController(t *testing.T, AviClient *clients.AviClient, start string, end string, Nextpage ...int) bool {
+	var page_num int
+	if len(Nextpage) == 1 {
+		page_num = Nextpage[0]
+	} else {
+		page_num = 1
+	}
+	uri := "/api/analytics/logs/" +
+		"?type=2" +
+		"&filter=ne(internal,EVENT_INTERNAL)" +
+		"&filter=co(event_id,CONFIG_UPDATE)" +
+		"&orderby=-report_timestamp" +
+		"&start=" + start +
+		"&end=" + end +
+		"&page=" + strconv.Itoa(page_num)
+
+	result, err := AviClient.AviSession.GetCollectionRaw(uri)
+	if err != nil {
+		t.Errorf("Get uri %v returned err for Event log %v", uri, err)
+	}
+	elems := make([]json.RawMessage, result.Count)
+	t.Logf("Found %d config updates", result.Count)
+
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		t.Errorf("Failed to unmarshal Event log data, err: %v", err)
+	}
+	for _, elem := range elems {
+		eventLog := models.EventLog{}
+		err = json.Unmarshal(elem, &eventLog)
+		if err != nil {
+			t.Logf("Failed to unmarshal Event log data, err: %v", err)
+		}
+		objectType := eventLog.ObjType
+
+		if *objectType == "VIRTUALSERVICE" {
+			if !CompareVirtualServiceResources(t, eventLog) {
+				return false
+			}
+		} else if *objectType == "POOL" {
+			if !ComparePoolResources(t, eventLog) {
+				return false
+			}
+		} else if *objectType == "POOLGROUP" {
+			if !ComparePoolGroupResources(t, eventLog) {
+				return false
+			}
+		} else if *objectType == "VSVIP" {
+			if !CompareVsVipResources(t, eventLog) {
+				return false
+			}
+		}
+	}
+	if result.Next != "" {
+		return CheckForUnwantedAPICallsToController(t, AviClient, start, end, page_num+1)
+	}
+	return true
+
 }

--- a/tests/scaletest/lib/utils.go
+++ b/tests/scaletest/lib/utils.go
@@ -294,11 +294,11 @@ func CompareVirtualServiceResources(t *testing.T, eventLog models.EventLog) bool
 	var new, old models.VirtualService
 	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
 	if err != nil {
-		t.Logf("Error unmarshalling data into VS. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into VS. Error : %v", err)
 	}
 	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
 	if err != nil {
-		t.Logf("Error unmarshalling data into VS. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into VS. Error : %v", err)
 	}
 	if *new.LastModified == *old.LastModified {
 		return true
@@ -325,11 +325,11 @@ func ComparePoolResources(t *testing.T, eventLog models.EventLog) bool {
 	var new, old models.Pool
 	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
 	if err != nil {
-		t.Logf("Error unmarshalling data into Pool. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into Pool. Error : %v", err)
 	}
 	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
 	if err != nil {
-		t.Logf("Error unmarshalling data into Pool. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into Pool. Error : %v", err)
 	}
 	if *new.LastModified == *old.LastModified {
 		return true
@@ -356,11 +356,11 @@ func ComparePoolGroupResources(t *testing.T, eventLog models.EventLog) bool {
 	var new, old models.PoolGroup
 	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
 	if err != nil {
-		t.Logf("Error unmarshalling data into PoolGroup. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into PoolGroup. Error : %v", err)
 	}
 	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
 	if err != nil {
-		t.Logf("Error unmarshalling data into PoolGroup. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into PoolGroup. Error : %v", err)
 	}
 
 	if *new.LastModified == *old.LastModified {
@@ -388,11 +388,11 @@ func CompareVsVipResources(t *testing.T, eventLog models.EventLog) bool {
 	var new, old models.VsVip
 	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
 	if err != nil {
-		t.Logf("Error unmarshalling data into VsVip. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into VsVip. Error : %v", err)
 	}
 	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
 	if err != nil {
-		t.Logf("Error unmarshalling data into VsVip. Error : %v", err)
+		t.Fatalf("Error unmarshalling data into VsVip. Error : %v", err)
 	}
 	if *new.LastModified == *old.LastModified {
 		return true
@@ -405,6 +405,61 @@ func CompareVsVipResources(t *testing.T, eventLog models.EventLog) bool {
 		return false
 	}
 	// Genuine update of VsVip object
+	return true
+}
+
+func CompareHTTPPolicySet(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.HTTPPolicySet
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Fatalf("Error unmarshalling data into HttpPolicySet. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Fatalf("Error unmarshalling data into HttpPolicySet. Error : %v", err)
+	}
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old HttpPolicySet to LastModified of New HttpPolicySet to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New HttpPolicySet are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Check if all fields other than LastModified and CloudConfigCksum are equal
+	// Set the CloudConfigCksum field of Old HttpPolicySet to CloudConfigCksum of New HttpPolicySet to Mask the difference from DeepEqual
+	old.CloudConfigCksum = new.CloudConfigCksum
+	if reflect.DeepEqual(new, old) {
+		// Old and New HttpPolicySet are same. Only the LastModified and CloudConfigCksum field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of HttpPolicySet object
+	return true
+}
+
+func CompareSSLKeyCertificate(t *testing.T, eventLog models.EventLog) bool {
+	var new, old models.SSLKeyAndCertificate
+	err := json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.NewResourceData)), &new)
+	if err != nil {
+		t.Fatalf("Error unmarshalling data into SSLKeyCertificate. Error : %v", err)
+	}
+	err = json.Unmarshal([]byte(CleanResourceData(*eventLog.EventDetails.ConfigUpdateDetails.OldResourceData)), &old)
+	if err != nil {
+		t.Fatalf("Error unmarshalling data into SSLKeyCertificate. Error : %v", err)
+	}
+	if *new.LastModified == *old.LastModified {
+		return true
+	}
+	// Check if all fields other than LastModified are equal
+	// Set the LastModified field of Old SSLKeyCertificate to LastModified of New SSLKeyCertificate to Mask the difference from DeepEqual
+	old.LastModified = new.LastModified
+	if reflect.DeepEqual(new, old) {
+		// Old and New SSLKeyCertificate are same. Only the LastModified field has been updated -> Unnecessary API call by AKO
+		return false
+	}
+	// Genuine update of SSLKeyCertificate object
 	return true
 }
 
@@ -429,11 +484,11 @@ func CheckForUnwantedAPICallsToController(t *testing.T, AviClient *clients.AviCl
 		t.Errorf("Get uri %v returned err for Event log %v", uri, err)
 	}
 	elems := make([]json.RawMessage, result.Count)
-	t.Logf("Found %d config updates", result.Count)
+	t.Logf("Found %d config updates between %s and %s", result.Count, start, end)
 
 	err = json.Unmarshal(result.Results, &elems)
 	if err != nil {
-		t.Errorf("Failed to unmarshal Event log data, err: %v", err)
+		t.Fatalf("Failed to unmarshal Event log data, err: %v", err)
 	}
 	for _, elem := range elems {
 		eventLog := models.EventLog{}
@@ -457,6 +512,14 @@ func CheckForUnwantedAPICallsToController(t *testing.T, AviClient *clients.AviCl
 			}
 		} else if *objectType == "VSVIP" {
 			if !CompareVsVipResources(t, eventLog) {
+				return false
+			}
+		} else if *objectType == "HTTPPOLICYSET" {
+			if !CompareHTTPPolicySet(t, eventLog) {
+				return false
+			}
+		} else if *objectType == "SSLKEYANDCERTIFICATE" {
+			if !CompareSSLKeyCertificate(t, eventLog) {
 				return false
 			}
 		}

--- a/tests/scaletest/scale_test.go
+++ b/tests/scaletest/scale_test.go
@@ -277,6 +277,13 @@ func CheckReboot(t *testing.T, wg *sync.WaitGroup) {
 		}
 		json.Unmarshal(byteValue, &testbedParams)
 		go Reboot(t, wg, KUBENODE, testbedParams.AkoParam.Clusters[0].KubeNodes[0].IP, testbedParams.AkoParam.Clusters[0].KubeNodes[0].UserName, testbedParams.AkoParam.Clusters[0].KubeNodes[0].Password, 0)
+		// Disable swap on the rebooted node
+		g := gomega.NewGomegaWithT(t)
+		time.Sleep(20 * time.Second)
+		g.Eventually(func() error {
+			_, err := RemoteExecute(testbedParams.AkoParam.Clusters[0].KubeNodes[0].UserName, testbedParams.AkoParam.Clusters[0].KubeNodes[0].IP, testbedParams.AkoParam.Clusters[0].KubeNodes[0].Password, "swapoff -a")
+			return err
+		}, 100, "20s").Should(gomega.BeNil())
 	}
 }
 

--- a/vendor/github.com/avinetworks/sdk/go/models/event_log.go
+++ b/vendor/github.com/avinetworks/sdk/go/models/event_log.go
@@ -56,7 +56,7 @@ type EventLog struct {
 
 	// Number of report_timestamp.
 	// Required: true
-	ReportTimestamp *int64 `json:"report_timestamp"`
+	ReportTimestamp *string `json:"report_timestamp"`
 
 	// tenant of EventLog.
 	Tenant *string `json:"tenant,omitempty"`


### PR DESCRIPTION
Adding test case to Scale test to check for any unwanted/redundant API calls to AVI controller on AKO reboot. 
An unwanted API call is one where only the Last Modified or Cloud Config Checksum fields of objects are updated without an update of any other fields
Config update event logs are fetched from the controller after AKO reboots. These logs are scanned for any unwanted API calls.

The second commit disables swap on a rebooted Kubernetes node. Without this, Kubelet fails to start after a node is rebooted. 