### PR TITLE
Make AKO bootups faster

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -32,6 +32,8 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/retry"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -269,9 +271,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	}
 
 	// Setup and start event handlers for objects.
-	c.SetupEventHandlers(informers)
 	c.Start(stopCh)
-
 	graphQueue.SyncFunc = SyncFromNodesLayer
 	graphQueue.Run(stopCh, graphwg)
 	fullSyncInterval := os.Getenv(utils.FULL_SYNC_INTERVAL)
@@ -312,7 +312,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 			go tokenWorker.Run()
 		}
 	}
-
+	c.SetupEventHandlers(informers)
 	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
 	ingestionQueue.SyncFunc = SyncFromIngestionLayer
 	ingestionQueue.Run(stopCh, ingestionwg)
@@ -448,6 +448,11 @@ func (c *AviController) FullSyncK8s() error {
 			}
 			key = utils.Service + "/" + utils.ObjKey(svcObj)
 		}
+		meta, err := meta.Accessor(svcObj)
+		if err == nil {
+			resVer := meta.GetResourceVersion()
+			objects.SharedResourceVerInstanceLister().Save(key, resVer)
+		}
 		nodes.DequeueIngestion(key, true)
 	}
 
@@ -459,6 +464,11 @@ func (c *AviController) FullSyncK8s() error {
 		}
 		for _, podObj := range podObjs {
 			key := utils.Pod + "/" + utils.ObjKey(podObj)
+			meta, err := meta.Accessor(podObj)
+			if err == nil {
+				resVer := meta.GetResourceVersion()
+				objects.SharedResourceVerInstanceLister().Save(key, resVer)
+			}
 			nodes.DequeueIngestion(key, true)
 		}
 	}
