### PR TITLE
Support for multi-port services with port number

### DIFF
--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -84,12 +84,10 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 		storedHosts = append(storedHosts, hostname)
 		RemoveFQDNsFromModel(vsNode[0], storedHosts, key)
 		if pgNode != nil {
-			//utils.AviLog.Infof("key: %s, msg: hostpathsvc list: %s", key, utils.Stringify(parsedIng))
 			// Processsing insecure ingress
 			if !utils.HasElem(vsNode[0].VSVIPRefs[0].FQDNs, hostname) {
 				vsNode[0].VSVIPRefs[0].FQDNs = append(vsNode[0].VSVIPRefs[0].FQDNs, hostname)
 			}
-
 			poolNode := &AviPoolNode{
 				Name:          poolName,
 				IngressName:   ingName,

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -637,7 +637,7 @@ func TestMultiPortServiceIngress(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
 		ServiceName: "avisvc",
-	}).Ingress(true)
+	}).IngressMultiPort()
 
 	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
This commit removes the limitation in the current code that required
a portName to be specified in the Ingress object for Services of type
ClusterIP with multiple ports.

Now, we do the following:

- User specifies a port information with a numeric value on the ingress.
- We query the service and find the corresponding targetPort for this port.
- We use the targetPort to find a match with the endpoint list. (Like single port Service)
- Populate the servers using endpoint IPs (No change in behavior)