### PR TITLE
Add VCF network to IPAM and use SEgroup from NS annotation

### DIFF
--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -17,7 +17,7 @@ package avirest
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
+	"net"
 	"strings"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
@@ -27,12 +27,14 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/session"
 
+	gocidr "github.com/apparentlymart/go-cidr/cidr"
 	"github.com/vmware/alb-sdk/go/models"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var CloudCache *models.Cloud
 var NetCache *models.Network
+var IPAMCache *models.IPAMDNSProviderProfile
 
 // SyncLSLRNetwork fetches all networkinfo CR objects, compares them with the data network configured in the cloud,
 // and updates the cloud if any LS-LR data is missing. It also creates or updates the VCF network with the CIDRs
@@ -67,6 +69,7 @@ func SyncLSLRNetwork() {
 		utils.AviLog.Infof("LS LR update not required in cloud: %s", utils.CloudName)
 	}
 	addNetworkInCloud("fullsync", cidrs, true)
+	addNetworkInIPAM()
 }
 
 func AddSegment(obj interface{}) bool {
@@ -85,14 +88,14 @@ func AddSegment(obj interface{}) bool {
 		utils.AviLog.Infof("key: %s, ls not found from NetInfo CR", objKey)
 		return false
 	}
-	var cidrs []string
+	cidrs := make(map[string]struct{})
 	cidrIntf, ok := spec["ingressCIDRs"].([]interface{})
 	if !ok {
 		utils.AviLog.Infof("key: %s, cidr not found from NetInfo CR", objKey)
 		return false
 	} else {
 		for _, cidr := range cidrIntf {
-			cidrs = append(cidrs, cidr.(string))
+			cidrs[cidr.(string)] = struct{}{}
 		}
 	}
 
@@ -134,14 +137,14 @@ func DeleteSegment(obj interface{}) {
 		utils.AviLog.Infof("key: %s, ls not found from NetInfo CR", objKey)
 		return
 	}
-	var cidrs []string
+	cidrs := make(map[string]struct{})
 	cidrIntf, ok := spec["ingressCIDRs"].([]interface{})
 	if !ok {
 		utils.AviLog.Infof("key: %s, cidr not found from NetInfo CR", objKey)
 		return
 	} else {
 		for _, cidr := range cidrIntf {
-			cidrs = append(cidrs, cidr.(string))
+			cidrs[cidr.(string)] = struct{}{}
 		}
 	}
 
@@ -166,7 +169,7 @@ func DeleteSegment(obj interface{}) {
 	delCIDRFromNetwork(objKey, cidrs, false)
 }
 
-func matchCidrInNetwork(subnets []*models.Subnet, cidrs []string) bool {
+func matchCidrInNetwork(subnets []*models.Subnet, cidrs map[string]struct{}) bool {
 	if len(subnets) != len(cidrs) {
 		return false
 	}
@@ -182,16 +185,14 @@ func matchCidrInNetwork(subnets []*models.Subnet, cidrs []string) bool {
 	return true
 }
 
-func findAndRemoveCidrInNetwork(subnets []*models.Subnet, cidrs []string) ([]*models.Subnet, bool) {
+func findAndRemoveCidrInNetwork(subnets []*models.Subnet, cidrs map[string]struct{}) ([]*models.Subnet, bool) {
 	subnetsCopy := make([]*models.Subnet, len(subnets))
-	var found bool
 	copy(subnetsCopy, subnets)
 	for i, subnet := range subnets {
 		addr := *subnet.Prefix.IPAddr.Addr
 		mask := *subnet.Prefix.Mask
 		cidr := fmt.Sprintf("%s/%d", addr, mask)
-		found, cidrs = utils.FindAndRemove(cidrs, cidr)
-		if found {
+		if _, found := cidrs[cidr]; found {
 			subnetsCopy = append(subnetsCopy[:i], subnetsCopy[i+1:]...)
 		}
 		if len(cidrs) == 0 {
@@ -201,7 +202,7 @@ func findAndRemoveCidrInNetwork(subnets []*models.Subnet, cidrs []string) ([]*mo
 	return subnetsCopy, false
 }
 
-func addNetworkInCloud(objKey string, cidrs []string, replaceAll bool) {
+func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool) {
 	client := avicache.SharedAVIClients().AviClient[0]
 	netName := lib.GetVCFNetworkName()
 	method := utils.RestPost
@@ -234,28 +235,48 @@ func addNetworkInCloud(objKey string, cidrs []string, replaceAll bool) {
 	}
 
 	utils.AviLog.Infof("key: %s, list of CIDRs to be added: %v", objKey, cidrs)
-	for _, cidr := range cidrs {
-		s := strings.Split(cidr, "/")
-		if len(s) != 2 {
-			utils.AviLog.Warnf("key: %s, cidr %s is not of correct format", objKey, cidr)
+
+	for cidr := range cidrs {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			utils.AviLog.Warnf("key: %s, cidr %s is not of correct format, err %v", objKey, cidr, err)
 			continue
 		}
+		startIP, endIP := gocidr.AddressRange(ipnet)
+		startIPStr := startIP.String()
+		endIPStr := endIP.String()
+		ipStr := ipnet.IP.String()
 		addrType := "V4"
-		if !utils.IsV4(s[0]) {
+		if !utils.IsV4(ipStr) {
 			addrType = "V6"
 		}
-		mask, _ := strconv.Atoi(s[1])
+		mask, _ := ipnet.Mask.Size()
 		mask32 := int32(mask)
+
 		subnet := models.Subnet{
 			Prefix: &models.IPAddrPrefix{
 				IPAddr: &models.IPAddr{
-					Addr: &s[0],
+					Addr: &ipStr,
 					Type: &addrType,
 				},
 				Mask: &mask32,
 			},
 		}
+		staticRange := models.StaticIPRange{
+			Range: &models.IPAddrRange{
+				Begin: &models.IPAddr{
+					Addr: &startIPStr,
+					Type: &addrType,
+				},
+				End: &models.IPAddr{
+					Addr: &endIPStr,
+					Type: &addrType,
+				},
+			},
+		}
+		subnet.StaticIPRanges = append(subnet.StaticIPRanges, &staticRange)
 		netModel.ConfiguredSubnets = append(netModel.ConfiguredSubnets, &subnet)
+
 	}
 	restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: method, Obj: &netModel,
 		Tenant: "admin", Model: "network", Version: utils.CtrlVersion}
@@ -264,7 +285,27 @@ func addNetworkInCloud(objKey string, cidrs []string, replaceAll bool) {
 	executeRestOp(objKey, client, &restOp)
 }
 
-func delCIDRFromNetwork(objKey string, cidrs []string, replaceAll bool) {
+func addNetworkInIPAM() {
+	client := avicache.SharedAVIClients().AviClient[0]
+	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
+	if !found {
+		utils.AviLog.Warnf("Failed to get Cloud data from cache")
+		return
+	}
+	found, ipam := getAviIPAMFromCache(client, *cloudModel.IPAMProviderRef)
+	if !found {
+		utils.AviLog.Warnf("Failed to get IPAM data from cache")
+		return
+	}
+	netName := lib.GetVCFNetworkName()
+	networkRef := "/api/network/?name=" + netName
+
+	if !utils.HasElem(ipam.InternalProfile.UsableNetworkRefs, networkRef) {
+		ipam.InternalProfile.UsableNetworkRefs = append(ipam.InternalProfile.UsableNetworkRefs, networkRef)
+	}
+}
+
+func delCIDRFromNetwork(objKey string, cidrs map[string]struct{}, replaceAll bool) {
 	client := avicache.SharedAVIClients().AviClient[0]
 	netName := lib.GetVCFNetworkName()
 	method := utils.RestPut
@@ -359,6 +400,17 @@ func getAviNetFromCache(client *clients.AviClient, netName string) (bool, models
 	return true, *NetCache
 }
 
+func getAviIPAMFromCache(client *clients.AviClient, ipamRef string) (bool, models.IPAMDNSProviderProfile) {
+	if IPAMCache == nil {
+		ipamRefStr := strings.Split(ipamRef, "/")
+		ipamUuid := ipamRefStr[len(ipamRefStr)-1]
+		if AviIPAMCachePopulate(client, ipamUuid) != nil {
+			return false, models.IPAMDNSProviderProfile{}
+		}
+	}
+	return true, *IPAMCache
+}
+
 // AviCloudCachePopulate queries avi rest api to get cloud data and stores in CloudCache
 func AviCloudCachePopulate(client *clients.AviClient, cloudName string) error {
 	uri := "/api/cloud/?name=" + cloudName
@@ -412,6 +464,29 @@ func AviNetCachePopulate(client *clients.AviClient, netName, cloudName string) e
 	NetCache = &models.Network{}
 	if err = json.Unmarshal(elems[0], &NetCache); err != nil {
 		utils.AviLog.Warnf("Failed to unmarshal network data, err: %v", err)
+		return err
+	}
+	return nil
+}
+
+// AviIPAMCachePopulate queries avi rest api to get IPAM data and stores in IPAMCache
+func AviIPAMCachePopulate(client *clients.AviClient, ipamUuid string) error {
+	uri := "/api/ipamdnsproviderprofile/" + ipamUuid
+	result, err := lib.AviGetRaw(client, uri)
+	if err != nil {
+		utils.AviLog.Warnf("Cloud Get uri %v returned err %v", uri, err)
+		return err
+	}
+
+	var data json.RawMessage
+	err = json.Unmarshal(result, &data)
+	if err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
+		return err
+	}
+
+	if err = json.Unmarshal(data, &IPAMCache); err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
 		return err
 	}
 	return nil

--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -130,7 +130,7 @@ func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
 	}
 	utils.AviLog.Infof("Obtained matching cloud to be used: %s", cloudName)
 	utils.SetCloudName(cloudName)
-	if CheckSeGroup(a.AviRestClients.AviClient[0]) {
+	if checkSeGroup(a.AviRestClients.AviClient[0], cloudName) {
 		return true
 	}
 	var uri string
@@ -196,12 +196,10 @@ func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGr
 
 }
 
-// ConfigureSeGroup creates the SE group with the supplied properties, alters just the SE group name and the labels.
-func CheckSeGroup(client *clients.AviClient) bool {
-	// Change the name of the SE group
+func checkSeGroup(client *clients.AviClient, cloudName string) bool {
 	segroupName := lib.GetClusterID()
 
-	uri := "/api/serviceenginegroup/?name=" + segroupName
+	uri := "/api/serviceenginegroup/?name=" + segroupName + "cloud_ref.name=" + cloudName
 	response := models.ServiceEngineGroupAPIResponse{}
 	err := lib.AviGet(client, uri, &response)
 	if err != nil {
@@ -209,7 +207,6 @@ func CheckSeGroup(client *clients.AviClient) bool {
 		return false
 	}
 	utils.AviLog.Infof("Found Service Engine Group :%v", segroupName)
-	utils.IsVCFCluster()
 	return true
 }
 

--- a/ako-infra/ingestion/vcf_k8s_controller.go
+++ b/ako-infra/ingestion/vcf_k8s_controller.go
@@ -78,7 +78,6 @@ func (c *VCFK8sController) Run(stopCh <-chan struct{}) error {
 	utils.AviLog.Info("Started the Kubernetes Controller")
 	<-stopCh
 	utils.AviLog.Info("Shutting down the Kubernetes Controller")
-
 	return nil
 }
 func (c *VCFK8sController) AddNCPSecretEventHandler(k8sinfo K8sinformers, stopCh <-chan struct{}, startSyncCh chan struct{}) {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/vmware/load-balancer-and-ingress-services-for-kubernetes
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -142,17 +142,11 @@ func (c *AviController) SetSEGroupCloudName() bool {
 
 	if !utils.IsVCFCluster() {
 		lib.SetSEGName(seGroupToUse)
-		cloudName := os.Getenv("CLOUD_NAME")
-		if cloudName == "" {
-			// If the cloud name is blank - assume it to be Default-Cloud
-			cloudName = "Default-Cloud"
-		}
-		utils.SetCloudName(cloudName)
 		return true
 	}
 
 	nsName := utils.GetAKONamespace()
-	nsObj, err := c.informers.ClientSet.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+	nsObj, err := c.informers.NSInformer.Lister().Get(nsName)
 	if err != nil {
 		utils.AviLog.Warnf("Failed to GET the namespace %s details due to the following error: %v", nsName, err.Error())
 		return false

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -153,7 +153,6 @@ const (
 	AutoFQDNDefault                            = "Default"
 	AutoFQDNFlat                               = "Flat"
 	AutoFQDNDisabled                           = "Disabled"
-	VCF_CLUSTER                                = "VCF_CLUSTER"
 	VCF_NETWORK                                = "vcf-ako-net"
 	VIP_PER_NAMESPACE                          = "VIP_PER_NAMESPACE"
 	CRDActive                                  = "ACTIVE"
@@ -193,6 +192,8 @@ const (
 	SkipNodePortAnnotation         = "skipnodeport.ako.vmware.com/enabled"
 	PassthroughAnnotation          = "passthrough.ako.vmware.com/enabled"
 	StaticRouteAnnotation          = "ako.vmware.com/pod-cidrs"
+	WCPSEGroup                     = "ako.vmware.com/wcp-se-group"
+	WCPCloud                       = "ako.vmware.com/wcp-cloud-name"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -73,7 +73,7 @@ type BootstrapCRData struct {
 // NewDynamicClientSet initializes dynamic client set instance
 func NewDynamicClientSet(config *rest.Config) (dynamic.Interface, error) {
 	// do not instantiate the dynamic client set if the CNI being used is NOT calico
-	if GetCNIPlugin() != CALICO_CNI && GetCNIPlugin() != OPENSHIFT_CNI && !IsVCFCluster() {
+	if GetCNIPlugin() != CALICO_CNI && GetCNIPlugin() != OPENSHIFT_CNI && !utils.IsVCFCluster() {
 		return nil, nil
 	}
 
@@ -233,9 +233,9 @@ func GetBootstrapCRData() (BootstrapCRData, bool) {
 	return boostrapdata, true
 }
 
-func GetNetinfoCRData() (map[string]string, []string) {
+func GetNetinfoCRData() (map[string]string, map[string]struct{}) {
 	lslrMap := make(map[string]string)
-	var cidrs []string
+	cidrs := make(map[string]struct{})
 	dynamicClient := GetVCFDynamicClientSet()
 	crdClient := dynamicClient.Resource(NetworkInfoGVR)
 	crList, err := crdClient.List(context.TODO(), metav1.ListOptions{})
@@ -263,7 +263,7 @@ func GetNetinfoCRData() (map[string]string, []string) {
 			continue
 		} else {
 			for _, cidr := range cidrIntf {
-				cidrs = append(cidrs, cidr.(string))
+				cidrs[cidr.(string)] = struct{}{}
 			}
 		}
 	}

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -513,7 +513,7 @@ func GetVipNetworkList() []akov1alpha1.AviInfraSettingVipNetwork {
 
 func GetVipNetworkListEnv() ([]akov1alpha1.AviInfraSettingVipNetwork, error) {
 	var vipNetworkList []akov1alpha1.AviInfraSettingVipNetwork
-	if GetAdvancedL4() {
+	if GetAdvancedL4() || utils.IsVCFCluster() {
 		// do not return error in case of advancedL4 (wcp)
 		return vipNetworkList, nil
 	}
@@ -545,8 +545,16 @@ func GetGlobalBgpPeerLabels() []string {
 	return bgpPeerLabels
 }
 
+var t1LrPath string
+
+func SetT1LRPath(lr string) {
+	t1LrPath = lr
+}
+
 func GetT1LRPath() string {
-	t1LrPath := os.Getenv("NSXT_T1_LR")
+	if t1LrPath == "" {
+		t1LrPath = os.Getenv("NSXT_T1_LR")
+	}
 	return t1LrPath
 }
 
@@ -1453,10 +1461,6 @@ func VIPPerNamespace() bool {
 	return vipPerNS == "true"
 }
 
-func IsVCFCluster() bool {
-	vcfCluster := os.Getenv(VCF_CLUSTER)
-	return vcfCluster == "true"
-}
-
 var VCFInitialized bool
 var AviSecretInitialized bool
+var AviSEInitialized bool

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -81,6 +81,7 @@ const (
 	ENV_CTRL_AUTHTOKEN            = "CTRL_AUTHTOKEN"
 	ENV_CTRL_IPADDRESS            = "CTRL_IPADDRESS"
 	POD_NAMESPACE                 = "POD_NAMESPACE"
+	VCF_CLUSTER                   = "VCF_CLUSTER"
 
 	RefreshAuthTokenInterval = 12  //hours
 	AuthTokenExpiry          = 240 //hours

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -413,6 +413,11 @@ func IsServiceNSValid(namespace string) bool {
 	return true
 }
 
+func IsVCFCluster() bool {
+	vcfCluster := os.Getenv(VCF_CLUSTER)
+	return vcfCluster == "true"
+}
+
 // This utility returns a true/false depending on whether
 // the user requires advanced L4 functionality
 func GetAdvancedL4() bool {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -415,7 +415,10 @@ func IsServiceNSValid(namespace string) bool {
 
 func IsVCFCluster() bool {
 	vcfCluster := os.Getenv(VCF_CLUSTER)
-	return vcfCluster == "true"
+	if val, err := strconv.ParseBool(vcfCluster); err == nil {
+		return val
+	}
+	return false
 }
 
 // This utility returns a true/false depending on whether

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -101,6 +101,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
+	ctrl.SetSEGroupCloudName()
+
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -135,7 +135,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-
+	ctrl.SetSEGroupCloudName()
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())
 }

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -151,9 +151,6 @@ func TestEVHWrongClassMappingInIngress(t *testing.T) {
 }
 
 func TestEVHDefaultIngressClassChange(t *testing.T) {
-	if lib.VIPPerNamespace() {
-		t.Skip()
-	}
 	// use default ingress class, change default annotation to false
 	// check that ingress status is removed
 	// change back default class annotation to true
@@ -161,9 +158,12 @@ func TestEVHDefaultIngressClassChange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	ingClassName, ingressName, ns := "avi-lb", "foo-with-class", "default"
-	modelName, _ := GetModelName("bar.com", "default")
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-1"}
+	modelName, vsName := GetModelName("bar.com", "default")
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
 	evhKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--bar.com", lib.EVHVS)}
+
+	mcache := cache.SharedAviObjCache()
+	mcache.VsCacheMeta.AviCacheDelete(vsKey)
 
 	SetUpTestForIngress(t, modelName)
 	integrationtest.RemoveDefaultIngressClass()

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -151,6 +151,9 @@ func TestEVHWrongClassMappingInIngress(t *testing.T) {
 }
 
 func TestEVHDefaultIngressClassChange(t *testing.T) {
+	if lib.VIPPerNamespace() {
+		t.Skip()
+	}
 	// use default ingress class, change default annotation to false
 	// check that ingress status is removed
 	// change back default class annotation to true
@@ -564,9 +567,13 @@ func TestEVHAddIngressClassWithInfraSetting(t *testing.T) {
 }
 
 func TestEVHUpdateIngressClassWithInfraSetting(t *testing.T) {
+
+	settingModelName1, settingModelName2 := "admin/cluster--Shared-L7-EVH-my-infrasetting1-0", "admin/cluster--Shared-L7-EVH-my-infrasetting2-1"
 	if lib.VIPPerNamespace() {
-		t.Skip()
+		settingModelName1, settingModelName2 = "admin/cluster--Shared-L7-EVH-my-infrasetting1-NS-default", "admin/cluster--Shared-L7-EVH-my-infrasetting2-NS-default"
 	}
+	objects.SharedAviGraphLister().Delete(settingModelName1)
+	objects.SharedAviGraphLister().Delete(settingModelName2)
 	// update from ingressclass with infrasetting to another
 	// ingressclass with infrasetting in ingress
 
@@ -584,7 +591,6 @@ func TestEVHUpdateIngressClassWithInfraSetting(t *testing.T) {
 
 	integrationtest.SetupAviInfraSetting(t, settingName1, "SMALL")
 	integrationtest.SetupAviInfraSetting(t, settingName2, "MEDIUM")
-	settingModelName1, settingModelName2 := "admin/cluster--Shared-L7-EVH-my-infrasetting1-0", "admin/cluster--Shared-L7-EVH-my-infrasetting2-1"
 
 	integrationtest.SetupIngressClass(t, ingClassName1, lib.AviIngressController, settingName1)
 	integrationtest.SetupIngressClass(t, ingClassName2, lib.AviIngressController, settingName2)

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -117,6 +117,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
+	ctrl.SetSEGroupCloudName()
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -139,6 +139,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap(KubeClient)
+	ctrl.SetSEGroupCloudName()
 	PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -266,6 +266,8 @@ func TestMain(m *testing.M) {
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
 	AddCMap()
+	ctrl.SetSEGroupCloudName()
+
 	ctrl.HandleConfigMap(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}, ctrlCh, stopCh, quickSyncCh)
 	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient})
 	setupQueue(stopCh)

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -108,6 +108,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
+	ctrl.SetSEGroupCloudName()
+
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -224,6 +224,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
+	ctrl.SetSEGroupCloudName()
+
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -185,6 +185,8 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
+	ctrl.SetSEGroupCloudName()
+
 	defaultKey = "app"
 	defaultValue = "migrate"
 	SetupRouteNamespaceSync(defaultKey, defaultValue)

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -116,6 +116,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
+	ctrl.SetSEGroupCloudName()
+
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -105,6 +105,8 @@ func TestMain(m *testing.M) {
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
+	ctrl.SetSEGroupCloudName()
+
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
 

--- a/vendor/github.com/apparentlymart/go-cidr/LICENSE
+++ b/vendor/github.com/apparentlymart/go-cidr/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Martin Atkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -1,0 +1,236 @@
+// Package cidr is a collection of assorted utilities for computing
+// network and host addresses within network ranges.
+//
+// It expects a CIDR-type address structure where addresses are divided into
+// some number of prefix bits representing the network and then the remaining
+// suffix bits represent the host.
+//
+// For example, it can help to calculate addresses for sub-networks of a
+// parent network, or to calculate host addresses within a particular prefix.
+//
+// At present this package is prioritizing simplicity of implementation and
+// de-prioritizing speed and memory usage. Thus caution is advised before
+// using this package in performance-critical applications or hot codepaths.
+// Patches to improve the speed and memory usage may be accepted as long as
+// they do not result in a significant increase in code complexity.
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+// Subnet takes a parent CIDR range and creates a subnet within it
+// with the given number of additional prefix bits and the given
+// network number.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number
+// of 5, becomes 10.3.5.0/24 .
+func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	return SubnetBig(base, newBits, big.NewInt(int64(num)))
+}
+
+// SubnetBig takes a parent CIDR range and creates a subnet within it with the
+// given number of additional prefix bits and the given network number. It
+// differs from Subnet in that it takes a *big.Int for the num, instead of an int.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number of 5,
+// becomes 10.3.5.0/24 .
+func SubnetBig(base *net.IPNet, newBits int, num *big.Int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	newPrefixLen := parentLen + newBits
+
+	if newPrefixLen > addrLen {
+		return nil, fmt.Errorf("insufficient address space to extend prefix of %d by %d", parentLen, newBits)
+	}
+
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if num.Uint64() > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addrLen),
+	}, nil
+}
+
+// Host takes a parent CIDR range and turns it into a host IP address with the
+// given host number.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func Host(base *net.IPNet, num int) (net.IP, error) {
+	return HostBig(base, big.NewInt(int64(num)))
+}
+
+// HostBig takes a parent CIDR range and turns it into a host IP address with
+// the given host number. It differs from Host in that it takes a *big.Int for
+// the num, instead of an int.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func HostBig(base *net.IPNet, num *big.Int) (net.IP, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	hostLen := addrLen - parentLen
+
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
+
+	numUint64 := big.NewInt(int64(num.Uint64()))
+	if num.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(num)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		num.Sub(maxHostNum, numUint64)
+	}
+
+	if numUint64.Cmp(maxHostNum) == 1 {
+		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
+	}
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, num, bitlength), nil
+}
+
+// AddressRange returns the first and last addresses in the given CIDR range.
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+
+// AddressCount returns the number of distinct host addresses within the given
+// CIDR range.
+//
+// Since the result is a uint64, this function returns meaningful information
+// only for IPv4 ranges and IPv6 ranges with a prefix size of at least 65.
+func AddressCount(network *net.IPNet) uint64 {
+	prefixLen, bits := network.Mask.Size()
+	return 1 << (uint64(bits) - uint64(prefixLen))
+}
+
+//VerifyNoOverlap takes a list subnets and supernet (CIDRBlock) and verifies
+//none of the subnets overlap and all subnets are in the supernet
+//it returns an error if any of those conditions are not satisfied
+func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
+	firstLastIP := make([][]net.IP, len(subnets))
+	for i, s := range subnets {
+		first, last := AddressRange(s)
+		firstLastIP[i] = []net.IP{first, last}
+	}
+	for i, s := range subnets {
+		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
+			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
+		}
+		for j := 0; j < len(subnets); j++ {
+			if i == j {
+				continue
+			}
+
+			first := firstLastIP[j][0]
+			last := firstLastIP[j][1]
+			if s.Contains(first) || s.Contains(last) {
+				return fmt.Errorf("%s overlaps with %s", subnets[j].String(), s.String())
+			}
+		}
+	}
+	return nil
+}
+
+// PreviousSubnet returns the subnet of the desired mask in the IP space
+// just lower than the start of IPNet provided. If the IP space rolls over
+// then the second return value is true
+func PreviousSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	startIP := checkIPv4(network.IP)
+	previousIP := make(net.IP, len(startIP))
+	copy(previousIP, startIP)
+	cMask := net.CIDRMask(prefixLen, 8*len(previousIP))
+	previousIP = Dec(previousIP)
+	previous := &net.IPNet{IP: previousIP.Mask(cMask), Mask: cMask}
+	if startIP.Equal(net.IPv4zero) || startIP.Equal(net.IPv6zero) {
+		return previous, true
+	}
+	return previous, false
+}
+
+// NextSubnet returns the next available subnet of the desired mask size
+// starting for the maximum IP of the offset subnet
+// If the IP exceeds the maxium IP then the second return value is true
+func NextSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	_, currentLast := AddressRange(network)
+	mask := net.CIDRMask(prefixLen, 8*len(currentLast))
+	currentSubnet := &net.IPNet{IP: currentLast.Mask(mask), Mask: mask}
+	_, last := AddressRange(currentSubnet)
+	last = Inc(last)
+	next := &net.IPNet{IP: last.Mask(mask), Mask: mask}
+	if last.Equal(net.IPv4zero) || last.Equal(net.IPv6zero) {
+		return next, true
+	}
+	return next, false
+}
+
+//Inc increases the IP by one this returns a new []byte for the IP
+func Inc(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	incIP := make([]byte, len(IP))
+	copy(incIP, IP)
+	for j := len(incIP) - 1; j >= 0; j-- {
+		incIP[j]++
+		if incIP[j] > 0 {
+			break
+		}
+	}
+	return incIP
+}
+
+//Dec decreases the IP by one this returns a new []byte for the IP
+func Dec(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	decIP := make([]byte, len(IP))
+	copy(decIP, IP)
+	decIP = checkIPv4(decIP)
+	for j := len(decIP) - 1; j >= 0; j-- {
+		decIP[j]--
+		if decIP[j] < 255 {
+			break
+		}
+	}
+	return decIP
+}
+
+func checkIPv4(ip net.IP) net.IP {
+	// Go for some reason allocs IPv6len for IPv4 so we have to correct it
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -1,0 +1,37 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}
+
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+	return intToIP(ipInt, totalBits)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,6 +3,9 @@ cloud.google.com/go/compute/metadata
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
+# github.com/apparentlymart/go-cidr v1.1.0
+## explicit
+github.com/apparentlymart/go-cidr/cidr
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.1


### PR DESCRIPTION
In this commit changes for ako-infra is integrated to be consumed in the main AKO.
Changes include,
- SEgroup and cloud annotation in the vmware-systems-ns are being consumed in main ako
- VCF Network is added to IPAM
- Code reorganisation to maintain correct sequence flow.