### PR TITLE
Fix: EVH Passthrough VS Update Scenario and Add Cloud Name while fetching SEG

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2583,7 +2583,7 @@ func validateAndConfigureSeGroup(client *clients.AviClient) bool {
 	seGroupSet.Insert(lib.GetSEGName())
 
 	// This assumes that a single cluster won't use more than 100 distinct SEGroups.
-	uri := "/api/serviceenginegroup/?include_name&page_size=100&name.in=" + strings.Join(seGroupSet.List(), ",")
+	uri := "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName + "&name.in=" + strings.Join(seGroupSet.List(), ",")
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)


### PR DESCRIPTION
This PR fixes:
1. Issue : in EVH Passthrough, old stale data deletion was issue when passthrough route/ingress updated.
2. Add cloud name while fetching SEG