### PR TITLE
Calculate graph checksum using all nested nodes' checksums

### DIFF
--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -41,10 +41,7 @@ func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace string, gatewayName stri
 	if vsNode != nil {
 		o.ConstructAdvL4PolPoolNodes(vsNode, gatewayName, namespace, key)
 		o.AddModelNode(vsNode)
-		vsNode.CalculateCheckSum()
-		o.GraphChecksum = o.GraphChecksum + vsNode.GetCheckSum()
 		utils.AviLog.Infof("key: %s, msg: checksum  for AVI VS object %v", key, vsNode.GetCheckSum())
-		utils.AviLog.Infof("key: %s, msg: computed Graph checksum for VS is: %v", key, o.GraphChecksum)
 	}
 }
 
@@ -286,9 +283,6 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		portPoolSet = append(portPoolSet, portPool)
 		vsNode.PoolRefs = append(vsNode.PoolRefs, poolNode)
 		utils.AviLog.Infof("key: %s, msg: evaluated L4 pool values :%v", key, utils.Stringify(poolNode))
-		poolNode.CalculateCheckSum()
-		o.AddModelNode(poolNode)
-		o.GraphChecksum = o.GraphChecksum + poolNode.GetCheckSum()
 	}
 	l4policyNode := &AviL4PolicyNode{
 		Name:     vsNode.Name,
@@ -296,8 +290,6 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		PortPool: portPoolSet,
 	}
 	l4Policies = append(l4Policies, l4policyNode)
-	l4policyNode.CalculateCheckSum()
-	o.GraphChecksum = o.GraphChecksum + l4policyNode.GetCheckSum()
 	vsNode.L4PolicyRefs = l4Policies
 	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
 }

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -700,7 +700,6 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 			// Replace the poolNode.
 			childNode.ReplaceEvhPoolInEVHNode(poolNode, key)
 		}
-		o.AddModelNode(poolNode)
 		if !pgfound {
 			httppolname := lib.GetSniHttpPolName(ingName, namespace, hosts[0], path.Path, infraSettingName)
 			policyNode := &AviHttpPolicySetNode{Name: httppolname, HppMap: httpPolicySet, Tenant: lib.GetTenant()}

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -190,15 +190,9 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 
 		vsNode.PoolRefs = append(vsNode.PoolRefs, poolNode)
 		utils.AviLog.Infof("key: %s, msg: evaluated L4 pool values :%v", key, utils.Stringify(poolNode))
-
-		poolNode.CalculateCheckSum()
-		o.AddModelNode(poolNode)
-		o.GraphChecksum = o.GraphChecksum + poolNode.GetCheckSum()
 	}
 	l4policyNode := &AviL4PolicyNode{Name: vsNode.Name, Tenant: lib.GetTenant(), PortPool: portPoolSet}
 	l4Policies = append(l4Policies, l4policyNode)
-	l4policyNode.CalculateCheckSum()
-	o.GraphChecksum = o.GraphChecksum + l4policyNode.GetCheckSum()
 	vsNode.L4PolicyRefs = l4Policies
 	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
 
@@ -403,8 +397,6 @@ func (o *AviObjectGraph) BuildL4LBGraph(namespace string, svcName string, key st
 	VsNode = o.ConstructAviL4VsNode(svcObj, key)
 	o.ConstructAviL4PolPoolNodes(svcObj, VsNode, key)
 	o.AddModelNode(VsNode)
-	VsNode.CalculateCheckSum()
-	o.GraphChecksum = o.GraphChecksum + VsNode.GetCheckSum()
 	utils.AviLog.Infof("key: %s, msg: checksum  for AVI VS object %v", key, VsNode.GetCheckSum())
 	utils.AviLog.Infof("key: %s, msg: computed Graph checksum for VS is: %v", key, o.GraphChecksum)
 }

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -125,8 +125,6 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 					poolNode.Servers = servers
 				}
 			}
