### PR TITLE
Allow SharedVS configuration with HostRule fqdn

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1032,7 +1032,7 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *sslkey.Name}
 		c.SSLKeyCache.AviCacheAdd(k, &sslCacheObj)
-		utils.AviLog.Debugf("Adding sslkey to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding sslkey to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1078,7 +1078,7 @@ func (c *AviObjCache) AviPopulateOnePKICache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *pkikey.Name}
 		c.SSLKeyCache.AviCacheAdd(k, &sslCacheObj)
-		utils.AviLog.Debugf("Adding pkikey to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding pkikey to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1143,7 +1143,7 @@ func (c *AviObjCache) AviPopulateOnePoolCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *pool.Name}
 		c.PoolCache.AviCacheAdd(k, &poolCacheObj)
-		utils.AviLog.Debugf("Adding pool to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding pool to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1204,7 +1204,7 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 		dsCacheObj.CloudConfigCksum = checksum
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *ds.Name}
 		c.DSCache.AviCacheAdd(k, &dsCacheObj)
-		utils.AviLog.Debugf("Adding ds to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding ds to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1263,7 +1263,7 @@ func (c *AviObjCache) AviPopulateOnePGCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *pg.Name}
 		c.PgCache.AviCacheAdd(k, &pgCacheObj)
-		utils.AviLog.Debugf("Adding pg to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding pg to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1342,7 +1342,7 @@ func (c *AviObjCache) AviPopulateOneVsVipCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *vsvip.Name}
 		c.VSVIPCache.AviCacheAdd(k, &vsVipCacheObj)
-		utils.AviLog.Debugf("Adding vsvip to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding vsvip to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1414,7 +1414,7 @@ func (c *AviObjCache) AviPopulateOneVsHttpPolCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *httppol.Name}
 		c.HTTPPolicyCache.AviCacheAdd(k, &httpPolCacheObj)
-		utils.AviLog.Debugf("Adding httppolicy to Cache during refresh %s\n", k)
+		utils.AviLog.Debugf("Adding httppolicy to Cache during refresh %s", k)
 	}
 	return nil
 }
@@ -1482,7 +1482,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 		}
 		k := NamespaceName{Namespace: lib.GetTenant(), Name: *l4pol.Name}
 		c.L4PolicyCache.AviCacheAdd(k, &l4PolCacheObj)
-		utils.AviLog.Infof("Adding l4pol to Cache during refresh %s\n", utils.Stringify(l4PolCacheObj))
+		utils.AviLog.Infof("Adding l4pol to Cache during refresh %s", utils.Stringify(l4PolCacheObj))
 	}
 	return nil
 }
@@ -1776,7 +1776,7 @@ func (c *AviObjCache) AviObjVrfCachePopulate(client *clients.AviClient, cloud st
 		}
 		// set the vrf context. The result shouldn't be more than 1.
 		lib.SetVrfUuid(*vrf.UUID)
-		utils.AviLog.Debugf("Adding vrf to Cache %s\n", vrfName)
+		utils.AviLog.Debugf("Adding vrf to Cache %s", vrfName)
 		c.VrfCache.AviCacheAdd(vrfName, &vrfCacheObj)
 	}
 	return nil

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -427,7 +427,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
-			utils.AviLog.Debugf("key: %s, msg: ADD\n", key)
+			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if c.DisableSync {
@@ -910,7 +910,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			} else {
-				utils.AviLog.Debugf("key: %s, msg: node object did not change\n", key)
+				utils.AviLog.Debugf("key: %s, msg: node object did not change", key)
 			}
 		},
 	}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -67,6 +67,7 @@ const (
 	NODE_PORT                                  = "NodePort"
 	NODE_KEY                                   = "NODE_KEY"
 	NODE_VALUE                                 = "NODE_VALUE"
+	ShardVSSubstring                           = "Shared-"
 	ShardVSPrefix                              = "Shared-L7"
 	ShardEVHVSPrefix                           = "Shared-L7-EVH-"
 	PassthroughPrefix                          = "Shared-Passthrough-"

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -114,7 +114,7 @@ func NewDynamicInformers(client dynamic.Interface) *DynamicInformers {
 	case OPENSHIFT_CNI:
 		informers.HostSubnetInformer = f.ForResource(HostSubnetGVR)
 	default:
-		utils.AviLog.Infof("Skipped initializing dynamic informers %s \n", GetCNIPlugin())
+		utils.AviLog.Infof("Skipped initializing dynamic informers %s ", GetCNIPlugin())
 	}
 
 	dynamicInformerInstance = informers

--- a/internal/lib/parse_objects.go
+++ b/internal/lib/parse_objects.go
@@ -26,7 +26,7 @@ func StaticRoutesIntfToObj(staticRoutesIntf []interface{}) []*avimodels.StaticRo
 	for _, staticRouteIf := range staticRoutesIntf {
 		staticRouteMap, ok := staticRouteIf.(map[string]interface{})
 		if !ok {
-			utils.AviLog.Warnf("object type %T did not match for StaticRoute\n", staticRouteIf)
+			utils.AviLog.Warnf("object type %T did not match for StaticRoute", staticRouteIf)
 			continue
 		}
 		staticRoute := avimodels.StaticRoute{}
@@ -36,40 +36,40 @@ func StaticRoutesIntfToObj(staticRoutesIntf []interface{}) []*avimodels.StaticRo
 				if disableGatewayMonitor, ok := val.(bool); ok {
 					staticRoute.DisableGatewayMonitor = &disableGatewayMonitor
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for disableGatewayMonitor in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for disableGatewayMonitor in staticRoute", val)
 				}
 			case "if_name":
 				if ifName, ok := val.(string); ok {
 					staticRoute.IfName = &ifName
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for ifName in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for ifName in staticRoute", val)
 				}
 			case "next_hop":
 				if nextHop, ok := val.(map[string]interface{}); ok {
 					staticRoute.NextHop = IPAddrIntfToObj(nextHop)
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for nextHop in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for nextHop in staticRoute", val)
 				}
 			case "prefix":
 				if prefix, ok := val.(map[string]interface{}); ok {
 					staticRoute.Prefix = IAddrPrefixIntfToObj(prefix)
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for prefix in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for prefix in staticRoute", val)
 				}
 			case "route_id":
 				if routeId, ok := val.(string); ok {
 					staticRoute.RouteID = &routeId
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for routeId in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for routeId in staticRoute", val)
 				}
 			case "labels":
 				if labels, ok := val.([]interface{}); ok {
 					staticRoute.Labels = LabelsIntfToObj(labels)
 				} else {
-					utils.AviLog.Warnf("wrong object type %T for labels in staticRoute\n", val)
+					utils.AviLog.Warnf("wrong object type %T for labels in staticRoute", val)
 				}
 			default:
-				utils.AviLog.Warnf("Unknown key %s in staticRoute\n", key)
+				utils.AviLog.Warnf("Unknown key %s in staticRoute", key)
 			}
 		}
 		staticRoutes = append(staticRoutes, &staticRoute)
