### PR TITLE
Correct problem with status checks on CRD

### DIFF
--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -79,11 +79,11 @@ nodePortSelector: # Only applicable if serviceType is NodePort
 
 resources:
   limits:
-    cpu: 250m
-    memory: 300Mi
+    cpu: 350m
+    memory: 400Mi
   requests:
-    cpu: 100m
-    memory: 200Mi
+    cpu: 200m
+    memory: 300Mi
 
 podSecurityContext: {}
 

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -100,6 +100,10 @@ func isAviInfraUpdated(oldAviInfra, newAviInfra *akov1alpha1.AviInfraSetting) bo
 }
 
 // SetupAKOCRDEventHandlers handles setting up of AKO CRD event handlers
+// TODO: The CRD are getting re-enqueued for the same resourceVersion via fullsync as well as via these handlers.
+// We can leverage the resourceVersion checks to optimize this code. However the CRDs would need a check on
+// status for re-publish. The status does not change the resourceVersion and during fullsync we ignore a CRD
+// if it's status is not updated.
 func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 	utils.AviLog.Infof("Setting up AKO CRD Event handlers")
 	informer := lib.AKOControlConfig().CRDInformers()
@@ -113,16 +117,8 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				hostrule := obj.(*akov1alpha1.HostRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
-				statusBefore := hostrule.Status.Status
 				if err := validateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
-				}
-				// It's a reference, so pointer should be able to access the updated status.
-				statusAfter := hostrule.Status.Status
-				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == hostrule.ResourceVersion && statusBefore == statusAfter {
-					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
-					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -183,16 +179,8 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				httprule := obj.(*akov1alpha1.HTTPRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(httprule))
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
-				statusBefore := httprule.Status.Status
 				if err := validateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
-				}
-				// It's a reference, so pointer should be able to access the updated status.
-				statusAfter := httprule.Status.Status
-				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == httprule.ResourceVersion && statusAfter == statusBefore {
-					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
-					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -256,16 +244,8 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				aviinfra := obj.(*akov1alpha1.AviInfraSetting)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(aviinfra))
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
-				statusBefore := aviinfra.Status.Status
 				if err := validateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
-				}
-				// It's a reference, so pointer should be able to access the updated status.
-				statusAfter := aviinfra.Status.Status
-				ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
-				if ok && resVer.(string) == aviinfra.ResourceVersion && statusAfter == statusBefore {
-					utils.AviLog.Debugf("key: %s, msg: Same resource version returning", key)
-					return
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -177,11 +177,7 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 		case EndpointInformer:
 			informers.EpInformer = kubeInformerFactory.Core().V1().Endpoints()
 		case SecretInformer:
-			if akoNSBoundInformer {
-				informers.SecretInformer = akoNSInformerFactory.Core().V1().Secrets()
-			} else {
-				informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
-			}
+			informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
 		case NodeInformer:
 			informers.NodeInformer = kubeInformerFactory.Core().V1().Nodes()
 		case ConfigMapInformer:
@@ -241,9 +237,6 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 		}
 	}
 
-	if oshiftclient != nil {
-		akoNSBoundInformer = true
-	}
 	if !instantiateOnce {
 		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, namespace, akoNSBoundInformer)
 	}


### PR DESCRIPTION
This commit addresses 2 problems:

- The CRD status verification in layer 1 for optimization is now
removed..

- The secret informer is now switched on for all namespaces.
This helps with bootup speed because we don't use the clientsets
anymore. As a result of this change, the pod resource sizing
of AKO is altered in the values.yaml