### PR TITLE
EVH & SNI: Hostrule SSLcertkeyref fixes for secure/insecure ingress, routes

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -363,7 +363,7 @@ func (o *AviEvhVsNode) DeleteCACertRefInEVHNode(cacertNodeName, key string) {
 	for i, cacert := range o.CACertRefs {
 		if cacert.Name == cacertNodeName {
 			o.CACertRefs = append(o.CACertRefs[:i], o.CACertRefs[i+1:]...)
-			utils.AviLog.Infof("key: %s, msg: replaced cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
+			utils.AviLog.Debugf("key: %s, msg: deleted cacert for evh in model: %s Pool name: %s", key, o.Name, cacert.Name)
 			return
 		}
 	}
@@ -443,6 +443,9 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 
 	for _, evhnode := range v.EvhNodes {
 		checksumStringSlice = append(checksumStringSlice, "EVHNode"+evhnode.Name)
+		if evhnode.SSLKeyCertAviRef != "" {
+			checksumStringSlice = append(checksumStringSlice, "EVHNodeSSL"+evhnode.SSLKeyCertAviRef)
+		}
 	}
 
 	// Note: Changing the order of strings being appended, while computing vsRefs and checksum,
@@ -1053,9 +1056,6 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 		evhNode.ServiceMetadata.NamespaceIngressName = ingressHostMap.GetIngressesForHostName(host)
 		evhNode.ServiceMetadata.Namespace = namespace
 		evhNode.ServiceMetadata.HostNames = hosts
-		if evhNode.SSLKeyCertAviRef != "" {
-			certsBuilt = true
-		}
 	}
 	evhNode.ApplicationProfile = utils.DEFAULT_L7_APP_PROFILE
 	evhNode.ServiceEngineGroup = lib.GetSEGName()
@@ -1078,7 +1078,17 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 	}
 	if !certsBuilt {
 		certsBuilt = o.BuildTlsCertNodeForEvh(routeIgrObj.GetSvcLister(), vsNode[0], namespace, tlssetting, key, infraSettingName, host)
+	} else {
+		//Delete sslcertref object if host crd sslcertref (sslcertAviRef) is present for given host
+		secretName := tlssetting.SecretName
+		if strings.HasPrefix(secretName, lib.RouteSecretsPrefix) {
+			//Openshift: Remove CA cert if present
+			vsNode[0].DeleteCACertRefInEVHNode(lib.GetCACertNodeName(infraSettingName, host), key)
+		}
+		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, host), key)
+
 	}
