### PR TITLE
Auto-detect cloud and create SE group

### DIFF
--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -119,7 +119,7 @@ func AviPost(client *clients.AviClient, uri string, payload interface{}, respons
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
 		if retry >= 3 {
-			err := errors.New("msg: AviPut retried 3 times, aborting")
+			err := errors.New("msg: AviPost retried 3 times, aborting")
 			return err
 		}
 	}


### PR DESCRIPTION
The following commit introduces the following changes:

- Derives the NSX-T cloud name from the controller based on the
transport zone info.
- Caches the cloud in an AKO in memory story.
- Verifies if the cloud has an SE group template populated or not.
- If SE group template exists, then uses that to create an SE group.
- If the SE group template does not exist then it uses the `Default-Group`
settings

NOTE: This code requires a resolution on: https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/654
before merge

Integration tests cannot be performed till then.