### PR TITLE
Annotate the system namespaces for ako-infra

### DIFF
--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -119,6 +119,10 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 }
 
 func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
+	err, seGroup := lib.FetchSEGroupWithMarkerSet(a.AviRestClients.AviClient[0])
+	if err == nil && seGroup != "" {
+		utils.AviLog.Infof("SE Group: %s already configured with the marker labels: %s", seGroup, lib.GetClusterID())
+	}
 	// This method checks if the cloud in Avi has a SE Group template configured or not. If has the SEG template then it returns true, else false
 	err, cloudName, segUuid := a.DeriveCloudNameAndSEGroupTmpl(tz)
 	if err != nil {

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2586,7 +2586,7 @@ func validateAndConfigureSeGroup(client *clients.AviClient) bool {
 	var err error
 	// 2. Marker based (only advancedL4)
 	if seGroupToUse == "" && lib.GetAdvancedL4() {
-		err, seGroupToUse = fetchSEGroupWithMarkerSet(client)
+		err, seGroupToUse = lib.FetchSEGroupWithMarkerSet(client)
 		if err != nil {
 			return false
 		}
@@ -2649,60 +2649,6 @@ func validateAndConfigureSeGroup(client *clients.AviClient) bool {
 	}
 
 	return true
-}
-
-func fetchSEGroupWithMarkerSet(client *clients.AviClient, overrideUri ...NextPage) (error, string) {
-	var uri string
-	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
-	} else {
-		uri = "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName
-	}
-
-	result, err := lib.AviGetCollectionRaw(client, uri)
-	if err != nil {
-		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
-		return err, ""
-	}
-
-	elems := make([]json.RawMessage, result.Count)
-	err = json.Unmarshal(result.Results, &elems)
-	if err != nil {
-		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
-		return err, ""
-	}
-
-	// Using clusterID for advl4.
-	clusterName := lib.GetClusterID()
-	for _, elem := range elems {
-		seg := models.ServiceEngineGroup{}
-		err = json.Unmarshal(elem, &seg)
-		if err != nil {
-			utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
-			continue
-		}
-
-		if len(seg.Markers) == 1 &&
-			*seg.Markers[0].Key == lib.ClusterNameLabelKey &&
-			len(seg.Markers[0].Values) == 1 &&
-			seg.Markers[0].Values[0] == clusterName {
-			utils.AviLog.Infof("Marker configuration found in Service Engine Group %s.", *seg.Name)
-			return nil, *seg.Name
-		}
-	}
-
-	if result.Next != "" {
-		// It has a next page, let's recursively call the same method.
-		next_uri := strings.Split(result.Next, "/api/serviceenginegroup")
-		if len(next_uri) > 1 {
-			overrideUri := "/api/serviceenginegroup" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
-			return fetchSEGroupWithMarkerSet(client, nextPage)
-		}
-	}
-
-	utils.AviLog.Infof("No Marker configured Service Engine Group found.")
-	return nil, ""
 }
 
 // ConfigureSeGroupLabels configures labels on the SeGroup if not present already


### PR DESCRIPTION
This commit takes care annotating the system namespace with the cloudName
and the seGroup keys which are to be used by AKO to sync the objects.