### PR TITLE
Make the bootup cache population parallel

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -42,15 +42,10 @@ func SharedAVIClients() *utils.AviRestClientPool {
 	}
 
 	if AviClientInstance == nil || len(AviClientInstance.AviClient) == 0 {
-		shardSize := lib.GetshardSize()
-		if shardSize == 0 {
-			// For dedicated VSes, we will have 8 threads in layer 3
-			shardSize = 8
-		}
 		if AviClientInstance == nil || len(AviClientInstance.AviClient) == 0 {
-			// initializing shardSize+1 clients in pool, the +1 is used by CRD ref verification calls
+			// Always create 9 clients irrespective of shard size
 			AviClientInstance, err = utils.NewAviRestClientPool(
-				shardSize+1,
+				9,
 				ctrlIpAddress,
 				ctrlUsername,
 				ctrlPassword,

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -55,7 +55,7 @@ func PopulateCache() error {
 	avi_obj_cache := avicache.SharedAviObjCache()
 	// Randomly pickup a client.
 	if avi_rest_client_pool != nil && len(avi_rest_client_pool.AviClient) > 0 {
-		_, _, err := avi_obj_cache.AviObjCachePopulate(avi_rest_client_pool.AviClient[0], utils.CtrlVersion, utils.CloudName)
+		_, _, err := avi_obj_cache.AviObjCachePopulate(avi_rest_client_pool.AviClient, utils.CtrlVersion, utils.CloudName)
 		if err != nil {
 			utils.AviLog.Warnf("failed to populate avi cache with error: %v", err.Error())
 			return err

--- a/internal/objects/avigraph.go
+++ b/internal/objects/avigraph.go
@@ -27,7 +27,7 @@ var avionce sync.Once
 
 func SharedAviGraphLister() *AviGraphLister {
 	avionce.Do(func() {
-		AviGraphStore := NewObjectMapStore()
+		AviGraphStore := NewObjectMapStoreWithLock()
 		aviGraphinstance = &AviGraphLister{}
 		aviGraphinstance.AviGraphStore = AviGraphStore
 	})
@@ -35,24 +35,24 @@ func SharedAviGraphLister() *AviGraphLister {
 }
 
 type AviGraphLister struct {
-	AviGraphStore *ObjectMapStore
+	AviGraphStore *ObjectMapStoreWithLock
 }
 
 func (a *AviGraphLister) Save(vsName string, aviGraph interface{}) {
 	utils.AviLog.Infof("Saving Model: %s", vsName)
-	a.AviGraphStore.AddOrUpdate(vsName, aviGraph)
+	a.AviGraphStore.AddOrUpdateWithLock(vsName, aviGraph)
 }
 
 func (a *AviGraphLister) Get(vsName string) (bool, interface{}) {
-	ok, obj := a.AviGraphStore.Get(vsName)
+	ok, obj := a.AviGraphStore.GetWithLock(vsName)
 	return ok, obj
 }
 
 func (a *AviGraphLister) GetAll() interface{} {
-	obj := a.AviGraphStore.GetAllObjectNames()
+	obj := a.AviGraphStore.GetAllObjectNamesWithLock()
 	return obj
 }
 
 func (a *AviGraphLister) Delete(vsName string) {
-	a.AviGraphStore.Delete(vsName)
+	a.AviGraphStore.DeleteWithLock(vsName)
 }

--- a/internal/objects/store_lock less.go
+++ b/internal/objects/store_lock less.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+// Construct in memory database that populates updates from both kubernetes and MCP
+// The format is: namespace:[object_name: obj]
+
+package objects
+
+import (
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type ObjectStore struct {
+	NSObjectMap map[string]*ObjectMapStore
+}
+
+func NewObjectStore() *ObjectStore {
+	objectStore := &ObjectStore{}
+	objectStore.NSObjectMap = make(map[string]*ObjectMapStore)
+	return objectStore
+}
+
+func (store *ObjectStore) GetNSStore(nsName string) *ObjectMapStore {
+
+	val, ok := store.NSObjectMap[nsName]
+	if ok {
+		return val
+	} else {
+		// This namespace is not initialized, let's initialze it
+		nsObjStore := NewObjectMapStore()
+		// Update the store.
+		store.NSObjectMap[nsName] = nsObjStore
+		return nsObjStore
+	}
+}
+
+func (store *ObjectStore) DeleteNSStore(nsName string) bool {
+	// Deletes the key for a namespace. Wipes off the entire NS. So use with care.
+	_, ok := store.NSObjectMap[nsName]
+	if ok {
+		delete(store.NSObjectMap, nsName)
+		return true
+	}
+	utils.AviLog.Warnf("Namespace: %s not found, nothing to delete returning false", nsName)
+	return false
+
+}
+
+func (store *ObjectStore) GetAllNamespaces() []string {
+	// Take a read lock on the store and write lock on NS object
+	var allNamespaces []string
+	for ns := range store.NSObjectMap {
+		allNamespaces = append(allNamespaces, ns)
+	}
+	return allNamespaces
+
+}
+
+type ObjectMapStore struct {
+	ObjectMap map[string]interface{}
+}
+
+func NewObjectMapStore() *ObjectMapStore {
+	nsObjStore := &ObjectMapStore{}
+	nsObjStore.ObjectMap = make(map[string]interface{})
+	return nsObjStore
+}
+
+func (o *ObjectMapStore) AddOrUpdate(objName string, obj interface{}) {
+	o.ObjectMap[objName] = obj
+}
+
+func (o *ObjectMapStore) Delete(objName string) bool {
+	_, ok := o.ObjectMap[objName]
+	if ok {
+		delete(o.ObjectMap, objName)
+		return true
+	}
+	return false
+
+}
+
+func (o *ObjectMapStore) Get(objName string) (bool, interface{}) {
+	val, ok := o.ObjectMap[objName]
+	if ok {
+		return true, val
+	}
+	return false, nil
+
+}
+
+func (o *ObjectMapStore) GetAllObjectNames() map[string]interface{} {
+	// TODO (sudswas): Pass a copy instead of the reference
+	return o.ObjectMap
+
+}
+
+func (o *ObjectMapStore) CopyAllObjects() map[string]interface{} {
+
+	CopiedObjMap := make(map[string]interface{})
+	for k, v := range o.ObjectMap {
+		CopiedObjMap[k] = v
+	}
+	return CopiedObjMap
+}


### PR DESCRIPTION
This commit introduces a way to make the bootup cache population
parallel. Additionally, the number of Avi clients are always init
to 9 irrespective of shard size.

Fixes: AV-125494