### PR TITLE
cherry-pick: Fix status update issue during WCP full sync

### DIFF
--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -76,21 +76,6 @@ func (rest *RestOperations) SyncObjectStatuses() {
 						VirtualServiceUUID: vsCacheObj.Uuid,
 					})
 			}
-		} else if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
-			// serviceLB
-			if vsCacheObj.Fip != "" {
-				IPAddrs = append(IPAddrs, vsCacheObj.Fip)
-			} else {
-				IPAddrs = append(IPAddrs, vsCacheObj.Vip)
-			}
-			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
-
-				status.UpdateOptions{
-					Vip:                IPAddrs,
-					ServiceMetadata:    vsSvcMetadataObj,
-					Key:                lib.SyncStatusKey,
-					VirtualServiceUUID: vsCacheObj.Uuid,
-				})
 		} else {
 			// insecure VSes handler
 			for _, poolKey := range vsCacheObj.PoolKeyCollection {
@@ -118,8 +103,37 @@ func (rest *RestOperations) SyncObjectStatuses() {
 							Key:                lib.SyncStatusKey,
 							VirtualServiceUUID: vsCacheObj.Uuid,
 						})
+				} else if len(poolCacheObj.ServiceMetadataObj.NamespaceServiceName) > 0 {
+					if vsCacheObj.Fip != "" {
+						IPAddrs = append(IPAddrs, vsCacheObj.Fip)
+					} else {
+						IPAddrs = append(IPAddrs, vsCacheObj.Vip)
+					}
+					allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
+						status.UpdateOptions{
+							Vip:                IPAddrs,
+							ServiceMetadata:    poolCacheObj.ServiceMetadataObj,
+							Key:                lib.SyncStatusKey,
+							VirtualServiceUUID: vsCacheObj.Uuid,
+						})
 				}
 			}
+		}
+
+		if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
+			var IPAddrsSvc []string
+			if vsCacheObj.Fip != "" {
+				IPAddrsSvc = append(IPAddrsSvc, vsCacheObj.Fip)
+			} else {
+				IPAddrsSvc = append(IPAddrsSvc, vsCacheObj.Vip)
+			}
+			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
+				status.UpdateOptions{
+					Vip:                IPAddrsSvc,
+					ServiceMetadata:    vsSvcMetadataObj,
+					Key:                lib.SyncStatusKey,
+					VirtualServiceUUID: vsCacheObj.Uuid,
+				})
 		}
 	}
 

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -43,7 +43,6 @@ type UpdateGWStatusConditionOptions struct {
 
 func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	gatewaysToUpdate, updateGWOptions := parseOptionsFromMetadata(options, bulk)
-	var updateServiceOptions []UpdateOptions
 
 	// gatewayMap: {ns/gateway: gatewayObj}
 	// this pre-fetches all gateways to be candidates for status update
@@ -52,14 +51,6 @@ func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 	gatewayMap := getGateways(gatewaysToUpdate, bulk)
 	skipDelete := map[string]bool{}
 	for _, option := range updateGWOptions {
-		updateServiceOptions = append(updateServiceOptions, UpdateOptions{
-			Vip: option.Vip,
-			Key: option.Key,
-			ServiceMetadata: avicache.ServiceMetadataObj{
-				NamespaceServiceName: option.ServiceMetadata.NamespaceServiceName,
-			},
-		})
-
 		if gw := gatewayMap[option.IngSvc]; gw != nil {
 			// assuming 1 IP per gateway
 			gwStatus := gw.Status.DeepCopy()
@@ -92,8 +83,6 @@ func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 			}, lib.SyncStatusKey)
 		}
 	}
-
-	UpdateL4LBStatus(updateServiceOptions, bulk)
 }
 
 func parseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, []UpdateOptions) {


### PR DESCRIPTION
The issue was introduced as part of
https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/commit/46e8d1da1496b4bf66220158150d704574a58aee
The changes were left out for advl4 usecases.