### PR TITLE
Refresh cache even if retry count is exhausted

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -566,13 +566,12 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 								utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
 								continue
 							}
+							retryable, fastRetryable := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
+							retry = retry || retryable
 							if avimodel.GetRetryCounter() != 0 {
-								retryable, fastRetryable := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
 								fastRetry = fastRetry || fastRetryable
-								retry = retry || retryable
 							} else {
 								fastRetry = false
-								retry = true
 								utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
 							}
 						} else {


### PR DESCRIPTION
Even if retry count is exhausted, AKO would do a slow retry.
In this case also, we have to refresh the cache.

(cherry picked from commit a1d00726c9f1fd7b2d58de822bd0bd5e89d4f016)