### PR TITLE
cherry-pick: status update gateway and ingress when svcapi is used.

### DIFF
--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -112,10 +112,11 @@ func (rest *RestOperations) SyncObjectStatuses() {
 	if lib.GetAdvancedL4() {
 		status.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
 		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
-	} else if lib.UseServicesAPI() {
-		status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
-		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 	} else {
+		if lib.UseServicesAPI() {
+			status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
+			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		}
 		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
 		if !lib.GetLayer7Only() {
 			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)


### PR DESCRIPTION
Other status update fix includes status update fix during bootup
that prevented status update in ingresses hosting multiple vips.