### PR TITLE
Publish the CRD if the status changes during bootup

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -113,11 +113,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				hostrule := obj.(*akov1alpha1.HostRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
+				statusBefore := hostrule.Status.Status
 				if err := validateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := hostrule.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == hostrule.ResourceVersion {
+				if ok && resVer.(string) == hostrule.ResourceVersion && statusBefore == statusAfter {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}
@@ -180,11 +183,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				httprule := obj.(*akov1alpha1.HTTPRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(httprule))
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
+				statusBefore := httprule.Status.Status
 				if err := validateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := httprule.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == httprule.ResourceVersion {
+				if ok && resVer.(string) == httprule.ResourceVersion && statusAfter == statusBefore {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}
@@ -250,11 +256,14 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				aviinfra := obj.(*akov1alpha1.AviInfraSetting)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(aviinfra))
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
+				statusBefore := aviinfra.Status.Status
 				if err := validateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
 				}
+				// It's a reference, so pointer should be able to access the updated status.
+				statusAfter := aviinfra.Status.Status
 				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == aviinfra.ResourceVersion {
+				if ok && resVer.(string) == aviinfra.ResourceVersion && statusAfter == statusBefore {
 					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
 					return
 				}

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -15,7 +15,6 @@
 package nodes
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -27,7 +26,6 @@ import (
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
 	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TODO: Move to utils
@@ -185,7 +183,6 @@ func (o *AviObjectGraph) BuildCACertNode(tlsNode *AviVsNode, cacert, infraSettin
 }
 
 func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode *AviVsNode, namespace string, tlsData TlsSettings, key, infraSettingName, sniHost string) bool {
-	mClient := utils.GetInformers().ClientSet
 	secretName := tlsData.SecretName
 	secretNS := tlsData.SecretNS
 	if secretNS == "" {
@@ -218,7 +215,7 @@ func (o *AviObjectGraph) BuildTlsCertNode(svcLister *objects.SvcLister, tlsNode 
 			return false
 		}
 	} else {
-		secretObj, err := mClient.CoreV1().Secrets(secretNS).Get(context.TODO(), secretName, metav1.GetOptions{})
+		secretObj, err := utils.GetInformers().SecretInformer.Lister().Secrets(secretNS).Get(secretName)
 		if err != nil || secretObj == nil {
 			// This secret has been deleted.
 			ok, ingNames := svcLister.IngressMappings(namespace).GetSecretToIng(secretName)


### PR DESCRIPTION
Consider the scenario:

- AKO boots up. During  bootup, a HostRule CRD is created.
- The HostRule CRD does not perform a validation logic during full
sync.
- We cache the resource version during fullsync.
- When the event handlers are switched on, we find the same resource
version, so we don't do the validation.
- The HostRule is never applied.

This fix will force a re-publish of the HostRule/HTTPRule/AviInfra
CRD if they are found to have a status change during the validation.