### PR TITLE
Add autoFQDN for shared VSes

### DIFF
--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -113,6 +113,35 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 	o.ConstructShardVsPGNode(vsName, key, avi_vs_meta)
 	o.ConstructHTTPDataScript(vsName, key, avi_vs_meta)
 	var fqdns []string
+	subDomains := GetDefaultSubDomain()
+	autoFQDN := true
+	if lib.GetL4FqdnFormat() == lib.AutoFQDNDisabled {
+		autoFQDN = false
+	}
+	if subDomains != nil && autoFQDN {
+		var fqdn string
+		// honour defaultSubDomain from values.yaml if specified
+		defaultSubDomain := lib.GetDomain()
+		if defaultSubDomain != "" && utils.HasElem(subDomains, defaultSubDomain) {
+			subDomains = []string{defaultSubDomain}
+		}
+
+		// subDomains[0] would either have the defaultSubDomain value
+		// or would default to the first dns subdomain it gets from the dns profile
+		subdomain := subDomains[0]
+		if strings.HasPrefix(subDomains[0], ".") {
+			subdomain = strings.Replace(subDomains[0], ".", "", -1)
+		}
+		if lib.GetL4FqdnFormat() == lib.AutoFQDNDefault {
+			// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+			fqdn = vsName + "." + lib.GetTenant() + "." + subdomain
+		} else if lib.GetL4FqdnFormat() == lib.AutoFQDNFlat {
+			// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+			fqdn = vsName + "-" + lib.GetTenant() + "." + subdomain
+		}
+		utils.AviLog.Infof("key: %s, msg: Configured the shared VS with default fqdn as: %s", fqdn)
+		fqdns = append(fqdns, fqdn)
+	}
 
 	vsVipNode := &AviVSVIPNode{
 		Name:        lib.GetVsVipName(vsName),


### PR DESCRIPTION
For infoblox DNS, we need to retain a FQDN in the shared VS for
it to not release the IP address in the backed.

This commit introduces the feature in the following way:

- Generate the shared VS default FQDN based on the format suggested
by the autoFQDN flag.
- If it's flat then it will generated it of the form:
 vsName + "-" + tenant + "." + <subdomain> else,
 it will be vsName + "." + tenant + "." + <subdomain>

- This FQDN won't be added if autoFQDN is set to disabled

In 1.5.2, we will keep this setting still under the L4Settings
because moving it to a generic AKOSettings now will have impact
on the AKO operator. But in 1.6.1, we would want to move this
autoFQDN flag under AKOSettings