@@ -470,6 +480,11 @@ func (c *AviController) FullSyncK8s() error {
 		} else {
 			for _, hostRuleObj := range hostRuleObjs {
 				key := lib.HostRule + "/" + utils.ObjKey(hostRuleObj)
+				meta, err := meta.Accessor(hostRuleObj)
+				if err == nil {
+					resVer := meta.GetResourceVersion()
+					objects.SharedResourceVerInstanceLister().Save(key, resVer)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -480,6 +495,11 @@ func (c *AviController) FullSyncK8s() error {
 		} else {
 			for _, httpRuleObj := range httpRuleObjs {
 				key := lib.HTTPRule + "/" + utils.ObjKey(httpRuleObj)
+				meta, err := meta.Accessor(httpRuleObj)
+				if err == nil {
+					resVer := meta.GetResourceVersion()
+					objects.SharedResourceVerInstanceLister().Save(key, resVer)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -490,6 +510,11 @@ func (c *AviController) FullSyncK8s() error {
 		} else {
 			for _, aviInfraObj := range aviInfraObjs {
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviInfraObj)
+				meta, err := meta.Accessor(aviInfraObj)
+				if err == nil {
+					resVer := meta.GetResourceVersion()
+					objects.SharedResourceVerInstanceLister().Save(key, resVer)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -505,6 +530,11 @@ func (c *AviController) FullSyncK8s() error {
 					ns := strings.Split(ingLabel, "/")
 					if utils.CheckIfNamespaceAccepted(ns[0]) {
 						key := utils.Ingress + "/" + utils.ObjKey(ingObj)
+						meta, err := meta.Accessor(ingObj)
+						if err == nil {
+							resVer := meta.GetResourceVersion()
+							objects.SharedResourceVerInstanceLister().Save(key, resVer)
+						}
 						utils.AviLog.Debugf("Dequeue for ingress key: %v", key)
 						nodes.DequeueIngestion(key, true)
 					}
@@ -524,6 +554,11 @@ func (c *AviController) FullSyncK8s() error {
 					ns := strings.Split(routeLabel, "/")
 					if utils.CheckIfNamespaceAccepted(ns[0]) {
 						key := utils.OshiftRoute + "/" + utils.ObjKey(routeObj)
+						meta, err := meta.Accessor(routeObj)
+						if err == nil {
+							resVer := meta.GetResourceVersion()
+							objects.SharedResourceVerInstanceLister().Save(key, resVer)
+						}
 						utils.AviLog.Debugf("Dequeue for route key: %v", key)
 						nodes.DequeueIngestion(key, true)
 					}
@@ -541,6 +576,11 @@ func (c *AviController) FullSyncK8s() error {
 				ns := strings.Split(gatewayLabel, "/")
 				if utils.CheckIfNamespaceAccepted(ns[0]) {
 					key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
+					meta, err := meta.Accessor(gatewayObj)
+					if err == nil {
+						resVer := meta.GetResourceVersion()
+						objects.SharedResourceVerInstanceLister().Save(key, resVer)
+					}
 					InformerStatusUpdatesForSvcApiGateway(key, gatewayObj)
 					nodes.DequeueIngestion(key, true)
 				}
@@ -553,6 +593,11 @@ func (c *AviController) FullSyncK8s() error {
 			}
 			for _, gwClassObj := range gwClassObjs {
 				key := lib.GatewayClass + "/" + utils.ObjKey(gwClassObj)
+				meta, err := meta.Accessor(gwClassObj)
+				if err == nil {
+					resVer := meta.GetResourceVersion()
+					objects.SharedResourceVerInstanceLister().Save(key, resVer)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -344,7 +344,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == route.ResourceVersion {
-				utils.AviLog.Debugf("Same resource version returning")
+				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
@@ -379,6 +379,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			objects.SharedResourceVerInstanceLister().Delete(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -417,7 +418,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			key := utils.Pod + "/" + utils.ObjKey(pod)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == pod.ResourceVersion {
-				utils.AviLog.Debugf("Same resource version returning")
+				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
@@ -444,6 +445,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
 			bkt := utils.Bkt(namespace, numWorkers)
+			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
@@ -557,7 +559,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == svc.ResourceVersion {
-				utils.AviLog.Debugf("Same resource version returning")
+				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
@@ -599,6 +601,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			objects.SharedResourceVerInstanceLister().Delete(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -641,22 +644,6 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 	c.informers.EpInformer.Informer().AddEventHandler(epEventHandler)
 
 	c.informers.ServiceInformer.Informer().AddEventHandler(svcEventHandler)
-	c.informers.ServiceInformer.Informer().AddIndexers(
-		cache.Indexers{
-			lib.AviSettingServicesIndex: func(obj interface{}) ([]string, error) {
-				service, ok := obj.(*corev1.Service)
-				if !ok {
-					return []string{}, nil
-				}
-				if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
-					if val, ok := service.Annotations[lib.InfraSettingNameAnnotation]; ok && val != "" {
-						return []string{val}, nil
-					}
-				}
-				return []string{}, nil
-			},
-		},
-	)
 
 	if lib.GetCNIPlugin() == lib.CALICO_CNI {
 		blockAffinityHandler := cache.ResourceEventHandlerFuncs{
@@ -817,7 +804,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == ingress.ResourceVersion {
-				utils.AviLog.Debugf("Same resource version returning")
+				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
@@ -848,6 +835,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				return
 			}
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
+			objects.SharedResourceVerInstanceLister().Delete(key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
@@ -882,7 +870,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == node.ResourceVersion {
-				utils.AviLog.Debugf("Same resource version returning")
+				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
 			c.workqueue[bkt].AddRateLimited(key)
@@ -907,6 +895,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			key := utils.NodeObj + "/" + node.Name
 			bkt := utils.Bkt(lib.GetTenant(), numWorkers)
+			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
@@ -942,7 +931,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.IngressClass + "/" + utils.ObjKey(ingClass)
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 				if ok && resVer.(string) == ingClass.ResourceVersion {
-					utils.AviLog.Debugf("Same resource version returning")
+					utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 					return
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -969,6 +958,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingClass))
 				key := utils.IngressClass + "/" + utils.ObjKey(ingClass)
 				bkt := utils.Bkt(namespace, numWorkers)
+				objects.SharedResourceVerInstanceLister().Delete(key)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 			},
@@ -1017,20 +1007,6 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 	if c.informers.RouteInformer != nil {
 		routeEventHandler := AddRouteEventHandler(numWorkers, c)
 		c.informers.RouteInformer.Informer().AddEventHandler(routeEventHandler)
-		c.informers.RouteInformer.Informer().AddIndexers(
-			cache.Indexers{
-				lib.AviSettingRouteIndex: func(obj interface{}) ([]string, error) {
-					route, ok := obj.(*routev1.Route)
-					if !ok {
-						return []string{}, nil
-					}
-					if settingName, ok := route.Annotations[lib.InfraSettingNameAnnotation]; ok {
-						return []string{settingName}, nil
-					}
-					return []string{}, nil
-				},
-			},
-		)
 	}
 
 	// Add CRD handlers HostRule/HTTPRule/AviInfraSettings

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -96,6 +96,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				if err := validateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
 				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == hostrule.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
+				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
@@ -156,6 +161,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
 				if err := validateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
+				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == httprule.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -220,6 +230,11 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
 				if err := validateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
+				}
+				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
+				if ok && resVer.(string) == aviinfra.ResourceVersion {
+					utils.AviLog.Debugf("Same resource version returning")
+					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)

--- a/internal/objects/resourceversions.go
+++ b/internal/objects/resourceversions.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020-2021 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// APIs to access AVI graph from and to memory. The VS should have a uuid and the corresponding model.
+
+package objects
+
+import (
+	"sync"
+)
+
+var resouceVerInstance *ResourceVersionLister
+var resourceVerOnce sync.Once
+
+func SharedResourceVerInstanceLister() *ResourceVersionLister {
+	resourceVerOnce.Do(func() {
+		ResourceVerStore := NewObjectMapStore()
+		resouceVerInstance = &ResourceVersionLister{}
+		resouceVerInstance.ResourceVerStore = ResourceVerStore
+	})
+	return resouceVerInstance
+}
+
+type ResourceVersionLister struct {
+	ResourceVerStore *ObjectMapStore
+}
+
+func (a *ResourceVersionLister) Save(vsName string, resVer interface{}) {
+	a.ResourceVerStore.AddOrUpdate(vsName, resVer)
+}
+
+func (a *ResourceVersionLister) Get(resName string) (bool, interface{}) {
+	ok, obj := a.ResourceVerStore.Get(resName)
+	return ok, obj
+}
+
+func (a *ResourceVersionLister) GetAll() interface{} {
+	obj := a.ResourceVerStore.GetAllObjectNames()
+	return obj
+}
+
+func (a *ResourceVersionLister) Delete(resName string) {
+	a.ResourceVerStore.Delete(resName)
+
+}


### PR DESCRIPTION
This commit introduces a change that works as follows:

    - During bootup of AKO, we perform a full sync. This results
    into the layer 2 models getting built before activating layer 3.
    - The informer event handlers are then used to enqueue updates to
    the layer 2 queues as well for the same updates which were processed
    as a part of the full sync update.

    This current fix optimizes the second point by caching the resource
    version of the k8s objects during fullsync.

    Then during the regular event updates, it compares the cached resource
    versions in AKO with that of the event updated objects.

    If the resource versions are same, then AKO does not enqueue the same
    key again in layer 2, thus reducing the burden of layer 2 significantly
    during bootup.

    This fix potentially solves a starvation problem in AKO when during a
    heavily loaded system, if AKO is rebooted, and some new routes/ingresses
    are created, they are starved for these already pre-processed updates.