### PR TITLE
Publish the CRD if the status changes during bootup

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -93,11 +93,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				hostrule := obj.(*akov1alpha1.HostRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
+				statusBefore := hostrule.Status.Status
 				if err := validateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := hostrule.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == hostrule.ResourceVersion {
+				if ok && resVer.(string) == hostrule.ResourceVersion && statusBefore == statusAfter {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}
@@ -160,11 +163,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				httprule := obj.(*akov1alpha1.HTTPRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(httprule))
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
+				statusBefore := httprule.Status.Status
 				if err := validateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := httprule.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == httprule.ResourceVersion {
+				if ok && resVer.(string) == httprule.ResourceVersion && statusAfter == statusBefore {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}
@@ -230,11 +236,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				aviinfra := obj.(*akov1alpha1.AviInfraSetting)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(aviinfra))
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
+				statusBefore := aviinfra.Status.Status
 				if err := validateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := aviinfra.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == aviinfra.ResourceVersion {
+				if ok && resVer.(string) == aviinfra.ResourceVersion && statusAfter == statusBefore {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}


### PR DESCRIPTION
Consider the scenario:

- AKO boots up. During  bootup, a HostRule CRD is created.
- The HostRule CRD does not perform a validation logic during full
sync.
- We cache the resource version during fullsync.
- When the event handlers are switched on, we find the same resource
version, so we don't do the validation.
- The HostRule is never applied.

This fix will force a re-publish of the HostRule/HTTPRule/AviInfra
CRD if they are found to have a status change during the validation.