### PR TITLE
Calculate checksum based on VS type

### DIFF
--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -131,16 +131,12 @@ func (v *AviObjectGraph) CalculateCheckSum() {
 	defer v.Lock.Unlock()
 	v.GraphChecksum = 0
 	for _, model := range v.modelNodes {
-		if lib.IsEvhEnabled() {
-			if modelVsNode, ok := model.(*AviEvhVsNode); ok {
-				v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
-				continue
-			}
-		} else {
-			if modelVsNode, ok := model.(*AviVsNode); ok {
-				v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
-				continue
-			}
+		if modelVsNode, ok := model.(*AviEvhVsNode); ok {
+			v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
+			continue
+		} else if modelVsNode, ok := model.(*AviVsNode); ok {
+			v.GraphChecksum = v.GraphChecksum + modelVsNode.CalculateForGraphChecksum()
+			continue
 		}
 		v.GraphChecksum = v.GraphChecksum + model.GetCheckSum()
 	}


### PR DESCRIPTION
We should not check if EVH is enabled for checksum calculation

(cherry picked from commit b2f6d9737674ce81861c925e92bc44b1cd9783c2)