### PR TITLE
Add indexers for services API before setting up event handlers

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -332,6 +332,9 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	// Setup and start event handlers for objects.
 	c.addIndexers()
 	c.AddCrdIndexer()
+	if lib.UseServicesAPI() {
+		c.AddSvcApiIndexers()
+	}
 	c.Start(stopCh)
 	graphQueue.SyncFunc = SyncFromNodesLayer
 	graphQueue.Run(stopCh, graphwg)

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -309,6 +309,12 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 	}
 
 	informer.GatewayInformer.Informer().AddEventHandler(gatewayEventHandler)
+	informer.GatewayClassInformer.Informer().AddEventHandler(gatewayClassEventHandler)
+	return
+}
+
+func (c *AviController) AddSvcApiIndexers() {
+	informer := lib.AKOControlConfig().SvcAPIInformers()
 	informer.GatewayInformer.Informer().AddIndexers(
 		cache.Indexers{
 			lib.GatewayClassGatewayIndex: func(obj interface{}) ([]string, error) {
@@ -320,8 +326,6 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			},
 		},
 	)
-
-	informer.GatewayClassInformer.Informer().AddEventHandler(gatewayClassEventHandler)
 	informer.GatewayClassInformer.Informer().AddIndexers(
 		cache.Indexers{
 			lib.AviSettingGWClassIndex: func(obj interface{}) ([]string, error) {
@@ -338,6 +342,4 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			},
 		},
 	)
-
-	return
 }


### PR DESCRIPTION
This commit adds the services API index handlers before the
event handlers are setup during AKO bootup.