### PR TITLE
Allow specifying hostname per gateway listener

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -171,6 +171,11 @@ func GetshardSize() uint32 {
 }
 
 func GetL4FqdnFormat() int32 {
+	if GetAdvancedL4() {
+		// disable for advancedL4
+		return 3
+	}
+
 	fqdnFormat := os.Getenv("AUTO_L4_FQDN")
 	enumVal, ok := fqdnEnum[fqdnFormat]
 	if ok {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -164,7 +164,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 
 		var fqdns []string
 		for _, listener := range gw.Spec.Listeners {
-			autoFQDN := false
+			autoFQDN := true
 			// Honour the hostname if specified corresponding to the listener.
 			if listener.Hostname != nil && string(*listener.Hostname) != "" {
 				fqdns = append(fqdns, string(*listener.Hostname))
@@ -172,8 +172,8 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			}
 
 			subDomains := GetDefaultSubDomain()
-			services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
 			if subDomains != nil && autoFQDN {
+				services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
 				for _, service := range services {
 					svcNsName := strings.Split(service, "/")
 					fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1])

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -147,11 +147,37 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		gw, _ := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
 
 		var serviceNSNames []string
+		listenerSvcMapping := make(map[string][]string)
 		if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
 			for svcListener, service := range services {
 				// assume it to have only a single backend service, the check is in isGatewayDelete
 				if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
 					serviceNSNames = append(serviceNSNames, service[0])
+					if val, ok := listenerSvcMapping[svcListener]; ok {
+						listenerSvcMapping[svcListener] = append(val, service[0])
+					} else {
+						listenerSvcMapping[svcListener] = []string{service[0]}
+					}
+				}
+			}
+		}
+
+		var fqdns []string
+		for _, listener := range gw.Spec.Listeners {
+			autoFQDN := false
+			// Honour the hostname if specified corresponding to the listener.
+			if listener.Hostname != nil && string(*listener.Hostname) != "" {
+				fqdns = append(fqdns, string(*listener.Hostname))
+				autoFQDN = false
+			}
+
+			subDomains := GetDefaultSubDomain()
+			services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
+			if subDomains != nil && autoFQDN {
+				for _, service := range services {
+					svcNsName := strings.Split(service, "/")
+					fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1])
+					fqdns = append(fqdns, fqdn)
 				}
 			}
 		}
@@ -161,8 +187,8 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
 			ServiceMetadata: avicache.ServiceMetadataObj{
-				NamespaceServiceName: serviceNSNames,
-				Gateway:              namespace + "/" + gatewayName,
+				Gateway:   namespace + "/" + gatewayName,
+				HostNames: fqdns,
 			},
 			ServiceEngineGroup: lib.GetSEGName(),
 		}
@@ -194,6 +220,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			Name:       lib.GetL4VSVipName(gatewayName, namespace),
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
+			FQDNs:      fqdns,
 		}
 
 		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -228,6 +255,19 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 	if !found || !foundGW {
 		return
 	}
+
+	// create a mapping of portProto to hostname
+	gwListenerHostNameMapping := make(map[string]string)
+	if lib.UseServicesAPI() {
+		// enable fqdn for gateway services only for non-advancedl4 usecases.
+		gw, _ := lib.GetSvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
+		for _, gwlistener := range gw.Spec.Listeners {
+			if gwlistener.Hostname != nil && string(*gwlistener.Hostname) != "" {
+				gwListenerHostNameMapping[fmt.Sprintf("%s/%d", gwlistener.Protocol, gwlistener.Port)] = string(*gwlistener.Hostname)
+			}
+		}
+	}
+
 	var portPoolSet []AviHostPathPortPoolPG
 	for listener, svc := range svcListeners {
 		if !utils.HasElem(gwListeners, listener) || len(svc) != 1 {
@@ -238,6 +278,14 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		svcNSName := strings.Split(svc[0], "/")
 		port, _ := utilsnet.ParsePort(portProto[1], true)
 
+		var svcFQDN string
+		if fqdn, ok := gwListenerHostNameMapping[listener]; ok {
+			svcFQDN = fqdn
+		}
+		if lib.GetL4FqdnFormat() != 3 && svcFQDN == "" {
+			svcFQDN = getAutoFQDNForService(svcNSName[0], svcNSName[1])
+		}
+
 		poolNode := &AviPoolNode{
 			Name:     lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port)),
 			Tenant:   lib.GetTenant(),
@@ -247,6 +295,10 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 				NamespaceServiceName: []string{svc[0]},
 			},
 			VrfContext: lib.GetVrf(),
