### PR TITLE
Modified tests for EVH to include VIP per namespace use case

### DIFF
--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -56,7 +56,7 @@ func VerifyEvhIngressDeletion(t *testing.T, g *gomega.WithT, aviModel interface{
 func TestL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -106,7 +106,7 @@ func TestShardObjectsForEvh(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, vsName := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
 
@@ -144,12 +144,12 @@ func TestShardObjectsForEvh(t *testing.T) {
 	}, 5*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--Shared-L7-EVH-0"))
+	g.Expect(nodes[0].Name).To(gomega.Equal(vsName))
 	// Shared VS in EVH will not have any pool or pool group unlike the normal VS
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 	g.Expect(nodes[0].HTTPDSrefs).Should(gomega.HaveLen(0))
-	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal("cluster--Shared-L7-EVH-0"))
+	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal(vsName))
 	// the certs will be associated to parent evh vs
 	g.Expect(nodes[0].SSLKeyCertRefs).Should(gomega.HaveLen(1))
 	// There will be 2 evh node one for each host
@@ -181,7 +181,7 @@ func TestShardObjectsForEvh(t *testing.T) {
 func TestNoBackendL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -218,7 +218,7 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 
 func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
 	svcExample := (integrationtest.FakeService{
 		Name:         "avisvc",
@@ -342,7 +342,7 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	modelName = "admin/cluster--Shared-L7-EVH-1"
+	modelName, _ = GetModelName("bar.com", "default")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	// We should be able to get one model now in the queue
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
@@ -390,7 +390,7 @@ func TestMultiPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -457,7 +457,7 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
 	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, true)
 	integrationtest.CreateEP(t, "default", "avisvc", true, true, "1.1.1")
@@ -521,7 +521,7 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 func TestMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -608,7 +608,7 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 func TestDeleteBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -689,7 +689,7 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 
 func TestUpdateBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-backend-svc",
@@ -753,7 +753,7 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
 	//create ingress with tls secret
@@ -866,7 +866,7 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 
 func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -911,7 +911,7 @@ func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 
 func TestEditPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -997,7 +997,7 @@ func TestEditPathIngressForEvh(t *testing.T) {
 
 func TestEditMultiPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1121,7 +1121,7 @@ func TestEditMultiPathIngressForEvh(t *testing.T) {
 func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	model_name := "admin/cluster--Shared-L7-EVH-0"
+	model_name, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, model_name)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -1219,7 +1219,7 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 
 func TestNoHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-2"
+	modelName, _ := GetModelName("ingress-nohost.default.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1266,7 +1266,7 @@ func TestNoHostIngressForEvh(t *testing.T) {
 
 func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-2"
+	modelName, _ := GetModelName("ingress-nohost.default.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1326,13 +1326,15 @@ func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 		g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
-		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(0))
+		if !lib.IsVCFCluster() {
+			g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(0))
+		}
 
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	modelName = "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ = GetModelName("foo.com", "default")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	integrationtest.DetectModelChecksumChange(t, modelName, 5)
 
@@ -1369,7 +1371,7 @@ func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 func TestScaleEndpointsForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -1462,7 +1464,7 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 
 func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1525,7 +1527,7 @@ func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 
 func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1627,7 +1629,7 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 func TestL7ModelMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1680,9 +1682,9 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
 	// Clean up any earlier models.
-	modelName := "admin/cluster--Shared-L7-EVH-1"
+	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
-	modelName = "admin/cluster--Shared-L7-EVH-0"
+	modelName, _ = GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
 	SetUpTestForIngress(t, modelName)
 
@@ -1744,22 +1746,26 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 
 	// Because of change of the hostnames, the SNI nodes should now get distributed to two shared VSes.
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	evhNodesLen := 1
+	if lib.IsVCFCluster() {
+		evhNodesLen = 2
+	}
 	if found {
 		// Check if the secret affected both the models.
 		g.Eventually(func() int {
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 			return len(nodes[0].EvhNodes)
-		}, 10*time.Second).Should(gomega.Equal(1))
+		}, 20*time.Second).Should(gomega.Equal(evhNodesLen))
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	modelName = "admin/cluster--Shared-L7-EVH-1"
+	modelName, _ = GetModelName("foo.com", "default")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		g.Eventually(func() int {
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 			return len(nodes[0].EvhNodes)
-		}, 10*time.Second).Should(gomega.Equal(1))
+		}, 10*time.Second).Should(gomega.Equal(evhNodesLen))
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
@@ -1779,7 +1785,7 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-EVH-1"
+	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, integrationtest.AllModels...)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1817,6 +1823,7 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	}).Ingress()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
+	modelName, _ = GetModelName("bar.com", "default")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	if found {
@@ -1832,7 +1839,7 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 		g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
 		g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(1))
 	} else {
-		t.Fatalf("Could not find Model: %v", err)
+		t.Fatalf("Could not find Model: %v", modelName)
 	}
 	err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1032,6 +1032,9 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 
 			} else if strings.Contains(rName, "Shared-L7-EVH-") {
 				shardVSNum = strings.Split(rName, "Shared-L7-EVH-")[1]
+				if strings.Contains(shardVSNum, "NS-") {
+					shardVSNum = "0"
+				}
 				vipAddress = fmt.Sprintf("%s.1%s", addrPrefix, shardVSNum)
 			} else if strings.Contains(rName, "Shared-L7") {
 				shardVSNum = strings.Split(rName, "Shared-L7-")[1]
@@ -1057,6 +1060,9 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 				vipAddress = fmt.Sprintf("%s.1%s", addrPrefix, shardVSNum)
 			} else if strings.Contains(rName, "Shared-L7-EVH-") {
 				shardVSNum = strings.Split(rName, "Shared-L7-EVH-")[1]
+				if strings.Contains(shardVSNum, "NS-") {
+					shardVSNum = "0"
+				}
 				vipAddress = fmt.Sprintf("%s.1%s", addrPrefix, shardVSNum)
 			} else if strings.Contains(rName, "Shared-L7") {
 				shardVSNum = strings.Split(rName, "Shared-L7-")[1]


### PR DESCRIPTION
AV-120552 : Modified the tests to check for model name with hostname shard or
vip per namespace (for VCF).
Skipping a few tests whcih would require substantially different verifications
in vip per namespace mode.