-			poolNode.CalculateCheckSum()
-			o.AddModelNode(poolNode)
 			vsNode[0].PoolRefs = append(vsNode[0].PoolRefs, poolNode)
 			utils.AviLog.Debugf("key: %s, msg: the pools after append are: %v", key, utils.Stringify(vsNode[0].PoolRefs))
 		}

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -380,7 +380,6 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 				// Replace the poolNode.
 				tlsNode.ReplaceSniPoolInSNINode(poolNode, key)
 			}
-			o.AddModelNode(poolNode)
 			if !pgfound {
 				httppolname := lib.GetSniHttpPolName(ingName, namespace, host, path.Path, infraSettingName)
 				policyNode := &AviHttpPolicySetNode{Name: httppolname, HppMap: httpPolicySet, Tenant: lib.GetTenant()}

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -129,13 +129,87 @@ func (v *AviObjectGraph) DecrementRetryCounter() {
 func (v *AviObjectGraph) CalculateCheckSum() {
 	v.Lock.Lock()
 	defer v.Lock.Unlock()
-	// A sum of fields for this model.
 	v.GraphChecksum = 0
 	for _, model := range v.modelNodes {
-		//chksumStr += strconv.Itoa(int(model.GetCheckSum())) + delim
+		if lib.IsEvhEnabled() {
+			if modelVsNode, ok := model.(*AviEvhVsNode); ok {
+				v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
+				continue
+			}
+		} else {
+			if modelVsNode, ok := model.(*AviVsNode); ok {
+				v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
+				continue
+			}
+		}
 		v.GraphChecksum = v.GraphChecksum + model.GetCheckSum()
-
 	}
+}
+
+func (v *AviVsNode) CalculateForGraphChecksum() uint32 {
+	checksumStringSlice := []string{fmt.Sprint(v.GetCheckSum())}
+	for _, pool := range v.PoolRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(pool.GetCheckSum()))
+	}
+	for _, pg := range v.PoolGroupRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(pg.GetCheckSum()))
+	}
+	for _, ds := range v.HTTPDSrefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(ds.GetCheckSum()))
+	}
+	for _, sni := range v.SniNodes {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(sni.CalculateForGraphChecksum()))
+	}
+	for _, passthrough := range v.PassthroughChildNodes {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(passthrough.CalculateForGraphChecksum()))
+	}
+	for _, cacert := range v.CACertRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(cacert.GetCheckSum()))
+	}
+	for _, sslkey := range v.SSLKeyCertRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(sslkey.GetCheckSum()))
+	}
+	for _, httppol := range v.HttpPolicyRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(httppol.GetCheckSum()))
+	}
+	for _, vsvip := range v.VSVIPRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(vsvip.GetCheckSum()))
+	}
+	for _, l4pol := range v.L4PolicyRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(l4pol.GetCheckSum()))
+	}
+
+	return utils.Hash(strings.Join(checksumStringSlice, ":"))
+}
+
+func (v *AviEvhVsNode) CalculateForGraphChecksum() uint32 {
+	checksumStringSlice := []string{fmt.Sprint(v.GetCheckSum())}
+	for _, pool := range v.PoolRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(pool.GetCheckSum()))
+	}
+	for _, pg := range v.PoolGroupRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(pg.GetCheckSum()))
+	}
+	for _, ds := range v.HTTPDSrefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(ds.GetCheckSum()))
+	}
+	for _, evh := range v.EvhNodes {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(evh.CalculateForGraphChecksum()))
+	}
+	for _, cacert := range v.CACertRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(cacert.GetCheckSum()))
+	}
+	for _, sslkey := range v.SSLKeyCertRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(sslkey.GetCheckSum()))
+	}
+	for _, httppol := range v.HttpPolicyRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(httppol.GetCheckSum()))
+	}
+	for _, vsvip := range v.VSVIPRefs {
+		checksumStringSlice = append(checksumStringSlice, fmt.Sprint(vsvip.GetCheckSum()))
+	}
+
+	return utils.Hash(strings.Join(checksumStringSlice, ":"))
 }
 
 func NewAviObjectGraph() *AviObjectGraph {
@@ -284,7 +358,6 @@ type AviVsNode struct {
 	SNIParent             bool
 	PoolGroupRefs         []*AviPoolGroupNode
 	PoolRefs              []*AviPoolNode
-	TCPPoolGroupRefs      []*AviPoolGroupNode
 	HTTPDSrefs            []*AviHTTPDataScriptNode
 	SniNodes              []*AviVsNode
 	PassthroughChildNodes []*AviVsNode
@@ -1211,17 +1284,6 @@ func (v *AviPoolNode) CopyNode() AviModelNode {
 		utils.AviLog.Warnf("Unable to unmarshal AviPoolNode: %s", err)
 	}
 	return &newNode
-}
-
-func (o *AviObjectGraph) GetAviPoolNodes() []*AviPoolNode {
-	var aviPool []*AviPoolNode
-	for _, model := range o.modelNodes {
-		pool, ok := model.(*AviPoolNode)
-		if ok {
-			aviPool = append(aviPool, pool)
-		}
-	}
-	return aviPool
 }
 
 func (o *AviObjectGraph) GetAviPoolNodesByIngress(tenant string, ingName string) []*AviPoolNode {

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -135,7 +135,6 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 				// Unset the poolnode's vrfcontext.
 				poolNode.VrfContext = ""
 			}
-			o.AddModelNode(poolNode)
 		}
 		poolNode.IngressName = objName
 		poolNode.PortName = obj.PortName

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -371,8 +371,8 @@ func TestAviSvcUpdateEndpoint(t *testing.T) {
 	var aviModel interface{}
 	g.Eventually(func() []avinodes.AviPoolMetaServer {
 		_, aviModel = objects.SharedAviGraphLister().Get(modelName)
-		pools := aviModel.(*avinodes.AviObjectGraph).GetAviPoolNodes()
-		return pools[0].Servers
+		node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+		return node.PoolRefs[0].Servers
 	}, 5*time.Second).Should(gomega.HaveLen(2))
 
 	g.Eventually(func() bool {
@@ -380,8 +380,8 @@ func TestAviSvcUpdateEndpoint(t *testing.T) {
 		return found
 	}, 10*time.Second).Should(gomega.Equal(true))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
-	pools := aviModel.(*avinodes.AviObjectGraph).GetAviPoolNodes()
-	for _, pool := range pools {
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	for _, pool := range nodes[0].PoolRefs {
 		if pool.Port == 8080 {
 			address := "1.2.3.24"
 			g.Expect(pool.Servers).To(gomega.HaveLen(2))

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -575,7 +575,7 @@ func TestServicesAPIProtocolChangeInService(t *testing.T) {
 			}
 		}
 		return false
-	}, 40*time.Second).Should(gomega.Equal(true))
+	}, 50*time.Second).Should(gomega.Equal(true))
 
 	TeardownAdvLBService(t, "svc", ns)
 	TeardownGateway(t, gatewayName, ns)


### PR DESCRIPTION
This also removes redundant AddModelNode calls for Pools and L4PolicySets
since AKO does not really operate on these node objects apart from VsNode.

What all we can move away from with this:
1. Adding nodes to the graph, even though individual nodes are not used. See `DequeueNodes`, that relies solely on VsNodes. Adding Pool/L4PolicySet nodes in the graph, and not deleting them at any point could cause unnecessary memory utilization at scale. As far as pool nodes are concerned, since there was no checks of name uniqueness in the graph's pool nodes, multiple identical pool nodes were being added which again causes unnecessary in-memory consumption.
2. Should eliminate the need to include sni/passthrough/evh child VS Node checksum inclusion in parent VSes.
3. Eliminates the need to add VsVipNode's fields (and in extension other Node's fields too) in VsNode's checksum calculation like this PR (currently open) needs to do. https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/493/files#diff-69ab2338bb5b9be3fd86d13a9e41ec013d5f93ab75dc1a6f169ab5dbff885c35R707