### PR TITLE
skip serviceLB status updates during bootup for layer7Only usecases

### DIFF
--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -115,8 +115,9 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
 	} else {
 		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
-		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		if !lib.GetLayer7Only() {
+			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		}
 	}
 	utils.AviLog.Infof("Status syncing completed")
-	return
 }


### PR DESCRIPTION
This commit also adds a status check during deleting the service status.