### PR TITLE
VIP per namespace for EVH in VCF

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -150,6 +150,7 @@ const (
 	AutoFQDNDefault                            = "Default"
 	AutoFQDNFlat                               = "Flat"
 	AutoFQDNDisabled                           = "Disabled"
+	VCF_CLUSTER                                = "VCF_CLUSTER"
 
 	INGRESS_CLASS_ANNOT            = "kubernetes.io/ingress.class"
 	DefaultIngressClassAnnotation  = "ingressclass.kubernetes.io/is-default-class"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1319,3 +1319,11 @@ func GetK8sMinSupportedVersion() string {
 func GetK8sMaxSupportedVersion() string {
 	return k8sMaxVersion
 }
+
+func IsVCFCluster() bool {
+	vcfCluster := os.Getenv(VCF_CLUSTER)
+	if vcfCluster == "true" {
+		return true
+	}
+	return false
+}

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1322,8 +1322,5 @@ func GetK8sMaxSupportedVersion() string {
 
 func IsVCFCluster() bool {
 	vcfCluster := os.Getenv(VCF_CLUSTER)
-	if vcfCluster == "true" {
-		return true
-	}
-	return false
+	return vcfCluster == "true"
 }

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -68,6 +68,14 @@ func validateSpecFromHostnameCache(key, ns, ingName string, ingSpec networkingv1
 					utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s%s: %s in ingresses: %+v", key, nsIngress, rule.Host, svcPath.Path, utils.Stringify(val))
 				}
 			}
+			// In VCF, we use VIP per Namespace, hence same hostname can should not be present across multiple namespaces
+			if lib.IsVCFCluster() {
+				if ok, oldNS := SharedHostNameLister().GetNamespace(rule.Host); ok {
+					if oldNS != ns {
+						utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostname %s in multiple namespaces: %s and %s", key, rule.Host, oldNS, ns)
+					}
+				}
+			}
 		} else {
 			utils.AviLog.Warnf("key: %s, msg: Found Ingress: %s without service backends. Not going to process.", key, ingName)
 			return false

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -45,11 +45,11 @@ func CheckNPLSvcAnnotation(key, namespace, name string) bool {
 func UpdateNPLAnnotation(key, namespace, name string) {
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
-		utils.AviLog.Infof("key: %s, returning without updating NPL annotation, err %v", err)
+		utils.AviLog.Infof("key: %s, returning without updating NPL annotation, err %v", key, err)
 		return
 	}
 	if service.Spec.Type == corev1.ServiceTypeNodePort {
-		utils.AviLog.Infof("key: %s, returning without updating NPL annotation for Service type NodePort")
+		utils.AviLog.Infof("key: %s, returning without updating NPL annotation for Service type NodePort", key)
 		return
 	}
 	ann := service.GetAnnotations()


### PR DESCRIPTION
In VCF, we would create VIP per namespace, adding support for that in this PR.
We would look for an environment variable USE_VCF to enable this feature.

In this case, a mapping between namespace and hostname is saved to find out if
a hostname is present in multiple namespaces.

The parent VS name is modified in this case to include namespace instead of shard.

To do in next PRs
- UTs, Helm chart modification