### PR TITLE
Scale Test changes for EVH support

### DIFF
--- a/tests/scaletest/configs/st_testbed.json
+++ b/tests/scaletest/configs/st_testbed.json
@@ -32,6 +32,11 @@
         ]
     },
     "TestParams": {
+        "akoRepoPath" : "",
+        "testTimeout" : "",
+        "numGoRoutines" : 0,
+        "numOfLBSvc": 0,
+        "numOfIng" : 0,
         "akoPodName" : "",
         "namespace" : "",
         "appName" : "",

--- a/tests/scaletest/configs/st_testbed.json
+++ b/tests/scaletest/configs/st_testbed.json
@@ -6,6 +6,7 @@
                 "cluster_name" : "",
                 "kubeconfig_file": "",
                 "cniPlugin": "",
+                "evhEnabled": false,
                 "disableStaticRouteSync": "",
                 "defaultIngController": "",
                 "vipNetworkList": [

--- a/tests/scaletest/lib/parser.go
+++ b/tests/scaletest/lib/parser.go
@@ -41,6 +41,7 @@ type Cluster struct {
 	ClusterName            string       `json:"cluster_name"`
 	KubeConfigFilePath     string       `json:"kubeconfig_file"`
 	CniPlugin              string       `json:"cniPlugin"`
+	EVHEnabled             bool         `json:"evhEnabled"`
 	CloudName              string       `json:"cloudName"`
 	DisableStaticRouteSync string       `json:"disableStaticRouteSync"`
 	DefaultIngController   string       `json:"defaultIngController"`


### PR DESCRIPTION
This commit introduces changes in the scale test suite for EVH.
'evhEnabled' should be set to true in the testbed file if EVH is enabled on AKO
The test then verifies the AVI objects based on the encoded naming convention of EVH