### PR TITLE
Add update/patch verb permissions for Events

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -1,7 +1,7 @@
 {
     "version": "1.6.1",
     "avi": {
-        "maxVersion": "20.1.6",
+        "maxVersion": "21.1.3",
         "minVersion": "20.1.3"
     },
     "kubernetes": {

--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     verbs: ["get","watch","list","patch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create"]
+    verbs: ["create","patch","update"]
   - apiGroups: ["crd.projectcalico.org"]
     resources: ["blockaffinities"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
The k8s event handler chooses create/update/patch calls internally,
and is not the responsibility of the AKO pod. The AKO pod still needs
the permissions to do update/patch.
Also upgrades the max controller version to 21.1.6