@@ -83,7 +83,7 @@ func LabelsIntfToObj(labelsIntf []interface{}) []*avimodels.KeyValue {
 	for _, labelIntf := range labelsIntf {
 		labelMap, ok := labelIntf.(map[string]interface{})
 		if !ok {
-			utils.AviLog.Warnf("object type %T did not match for label\n", labelIntf)
+			utils.AviLog.Warnf("object type %T did not match for label", labelIntf)
 			continue
 		}
 		kv := keyValueIntfToObj(labelMap)
@@ -101,16 +101,16 @@ func keyValueIntfToObj(keyValueIntf map[string]interface{}) *avimodels.KeyValue 
 			if k, ok := val.(string); ok {
 				keyValue.Key = &k
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for addr in KeyValue\n", val)
+				utils.AviLog.Warnf("wrong object type %T for addr in KeyValue", val)
 			}
 		case "value":
 			if v, ok := val.(string); ok {
 				keyValue.Value = &v
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for type in KeyValue\n", val)
+				utils.AviLog.Warnf("wrong object type %T for type in KeyValue", val)
 			}
 		default:
-			utils.AviLog.Warnf("Unknown key %s in KeyValue\n", key)
+			utils.AviLog.Warnf("Unknown key %s in KeyValue", key)
 		}
 	}
 	return &keyValue
@@ -124,16 +124,16 @@ func IPAddrIntfToObj(ipAddrIntf map[string]interface{}) *avimodels.IPAddr {
 			if addr, ok := val.(string); ok {
 				ipAddr.Addr = &addr
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for addr in IPAddr\n", val)
+				utils.AviLog.Warnf("wrong object type %T for addr in IPAddr", val)
 			}
 		case "type":
 			if addrType, ok := val.(string); ok {
 				ipAddr.Type = &addrType
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for type in IPAddr\n", val)
+				utils.AviLog.Warnf("wrong object type %T for type in IPAddr", val)
 			}
 		default:
-			utils.AviLog.Warnf("Unknown key %s in IPAddr\n", key)
+			utils.AviLog.Warnf("Unknown key %s in IPAddr", key)
 		}
 	}
 	return &ipAddr
@@ -147,17 +147,17 @@ func IAddrPrefixIntfToObj(ipAddrPrefixIntf map[string]interface{}) *avimodels.IP
 			if ipaddr, ok := val.(map[string]interface{}); ok {
 				ipAddrPrefix.IPAddr = IPAddrIntfToObj(ipaddr)
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for IPAddr in IPAddrPrefix\n", val)
+				utils.AviLog.Warnf("wrong object type %T for IPAddr in IPAddrPrefix", val)
 			}
 		case "mask":
 			if mask, ok := val.(float64); ok {
 				mask32 := int32(mask)
 				ipAddrPrefix.Mask = &mask32
 			} else {
-				utils.AviLog.Warnf("wrong object type %T for Mask in IPAddrPrefix\n", val)
+				utils.AviLog.Warnf("wrong object type %T for Mask in IPAddrPrefix", val)
 			}
 		default:
-			utils.AviLog.Warnf("Unknown key %s in IPAddrPefix\n", key)
+			utils.AviLog.Warnf("Unknown key %s in IPAddrPefix", key)
 		}
 	}
 	return &ipAddrPrefix

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
+
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
@@ -59,10 +61,8 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 			HostNames:            fqdns,
 		},
 		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
 	}
-
-	enableRhi := lib.GetEnableRHI()
-	avi_vs_meta.EnableRhi = &enableRhi
 
 	vrfcontext := lib.GetVrf()
 	if lib.GetT1LRPath() != "" {

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -416,7 +416,7 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 			}
 			o.BuildPolicyRedirectForVS(vsNode, sniHosts, key)
 		}
