### PR TITLE
Support IPv6 vip and static routes

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}
   autoFQDN: {{ .Values.L4Settings.autoFQDN | quote }}
+  ipScheme: {{ .Values.AKOSettings.ipScheme | quote }}
   {{ if .Values.AKOSettings.syncNamespace  }}
   syncNamespace: {{ .Values.AKOSettings.syncNamespace | quote }}
   {{ end }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -214,6 +214,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: autoFQDN
+          - name: IP_SCHEME
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: ipscheme
           {{ if .Values.persistentVolumeClaim }}
           - name: USE_PVC
             value: "true"

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -28,6 +28,7 @@ AKOSettings:
                      # with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 
   istioEnabled: "false" # This flag indicates to AKO that it should listen on Istio resources.
   vipPerNamespace: "false" # Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
+  ipScheme: "V4" # enum: V4, V6.
 
 ### This section outlines the network settings for virtualservices. 
 NetworkSettings:

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -277,6 +277,9 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	var worker *utils.FullSyncThread
 	var tokenWorker *utils.FullSyncThread
 	informersArg := make(map[string]interface{})
+	if lib.GetIpScheme() == lib.IPV6 {
+		utils.AviLog.Infof("AKO is running with IPv6 scheme")
+	}
 	informersArg[utils.INFORMERS_OPENSHIFT_CLIENT] = informers.OshiftClient
 	if lib.GetNamespaceToSync() != "" {
 		informersArg[utils.INFORMERS_NAMESPACE] = lib.GetNamespaceToSync()

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -28,6 +28,8 @@ const (
 	AviSecret                 = "avi-secret"
 	VLAN_TRANSPORT_ZONE       = "VLAN"
 	OVERLAY_TRANSPORT_ZONE    = "OVERLAY"
+	IPV4                      = "IPV4"
+	IPV6                      = "IPV6"
 
 	AVI_INGRESS_CLASS                          = "avi"
 	SUBNET_IP                                  = "SUBNET_IP"
@@ -40,6 +42,7 @@ const (
 	NODE_NETWORK_LIST                          = "NODE_NETWORK_LIST"
 	NODE_NETWORK_MAX_ENTRIES                   = 5
 	DEFAULT_DOMAIN                             = "DEFAULT_DOMAIN"
+	IPSCHEME                                   = "IP_SCHEME"
 	ADVANCED_L4                                = "ADVANCED_L4"
 	SERVICES_API                               = "SERVICES_API"
 	CLUSTER_NAME                               = "CLUSTER_NAME"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -55,6 +55,11 @@ var ShardSizeMap = map[string]uint32{
 	"DEDICATED": 0,
 }
 
+var ipSchemeMap = map[string]string{
+	"V6": "IPV6",
+	"V4": "IPV4",
+}
+
 var fqdnMap = map[string]string{
 	"default": AutoFQDNDefault,
 	"flat":    AutoFQDNFlat,
@@ -575,6 +580,16 @@ func GetDomain() string {
 		return subDomain
 	}
 	return ""
+}
+
+func GetIpScheme() string {
+	subDomain := os.Getenv(IPSCHEME)
+	scheme, ok := ipSchemeMap[subDomain]
+	if !ok {
+		// Default to IPv4 if the scheme is an invalid string
+		return "IPV4"
+	}
+	return scheme
 }
 
 // This utility returns a true/false depending on whether

--- a/internal/nodes/avi_vrf_translator.go
+++ b/internal/nodes/avi_vrf_translator.go
@@ -99,7 +99,12 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 		utils.AviLog.Errorf("Error in fetching Pod CIDR for %v: %s", node.ObjectMeta.Name, err.Error())
 		return nil, errors.New("podcidr not found")
 	}
-	nodeipType := "V4"
+	var nodeipType string
+	if lib.GetIpScheme() == lib.IPV6 {
+		nodeipType = "V6"
+	} else {
+		nodeipType = "V4"
+	}
 
 	for _, podCIDR := range podCIDRs {
 		s := strings.Split(podCIDR, "/")
@@ -116,7 +121,6 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 
 		clusterName := lib.GetClusterName()
 		labels := lib.GetLabels()
-		prefixipType := "V4"
 		mask := int32(m)
 		routeIDString := clusterName + "-" + strconv.Itoa(routeid)
 		nodeRoute := models.StaticRoute{
@@ -124,7 +128,7 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 			Prefix: &models.IPAddrPrefix{
 				IPAddr: &models.IPAddr{
 					Addr: &s[0],
-					Type: &prefixipType,
+					Type: &nodeipType,
 				},
 				Mask: &mask,
 			},

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -46,7 +46,12 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 	var dns_info_arr []*avimodels.DNSInfo
 	var path string
 	var rest_op utils.RestOp
-	vipId, ipType := "0", "V4"
+	var vipId, ipType string
+	if lib.GetIpScheme() == lib.IPV6 {
+		vipId, ipType = "0", "V6"
+	} else {
+		vipId, ipType = "0", "V4"
+	}
 
 	cksum := vsvip_meta.CloudConfigCksum
 	cksumstr := strconv.Itoa(int(cksum))


### PR DESCRIPTION
This commit introduces the following:

- A helm knob to specify the IP scheme.
- Based on the IP scheme, AKO requests a VIP in either IPv6 format
or IPv4 format.
- Based on the IP scheme, the static routes are programmed.

It's assumed that in ClusterIP mode, the `Node` object of Kubernetes
and associated CNI metadata would be in IPv6 scheme to program the
nextHop in Avi.