+		}
+
+		if svcFQDN != "" {
+			poolNode.ServiceMetadata.HostNames = []string{svcFQDN}
 		}
 
 		// If the service has multiple ports but the gateway specifies one of them as listeners then we pick the portname from the service and populate it in pool portname.

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1162,12 +1162,16 @@ func (v *AviPoolNode) CalculateCheckSum() {
 		v.SslProfileRef,
 		v.PriorityLabel,
 		utils.Stringify(nodeNetworkMap),
-		utils.Stringify(v.ServiceMetadata.NamespaceServiceName),
 	}
 
 	if len(v.ServiceMetadata.NamespaceServiceName) > 0 {
 		sort.Strings(v.ServiceMetadata.NamespaceServiceName)
 		checksumStringSlice = append(checksumStringSlice, utils.Stringify(v.ServiceMetadata.NamespaceServiceName))
+	}
+
+	if len(v.ServiceMetadata.HostNames) > 0 {
+		sort.Strings(v.ServiceMetadata.HostNames)
+		checksumStringSlice = append(checksumStringSlice, utils.Stringify(v.ServiceMetadata.HostNames))
 	}
 
 	chksumStr := fmt.Sprint(strings.Join(checksumStringSlice, delim))

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -276,7 +276,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 						Op:      lib.UpdateStatus,
 						Options: &updateOptions,
 					}
-					status.PublishToStatusQueue(svc_mdata_obj.NamespaceServiceName[0], statusOption)
+					status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
 				} else if svc_mdata_obj.Namespace != "" {
 					updateOptions := status.UpdateOptions{
 						Vip:                vs_cache_obj.Vip,

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -111,8 +111,10 @@ func (rest *RestOperations) SyncObjectStatuses() {
 
 	if lib.GetAdvancedL4() {
 		status.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
+		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 	} else if lib.UseServicesAPI() {
 		status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
+		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 	} else {
 		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
 		if !lib.GetLayer7Only() {

--- a/internal/status/svcapi_status.go
+++ b/internal/status/svcapi_status.go
@@ -40,7 +40,6 @@ type UpdateSvcApiGWStatusConditionOptions struct {
 
 func UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	gatewaysToUpdate, updateGWOptions := parseOptionsFromMetadata(options, bulk)
-	var updateServiceOptions []UpdateOptions
 
 	// gatewayMap: {ns/gateway: gatewayObj}
 	// this pre-fetches all gateways to be candidates for status update
@@ -48,14 +47,6 @@ func UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	// in which case gateway will be fetched again in updateObject, as part of a retry
 	gatewayMap := getSvcApiGateways(gatewaysToUpdate, bulk)
 	for _, option := range updateGWOptions {
-		updateServiceOptions = append(updateServiceOptions, UpdateOptions{
-			Vip: option.Vip,
-			Key: option.Key,
-			ServiceMetadata: avicache.ServiceMetadataObj{
-				NamespaceServiceName: option.ServiceMetadata.NamespaceServiceName,
-			},
-		})
-
 		if gw := gatewayMap[option.IngSvc]; gw != nil {
 			// assuming 1 IP per gateway
 			gwStatus := gw.Status.DeepCopy()
@@ -83,9 +74,6 @@ func UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 			})
 		}
 	}
-
-	UpdateL4LBStatus(updateServiceOptions, bulk)
-	return
 }
 
 // getGateways fetches all ingresses and returns a map: {"namespace/name": ingressObj...}

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -415,7 +415,7 @@ func TestAdvL4WrongControllerGWClass(t *testing.T) {
 			return gw.Status.Addresses[0].Value
 		}
 		return ""
-	}, 40*time.Second).Should(gomega.Equal("10.250.250.250"))
+	}, 50*time.Second).Should(gomega.Equal("10.250.250.250"))
 
 	gwclassUpdate := FakeGWClass{
 		Name:       gwClassName,

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -179,7 +179,7 @@ func TestAdvL4WrongClassMappingInIngress(t *testing.T) {
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1beta1().Ingresses(ns).Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
-	}, 40*time.Second).Should(gomega.Equal(1))
+	}, 50*time.Second).Should(gomega.Equal(1))
 
 	err = KubeClient.NetworkingV1beta1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {

--- a/tests/oshiftroutetests/oshift_secure_route_test.go
+++ b/tests/oshiftroutetests/oshift_secure_route_test.go
@@ -137,7 +137,7 @@ func CheckMultiSNIMultiNS(t *testing.T, g *gomega.GomegaWithT, aviModel interfac
 	g.Eventually(func() string {
 		sniVS = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].SniNodes[0]
 		return sniVS.VHDomainNames[0]
-	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
+	}, 40*time.Second).Should(gomega.Equal(defaultHostname))
 
 	g.Expect(sniVS.CACertRefs).To(gomega.HaveLen(1))
 	g.Expect(sniVS.SSLKeyCertRefs).To(gomega.HaveLen(1))
@@ -145,7 +145,7 @@ func CheckMultiSNIMultiNS(t *testing.T, g *gomega.GomegaWithT, aviModel interfac
 	g.Eventually(func() int {
 		sniVS = aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0].SniNodes[0]
 		return len(sniVS.PoolRefs)
-	}, 20*time.Second).Should(gomega.Equal(2))
+	}, 40*time.Second).Should(gomega.Equal(2))
 	g.Expect(sniVS.HttpPolicyRefs).To(gomega.HaveLen(2))
 	g.Expect(sniVS.PoolGroupRefs).To(gomega.HaveLen(2))
 


### PR DESCRIPTION
The hostname can be provided using the `HostName` field in gateway listener spec.
If not provided, AKO carries out the autoFQDN routine, based on the
`autoFQDN` field provided during installation. Hostnames are eventually
updated with IPs in respective Services.