### PR TITLE
Reject hostrule if GSLB FQDN and local FQDN are same. Shard VS deletion when AKO migrate from SNI to EVH and vice-versa.

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -118,7 +118,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
 				if err := validateHostRuleObj(key, hostrule); err != nil {
-					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
+					utils.AviLog.Warnf("key: %s, msg: Error retrieved during validation of HostRule: %v", key, err)
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -134,7 +134,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 					key := lib.HostRule + "/" + utils.ObjKey(hostrule)
 					if err := validateHostRuleObj(key, hostrule); err != nil {
-						utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
+						utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
 					}
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
@@ -515,6 +515,16 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 			Error:  err.Error(),
 		})
 		return err
+	}
+	if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" {
+		if fqdn == hostrule.Spec.VirtualHost.Gslb.Fqdn {
+			err = fmt.Errorf("GSLB FQDN and local FQDN are same")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{
+				Status: lib.StatusRejected,
+				Error:  err.Error(),
+			})
+			return err
+		}
 	}
 
 	refData := map[string]string{

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -68,6 +68,7 @@ const (
 	NODE_KEY                                   = "NODE_KEY"
 	NODE_VALUE                                 = "NODE_VALUE"
 	ShardVSPrefix                              = "Shared-L7"
+	ShardEVHVSPrefix                           = "Shared-L7-EVH-"
 	PassthroughPrefix                          = "Shared-Passthrough-"
 	PolicyAllow                                = "ALLOW"
 	PolicyNone                                 = "NONE"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -145,6 +145,20 @@ func SetGRBACSupport() {
 	}
 }
 
+func IsShardVS(vsName string) bool {
+	if IsEvhEnabled() {
+		if strings.Contains(vsName, ShardEVHVSPrefix) {
+			return true
+		}
+	} else {
+		//Second condition is for migration from evh -> sni
+		if strings.Contains(vsName, ShardVSPrefix) && !strings.Contains(vsName, ShardEVHVSPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func GetGRBACSupport() bool {
 	return gRBAC
 }

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1151,7 +1151,9 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 	if certsBuilt {
 		hosts := []string{host}
 		if paths.gslbHostHeader != "" {
-			hosts = append(hosts, paths.gslbHostHeader)
+			if !utils.HasElem(hosts, paths.gslbHostHeader) {
+				hosts = append(hosts, paths.gslbHostHeader)
+			}
 		}
 		o.BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, infraSettingName, hosts, paths.ingressHPSvc, &tlssetting)
 		foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)
@@ -1364,7 +1366,7 @@ func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (s
 		newInfraPrefix = newSetting.Name
 	}
 
-	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-EVH-"
+	shardVsPrefix := lib.GetNamePrefix() + lib.ShardEVHVSPrefix
 	oldVsName, newVsName := shardVsPrefix, shardVsPrefix
 	if oldInfraPrefix != "" {
 		oldVsName += oldInfraPrefix + "-"

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -60,7 +60,7 @@ func (rest *RestOperations) DequeueNodes(key string) {
 		utils.AviLog.Warnf("key: %s, msg: no model found for the key", key)
 		// In the case of L7 shared VS, the following condition check makes sure the
 		// VIPs persist over AKO reboot.
-		if strings.Contains(key, lib.ShardVSPrefix) {
+		if lib.IsShardVS(key) {
 			return
 		}
 	}

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1351,7 +1351,7 @@ func TeardownHostRule(t *testing.T, g *gomega.WithT, vskey cache.NamespaceName, 
 	VerifyMetadataHostRule(g, vskey, "default/"+hrname, false)
 }
 
-func TearDownHostRuleWithNoVerif(t *testing.T, g *gomega.WithT, hrname string) {
+func TearDownHostRuleWithNoVerify(t *testing.T, g *gomega.WithT, hrname string) {
 	if err := lib.AKOControlConfig().CRDClientset().AkoV1alpha1().HostRules("default").Delete(context.TODO(), hrname, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("error in deleting HostRule: %v", err)
 	}


### PR DESCRIPTION


This PR fixes
1. Host rule rejection if GSLB FQDN and local FQDN in hostrule is same
2. Avoid duplicate fqdn addition for EVH.
3. Regression: When AKO migrate from SNI to EVH and vice-versa, EVH/SNI shared VS were not getting deleted.