### PR TITLE
infinite retry for all failures in rest layer

### DIFF
--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -108,7 +108,7 @@ func (v *AviObjectGraph) SetRetryCounter(num ...int) {
 	if len(num) > 0 {
 		v.RetryCount = num[0]
 	} else {
-		v.RetryCount = 10
+		v.RetryCount = 100
 	}
 }
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -570,12 +570,10 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 								retryable, fastRetryable := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
 								fastRetry = fastRetry || fastRetryable
 								retry = retry || retryable
-							} else if aviError.HttpStatusCode == 400 && strings.Contains(*aviError.Message, lib.NoFreeIPError) {
+							} else {
 								fastRetry = false
 								retry = true
-								utils.AviLog.Warnf("key: %s, msg: Got no free IP error, would be added to slow retry queue", key)
-							} else {
-								utils.AviLog.Warnf("key: %s, msg: retry count exhausted, skipping", key)
+								utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
 							}
 						} else {
 							utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)


### PR DESCRIPTION
- Infinite retry for all failures after retry counter is exhausted
- Increased retry counter to 100 from 10

In case rest request times out due to some problem, AKO would retry
all requests. But some of those requests might have been successful in
the controller. In that case AKO can get a 409 error if it tries to recreate
an objects on retry.

In case we get the timeout error object cache is not updated, so we would get
409 error on multiple objects.

fixes AV-120481