+
 	if certsBuilt {
 		hosts := []string{host}
 		if paths.gslbHostHeader != "" {
@@ -1616,8 +1626,6 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 }
 
 func manipulateEvhNodeForSSL(key string, vsNode *AviEvhVsNode, evhNode *AviEvhVsNode) {
-	vsNode.SetSSLKeyCertAviRef(evhNode.GetSSLKeyCertAviRef())
-	evhNode.SetSSLKeyCertAviRef("")
 	oldSSLProfile := vsNode.GetSSLProfileRef()
 	newSSLProfile := evhNode.GetSSLProfileRef()
 	if oldSSLProfile != "" && oldSSLProfile != newSSLProfile {

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -377,9 +377,6 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 		sniNode.ServiceMetadata.NamespaceIngressName = ingressHostMap.GetIngressesForHostName(sniHost)
 		sniNode.ServiceMetadata.Namespace = namespace
 		sniNode.ServiceMetadata.HostNames = sniHosts
-		if sniNode.SSLKeyCertAviRef != "" {
-			certsBuilt = true
-		}
 	}
 
 	sniNode.ServiceEngineGroup = lib.GetSEGName()

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -324,14 +324,16 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		}
 
 		if vs_meta.TLSType != utils.TLS_PASSTHROUGH {
-			// this overwrites the sslkeycert created from the Secret object, with the one mentioned in HostRule.TLS
-			if vs_meta.SSLKeyCertAviRef != "" {
-				vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, vs_meta.SSLKeyCertAviRef)
-			} else {
-				for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
-					certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
-					vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, certName)
+			//Append cert from hostrule
+			for _, evhNode := range vs_meta.EvhNodes {
+				if evhNode.SSLKeyCertAviRef != "" {
+					vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, evhNode.SSLKeyCertAviRef)
 				}
+			}
+			//Append cert present in ingress/route
+			for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
+				certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
+				vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, certName)
 			}
 			if vs_meta.SSLProfileRef != "" {
 				vs.SslProfileRef = &vs_meta.SSLProfileRef
@@ -454,15 +456,6 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 
 	// No need of HTTP rules for TLS passthrough.
 	if vs_meta.TLSType != utils.TLS_PASSTHROUGH {
-		// this overwrites the sslkeycert created from the Secret object, with the one mentioned in HostRule.TLS
-		if vs_meta.SSLKeyCertAviRef != "" {
-			evhChild.SslKeyAndCertificateRefs = append(evhChild.SslKeyAndCertificateRefs, vs_meta.SSLKeyCertAviRef)
-		} else {
-			for _, sslkeycert := range vs_meta.SSLKeyCertRefs {
-				certName := "/api/sslkeyandcertificate/?name=" + sslkeycert.Name
-				evhChild.SslKeyAndCertificateRefs = append(evhChild.SslKeyAndCertificateRefs, certName)
-			}
-		}
 		evhChild.HTTPPolicies = AviVsHttpPSAdd(vs_meta, true)
 	}
 

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -196,8 +196,8 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
-	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.HaveLen(0))
+	//At rest layer, sslref are switched to Parent
+	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))
 	g.Expect(nodes[0].EvhNodes[0].AppProfileRef).To(gomega.ContainSubstring("thisisaviref-appprof"))
 	g.Expect(nodes[0].EvhNodes[0].AnalyticsProfileRef).To(gomega.ContainSubstring("thisisaviref-analyticsprof"))
@@ -274,7 +274,6 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].AppProfileRef).To(gomega.Equal(""))
 	g.Expect(nodes[0].EvhNodes[0].AnalyticsProfileRef).To(gomega.Equal(""))
@@ -303,7 +302,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		if len(nodes[0].EvhNodes) == 1 {
-			return nodes[0].SSLKeyCertAviRef
+			return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 		}
 		return ""
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref-sslkey"))
@@ -315,7 +314,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		if len(nodes[0].EvhNodes) == 1 {
-			return nodes[0].SSLKeyCertAviRef
+			return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 		}
 		return ""
 	}, 10*time.Second).Should(gomega.Equal(""))
@@ -352,11 +351,12 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Rejected"))
 
-	// the last applied hostrule values would exist
+	// the last applied hostrule values would exist. At rest layer, all ssl avi ref will be assigned to parent
+	// In Avi model, sslaviref will be associated with child
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-		return nodes[0].SSLKeyCertAviRef
+		return nodes[0].EvhNodes[0].SSLKeyCertAviRef
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref"))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -1029,7 +1029,7 @@ func TestEVHCRDWithAviInfraSetting(t *testing.T) {
 	integrationtest.VerifyMetadataHTTPRule(g, poolKey, "default/"+rrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(settingModelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	g.Expect(nodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
+	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertAviRef).To(gomega.ContainSubstring("thisisaviref-sslkey"))
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.Equal("LB_ALGORITHM_CONSISTENT_HASH"))


### PR DESCRIPTION
This PR backport changes from master to 1.5.2 to fix issues
1. EVH: Secure , Insecure VS deployed with hostrule sslkeycert ref doesn't have sslkeycert ref as per expectations. Handles add, delete, update case.
2. SNI VS:  on delete hostrule with sslkeycert ref from SNI VS, SNI Vs gets default cert.