### PR TITLE
NSX-T VLAN Transport zone support

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2379,6 +2379,16 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	}
 
 	vtype := *cloud.Vtype
+	if vtype == lib.CLOUD_NSXT {
+		// Check the transport zone type.
+		if cloud.NsxtConfiguration != nil {
+			if cloud.NsxtConfiguration.DataNetworkConfig != nil {
+				tz := *cloud.NsxtConfiguration.DataNetworkConfig.TzType
+				lib.SetNSXTTransportZone(tz)
+			}
+		}
+
+	}
 	cloud_obj := &AviCloudPropertyCache{Name: cloudName, VType: vtype}
 
 	subdomains := c.AviDNSPropertyPopulate(client, *cloud.UUID)
@@ -2788,14 +2798,17 @@ func checkAndSetCloudType(client *clients.AviClient) bool {
 	}
 
 	// If an NSX-T cloud is configured without a T1LR param, we will disable sync.
-	if vType == lib.CLOUD_NSXT {
+	if vType == lib.CLOUD_NSXT && lib.GetNSXTTransportZone() == lib.OVERLAY_TRANSPORT_ZONE {
 		if lib.GetT1LRPath() == "" {
-			utils.AviLog.Errorf("Cloud is configured as NSX-T but the T1 LR mapping is not provided")
+			utils.AviLog.Errorf("Cloud is configured as NSX-T with overlay transport zone but the T1 LR mapping is not provided")
 			return false
 		}
-	} else if lib.GetT1LRPath() != "" {
+	} else if lib.GetT1LRPath() != "" && vType != lib.CLOUD_NSXT {
 		// If the cloud type is not NSX-T and yet the T1 LR is set then too disable sync
 		utils.AviLog.Errorf("Cloud is not configured as NSX-T but the T1 LR mapping is  provided")
+		return false
+	} else if lib.GetT1LRPath() != "" && vType == lib.CLOUD_NSXT && lib.GetNSXTTransportZone() == lib.VLAN_TRANSPORT_ZONE {
+		utils.AviLog.Errorf("Cloud configured as NSX-T with VLAN transport zone but the T1 LR mapping is  provided")
 		return false
 	}
 
@@ -3002,7 +3015,7 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient) bool {
 		utils.AviLog.Infof("Using global VRF for NodePort mode")
 		return true
 	}
-	if lib.GetCloudType() == lib.CLOUD_NSXT && lib.GetServiceType() == "ClusterIP" && lib.GetCNIPlugin() != lib.NCP_CNI {
+	if lib.GetCloudType() == lib.CLOUD_NSXT && lib.GetServiceType() == "ClusterIP" && lib.GetCNIPlugin() != lib.NCP_CNI && lib.GetNSXTTransportZone() != lib.VLAN_TRANSPORT_ZONE {
 		// Here we need to determine the right VRF for this T1LR
 		// The logic is: Get all the VRF context objects from the controller, figure out the VRF that matches the T1LR
 		// Current pagination size is set to 100, this may have to increased if we have more than 100 T1 routers.

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -26,6 +26,8 @@ const (
 	INGRESS_API               = "INGRESS_API"
 	AviConfigMap              = "avi-k8s-config"
 	AviSecret                 = "avi-secret"
+	VLAN_TRANSPORT_ZONE       = "VLAN"
+	OVERLAY_TRANSPORT_ZONE    = "OVERLAY"
 
 	AVI_INGRESS_CLASS                          = "avi"
 	SUBNET_IP                                  = "SUBNET_IP"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -101,6 +101,16 @@ func IsNameEncoded(name string) bool {
 var DisableSync bool
 var layer7Only bool
 var noPGForSNI, gRBAC bool
+var NsxTTzType string
+
+func SetNSXTTransportZone(tzType string) {
+	NsxTTzType = tzType
+	utils.AviLog.Infof("Setting NSX-T transport zone to: %v", tzType)
+}
+
+func GetNSXTTransportZone() string {
+	return NsxTTzType
+}
 
 func SetDisableSync(state bool) {
 	DisableSync = state


### PR DESCRIPTION
This commit supports the NSX-T VLAN transport zone.
When NSX-T is used with VLAN transport zone, the AKO code should
behave as the vCenter write access code.

This commit, removes the mandatory checks for the NSX-T cloud and
imposes them only if the NSX-T transport zone set to OVERLAY which
can be obtained from the cloud object.