-		BuildL7HostRule(sniHost, namespace, ingName, key, sniNode)
+		BuildL7HostRule(sniHost, key, sniNode)
 	} else {
 		hostMapOk, ingressHostMap := SharedHostNameLister().Get(sniHost)
 		if hostMapOk {

--- a/internal/nodes/avi_vrf_translator.go
+++ b/internal/nodes/avi_vrf_translator.go
@@ -45,13 +45,13 @@ func (o *AviObjectGraph) BuildVRFGraph(key string, vrfName string) error {
 	}
 	sort.Strings(nodeKeys)
 
-	utils.AviLog.Debugf("key: %s, All Nodes %v\n", key, allNodes)
+	utils.AviLog.Debugf("key: %s, All Nodes %v", key, allNodes)
 	routeid := 1
 	for _, k := range nodeKeys {
 		node := allNodes[k].(*v1.Node)
 		nodeRoutes, err := o.addRouteForNode(node, vrfName, routeid)
 		if err != nil {
-			utils.AviLog.Errorf("key: %s, Error Adding vrf for node %s: %v\n", key, node.Name, err)
+			utils.AviLog.Errorf("key: %s, Error Adding vrf for node %s: %v", key, node.Name, err)
 			continue
 		}
 		if !findRoutePrefix(nodeRoutes, aviVrfNode.StaticRoutes, key) {
@@ -61,8 +61,8 @@ func (o *AviObjectGraph) BuildVRFGraph(key string, vrfName string) error {
 	}
 	aviVrfNode.CalculateCheckSum()
 	o.AddModelNode(aviVrfNode)
-	utils.AviLog.Infof("key: %s, Added vrf node %s\n", key, vrfName)
-	utils.AviLog.Infof("key: %s, Number of static routes %v\n", key, len(aviVrfNode.StaticRoutes))
+	utils.AviLog.Infof("key: %s, Added vrf node %s", key, vrfName)
+	utils.AviLog.Infof("key: %s, Number of static routes %v", key, len(aviVrfNode.StaticRoutes))
 	return nil
 }
 

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -25,7 +25,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-func BuildL7HostRule(host, namespace, ingName, key string, vsNode AviVsEvhSniModel) {
+func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 	// use host to find out HostRule CRD if it exists
 	found, hrNamespaceName := objects.SharedCRDLister().GetFQDNToHostruleMapping(host)
 	deleteCase := false

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -52,7 +52,9 @@ func DequeueIngestion(key string, fullsync bool) {
 		}
 	}
 
-	if objType == lib.HostRule && len(ingressNames) == 0 {
+	if objType == lib.HostRule &&
+		((utils.GetInformers().IngressInformer != nil && len(ingressNames) == 0) ||
+			(utils.GetInformers().RouteInformer != nil && len(routeNames) == 0)) {
 		// We should be checking for hostrule being possibly connected to a SharedVS
 		handleHostRuleForSharedVS(key, fullsync)
 	}

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -545,13 +545,13 @@ func HostRuleToIng(hrname string, namespace string, key string) ([]string, bool)
 	allIngresses := make([]string, 0)
 	hostrule, err := lib.AKOControlConfig().CRDInformers().HostRuleInformer.Lister().HostRules(namespace).Get(hrname)
 	if k8serrors.IsNotFound(err) {
-		utils.AviLog.Debugf("key: %s, msg: HostRule Deleted\n", key)
+		utils.AviLog.Debugf("key: %s, msg: HostRule Deleted", key)
 		_, fqdn = objects.SharedCRDLister().GetHostruleToFQDNMapping(namespace + "/" + hrname)
 		if !strings.Contains(fqdn, lib.ShardVSSubstring) {
 			objects.SharedCRDLister().DeleteHostruleFQDNMapping(namespace + "/" + hrname)
 		}
 	} else if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: Error getting hostrule: %v\n", key, err)
+		utils.AviLog.Errorf("key: %s, msg: Error getting hostrule: %v", key, err)
 		return nil, false
 	} else {
 		if hostrule.Status.Status != lib.StatusAccepted {
@@ -613,7 +613,7 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 	var ok bool
 
 	if k8serrors.IsNotFound(err) {
-		utils.AviLog.Debugf("key: %s, msg: HTTPRule Deleted\n", key)
+		utils.AviLog.Debugf("key: %s, msg: HTTPRule Deleted", key)
 		_, oldFqdn = objects.SharedCRDLister().GetHTTPRuleFqdnMapping(namespace + "/" + rrname)
 		_, x := objects.SharedCRDLister().GetFqdnHTTPRulesMapping(oldFqdn)
 		for i, elem := range x {
@@ -621,7 +621,7 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 		}
 		objects.SharedCRDLister().RemoveFqdnHTTPRulesMappings(namespace + "/" + rrname)
 	} else if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: Error getting httprule: %v\n", key, err)
+		utils.AviLog.Errorf("key: %s, msg: Error getting httprule: %v", key, err)
 		return nil, false
 	} else {
 		if httprule.Status.Status != lib.StatusAccepted {

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -81,7 +81,7 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 		}
 	}
 
-	utils.AviLog.Debugf(spew.Sprintf("key: %s, msg: ds Restop %v DatascriptData %v\n", key,
+	utils.AviLog.Debugf(spew.Sprintf("key: %s, msg: ds Restop %v DatascriptData %v", key,
 		utils.Stringify(rest_op), *ds_meta))
 	return &rest_op
 }
@@ -90,7 +90,7 @@ func (rest *RestOperations) AviDSDel(uuid string, tenant string, key string) *ut
 	path := "/api/vsdatascriptset/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: DS DELETE Restop %v \n", key,
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: DS DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -155,10 +155,10 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToDSKeyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during datascriptset update %v val %v\n", key, vsKey,
+			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during datascriptset update %v val %v", key, vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added Datascriptset cache k %v val %v\n", key, k,
+		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added Datascriptset cache k %v val %v", key, k,
 			ds_cache_obj))
 	}
 

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -319,25 +319,25 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 		var pgMembers []string
 		var poolMembers []string
 		if resp["http_request_policy"] != nil {
-			rules, rulessOk := resp["http_request_policy"].(map[string]interface{})
-			if rulessOk {
-				rulesArr := rules["rules"].([]interface{})
-				for _, ruleIntf := range rulesArr {
-					rulemap, _ := ruleIntf.(map[string]interface{})
-					if rulemap["switching_action"] != nil {
-						switchAction := rulemap["switching_action"].(map[string]interface{})
-						if switchAction["pool_group_ref"] != nil {
-							pgUuid := avicache.ExtractUuid(switchAction["pool_group_ref"].(string), "poolgroup-.*.#")
-							// Search the poolName using this Uuid in the poolcache.
-							pgName, found := rest.cache.PgCache.AviCacheGetNameByUuid(pgUuid)
-							if found {
-								pgMembers = append(pgMembers, pgName.(string))
-							}
-						} else if switchAction["pool_ref"] != nil {
-							poolUuid := avicache.ExtractUuid(switchAction["pool_ref"].(string), "pool-.*.#")
-							poolName, found := rest.cache.PoolCache.AviCacheGetNameByUuid(poolUuid)
-							if found {
-								poolMembers = append(poolMembers, poolName.(string))
+			if rules, rulesOk := resp["http_request_policy"].(map[string]interface{}); rulesOk {
+				if rulesArr, rulesArrOk := rules["rules"].([]interface{}); rulesArrOk {
+					for _, ruleIntf := range rulesArr {
+						rulemap, _ := ruleIntf.(map[string]interface{})
+						if rulemap["switching_action"] != nil {
+							switchAction := rulemap["switching_action"].(map[string]interface{})
+							if switchAction["pool_group_ref"] != nil {
+								pgUuid := avicache.ExtractUuid(switchAction["pool_group_ref"].(string), "poolgroup-.*.#")
+								// Search the poolName using this Uuid in the poolcache.
+								pgName, found := rest.cache.PgCache.AviCacheGetNameByUuid(pgUuid)
+								if found {
+									pgMembers = append(pgMembers, pgName.(string))
+								}
+							} else if switchAction["pool_ref"] != nil {
+								poolUuid := avicache.ExtractUuid(switchAction["pool_ref"].(string), "pool-.*.#")
+								poolName, found := rest.cache.PoolCache.AviCacheGetNameByUuid(poolUuid)
+								if found {
+									poolMembers = append(poolMembers, poolName.(string))
+								}
 							}
 						}
 					}

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -265,7 +265,7 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 		}
 	}
 
-	utils.AviLog.Debug(spew.Sprintf("HTTPPolicySet Restop %v AviHttpPolicySetMeta %v\n",
+	utils.AviLog.Debug(spew.Sprintf("HTTPPolicySet Restop %v AviHttpPolicySetMeta %v",
 		rest_op, *hps_meta))
 	return &rest_op
 }
@@ -274,7 +274,7 @@ func (rest *RestOperations) AviHttpPolicyDel(uuid string, tenant string, key str
 	path := "/api/httppolicyset/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
-	utils.AviLog.Debug(spew.Sprintf("HTTP Policy Set DELETE Restop %v \n",
+	utils.AviLog.Debug(spew.Sprintf("HTTP Policy Set DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -368,10 +368,10 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToHTTPKeyCollection(k)
-			utils.AviLog.Debug(spew.Sprintf("Added VS cache key during http policy update %v val %v\n", vsKey,
+			utils.AviLog.Debug(spew.Sprintf("Added VS cache key during http policy update %v val %v", vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Debug(spew.Sprintf("Added Http Policy Set cache k %v val %v\n", k,
+		utils.AviLog.Debug(spew.Sprintf("Added Http Policy Set cache k %v val %v", k,
 			http_cache_obj))
 	}
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -120,7 +120,7 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 		}
 	}
 
-	utils.AviLog.Debug(spew.Sprintf("L4PolicySet Restop %v AviHttpPolicySetMeta %v\n",
+	utils.AviLog.Debug(spew.Sprintf("L4PolicySet Restop %v AviHttpPolicySetMeta %v",
 		rest_op, utils.Stringify(hps_meta)))
 	return &rest_op
 }
@@ -129,7 +129,7 @@ func (rest *RestOperations) AviL4PolicyDel(uuid string, tenant string, key strin
 	path := "/api/l4policyset/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
-	utils.AviLog.Infof(spew.Sprintf("L4 Policy Set DELETE Restop %v \n",
+	utils.AviLog.Infof(spew.Sprintf("L4 Policy Set DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -210,10 +210,10 @@ func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avi
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToL4PolicyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("Added VS cache key during l4 policy update %v val %v\n", vsKey,
+			utils.AviLog.Info(spew.Sprintf("Added VS cache key during l4 policy update %v val %v", vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Info(spew.Sprintf("Added L4 Policy Set cache k %v val %v\n", k,
+		utils.AviLog.Info(spew.Sprintf("Added L4 Policy Set cache k %v val %v", k,
 			l4_cache_obj))
 	}
 

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -177,7 +177,7 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		}
 	}
 
-	utils.AviLog.Debug(spew.Sprintf("key: %s, msg: pool Restop %v K8sAviPoolMeta %v\n", key,
+	utils.AviLog.Debug(spew.Sprintf("key: %s, msg: pool Restop %v K8sAviPoolMeta %v", key,
 		utils.Stringify(rest_op), *pool_meta))
 	return &rest_op
 }
@@ -186,7 +186,7 @@ func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *
 	path := "/api/pool/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "Pool", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: pool DELETE Restop %v \n", key,
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: pool DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -327,10 +327,10 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToPoolKeyCollection(k)
-			utils.AviLog.Debug(spew.Sprintf("key: %s, msg: added VS cache key during pool update %v val %v\n", key, vsKey,
+			utils.AviLog.Debug(spew.Sprintf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Info(spew.Sprintf("key: %s, msg: Added Pool cache k %v val %v\n", key, k,
+		utils.AviLog.Info(spew.Sprintf("key: %s, msg: Added Pool cache k %v val %v", key, k,
 			pool_cache_obj))
 	}
 

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -30,11 +30,11 @@ import (
 
 func (rest *RestOperations) AviVrfGet(key, uuid, name string) *avimodels.VrfContext {
 	if rest.aviRestPoolClient == nil {
-		utils.AviLog.Warnf("key: %s, msg: aviRestPoolClient not initialized\n", key)
+		utils.AviLog.Warnf("key: %s, msg: aviRestPoolClient not initialized", key)
 		return nil
 	}
 	if len(rest.aviRestPoolClient.AviClient) < 1 {
-		utils.AviLog.Warnf("key: %s, msg: client in aviRestPoolClient not initialized\n", key)
+		utils.AviLog.Warnf("key: %s, msg: client in aviRestPoolClient not initialized", key)
 		return nil
 	}
 	client := rest.aviRestPoolClient.AviClient[0]
@@ -104,7 +104,7 @@ func (rest *RestOperations) getVrfCacheObj(vrfName string) *avicache.AviVrfCache
 	if found {
 		vrfCacheObj, ok := vrfCache.(*avicache.AviVrfCache)
 		if !ok {
-			utils.AviLog.Warnf("Vrf object for %s found. Cannot cast. Not doing anything\n", vrfName)
+			utils.AviLog.Warnf("Vrf object for %s found. Cannot cast. Not doing anything", vrfName)
 			return nil
 		}
 		return vrfCacheObj
@@ -131,12 +131,12 @@ func (rest *RestOperations) AviVrfCacheAdd(restOp *utils.RestOp, vrfKey avicache
 	for _, resp := range respElems {
 		name, ok := resp["name"].(string)
 		if !ok {
-			utils.AviLog.Warnf("key: %s, msg: wrong object type %T for name in vrf %s\n", key, resp["name"], vrfName)
+			utils.AviLog.Warnf("key: %s, msg: wrong object type %T for name in vrf %s", key, resp["name"], vrfName)
 			continue
 		}
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
-			utils.AviLog.Warnf("key: %s, msg: wrong object type %T for uuid in vrf %s\n", key, resp["uuid"], vrfName)
+			utils.AviLog.Warnf("key: %s, msg: wrong object type %T for uuid in vrf %s", key, resp["uuid"], vrfName)
 			continue
 		}
 		if resp["static_routes"] == nil {
@@ -144,12 +144,12 @@ func (rest *RestOperations) AviVrfCacheAdd(restOp *utils.RestOp, vrfKey avicache
 		} else {
 			staticRoutesIntf, ok := resp["static_routes"].([]interface{})
 			if !ok {
-				utils.AviLog.Warnf("key: %s, msg: wrong object type %T for staticroutes in staticroutes %s\n", key, resp["staticroutes"], vrfName)
+				utils.AviLog.Warnf("key: %s, msg: wrong object type %T for staticroutes in staticroutes %s", key, resp["staticroutes"], vrfName)
 				continue
 			}
 			staticRoutes = lib.StaticRoutesIntfToObj(staticRoutesIntf)
 			if len(staticRoutes) == 0 {
-				utils.AviLog.Debugf("key: %s, no static routes found for vrf %s\n", key, vrfName)
+				utils.AviLog.Debugf("key: %s, no static routes found for vrf %s", key, vrfName)
 			}
 		}
 		checksum = lib.VrfChecksum(name, staticRoutes)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -44,27 +44,25 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		rest_ops := rest.AviVsSniBuild(vs_meta, rest_method, cache_obj, key)
 		return rest_ops
 	} else {
-		app_prof := "/api/applicationprofile/?name=" + vs_meta.ApplicationProfile
-		// TODO use PoolGroup and use policies if there are > 1 pool, etc.
-		name := vs_meta.Name
-		cksum := vs_meta.CloudConfigCksum
-		checksumstr := strconv.Itoa(int(cksum))
-		cr := lib.AKOUser
-		cloudRef := "/api/cloud?name=" + utils.CloudName
 		svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 		svc_mdata := string(svc_mdata_json)
-		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
-		seGroupRef := "/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup
+
 		vs := avimodels.VirtualService{
-			Name:                  &name,
-			ApplicationProfileRef: &app_prof,
-			CloudConfigCksum:      &checksumstr,
-			CreatedBy:             &cr,
-			CloudRef:              &cloudRef,
+			Name:                  proto.String(vs_meta.Name),
+			CloudConfigCksum:      proto.String(strconv.Itoa(int(vs_meta.CloudConfigCksum))),
+			CreatedBy:             proto.String(lib.AKOUser),
+			CloudRef:              proto.String("/api/cloud?name=" + utils.CloudName),
+			TenantRef:             proto.String(fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)),
+			ApplicationProfileRef: proto.String("/api/applicationprofile/?name=" + vs_meta.ApplicationProfile),
+			SeGroupRef:            proto.String("/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup),
+			VrfContextRef:         proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext),
+			WafPolicyRef:          &vs_meta.WafPolicyRef,
+			AnalyticsProfileRef:   &vs_meta.AnalyticsProfileRef,
+			ErrorPageProfileRef:   &vs_meta.ErrorPageProfileRef,
+			Enabled:               vs_meta.Enabled,
 			ServiceMetadata:       &svc_mdata,
-			SeGroupRef:            &seGroupRef,
-			VrfContextRef:         &vrfContextRef,
 		}
+
 		if lib.GetT1LRPath() != "" {
 			// Clear the vrfContextRef
 			vs.VrfContextRef = nil
@@ -80,21 +78,19 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		}
 
 		if lib.GetAdvancedL4() {
-			ignPool := true
-			vs.IgnPoolNetReach = &ignPool
+			vs.IgnPoolNetReach = proto.Bool(true)
 		}
+
 		if vs_meta.DefaultPoolGroup != "" {
-			pool_ref := "/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup
-			vs.PoolGroupRef = &pool_ref
+			vs.PoolGroupRef = proto.String("/api/poolgroup/?name=" + vs_meta.DefaultPoolGroup)
 		}
+
 		if len(vs_meta.VSVIPRefs) > 0 {
-			vipref := "/api/vsvip/?name=" + vs_meta.VSVIPRefs[0].Name
-			vs.VsvipRef = &vipref
+			vs.VsvipRef = proto.String("/api/vsvip/?name=" + vs_meta.VSVIPRefs[0].Name)
 		} else {
 			utils.AviLog.Warnf("key: %s, msg: unable to set the vsvip reference")
 		}
-		tenant := fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)
-		vs.TenantRef = &tenant
+
 		if vs_meta.SNIParent {
 			// This is a SNI parent
 			utils.AviLog.Debugf("key: %s, msg: vs %s is a SNI Parent", key, vs_meta.Name)
@@ -125,34 +121,36 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 
 		if vs_meta.SharedVS {
 			// This is a shared VS - which should have a datascript
-			var i int32
 			var vsdatascripts []*avimodels.VSDataScripts
-			for _, ds := range vs_meta.HTTPDSrefs {
-				var j int32
-				j = i
+			for i, ds := range vs_meta.HTTPDSrefs {
+				j := int32(i)
 				dsRef := "/api/vsdatascriptset/?name=" + ds.Name
 				vsdatascript := &avimodels.VSDataScripts{Index: &j, VsDatascriptSetRef: &dsRef}
 				vsdatascripts = append(vsdatascripts, vsdatascript)
-				i = i + 1
 			}
 			vs.VsDatascripts = vsdatascripts
 		}
 
+		var httpPolicyCollection []*avimodels.HTTPPolicies
+		internalPolicyIndexBuffer := int32(11)
 		if len(vs_meta.HttpPolicyRefs) > 0 {
-			var i int32
-			i = 0
-			var httpPolicyCollection []*avimodels.HTTPPolicies
-			for _, http := range vs_meta.HttpPolicyRefs {
+			for i, http := range vs_meta.HttpPolicyRefs {
 				// Update them on the VS object
-				var j int32
-				j = i + 11
-				i = i + 1
+				j := int32(i) + internalPolicyIndexBuffer
 				httpPolicy := fmt.Sprintf("/api/httppolicyset/?name=%s", http.Name)
 				httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}
 				httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
 			}
-			vs.HTTPPolicies = httpPolicyCollection
 		}
+
+		bufferLen := int32(len(httpPolicyCollection)) + internalPolicyIndexBuffer + 5
+		for i, policy := range vs_meta.HttpPolicySetRefs {
+			j := int32(i) + bufferLen
+			httpPolicy := policy
+			httpPolicies := &avimodels.HTTPPolicies{HTTPPolicySetRef: &httpPolicy, Index: &j}
+			httpPolicyCollection = append(httpPolicyCollection, httpPolicies)
+		}
+		vs.HTTPPolicies = httpPolicyCollection
 
 		if strings.Contains(*vs.Name, lib.PassthroughPrefix) && !strings.HasSuffix(*vs.Name, lib.PassthroughInsecure) {
 			// This is a passthrough secure VS, we want the VS to be down if all the pools are down.

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -532,7 +532,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				parentKey := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: ExtractVsName(vh_parent_uuid.(string))}
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(parentKey)
 				vs_cache_obj.AddToSNIChildCollection(uuid)
-				utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during SNI update %v val %v\n", key, vhParentKey,
+				utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during SNI update %v val %v", key, vhParentKey,
 					vs_cache_obj))
 			}
 		}
@@ -594,7 +594,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				} else {
 					vs_cache_obj.InvalidData = false
 				}
-				utils.AviLog.Debug(spew.Sprintf("key: %s, msg: updated VS cache key %v val %v\n", key, k,
+				utils.AviLog.Debug(spew.Sprintf("key: %s, msg: updated VS cache key %v val %v", key, k,
 					utils.Stringify(vs_cache_obj)))
 
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
@@ -644,7 +644,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 
 			rest.cache.VsCacheMeta.AviCacheAdd(k, vs_cache_obj)
 			status.HostRuleEventBroadcast(vs_cache_obj.Name, lib.CRDMetadata{}, svc_mdata_obj.CRDStatus)
-			utils.AviLog.Infof("key: %s, msg: added VS cache key %v val %v\n", key, k, utils.Stringify(vs_cache_obj))
+			utils.AviLog.Infof("key: %s, msg: added VS cache key %v val %v", key, k, utils.Stringify(vs_cache_obj))
 		}
 
 		rest.StatusUpdate(rest_op, vs_cache_obj, &svc_mdata_obj, parentVsObj, key, false)
@@ -758,7 +758,7 @@ func (rest *RestOperations) AviVSDel(uuid string, tenant string, key string) (*u
 	path := "/api/virtualservice/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "VirtualService", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VirtualService DELETE Restop %v \n",
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VirtualService DELETE Restop %v ",
 		key, utils.Stringify(rest_op)))
 	return &rest_op, true
 }

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -292,11 +292,11 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 
 func (rest *RestOperations) AviVsVipGet(key, uuid, name string) (*avimodels.VsVip, error) {
 	if rest.aviRestPoolClient == nil {
-		utils.AviLog.Warnf("key: %s, msg: aviRestPoolClient during vsvip not initialized\n", key)
+		utils.AviLog.Warnf("key: %s, msg: aviRestPoolClient during vsvip not initialized", key)
 		return nil, errors.New("client in aviRestPoolClient during vsvip not initialized")
 	}
 	if len(rest.aviRestPoolClient.AviClient) < 1 {
-		utils.AviLog.Warnf("key: %s, msg: client in aviRestPoolClient during vsvip not initialized\n", key)
+		utils.AviLog.Warnf("key: %s, msg: client in aviRestPoolClient during vsvip not initialized", key)
 		return nil, errors.New("client in aviRestPoolClient during vsvip not initialized")
 	}
 	client := rest.aviRestPoolClient.AviClient[0]
@@ -320,7 +320,7 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 	path := "/api/vsvip/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "VsVip", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VSVIP DELETE Restop %v \n", key,
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VSVIP DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -510,11 +510,11 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToVSVipKeyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v\n", key, vsKey,
+			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey,
 				vs_cache_obj))
 			rest.StatusUpdate(rest_op, vs_cache_obj, nil, nil, key, true)
 		}
-		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added vsvip cache k %v val %v\n", key, k,
+		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added vsvip cache k %v val %v", key, k,
 			vsvip_cache_obj))
 
 	}

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -100,7 +100,7 @@ func (rest *RestOperations) AviPGDel(uuid string, tenant string, key string) *ut
 	path := "/api/poolgroup/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: PG DELETE Restop %v \n", key,
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: PG DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -181,10 +181,10 @@ func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToPGKeyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during poolgroup update %v val %v\n", key, vsKey,
+			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during poolgroup update %v val %v", key, vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added PG cache k %v val %v\n", key, k,
+		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added PG cache k %v val %v", key, k,
 			pg_cache_obj))
 	}
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -88,7 +88,7 @@ func (rest *RestOperations) DequeueNodes(key string) {
 			return
 		}
 		if avimodel.IsVrf {
-			utils.AviLog.Infof("key: %s, msg: processing vrf object\n", key)
+			utils.AviLog.Infof("key: %s, msg: processing vrf object", key)
 			rest.vrfCU(key, name, avimodel)
 			return
 		}
@@ -115,7 +115,7 @@ func (rest *RestOperations) DequeueNodes(key string) {
 
 func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObjectGraph) {
 	if lib.GetDisableStaticRoute() {
-		utils.AviLog.Debugf("key: %s, msg: static route sync disabled\n", key)
+		utils.AviLog.Debugf("key: %s, msg: static route sync disabled", key)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)
 			lib.StaticRouteSyncChan = nil
@@ -124,12 +124,12 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 	}
 	// Disable static route sync if ako is in  NodePort mode
 	if lib.IsNodePortMode() {
-		utils.AviLog.Debugf("key: %s, msg: static route sync disabled in NodePort Mode\n", key)
+		utils.AviLog.Debugf("key: %s, msg: static route sync disabled in NodePort Mode", key)
 		return
 	}
 	vrfNode := avimodel.GetAviVRF()
 	if len(vrfNode) != 1 {
-		utils.AviLog.Warnf("key: %s, msg: Number of vrf nodes is not one\n", key)
+		utils.AviLog.Warnf("key: %s, msg: Number of vrf nodes is not one", key)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)
 			lib.StaticRouteSyncChan = nil
@@ -139,7 +139,7 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 	aviVrfNode := vrfNode[0]
 	vrfCacheObj := rest.getVrfCacheObj(vrfName)
 	if vrfCacheObj == nil {
-		utils.AviLog.Warnf("key: %s, vrf %s not found in cache, exiting\n", key, vrfName)
+		utils.AviLog.Warnf("key: %s, vrf %s not found in cache, exiting", key, vrfName)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)
 			lib.StaticRouteSyncChan = nil
@@ -147,7 +147,7 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 		return
 	}
 	if vrfCacheObj.CloudConfigCksum == aviVrfNode.CloudConfigCksum {
-		utils.AviLog.Debugf("key: %s, msg: checksum for vrf %s has not changed, skipping\n", key, vrfName)
+		utils.AviLog.Debugf("key: %s, msg: checksum for vrf %s has not changed, skipping", key, vrfName)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)
 			lib.StaticRouteSyncChan = nil
@@ -157,7 +157,7 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 	var restOps []*utils.RestOp
 	restOp := rest.AviVrfBuild(key, aviVrfNode, vrfCacheObj.Uuid)
 	if restOp == nil {
-		utils.AviLog.Debugf("key: %s, no rest operation for vrf %s\n", key, vrfName)
+		utils.AviLog.Debugf("key: %s, no rest operation for vrf %s", key, vrfName)
 		if lib.StaticRouteSyncChan != nil {
 			close(lib.StaticRouteSyncChan)
 			lib.StaticRouteSyncChan = nil
@@ -166,8 +166,8 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 	}
 	restOps = append(restOps, restOp)
 	vrfKey := avicache.NamespaceName{Namespace: lib.GetTenant(), Name: vrfName}
-	utils.AviLog.Debugf("key: %s, msg: Executing rest for vrf %s\n", key, vrfName)
-	utils.AviLog.Debugf("key: %s, msg: restops %v\n", key, *restOp)
+	utils.AviLog.Debugf("key: %s, msg: Executing rest for vrf %s", key, vrfName)
+	utils.AviLog.Debugf("key: %s, msg: restops %v", key, *restOp)
 	success := rest.ExecuteRestAndPopulateCache(restOps, vrfKey, avimodel, key, false)
 
 	if success && lib.ConfigDeleteSyncChan != nil {

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -90,7 +90,7 @@ func (rest *RestOperations) AviSSLKeyCertDel(uuid string, tenant string) *utils.
 	path := "/api/sslkeyandcertificate/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("SSLCertKey DELETE Restop %v \n",
+	utils.AviLog.Info(spew.Sprintf("SSLCertKey DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -164,10 +164,10 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			} else {
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 				vs_cache_obj.AddToSSLKeyCertCollection(k)
-				utils.AviLog.Info(spew.Sprintf("Added VS cache key during SSLKeyCert update %v val %v\n", vsKey,
+				utils.AviLog.Info(spew.Sprintf("Added VS cache key during SSLKeyCert update %v val %v", vsKey,
 					vs_cache_obj))
 			}
-			utils.AviLog.Info(spew.Sprintf("Added SSLKeyCert cache k %v val %v\n", k,
+			utils.AviLog.Info(spew.Sprintf("Added SSLKeyCert cache k %v val %v", k,
 				ssl_cache_obj))
 		}
 	}
@@ -235,7 +235,7 @@ func (rest *RestOperations) AviPkiProfileDel(uuid string, tenant string) *utils.
 	path := "/api/pkiprofile/" + uuid
 	rest_op := utils.RestOp{Path: path, Method: "DELETE",
 		Tenant: tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("PKIprofile DELETE Restop %v \n",
+	utils.AviLog.Info(spew.Sprintf("PKIprofile DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op
 }
@@ -300,10 +300,10 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 			} else {
 				pool_cache_obj := rest.cache.PoolCache.AviCacheAddPool(poolKey)
 				pool_cache_obj.PkiProfileCollection = k
-				utils.AviLog.Info(spew.Sprintf("Added Pool cache key during PkiProfile update %v val %v\n", poolKey,
+				utils.AviLog.Info(spew.Sprintf("Added Pool cache key during PkiProfile update %v val %v", poolKey,
 					pool_cache_obj))
 			}
-			utils.AviLog.Info(spew.Sprintf("Added PkiProfile cache k %v val %v\n", k,
+			utils.AviLog.Info(spew.Sprintf("Added PkiProfile cache k %v val %v", k,
 				pki_cache_obj))
 		}
 	}

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -69,7 +69,7 @@ type EventRecorder struct {
 
 func (e *EventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
 	if !e.Fake {
-		e.Recorder.Eventf(object, eventtype, reason, messageFmt, args)
+		e.Recorder.Eventf(object, eventtype, reason, messageFmt, args...)
 	}
 }
 

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -149,9 +149,9 @@ func SetupDomain() {
 }
 
 func SetUpTestForIngress(t *testing.T, modelNames ...string) {
-	for _, model := range modelNames {
-		objects.SharedAviGraphLister().Delete(model)
-	}
+	// for _, model := range modelNames {
+	// 	objects.SharedAviGraphLister().Delete(model)
+	// }
 	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, "default", "avisvc", false, false, "1.1.1")
 }

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -149,9 +149,9 @@ func SetupDomain() {
 }
 
 func SetUpTestForIngress(t *testing.T, modelNames ...string) {
-	// for _, model := range modelNames {
-	// 	objects.SharedAviGraphLister().Delete(model)
-	// }
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
 	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, "default", "avisvc", false, false, "1.1.1")
 }

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -16,7 +16,6 @@ package evhtests
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -199,7 +198,6 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, modelName)
 	objects.SharedAviGraphLister().Delete(modelName)
-	fmt.Printf("HAHA: modelName: %s", modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	// found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -218,7 +216,7 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
-	fmt.Println("INGRESS CREATED")
+
 	integrationtest.PollForCompletion(t, modelName, 5)
 
 	g.Eventually(func() bool {

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -368,7 +368,6 @@ func TestEVHAddRemoveInfraSettingInIngressClass(t *testing.T) {
 		}
 		return false
 	}, 40*time.Second).Should(gomega.Equal(true))
-	VerifyEvhNodeDeletionFromVsNode(g, modelName, vsKey, evhKey)
 
 	ingClassUpdate = (integrationtest.FakeIngressClass{
 		Name:       ingClassName,

--- a/tests/scaletest/scale_test.go
+++ b/tests/scaletest/scale_test.go
@@ -222,7 +222,7 @@ func FetchControllerTime(t *testing.T) string {
 	layout := "2006-01-02T15:04:05Z"
 	convertedDate, err := time.Parse(layout, controllerTime)
 	if err != nil {
-		t.Logf("Error parsing controller time : %v\n\n", err)
+		t.Logf("Error parsing controller time : %v\n", err)
 	}
 	return convertedDate.Format(time.RFC3339Nano)
 }
@@ -645,7 +645,7 @@ func CreateIngressesParallel(t *testing.T, numOfIng int, initialNumOfPools int) 
 	verificationSuccessful := false
 	for waitTime := 0; waitTime < testCaseTimeOut; {
 		if Verify(t) == true {
-			t.Logf("Created %d Ingresses and associated Avi objects\n", numOfIng)
+			t.Logf("Created %d Ingresses and associated Avi objects", numOfIng)
 			verificationSuccessful = true
 			break
 		}
@@ -662,7 +662,7 @@ func CreateIngressesParallel(t *testing.T, numOfIng int, initialNumOfPools int) 
 		return operUP
 	}, testCaseTimeOut, testPollInterval).Should(gomega.BeTrue())
 	if !verificationSuccessful {
-		t.Fatalf("Error : Verification failed\n")
+		t.Fatalf("Error : Verification failed")
 	}
 }
 
@@ -695,7 +695,7 @@ func DeleteIngressesParallel(t *testing.T, numOfIng int, initialNumOfPools int) 
 		pools := lib.FetchPools(t, AviClients[0])
 		return len(pools)
 	}, testCaseTimeOut, testPollInterval).Should(gomega.Equal(initialNumOfPools))
-	t.Logf("Deleted %d Ingresses and associated Avi objects\n", numOfIng)
+	t.Logf("Deleted %d Ingresses and associated Avi objects", numOfIng)
 }
 
 func UpdateIngressesParallel(t *testing.T, numOfIng int) {
@@ -728,7 +728,7 @@ func UpdateIngressesParallel(t *testing.T, numOfIng int) {
 		operUP := CheckVSOperDown(t, OPERDownVSes)
 		return operUP
 	}, testCaseTimeOut, testPollInterval).Should(gomega.BeTrue())
-	t.Logf("Updated %d Ingresses\n", numOfIng)
+	t.Logf("Updated %d Ingresses", numOfIng)
 }
 
 func CreateIngressesSerial(t *testing.T, numOfIng int, initialNumOfPools int) {
@@ -779,7 +779,7 @@ func CreateIngressesSerial(t *testing.T, numOfIng int, initialNumOfPools int) {
 		return operUP
 	}, testCaseTimeOut, testPollInterval).Should(gomega.BeTrue())
 	if !verificationSuccessful {
-		t.Fatalf("Error : Verification failed\n")
+		t.Fatalf("Error : Verification failed")
 	}
 
 }


### PR DESCRIPTION
This commit allows users to specify a SharedVS mapped
fqdn in a HostRule (.spec.virtualhost.fqdn), in order to
additionally configure the SharedVS with properties
configurable via the HostRule CRD.
Addresses AV-129015