### PR TITLE
Skip updating vs uuid in annotation for insecureedgeallow

### DIFF
--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -42,16 +42,17 @@ type AviPoolCache struct {
 }
 
 type ServiceMetadataObj struct {
-	NamespaceIngressName []string    `json:"namespace_ingress_name"`
-	IngressName          string      `json:"ingress_name"`
-	Namespace            string      `json:"namespace"`
-	HostNames            []string    `json:"hostnames"`
-	NamespaceServiceName []string    `json:"namespace_svc_name"` // []string{ns/name}
-	CRDStatus            CRDMetadata `json:"crd_status"`
-	PoolRatio            int32       `json:"pool_ratio"`
-	PassthroughParentRef string      `json:"passthrough_parent_ref"`
-	PassthroughChildRef  string      `json:"passthrough_child_ref"`
-	Gateway              string      `json:"gateway"` // ns/name
+	NamespaceIngressName  []string    `json:"namespace_ingress_name"`
+	IngressName           string      `json:"ingress_name"`
+	Namespace             string      `json:"namespace"`
+	HostNames             []string    `json:"hostnames"`
+	NamespaceServiceName  []string    `json:"namespace_svc_name"` // []string{ns/name}
+	CRDStatus             CRDMetadata `json:"crd_status"`
+	PoolRatio             int32       `json:"pool_ratio"`
+	PassthroughParentRef  string      `json:"passthrough_parent_ref"`
+	PassthroughChildRef   string      `json:"passthrough_child_ref"`
+	Gateway               string      `json:"gateway"` // ns/name
+	InsecureEdgeTermAllow bool        `json:"insecureedgetermallow"`
 }
 
 type CRDMetadata struct {

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -778,7 +778,7 @@ func ProcessInsecureHostsForEVH(routeIgrObj RouteIngressModel, key string, parse
 	utils.AviLog.Debugf("key: %s, msg: Storedhosts after processing insecurehosts: %s", key, utils.Stringify(Storedhosts))
 }
 
-func (o *AviObjectGraph) BuildModelGraphForInsecureEVH(routeIgrObj RouteIngressModel, host, infraSettingName, key string, pathsvcmap HostMetada) {
+func (o *AviObjectGraph) BuildModelGraphForInsecureEVH(routeIgrObj RouteIngressModel, host, infraSettingName, key string, pathsvcmap HostMetadata) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 	vsNode := o.GetAviEvhVS()
@@ -1033,7 +1033,7 @@ func evhNodeHostName(routeIgrObj RouteIngressModel, tlssetting TlsSettings, ingN
 	return hostPathSvcMap
 }
 
-func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressModel, ingressHostMap SecureHostNameMapProp, hosts []string, tlssetting TlsSettings, ingName, namespace, infraSettingName, host, key string, paths HostMetada) {
+func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressModel, ingressHostMap SecureHostNameMapProp, hosts []string, tlssetting TlsSettings, ingName, namespace, infraSettingName, host, key string, paths HostMetadata) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -28,7 +28,7 @@ import (
 	avimodels "github.com/avinetworks/sdk/go/models"
 )
 
-func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, routeIgrObj RouteIngressModel, pathsvc []IngressHostPathSvc, gslbHostHeader, key string) {
+func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, routeIgrObj RouteIngressModel, pathsvc []IngressHostPathSvc, gslbHostHeader string, insecureEdgeTermAllow bool, key string) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 	// We create pools and attach servers to them here. Pools are created with a priorty label of host/path
@@ -99,10 +99,11 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 				Port:          obj.Port,
 				TargetPort:    obj.TargetPort,
 				ServiceMetadata: avicache.ServiceMetadataObj{
-					IngressName: ingName,
-					Namespace:   namespace,
-					HostNames:   storedHosts,
-					PoolRatio:   obj.weight,
+					IngressName:           ingName,
+					Namespace:             namespace,
+					HostNames:             storedHosts,
+					PoolRatio:             obj.weight,
+					InsecureEdgeTermAllow: insecureEdgeTermAllow,
 				},
 				VrfContext: lib.GetVrf(),
 			}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1269,15 +1269,15 @@ type IngressHostPathSvc struct {
 	TargetPort  int32
 }
 
