### PR TITLE
Fix EVH and SNI: multiport service with portnumber specified in ingress definition

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -651,6 +651,13 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 			PortName:   path.PortName,
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
+			Port:       path.Port,
+			TargetPort: path.TargetPort,
+			ServiceMetadata: avicache.ServiceMetadataObj{
+				IngressName: ingName,
+				Namespace:   namespace,
+				PoolRatio:   path.weight,
+			},
 		}
 		if lib.GetT1LRPath() != "" {
 			poolNode.T1Lr = lib.GetT1LRPath()


### PR DESCRIPTION
This PR fixes issue of multi-port service with port number specified in ingress for 
1. EVH (Secure, insecure)
2. SNI (Secure)