### PR TITLE
Make AKO bootups faster

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -341,6 +342,11 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 				return
 			}
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
+			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+			if ok && resVer.(string) == route.ResourceVersion {
+				utils.AviLog.Debugf("Same resource version returning")
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			if !lib.HasValidBackends(route.Spec, route.Name, namespace, key) {
 				status.UpdateRouteStatusWithErrMsg(key, route.Name, namespace, lib.DuplicateBackends)
@@ -409,6 +415,11 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			pod := obj.(*corev1.Pod)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
+			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+			if ok && resVer.(string) == pod.ResourceVersion {
+				utils.AviLog.Debugf("Same resource version returning")
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD\n", key)
@@ -543,6 +554,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					return
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
+			}
+			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+			if ok && resVer.(string) == svc.ResourceVersion {
+				utils.AviLog.Debugf("Same resource version returning")
+				return
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
@@ -799,6 +815,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				return
 			}
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
+			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+			if ok && resVer.(string) == ingress.ResourceVersion {
+				utils.AviLog.Debugf("Same resource version returning")
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -859,6 +880,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			node := obj.(*corev1.Node)
 			key := utils.NodeObj + "/" + node.Name
 			bkt := utils.Bkt(lib.GetTenant(), numWorkers)
+			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+			if ok && resVer.(string) == node.ResourceVersion {
+				utils.AviLog.Debugf("Same resource version returning")
+				return
+			}
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
@@ -914,6 +940,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				ingClass := obj.(*networkingv1.IngressClass)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingClass))
 				key := utils.IngressClass + "/" + utils.ObjKey(ingClass)
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == ingClass.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
+				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -116,6 +116,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				if err := validateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
 				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == hostrule.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
+				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
@@ -176,6 +181,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
 				if err := validateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
+				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == httprule.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -240,6 +250,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
 				if err := validateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
+				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == aviinfra.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)

--- a/internal/objects/resourceversions.go
+++ b/internal/objects/resourceversions.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// APIs to access AVI graph from and to memory. The VS should have a uuid and the corresponding model.
+
+package objects
+
+import (
+	"sync"
+)
+
+var resouceVerInstance *ResourceVersionLister
+var resourceVerOnce sync.Once
+
+func SharedResourceVerInstanceLister() *ResourceVersionLister {
+	resourceVerOnce.Do(func() {
+		ResourceVerStore := NewObjectMapStore()
+		resouceVerInstance = &ResourceVersionLister{}
+		resouceVerInstance.ResourceVerStore = ResourceVerStore
+	})
+	return resouceVerInstance
+}
+
+type ResourceVersionLister struct {
+	ResourceVerStore *ObjectMapStore
+}
+
+func (a *ResourceVersionLister) Save(vsName string, resVer interface{}) {
+	a.ResourceVerStore.AddOrUpdate(vsName, resVer)
+}
+
+func (a *ResourceVersionLister) Get(resName string) (bool, interface{}) {
+	ok, obj := a.ResourceVerStore.Get(resName)
+	return ok, obj
+}
+
+func (a *ResourceVersionLister) GetAll() interface{} {
+	obj := a.ResourceVerStore.GetAllObjectNames()
+	return obj
+}
+
+func (a *ResourceVersionLister) Delete(resName string) {
+	a.ResourceVerStore.Delete(resName)
+
+}


### PR DESCRIPTION
This commit introduces a change that works as follows:

- During bootup of AKO, we perform a full sync. This results
into the layer 2 models getting built before activating layer 3.
- The informer event handlers are then used to enqueue updates to
the layer 2 queues as well for the same updates which were processed
as a part of the full sync update.

This current fix optimizes the second point by caching the resource
version of the k8s objects during fullsync.

Then during the regular event updates, it compares the cached resource
versions in AKO with that of the event updated objects.

If the resource versions are same, then AKO does not enqueue the same
key again in layer 2, thus reducing the burden of layer 2 significantly
during bootup.

This fix potentially solves a starvation problem in AKO when during a
heavily loaded system, if AKO is rebooted, and some new routes/ingresses
are created, they are starved for these already pre-processed updates.