### PR TITLE
Fix: Refresh the session and retry the APIs calls when controller returns 403 status code

### DIFF
--- a/third_party/github.com/vmware/alb-sdk/go/session/avisession.go
+++ b/third_party/github.com/vmware/alb-sdk/go/session/avisession.go
@@ -687,6 +687,7 @@ func (avisess *AviSession) restRequest(verb string, uri string, payload interfac
 				return nil, err
 			}
 			if avisess.ctrlStatusCheckDisabled {
+				resp.Body.Close()
 				return resp, nil
 			}
 			retryReq = true


### PR DESCRIPTION
This PR takes care of refreshing the session and retrying the below two API calls when the controller returns 403 HTTP status code in the response.

- api/initial-data - `done`
- api/cluster/runtime - `in-progress`