### PR TITLE
Fix EVH L4 service deletion

### DIFF
--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -89,7 +89,7 @@ func DequeueIngestion(key string, fullsync bool) {
 		if found {
 			objects.SharedlbLister().Delete(namespace + "/" + name)
 			utils.AviLog.Infof("key: %s, msg: service transitioned from type loadbalancer to ClusterIP or NodePort, will delete model", name)
-			model_name := lib.GetModelName(lib.GetTenant(), lib.GetNamePrefix()+namespace+"-"+name)
+			model_name := lib.GetModelName(lib.GetTenant(), lib.Encode(lib.GetNamePrefix()+namespace+"-"+name, lib.L4VS))
 			objects.SharedAviGraphLister().Save(model_name, nil)
 			if !fullsync {
 				PublishKeyToRestLayer(model_name, key, sharedQueue)
@@ -153,7 +153,7 @@ func DequeueIngestion(key string, fullsync bool) {
 			for _, gatewayKey := range gateways {
 				// Check the gateway has a valid subscription or not. If not, delete it.
 				namespace, _, gwName := lib.ExtractTypeNameNamespace(gatewayKey)
-				modelName := lib.GetModelName(lib.GetTenant(), lib.GetNamePrefix()+namespace+"-"+gwName)
+				modelName := lib.GetModelName(lib.GetTenant(), lib.Encode(lib.GetNamePrefix()+namespace+"-"+gwName, lib.ADVANCED_L4))
 				if isGatewayDelete(gatewayKey, key) {
 					// Check if a model corresponding to the gateway exists or not in memory.
 					if found, _ := objects.SharedAviGraphLister().Get(modelName); found {
@@ -349,7 +349,7 @@ func handleL4Service(key string, fullsync bool) {
 	}
 	// This is a DELETE event. The avi graph is set to nil.
 	utils.AviLog.Debugf("key: %s, msg: received DELETE event for service", key)
-	model_name := lib.GetModelName(lib.GetTenant(), lib.GetNamePrefix()+namespace+"-"+name)
+	model_name := lib.GetModelName(lib.GetTenant(), lib.Encode(lib.GetNamePrefix()+namespace+"-"+name, lib.L4VS))
 	objects.SharedAviGraphLister().Save(model_name, nil)
 	if !fullsync {
 		bkt := utils.Bkt(model_name, sharedQueue.NumWorkers)


### PR DESCRIPTION
This PR handles encoding of service names/model names
1.  For L4 Virtual Service deletion case
2. For Adv L4 service 
3. For Service transition from loadbalancer type to cluster type.