### PR TITLE
Correct problem with status checks on CRD

### DIFF
--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -77,11 +77,11 @@ nodePortSelector: # Only applicable if serviceType is NodePort
 
 resources:
   limits:
-    cpu: 250m
-    memory: 300Mi
+    cpu: 350m
+    memory: 400Mi
   requests:
-    cpu: 100m
-    memory: 200Mi
+    cpu: 200m
+    memory: 300Mi
 
 podSecurityContext: {}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -179,11 +179,7 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 		case EndpointInformer:
 			informers.EpInformer = kubeInformerFactory.Core().V1().Endpoints()
 		case SecretInformer:
-			if akoNSBoundInformer {
-				informers.SecretInformer = akoNSInformerFactory.Core().V1().Secrets()
-			} else {
-				informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
-			}
+			informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
 		case NodeInformer:
 			informers.NodeInformer = kubeInformerFactory.Core().V1().Nodes()
 		case ConfigMapInformer:
@@ -245,9 +241,6 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 		}
 	}
 
-	if oshiftclient != nil {
-		akoNSBoundInformer = true
-	}
 	if !instantiateOnce {
 		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace, akoNSBoundInformer)
 	}


### PR DESCRIPTION
This commit addresses 2 problems:

- The CRD status verification in layer 1 for optimization is now
   removed.

- The secret informer is now switched on for all namespaces.
This helps with bootup speed because we don't use the clientsets
anymore. As a result of this change, the pod resource sizing
of AKO is altered in the values.yaml

Fixes: AV-125902