### PR TITLE
EVH: Remove namespace field from child VS name

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -87,6 +87,16 @@ func Encode(s, objType string) string {
 	CheckObjectNameLength(encodedStr, objType)
 	return encodedStr
 }
+func IsNameEncoded(name string) bool {
+	split := strings.Split(name, "--")
+	if len(split) == 2 {
+		_, err := hex.DecodeString(split[1])
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
 
 var DisableSync bool
 var layer7Only bool
@@ -309,12 +319,12 @@ func GetEvhPoolNameNoEncoding(ingName, namespace, host, path, infrasetting, svcN
 	return poolName
 }
 
-func GetEvhNodeName(ingName, namespace, host, infrasetting string) string {
+func GetEvhNodeName(ingName, host, infrasetting string) string {
 
 	if infrasetting != "" {
-		return Encode(NamePrefix+infrasetting+"-"+namespace+"-"+host, EVHVS)
+		return Encode(NamePrefix+infrasetting+"-"+host, EVHVS)
 	}
-	return Encode(NamePrefix+namespace+"-"+host, EVHVS)
+	return Encode(NamePrefix+host, EVHVS)
 }
 
 func GetEvhPGName(ingName, namespace, host, path, infrasetting string) string {

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -187,7 +187,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.VerifyMetadataHostRule(g, sniVSKey, "default/samplehr-foo", true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -308,7 +308,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		return ""
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref-sslkey"))
 
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
 
 	g.Eventually(func() string {
@@ -331,7 +331,7 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.VerifyMetadataHostRule(g, sniVSKey, "default/samplehr-foo", true)
 
 	// update hostrule with bad ref
@@ -381,7 +381,7 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		return len(nodes[0].EvhNodes)
 	}, 10*time.Second).Should(gomega.Equal(1))
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.VerifyMetadataHostRule(g, sniVSKey, "default/samplehr-foo", true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()

--- a/tests/evhtests/l7_evh_rest_test.go
+++ b/tests/evhtests/l7_evh_rest_test.go
@@ -188,7 +188,7 @@ func TestCreateIngressCacheSyncForEvh(t *testing.T) {
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	vsCache, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
 	if !found {
 		t.Fatalf("Cache not found for VS: %v", vsKey)
@@ -335,7 +335,7 @@ func TestCreateCacheSyncForEvh(t *testing.T) {
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
@@ -371,7 +371,7 @@ func TestUpdateCacheSyncForEvh(t *testing.T) {
 	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
 
 	mcache := cache.SharedAviObjCache()
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 		return found
@@ -451,8 +451,8 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 		t.Fatalf("error in updating Ingress: %v", err)
 	}
 
-	sniVSKey1 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
-	sniVSKey2 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-bar.com", lib.EVHVS)}
+	sniVSKey1 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
+	sniVSKey2 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--bar.com", lib.EVHVS)}
 	g.Eventually(func() bool {
 		sniCache1, found1 := mcache.VsCacheMeta.AviCacheGet(sniVSKey1)
 		sniCache2, found2 := mcache.VsCacheMeta.AviCacheGet(sniVSKey2)
@@ -510,7 +510,7 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 	if _, err := KubeClient.NetworkingV1beta1().Ingresses("red").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in updating Ingress: %v", err)
 	}
-	sniVSKey3 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--red-foo.com", lib.EVHVS)}
+	sniVSKey3 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	g.Eventually(func() bool {
 		_, found1 := mcache.VsCacheMeta.AviCacheGet(sniVSKey3)
 		return found1
@@ -551,8 +551,8 @@ func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
-	sniVSKey1 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
-	sniVSKey2 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-bar.com", lib.EVHVS)}
+	sniVSKey1 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
+	sniVSKey2 := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--bar.com", lib.EVHVS)}
 	xyzParentKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-3"}
 	barParentKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-1"}
 
@@ -669,7 +669,7 @@ func TestDeleteCacheSyncForEvh(t *testing.T) {
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 
 	ingressUpdate := (integrationtest.FakeIngress{
 		Name:        "foo-with-targets",
@@ -709,8 +709,8 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"}
-	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com", lib.EVHVS)}
-	sslKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
+	sslKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.SSLKeyCert)}
 
 	// no ssl key cache would be found since the secret is not yet added
 	g.Eventually(func() bool {


### PR DESCRIPTION
This PR
1. Removes namespace from EVH Child VS name.
2. Handles upgrade scenario. Delete existing child EVH vs and objects related with it. This existing EVH Vs will have name with namespace included into it.
3. EVH IT modifications.