### PR TITLE
Allow AKO to identify pools for HTTPRule placement when InfraSetting is used.

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -697,7 +697,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 		}
 	}
 	for _, path := range paths {
-		BuildPoolHTTPRule(hosts[0], path.Path, ingName, namespace, key, childNode, true)
+		BuildPoolHTTPRule(hosts[0], path.Path, ingName, namespace, infraSettingName, key, childNode, true)
 	}
 
 	utils.AviLog.Infof("key: %s, msg: added pools and poolgroups. childNodeChecksum for childNode :%s is :%v", key, childNode.Name, childNode.Name)

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -134,7 +134,7 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 
 	}
 	for _, obj := range pathsvc {
-		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, key, vsNode[0], false)
+		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, infraSettingName, key, vsNode[0], false)
 	}
 
 	// Reset the PG Node members and rebuild them

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -387,7 +387,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 					tlsNode.ReplaceSniHTTPRefInSNINode(policyNode, key)
 				}
 			}
-			BuildPoolHTTPRule(host, path.Path, ingName, namespace, key, tlsNode, true)
+			BuildPoolHTTPRule(host, path.Path, ingName, namespace, infraSettingName, key, tlsNode, true)
 		}
 		sniFQDNs = append(sniFQDNs, pathFQDNs...)
 	}

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -135,7 +135,7 @@ func BuildL7HostRule(host, namespace, ingName, key string, vsNode AviVsEvhSniMod
 // BuildPoolHTTPRule notes
 // when we get an ingress update and we are building the corresponding pools of that ingress
 // we need to get all httprules which match ingress's host/path
-func BuildPoolHTTPRule(host, path, ingName, namespace, key string, vsNode AviVsEvhSniModel, isSNI bool) {
+func BuildPoolHTTPRule(host, path, ingName, namespace, infraSettingName, key string, vsNode AviVsEvhSniModel, isSNI bool) {
 	found, pathRules := objects.SharedCRDLister().GetFqdnHTTPRulesMapping(host)
 	if !found {
 		utils.AviLog.Debugf("key: %s, msg: HTTPRules for fqdn %s not found", key, host)
@@ -189,11 +189,15 @@ func BuildPoolHTTPRule(host, path, ingName, namespace, key string, vsNode AviVsE
 			// basic path prefix regex: ^<path_entered>.*
 			pathPrefix := strings.ReplaceAll(path, "/", "_")
 			// sni poolname match regex
-			secureRgx := regexp.MustCompile(fmt.Sprintf(`^%s%s-%s%s.*-%s`, lib.GetNamePrefix(), rrNamespace, host, pathPrefix, ingName))
+			secureRgx := regexp.MustCompile(fmt.Sprintf(`^%s%s-%s.*-%s`, lib.GetNamePrefix(), rrNamespace, host+pathPrefix, ingName))
 			// sharedvs poolname match regex
 			insecureRgx := regexp.MustCompile(fmt.Sprintf(`^%s%s.*-%s-%s`, lib.GetNamePrefix(), host+pathPrefix, rrNamespace, ingName))
+			if infraSettingName != "" {
+				secureRgx = regexp.MustCompile(fmt.Sprintf(`^%s%s-%s-%s.*-%s`, lib.GetNamePrefix(), infraSettingName, rrNamespace, host+pathPrefix, ingName))
+				insecureRgx = regexp.MustCompile(fmt.Sprintf(`^%s%s-%s.*-%s-%s`, lib.GetNamePrefix(), infraSettingName, host+pathPrefix, rrNamespace, ingName))
+			}
 			var poolName string
-			//FOR EVH: Build poolname using marker fields.
+			// FOR EVH: Build poolname using marker fields.
 			if lib.IsEvhEnabled() && pool.AviMarkers.Namespace != "" {
 				poolName = lib.GetEvhPoolNameNoEncoding(pool.AviMarkers.IngressName, pool.AviMarkers.Namespace, pool.AviMarkers.Host,
 					pool.AviMarkers.Path, pool.AviMarkers.InfrasettingName, pool.AviMarkers.ServiceName)


### PR DESCRIPTION
When AviInfraSetting is used, it changes the naming scheme for Pool names,
This is not accounted for while applying HTTPRules on pools, which causes AKO
to not identify any pool for HTTPRule placement.
Fixes AV-121134