-type IngressHostMap map[string]HostMetada
+type IngressHostMap map[string]HostMetadata
 
-type HostMetada struct {
+type HostMetadata struct {
 	ingressHPSvc   []IngressHostPathSvc
 	gslbHostHeader string
 }
 
 type TlsSettings struct {
-	Hosts            map[string]HostMetada
+	Hosts            map[string]HostMetadata
 	SecretName       string
 	SecretNS         string
 	key              string
@@ -1301,6 +1301,7 @@ type IngressConfig struct {
 	PassthroughCollection map[string]PassthroughSettings
 	TlsCollection         []TlsSettings
 	IngressHostMap
+	InsecureEdgeTermAllow bool
 }
 
 type SecureHostNameMapProp struct {

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -188,7 +188,7 @@ func ProcessInsecureHosts(routeIgrObj RouteIngressModel, key string, parsedIng I
 			}
 		}
 
-		aviModel.(*AviObjectGraph).BuildL7VSGraphHostNameShard(shardVsName, host, routeIgrObj, pathsvcmap.ingressHPSvc, pathsvcmap.gslbHostHeader, key)
+		aviModel.(*AviObjectGraph).BuildL7VSGraphHostNameShard(shardVsName, host, routeIgrObj, pathsvcmap.ingressHPSvc, pathsvcmap.gslbHostHeader, parsedIng.InsecureEdgeTermAllow, key)
 		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if !utils.HasElem(modelList, modelName) && changedModel {
 			*modelList = append(*modelList, modelName)

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -183,7 +183,7 @@ func (v *Validator) ParseHostPathForIngress(ns string, ingName string, ingSpec n
 
 	var tlsConfigs []TlsSettings
 	for _, rule := range ingSpec.Rules {
-		var hostPathMapSvcList HostMetada
+		var hostPathMapSvcList HostMetadata
 		var hostName string
 		if rule.Host == "" {
 			if subDomains == nil {
@@ -348,7 +348,7 @@ func (v *Validator) ParseHostPathForRoute(ns string, routeName string, routeSpec
 		return ingressConfig
 	}
 	defaultWeight := int32(100)
-	var hostPathMapSvcList HostMetada
+	var hostPathMapSvcList HostMetadata
 
 	hostPathMapSvc := IngressHostPathSvc{}
 	hostPathMapSvc.Path = routeSpec.Path
@@ -463,6 +463,9 @@ func (v *Validator) ParseHostPathForRoute(ns string, routeName string, routeSpec
 
 	if secretName == "" || (routeSpec.TLS != nil && routeSpec.TLS.InsecureEdgeTerminationPolicy == routev1.InsecureEdgeTerminationPolicyAllow) {
 		ingressConfig.IngressHostMap = hostMap
+		if routeSpec.TLS != nil && routeSpec.TLS.InsecureEdgeTerminationPolicy == routev1.InsecureEdgeTerminationPolicyAllow {
+			ingressConfig.InsecureEdgeTermAllow = true
+		}
 	}
 
 	utils.AviLog.Infof("key: %s, msg: host path config from routes: %+v", key, utils.Stringify(ingressConfig))

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -273,6 +273,10 @@ func updateRouteObject(mRoute *routev1.Route, updateOption UpdateOptions, retryN
 	if updateOption.Vip == "" {
 		return nil
 	}
+	if updateOption.ServiceMetadata.InsecureEdgeTermAllow {
+		utils.AviLog.Infof("Skipping update of parent VS annotation since the route :%v has InsecureEdgeTerminationAllow set to true", mRoute.Name)
+		return nil
+	}
 
 	retry := 0
 	if len(retryNum) > 0 {


### PR DESCRIPTION
If a route is marked as `insecureEdgeTerminationAllow` then we skip
updating the vs uuid in the Route's annotation for the insecure
pool update. This is done because the Route is expected to get updated
with the vs uuid information of the SNI children which shouldn't
get overwritten.