### PR TITLE
AV-122809: EVH: Hostrule SSLcertkeyref fixes for secure/insecure ingress, routes

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -363,7 +363,7 @@ func (o *AviEvhVsNode) DeleteCACertRefInEVHNode(cacertNodeName, key string) {
 	for i, cacert := range o.CACertRefs {
 		if cacert.Name == cacertNodeName {
 			o.CACertRefs = append(o.CACertRefs[:i], o.CACertRefs[i+1:]...)
-			utils.AviLog.Infof("key: %s, msg: deleted cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
+			utils.AviLog.Debugf("key: %s, msg: deleted cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
 			return
 		}
 	}

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -377,9 +377,6 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 		sniNode.ServiceMetadata.NamespaceIngressName = ingressHostMap.GetIngressesForHostName(sniHost)
 		sniNode.ServiceMetadata.Namespace = namespace
 		sniNode.ServiceMetadata.HostNames = sniHosts
-		if sniNode.SSLKeyCertAviRef != "" {
-			certsBuilt = true
-		}
 	}
 
 	sniNode.ServiceEngineGroup = lib.GetSEGName()

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -324,14 +324,16 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		}
 
 		if vs_meta.TLSType != utils.TLS_PASSTHROUGH {
-			// this overwrites the sslkeycert created from the Secret object, with the one mentioned in HostRule.TLS
-			if vs_meta.SSLKeyCertAviRef != "" {
-				vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, vs_meta.SSLKeyCertAviRef)
-			} else {
-				for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
-					certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
-					vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, certName)
+			//Append cert from hostrule
+			for _, evhNode := range vs_meta.EvhNodes {
+				if evhNode.SSLKeyCertAviRef != "" {
+					vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, evhNode.SSLKeyCertAviRef)
 				}
+			}
+			//Append cert present in ingress/route
+			for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
+				certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
+				vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, certName)
 			}
 			if vs_meta.SSLProfileRef != "" {
 				vs.SslProfileRef = &vs_meta.SSLProfileRef
@@ -454,15 +456,6 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 
 	// No need of HTTP rules for TLS passthrough.
 	if vs_meta.TLSType != utils.TLS_PASSTHROUGH {
-		// this overwrites the sslkeycert created from the Secret object, with the one mentioned in HostRule.TLS
-		if vs_meta.SSLKeyCertAviRef != "" {
-			evhChild.SslKeyAndCertificateRefs = append(evhChild.SslKeyAndCertificateRefs, vs_meta.SSLKeyCertAviRef)
-		} else {
-			for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
-				certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
-				evhChild.SslKeyAndCertificateRefs = append(evhChild.SslKeyAndCertificateRefs, certName)
-			}
-		}
 		evhChild.HTTPPolicies = AviVsHttpPSAdd(vs_meta, true)
 	}
 

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -219,8 +219,8 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
-	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.HaveLen(0))
+	//At rest layer, sslref are switched to Parent
+	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))
 	g.Expect(nodes[0].EvhNodes[0].AppProfileRef).To(gomega.ContainSubstring("thisisaviref-appprof"))
 	g.Expect(nodes[0].EvhNodes[0].AnalyticsProfileRef).To(gomega.ContainSubstring("thisisaviref-analyticsprof"))
@@ -297,7 +297,6 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].AppProfileRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].AnalyticsProfileRef).To(gomega.Equal(""))
@@ -326,7 +325,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		if len(nodes[0].EvhNodes) == 1 {
-			return nodes[0].SSLKeyCertAviRef
+			return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 		}
 		return ""
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref-sslkey"))
@@ -338,7 +337,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		if len(nodes[0].EvhNodes) == 1 {
-			return nodes[0].SSLKeyCertAviRef
+			return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 		}
 		return ""
 	}, 10*time.Second).Should(gomega.Equal(""))
@@ -375,11 +374,12 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Rejected"))
 
-	// the last applied hostrule values would exist
+	// the last applied hostrule values would exist. At rest layer, all ssl avi ref will be assigned to parent
+	// In Avi model, sslaviref will be associated with child
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-		return nodes[0].SSLKeyCertAviRef
+		return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref"))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -1059,7 +1059,7 @@ func TestEVHCRDWithAviInfraSetting(t *testing.T) {
 	integrationtest.VerifyMetadataHTTPRule(g, poolKey, "default/"+rrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(settingModelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
+	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.Equal("LB_ALGORITHM_CONSISTENT_HASH"))


### PR DESCRIPTION
This PR fixes issue with EVH deployment where 
1. For secure, insecure ingress/ route with hostrule CRDs with TLS configs and Ingress secrets are mixed, then sslkeycertref on parent was getting overwritten by later applied definition.