### PR TITLE
Status update fixes

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -132,7 +132,7 @@ func InitializeAKC() {
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, kubeClient, false)
 	pod, err := kubeClient.CoreV1().Pods(utils.GetAKONamespace()).Get(context.TODO(), os.Getenv("POD_NAME"), metav1.GetOptions{})
 	if err != nil {
-		utils.AviLog.Warnf("Error getting AKO pod details.")
+		utils.AviLog.Warnf("Error getting AKO pod details, %s.", err.Error())
 	}
 	akoControlConfig.SaveAKOPodObjectMeta(pod)
 

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -36,25 +36,11 @@ type AviPoolCache struct {
 	Tenant               string
 	Uuid                 string
 	CloudConfigCksum     string
-	ServiceMetadataObj   ServiceMetadataObj
+	ServiceMetadataObj   lib.ServiceMetadataObj
 	PkiProfileCollection NamespaceName
 	LastModified         string
 	InvalidData          bool
 	HasReference         bool
-}
-
-type ServiceMetadataObj struct {
-	NamespaceIngressName  []string        `json:"namespace_ingress_name"`
-	IngressName           string          `json:"ingress_name"`
-	Namespace             string          `json:"namespace"`
-	HostNames             []string        `json:"hostnames"`
-	NamespaceServiceName  []string        `json:"namespace_svc_name"` // []string{ns/name}
-	CRDStatus             lib.CRDMetadata `json:"crd_status"`
-	PoolRatio             int32           `json:"pool_ratio"`
-	PassthroughParentRef  string          `json:"passthrough_parent_ref"`
-	PassthroughChildRef   string          `json:"passthrough_child_ref"`
-	Gateway               string          `json:"gateway"` // ns/name
-	InsecureEdgeTermAllow bool            `json:"insecureedgetermallow"`
 }
 
 type AviDSCache struct {
@@ -97,7 +83,7 @@ type AviVsCache struct {
 	ParentVSRef          NamespaceName
 	PassthroughParentRef NamespaceName
 	PassthroughChildRef  NamespaceName
-	ServiceMetadataObj   ServiceMetadataObj
+	ServiceMetadataObj   lib.ServiceMetadataObj
 	LastModified         string
 	EnableRhi            bool
 	InvalidData          bool

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -69,8 +69,6 @@ type AviVsCache struct {
 	Name                 string
 	Tenant               string
 	Uuid                 string
-	Vip                  string
-	Fip                  string
 	CloudConfigCksum     string
 	PGKeyCollection      []NamespaceName
 	VSVipKeyCollection   []NamespaceName

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -583,7 +583,7 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 		}
 
 		svc_mdata_intf := *pool.ServiceMetadata
-		var svc_mdata_obj ServiceMetadataObj
+		var svc_mdata_obj lib.ServiceMetadataObj
 		if err := json.Unmarshal([]byte(svc_mdata_intf), &svc_mdata_obj); err != nil {
 			utils.AviLog.Warnf("Error parsing service metadata during pool cache :%v", err)
 		}
@@ -1119,7 +1119,7 @@ func (c *AviObjCache) AviPopulateOnePoolCache(client *clients.AviClient,
 		}
 
 		svc_mdata_intf := *pool.ServiceMetadata
-		var svc_mdata_obj ServiceMetadataObj
+		var svc_mdata_obj lib.ServiceMetadataObj
 		if err := json.Unmarshal([]byte(svc_mdata_intf), &svc_mdata_obj); err != nil {
 			utils.AviLog.Warnf("Error parsing service metadata during pool cache :%v", err)
 		}
@@ -1819,7 +1819,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 				continue
 			}
 			svc_mdata_intf, ok := vs["service_metadata"]
-			var svc_mdata_obj ServiceMetadataObj
+			var svc_mdata_obj lib.ServiceMetadataObj
 			if ok {
 				if err := json.Unmarshal([]byte(svc_mdata_intf.(string)),
 					&svc_mdata_obj); err != nil {
@@ -2080,7 +2080,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 		for _, vs_intf := range results {
 			vs := vs_intf.(map[string]interface{})
 			svc_mdata_intf, ok := vs["service_metadata"]
-			var svc_mdata_obj ServiceMetadataObj
+			var svc_mdata_obj lib.ServiceMetadataObj
 			if ok {
 				if err := json.Unmarshal([]byte(svc_mdata_intf.(string)),
 					&svc_mdata_obj); err != nil {

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1849,8 +1849,6 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 			if vs["cloud_config_cksum"] != nil {
 				k := NamespaceName{Namespace: lib.GetTenant(), Name: vs["name"].(string)}
 				*vsCacheCopy = RemoveNamespaceName(*vsCacheCopy, k)
-				var vip string
-				var fip string
 				var vsVipKey []NamespaceName
 				var sslKeys []NamespaceName
 				var dsKeys []NamespaceName
@@ -1872,12 +1870,6 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 							if ok {
 								vipKey := NamespaceName{Namespace: lib.GetTenant(), Name: vsVipData.Name}
 								vsVipKey = append(vsVipKey, vipKey)
-								if len(vsVipData.Vips) > 0 {
-									vip = vsVipData.Vips[0]
-									if len(vsVipData.Fips) > 0 {
-										fip = vsVipData.Fips[0]
-									}
-								}
 							}
 						}
 					}
@@ -2010,8 +2002,6 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 					SSLKeyCertCollection: sslKeys,
 					PGKeyCollection:      poolgroupKeys,
 					PoolKeyCollection:    poolKeys,
-					Vip:                  vip,
-					Fip:                  fip,
 					CloudConfigCksum:     vs["cloud_config_cksum"].(string),
 					SNIChildCollection:   sni_child_collection,
 					ParentVSRef:          parentVSKey,
@@ -2108,8 +2098,6 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 
 			}
 			if vs["cloud_config_cksum"] != nil {
-				var vip string
-				var fip string
 				var vsVipKey []NamespaceName
 				var sslKeys []NamespaceName
 				var dsKeys []NamespaceName
@@ -2129,12 +2117,6 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						if ok {
 							vipKey := NamespaceName{Namespace: lib.GetTenant(), Name: vsVipData.Name}
 							vsVipKey = append(vsVipKey, vipKey)
-							if len(vsVipData.Vips) > 0 {
-								vip = vsVipData.Vips[0]
-								if len(vsVipData.Fips) > 0 {
-									fip = vsVipData.Fips[0]
-								}
-							}
 						}
 					}
 				}
@@ -2254,8 +2236,6 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 					SSLKeyCertCollection: sslKeys,
 					PGKeyCollection:      poolgroupKeys,
 					PoolKeyCollection:    poolKeys,
-					Vip:                  vip,
-					Fip:                  fip,
 					CloudConfigCksum:     vs["cloud_config_cksum"].(string),
 					SNIChildCollection:   sni_child_collection,
 					ParentVSRef:          parentVSKey,

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -67,6 +67,20 @@ type CRDMetadata struct {
 	Status string `json:"status"`
 }
 
+type ServiceMetadataObj struct {
+	NamespaceIngressName  []string    `json:"namespace_ingress_name"`
+	IngressName           string      `json:"ingress_name"`
+	Namespace             string      `json:"namespace"`
+	HostNames             []string    `json:"hostnames"`
+	NamespaceServiceName  []string    `json:"namespace_svc_name"` // []string{ns/name}
+	CRDStatus             CRDMetadata `json:"crd_status"`
+	PoolRatio             int32       `json:"pool_ratio"`
+	PassthroughParentRef  string      `json:"passthrough_parent_ref"`
+	PassthroughChildRef   string      `json:"passthrough_child_ref"`
+	Gateway               string      `json:"gateway"` // ns/name
+	InsecureEdgeTermAllow bool        `json:"insecureedgetermallow"`
+}
+
 var NamePrefix string
 
 func CheckObjectNameLength(objName, objType string) bool {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -72,7 +71,7 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 			Name:       vsName,
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceServiceName: serviceNSNames,
 				Gateway:              namespace + "/" + gatewayName,
 			},
@@ -185,7 +184,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			Name:       vsName,
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				Gateway:   namespace + "/" + gatewayName,
 				HostNames: fqdns,
 			},
@@ -298,7 +297,7 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			Tenant:   lib.GetTenant(),
 			Protocol: portProto[0],
 			PortName: "",
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceServiceName: []string{svc[0]},
 			},
 			VrfContext: lib.GetVrf(),

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
@@ -53,8 +52,8 @@ type AviVsEvhSniModel interface {
 	GetHttpPolicyRefs() []*AviHttpPolicySetNode
 	SetHttpPolicyRefs([]*AviHttpPolicySetNode)
 
-	GetServiceMetadata() avicache.ServiceMetadataObj
-	SetServiceMetadata(avicache.ServiceMetadataObj)
+	GetServiceMetadata() lib.ServiceMetadataObj
+	SetServiceMetadata(lib.ServiceMetadataObj)
 
 	GetSSLKeyCertAviRef() string
 	SetSSLKeyCertAviRef(string)
@@ -113,7 +112,7 @@ type AviEvhVsNode struct {
 	HttpPolicyRefs      []*AviHttpPolicySetNode
 	VSVIPRefs           []*AviVSVIPNode
 	TLSType             string
-	ServiceMetadata     avicache.ServiceMetadataObj
+	ServiceMetadata     lib.ServiceMetadataObj
 	VrfContext          string
 	WafPolicyRef        string
 	AppProfileRef       string
@@ -169,11 +168,11 @@ func (v *AviEvhVsNode) SetHttpPolicyRefs(httpPolicyRefs []*AviHttpPolicySetNode)
 	v.HttpPolicyRefs = httpPolicyRefs
 }
 
-func (v *AviEvhVsNode) GetServiceMetadata() avicache.ServiceMetadataObj {
+func (v *AviEvhVsNode) GetServiceMetadata() lib.ServiceMetadataObj {
 	return v.ServiceMetadata
 }
 
-func (v *AviEvhVsNode) SetServiceMetadata(serviceMetadata avicache.ServiceMetadataObj) {
+func (v *AviEvhVsNode) SetServiceMetadata(serviceMetadata lib.ServiceMetadataObj) {
 	v.ServiceMetadata = serviceMetadata
 }
 
@@ -701,7 +700,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 			VrfContext: lib.GetVrf(),
 			Port:       path.Port,
 			TargetPort: path.TargetPort,
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				IngressName: ingName,
 				Namespace:   namespace,
 				HostNames:   hostslice,
@@ -859,7 +858,7 @@ func (o *AviObjectGraph) BuildModelGraphForInsecureEVH(routeIgrObj RouteIngressM
 			Tenant:       lib.GetTenant(),
 			EVHParent:    false,
 			EvhHostName:  host,
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceIngressName: ingressHostMap.GetIngressesForHostName(host),
 				Namespace:            namespace,
 				HostNames:            hostSlice,
@@ -1108,7 +1107,7 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 			Tenant:       lib.GetTenant(),
 			EVHParent:    false,
 			EvhHostName:  host,
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceIngressName: ingressHostMap.GetIngressesForHostName(host),
 				Namespace:            namespace,
 				HostNames:            hosts,

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -56,7 +56,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	avi_vs_meta = &AviVsNode{
 		Name:   vsName,
 		Tenant: lib.GetTenant(),
-		ServiceMetadata: avicache.ServiceMetadataObj{
+		ServiceMetadata: lib.ServiceMetadataObj{
 			NamespaceServiceName: []string{svcObj.ObjectMeta.Namespace + "/" + svcObj.ObjectMeta.Name},
 			HostNames:            fqdns,
 		},

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -19,7 +19,6 @@ import (
 	"regexp"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 
@@ -98,7 +97,7 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 				PriorityLabel: priorityLabel,
 				Port:          obj.Port,
 				TargetPort:    obj.TargetPort,
-				ServiceMetadata: avicache.ServiceMetadataObj{
+				ServiceMetadata: lib.ServiceMetadataObj{
 					IngressName:           ingName,
 					Namespace:             namespace,
 					HostNames:             storedHosts,
@@ -368,7 +367,7 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 			VHParentName: vsNode[0].Name,
 			Tenant:       lib.GetTenant(),
 			IsSNIChild:   true,
-			ServiceMetadata: avicache.ServiceMetadataObj{
+			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceIngressName: ingressHostMap.GetIngressesForHostName(sniHost),
 				Namespace:            namespace,
 				HostNames:            sniHosts,

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -18,15 +18,13 @@ import (
 	"fmt"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
+	"google.golang.org/protobuf/proto"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -384,7 +382,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 				PriorityLabel: priorityLabel,
 				Port:          path.Port,
 				TargetPort:    path.TargetPort,
-				ServiceMetadata: avicache.ServiceMetadataObj{
+				ServiceMetadata: lib.ServiceMetadataObj{
 					IngressName: ingName,
 					Namespace:   namespace,
 					HostNames:   hostSlice,

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -373,7 +372,7 @@ type AviVsNode struct {
 	VHDomainNames         []string
 	TLSType               string
 	IsSNIChild            bool
-	ServiceMetadata       avicache.ServiceMetadataObj
+	ServiceMetadata       lib.ServiceMetadataObj
 	VrfContext            string
 	WafPolicyRef          string
 	AppProfileRef         string
@@ -430,11 +429,11 @@ func (v *AviVsNode) SetHttpPolicyRefs(httpPolicyRefs []*AviHttpPolicySetNode) {
 	v.HttpPolicyRefs = httpPolicyRefs
 }
 
-func (v *AviVsNode) GetServiceMetadata() avicache.ServiceMetadataObj {
+func (v *AviVsNode) GetServiceMetadata() lib.ServiceMetadataObj {
 	return v.ServiceMetadata
 }
 
-func (v *AviVsNode) SetServiceMetadata(serviceMetadata avicache.ServiceMetadataObj) {
+func (v *AviVsNode) SetServiceMetadata(serviceMetadata lib.ServiceMetadataObj) {
 	v.ServiceMetadata = serviceMetadata
 }
 
@@ -1236,7 +1235,7 @@ type AviPoolNode struct {
 	LbAlgoHostHeader       string
 	IngressName            string
 	PriorityLabel          string
-	ServiceMetadata        avicache.ServiceMetadataObj
+	ServiceMetadata        lib.ServiceMetadataObj
 	SniEnabled             bool
 	SslProfileRef          string
 	PkiProfile             *AviPkiProfileNode

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -136,7 +135,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 		poolNode.PortName = obj.PortName
 		poolNode.Port = obj.Port
 		poolNode.TargetPort = obj.TargetPort
-		poolNode.ServiceMetadata = avicache.ServiceMetadataObj{
+		poolNode.ServiceMetadata = lib.ServiceMetadataObj{
 			IngressName: objName, Namespace: namespace, PoolRatio: obj.weight,
 			HostNames: []string{hostname},
 		}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -233,6 +233,9 @@ func handleHostRuleForSharedVS(key string, fullsync bool) {
 		}
 	}
 
+	if len(allModels) == 0 {
+		return
+	}
 	utils.AviLog.Infof("key: %s, msg: Models retrieved from HostRule %v", key, utils.Stringify(allModels))
 
 	for _, modelName := range allModels {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -218,7 +218,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 		}
 		cksum := resp["cloud_config_cksum"].(string)
 
-		var svc_mdata_obj avicache.ServiceMetadataObj
+		var svc_mdata_obj lib.ServiceMetadataObj
 		if resp["service_metadata"] != nil {
 			if err := json.Unmarshal([]byte(resp["service_metadata"].(string)),
 				&svc_mdata_obj); err != nil {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -281,7 +281,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for Pool Collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				IPAddrs := rest.GetIPAddrsFromCache(vs_cache_obj)
 				if len(IPAddrs) == 0 {
-					utils.AviLog.Debugf("key: %s, msg: Unable to find VIP corresponding to Pool %s", key, pool_cache_obj.Name)
+					utils.AviLog.Warnf("key: %s, msg: Unable to find VIP corresponding to Pool %s vsCache %v", key, pool_cache_obj.Name, utils.Stringify(vs_cache_obj))
 				} else {
 					switch pool_cache_obj.ServiceMetadataObj.ServiceMetadataMapping("Pool") {
 					case lib.GatewayPool:
@@ -376,7 +376,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					Options: &updateOptions,
 				}
 				status.PublishToStatusQueue(pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
-			case "SNI_INSECURE_OR_EVH_POOL":
+			case lib.SNIInsecureOrEVHPool:
 				updateOptions := status.UpdateOptions{
 					ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
 					Key:             key,

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -366,7 +366,7 @@ func AviVsHttpPSAdd(vs_meta interface{}, isEVH bool) []*avimodels.HTTPPolicies {
 	return httpPolicyCollection
 }
 
-func (rest *RestOperations) StatusUpdate(rest_op *utils.RestOp, vs_cache_obj *avicache.AviVsCache, svc_mdata_obj *avicache.ServiceMetadataObj, parentVsObj *avicache.AviVsCache, key string, oldObj bool) error {
+func (rest *RestOperations) StatusUpdate(rest_op *utils.RestOp, vs_cache_obj *avicache.AviVsCache, svc_mdata_obj *lib.ServiceMetadataObj, parentVsObj *avicache.AviVsCache, key string, oldObj bool) error {
 	if oldObj {
 		if rest_op.Method == utils.RestPost || rest_op.Method == utils.RestDelete || rest_op.Method == utils.RestPut {
 			for _, poolkey := range vs_cache_obj.PoolKeyCollection {
@@ -536,7 +536,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 					vs_cache_obj))
 			}
 		}
-		var svc_mdata_obj avicache.ServiceMetadataObj
+		var svc_mdata_obj lib.ServiceMetadataObj
 		if resp["service_metadata"] != nil {
 			utils.AviLog.Infof("key:%s, msg: Service Metadata: %s", key, resp["service_metadata"])
 			if err := json.Unmarshal([]byte(resp["service_metadata"].(string)),

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -366,101 +366,101 @@ func AviVsHttpPSAdd(vs_meta interface{}, isEVH bool) []*avimodels.HTTPPolicies {
 	return httpPolicyCollection
 }
 
-func (rest *RestOperations) StatusUpdate(rest_op *utils.RestOp, vs_cache_obj *avicache.AviVsCache, svc_mdata_obj *lib.ServiceMetadataObj, parentVsObj *avicache.AviVsCache, key string, oldObj bool) error {
-	if oldObj {
-		if rest_op.Method == utils.RestPost || rest_op.Method == utils.RestDelete || rest_op.Method == utils.RestPut {
-			for _, poolkey := range vs_cache_obj.PoolKeyCollection {
-				// Fetch the pool object from cache and check the service metadata
-				pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)
-				if ok {
-					utils.AviLog.Infof("key: %s, msg: found pool: %s, will update status", key, poolkey.Name)
-					pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
-					if found {
-						IPAddrs := rest.GetIPAddrsFromCache(vs_cache_obj)
-						if len(pool_cache_obj.ServiceMetadataObj.NamespaceServiceName) > 0 {
-							updateOptions := status.UpdateOptions{
-								Vip:                IPAddrs,
-								ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
-								Key:                key,
-								VirtualServiceUUID: vs_cache_obj.Uuid,
-								VSName:             vs_cache_obj.Name,
-							}
-							statusOption := status.StatusOptions{
-								ObjType: utils.L4LBService,
-								Op:      lib.UpdateStatus,
-								Options: &updateOptions,
-							}
-							status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
-						} else if pool_cache_obj.ServiceMetadataObj.Namespace != "" {
-							if len(IPAddrs) == 0 {
-								IPAddrs = []string{parentVsObj.Vip}
-							}
-							updateOptions := status.UpdateOptions{
-								Vip:                IPAddrs,
-								ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
-								Key:                key,
-								VirtualServiceUUID: vs_cache_obj.Uuid,
-								VSName:             vs_cache_obj.Name,
-							}
-							statusOption := status.StatusOptions{
-								ObjType: utils.Ingress,
-								Op:      lib.UpdateStatus,
-								Options: &updateOptions,
-							}
-							if utils.GetInformers().RouteInformer != nil {
-								statusOption.ObjType = utils.OshiftRoute
-							}
-							status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
+func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_cache_obj *avicache.AviVsCache, key string) {
+	if restMethod == utils.RestPost || restMethod == utils.RestDelete {
+		for _, poolkey := range vs_cache_obj.PoolKeyCollection {
+			// Fetch the pool object from cache and check the service metadata
+			pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)
+			if ok {
+				utils.AviLog.Infof("key: %s, msg: found pool: %s, will update status", key, poolkey.Name)
+				pool_cache_obj, found := pool_cache.(*avicache.AviPoolCache)
+				if found {
+					IPAddrs := rest.GetIPAddrsFromCache(vs_cache_obj)
+					if len(IPAddrs) == 0 {
+						utils.AviLog.Debugf("key: %s, msg: Unable to find VIP corresponding to Pool %s", key, pool_cache_obj.Name)
+						continue
+					}
+					switch pool_cache_obj.ServiceMetadataObj.ServiceMetadataMapping("Pool") {
+					case lib.GatewayPool:
+						updateOptions := status.UpdateOptions{
+							Vip:                IPAddrs,
+							ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
+							Key:                key,
+							VirtualServiceUUID: vs_cache_obj.Uuid,
+							VSName:             vs_cache_obj.Name,
 						}
-
+						statusOption := status.StatusOptions{
+							ObjType: utils.L4LBService,
+							Op:      lib.UpdateStatus,
+							Options: &updateOptions,
+						}
+						status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
+					case lib.SNIInsecureOrEVHPool:
+						updateOptions := status.UpdateOptions{
+							Vip:                IPAddrs,
+							ServiceMetadata:    pool_cache_obj.ServiceMetadataObj,
+							Key:                key,
+							VirtualServiceUUID: vs_cache_obj.Uuid,
+							VSName:             vs_cache_obj.Name,
+						}
+						statusOption := status.StatusOptions{
+							ObjType: utils.Ingress,
+							Op:      lib.UpdateStatus,
+							Options: &updateOptions,
+						}
+						if utils.GetInformers().RouteInformer != nil {
+							statusOption.ObjType = utils.OshiftRoute
+						}
+						status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 					}
 				}
 			}
 		}
+	}
+}
 
-	} else {
-		IPAddrs := rest.GetIPAddrsFromCache(vs_cache_obj)
-		if svc_mdata_obj.Gateway != "" {
+func (rest *RestOperations) StatusUpdateForVS(vsCacheObj *avicache.AviVsCache, parentVsObj *avicache.AviVsCache, key string) {
+	IPAddrs := rest.GetIPAddrsFromCache(vsCacheObj)
+	serviceMetadataObj := vsCacheObj.ServiceMetadataObj
+	switch serviceMetadataObj.ServiceMetadataMapping("VS") {
+	case lib.GatewayVS:
+		updateOptions := status.UpdateOptions{
+			Vip:             IPAddrs,
+			ServiceMetadata: serviceMetadataObj,
+			Key:             key,
+			VSName:          vsCacheObj.Name,
+		}
+		statusOption := status.StatusOptions{
+			ObjType: lib.Gateway,
+			Op:      lib.UpdateStatus,
+			Options: &updateOptions,
+		}
+		if lib.UseServicesAPI() {
+			statusOption.ObjType = lib.SERVICES_API
+		}
+		status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
+	case lib.ServiceTypeLBVS:
+		updateOptions := status.UpdateOptions{
+			Vip:                IPAddrs,
+			ServiceMetadata:    serviceMetadataObj,
+			Key:                key,
+			VirtualServiceUUID: vsCacheObj.Uuid,
+			VSName:             vsCacheObj.Name,
+		}
+		statusOption := status.StatusOptions{
+			ObjType: utils.L4LBService,
+			Op:      lib.UpdateStatus,
+			Options: &updateOptions,
+		}
+		status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
+	case lib.ChildVS:
+		if parentVsObj != nil {
 			updateOptions := status.UpdateOptions{
-				Vip:             IPAddrs,
-				ServiceMetadata: *svc_mdata_obj,
-				Key:             key,
-				VSName:          vs_cache_obj.Name,
-			}
-			statusOption := status.StatusOptions{
-				ObjType: lib.Gateway,
-				Op:      lib.UpdateStatus,
-				Options: &updateOptions,
-			}
-			if lib.UseServicesAPI() {
-				statusOption.ObjType = lib.SERVICES_API
-			}
-			status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
-
-		} else if len(svc_mdata_obj.NamespaceServiceName) > 0 {
-			// This service needs an update of the status
-			updateOptions := status.UpdateOptions{
-				Vip:                IPAddrs,
-				ServiceMetadata:    *svc_mdata_obj,
+				Vip:                []string{parentVsObj.Vip},
+				ServiceMetadata:    serviceMetadataObj,
 				Key:                key,
-				VirtualServiceUUID: vs_cache_obj.Uuid,
-				VSName:             vs_cache_obj.Name,
-			}
-			statusOption := status.StatusOptions{
-				ObjType: utils.L4LBService,
-				Op:      lib.UpdateStatus,
-				Options: &updateOptions,
-			}
-			status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
-		} else if (svc_mdata_obj.IngressName != "" || len(svc_mdata_obj.NamespaceIngressName) > 0) && svc_mdata_obj.Namespace != "" && parentVsObj != nil {
-			var parentVsVips []string
-			parentVsVips = append(parentVsVips, parentVsObj.Vip)
-			updateOptions := status.UpdateOptions{
-				Vip:                parentVsVips,
-				ServiceMetadata:    *svc_mdata_obj,
-				Key:                key,
-				VirtualServiceUUID: vs_cache_obj.Uuid,
-				VSName:             vs_cache_obj.Name,
+				VirtualServiceUUID: vsCacheObj.Uuid,
+				VSName:             vsCacheObj.Name,
 			}
 			statusOption := status.StatusOptions{
 				ObjType: utils.Ingress,
@@ -472,9 +472,7 @@ func (rest *RestOperations) StatusUpdate(rest_op *utils.RestOp, vs_cache_obj *av
 			}
 			status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 		}
-
 	}
-	return nil
 }
 
 func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) error {
@@ -599,7 +597,8 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 
 				// This code is most likely hit when the first time a shard vs is created and the vs_cache_obj is populated from the pool update.
 				// But before this a pool may have got created as a part of the macro operation, so update the ingress status here.
-				rest.StatusUpdate(rest_op, vs_cache_obj, nil, parentVsObj, key, true)
+
+				rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
 			}
 
 		} else {
@@ -647,7 +646,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 			utils.AviLog.Infof("key: %s, msg: added VS cache key %v val %v", key, k, utils.Stringify(vs_cache_obj))
 		}
 
-		rest.StatusUpdate(rest_op, vs_cache_obj, &svc_mdata_obj, parentVsObj, key, false)
+		rest.StatusUpdateForVS(vs_cache_obj, parentVsObj, key)
 	}
 
 	return nil
@@ -688,7 +687,8 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				}
 			}
 
-			if vs_cache_obj.ServiceMetadataObj.Gateway != "" {
+			switch vs_cache_obj.ServiceMetadataObj.ServiceMetadataMapping("VS") {
+			case lib.GatewayVS:
 				updateOptions := status.UpdateOptions{
 					ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
 					Key:             key,
@@ -700,7 +700,12 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					Options: &updateOptions,
 				}
 				status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
-			} else if len(vs_cache_obj.ServiceMetadataObj.NamespaceServiceName) > 0 {
+				// The pools would have service metadata for backend services, corresponding to which
+				// statuses need to be deleted.
+				for _, poolKey := range vs_cache_obj.PoolKeyCollection {
+					rest.DeletePoolIngressStatus(poolKey, true, vs_cache_obj.Name, key)
+				}
+			case lib.ServiceTypeLBVS:
 				updateOptions := status.UpdateOptions{
 					ServiceMetadata:    vs_cache_obj.ServiceMetadataObj,
 					Key:                key,
@@ -713,10 +718,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					Options: &updateOptions,
 				}
 				status.PublishToStatusQueue(vs_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
-			}
-
-			if (vs_cache_obj.ServiceMetadataObj.IngressName != "" || len(vs_cache_obj.ServiceMetadataObj.NamespaceIngressName) > 0) && vs_cache_obj.ServiceMetadataObj.Namespace != "" {
-				// SNI VS deletion related ingress status update
+			case lib.ChildVS:
 				if !hostFoundInParentPool {
 					updateOptions := status.UpdateOptions{
 						ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
@@ -736,7 +738,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				}
 
 				status.HostRuleEventBroadcast(vs_cache_obj.Name, vs_cache_obj.ServiceMetadataObj.CRDStatus, lib.CRDMetadata{})
-			} else {
+			default:
 				// insecure ingress status updates in regular AKO.
 				for _, poolKey := range vs_cache_obj.PoolKeyCollection {
 					rest.DeletePoolIngressStatus(poolKey, true, vs_cache_obj.Name, key)
@@ -794,12 +796,22 @@ func (rest *RestOperations) isHostPresentInSharedPool(hostname string, parentVs 
 
 func (rest *RestOperations) GetIPAddrsFromCache(vsCache *avicache.AviVsCache) []string {
 	var IPAddrs []string
+	if len(vsCache.VSVipKeyCollection) == 0 {
+		parentVSKey := vsCache.ParentVSRef
+		parentCache, ok := rest.cache.VsCacheMeta.AviCacheGet(parentVSKey)
+		if ok {
+			parentCacheObj, _ := parentCache.(*avicache.AviVsCache)
+			if parentCacheObj != nil && parentCacheObj.Vip != "" {
+				IPAddrs = append(IPAddrs, parentCacheObj.Vip)
+			}
+		}
+	}
+
 	for _, vsvipkey := range vsCache.VSVipKeyCollection {
 		vsvip_cache, ok := rest.cache.VSVIPCache.AviCacheGet(vsvipkey)
 		if ok {
 			vsvip_cache_obj, found := vsvip_cache.(*avicache.AviVSVIPCache)
 			if found {
-
 				if len(vsvip_cache_obj.Fips) == 0 {
 					IPAddrs = vsvip_cache_obj.Vips
 				} else {
@@ -808,5 +820,6 @@ func (rest *RestOperations) GetIPAddrsFromCache(vsCache *avicache.AviVsCache) []
 			}
 		}
 	}
+
 	return IPAddrs
 }

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -504,7 +504,10 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 			if found {
 				vs_cache_obj.AddToVSVipKeyCollection(k)
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for VSVIP collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
-				rest.StatusUpdate(rest_op, vs_cache_obj, nil, nil, key, true)
+				if rest_op.Method == utils.RestPut {
+					rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
+					rest.StatusUpdateForVS(vs_cache_obj, nil, key)
+				}
 			}
 
 		} else {
@@ -512,7 +515,10 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 			vs_cache_obj.AddToVSVipKeyCollection(k)
 			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey,
 				vs_cache_obj))
-			rest.StatusUpdate(rest_op, vs_cache_obj, nil, nil, key, true)
+			if rest_op.Method == utils.RestPut {
+				rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
+				rest.StatusUpdateForVS(vs_cache_obj, nil, key)
+			}
 		}
 		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added vsvip cache k %v val %v", key, k,
 			vsvip_cache_obj))

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -506,7 +506,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for VSVIP collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				if rest_op.Method == utils.RestPut {
 					rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
-					rest.StatusUpdateForVS(vs_cache_obj, nil, key)
+					rest.StatusUpdateForVS(vs_cache_obj, key)
 				}
 			}
 
@@ -517,7 +517,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 				vs_cache_obj))
 			if rest_op.Method == utils.RestPut {
 				rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
-				rest.StatusUpdateForVS(vs_cache_obj, nil, key)
+				rest.StatusUpdateForVS(vs_cache_obj, key)
 			}
 		}
 		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added vsvip cache k %v val %v", key, k,

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -49,10 +49,9 @@ func (rest *RestOperations) SyncObjectStatuses() {
 
 		parentVsKey := vsCacheObj.ParentVSRef
 		vsSvcMetadataObj := vsCacheObj.ServiceMetadataObj
-		var IPAddrs []string
+		IPAddrs := rest.GetIPAddrsFromCache(vsCacheObj)
 		if vsSvcMetadataObj.Gateway != "" {
 			// gateway based VSes
-			IPAddrs = append(IPAddrs, vsCacheObj.Vip)
 			allGatewayUpdateOptions = append(allGatewayUpdateOptions,
 				status.UpdateOptions{
 					Vip:             IPAddrs,
@@ -79,11 +78,6 @@ func (rest *RestOperations) SyncObjectStatuses() {
 						continue
 					}
 					if poolCacheObj.ServiceMetadataObj.Namespace != "" {
-						if vsCacheObj.Fip != "" {
-							IPAddrs = append(IPAddrs, vsCacheObj.Fip)
-						} else {
-							IPAddrs = []string{parentVsObj.Vip}
-						}
 						allIngressUpdateOptions = append(allIngressUpdateOptions,
 							status.UpdateOptions{
 								Vip:                IPAddrs,
@@ -109,11 +103,6 @@ func (rest *RestOperations) SyncObjectStatuses() {
 
 				// insecure pools
 				if poolCacheObj.ServiceMetadataObj.Namespace != "" {
-					if vsCacheObj.Fip != "" {
-						IPAddrs = append(IPAddrs, vsCacheObj.Fip)
-					} else {
-						IPAddrs = []string{vsCacheObj.Vip}
-					}
 					allIngressUpdateOptions = append(allIngressUpdateOptions,
 						status.UpdateOptions{
 							Vip:                IPAddrs,
@@ -122,11 +111,6 @@ func (rest *RestOperations) SyncObjectStatuses() {
 							VirtualServiceUUID: vsCacheObj.Uuid,
 						})
 				} else if len(poolCacheObj.ServiceMetadataObj.NamespaceServiceName) > 0 {
-					if vsCacheObj.Fip != "" {
-						IPAddrs = append(IPAddrs, vsCacheObj.Fip)
-					} else {
-						IPAddrs = append(IPAddrs, vsCacheObj.Vip)
-					}
 					allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
 						status.UpdateOptions{
 							Vip:                IPAddrs,
@@ -139,12 +123,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		}
 
 		if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
-			var IPAddrsSvc []string
-			if vsCacheObj.Fip != "" {
-				IPAddrsSvc = append(IPAddrsSvc, vsCacheObj.Fip)
-			} else {
-				IPAddrsSvc = append(IPAddrsSvc, vsCacheObj.Vip)
-			}
+			IPAddrsSvc := rest.GetIPAddrsFromCache(vsCacheObj)
 			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
 				status.UpdateOptions{
 					Vip:                IPAddrsSvc,

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -318,8 +318,7 @@ func (rest *RestOperations) AviPkiProfileCacheDel(rest_op *utils.RestOp, poolKey
 	if poolKey != (avicache.NamespaceName{}) {
 		poolCache, ok := rest.cache.PoolCache.AviCacheGet(poolKey)
 		if ok {
-			poolCacheObj, found := poolCache.(*avicache.AviPoolCache)
-			if found {
+			if poolCacheObj, found := poolCache.(*avicache.AviPoolCache); found {
 				poolCacheObj.PkiProfileCollection = avicache.NamespaceName{}
 			}
 		}

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -24,7 +24,6 @@ import (
 
 	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -78,7 +77,7 @@ func UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 			if val, ok := skipDelete[gwNSName]; ok && val {
 				continue
 			}
-			DeleteGatewayStatusAddress(avicache.ServiceMetadataObj{
+			DeleteGatewayStatusAddress(lib.ServiceMetadataObj{
 				Gateway: gwNSName,
 			}, lib.SyncStatusKey)
 		}
@@ -99,7 +98,7 @@ func parseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, []U
 	return objectsToUpdate, updateGWOptions
 }
 
-func DeleteGatewayStatusAddress(svcMetadataObj avicache.ServiceMetadataObj, key string) error {
+func DeleteGatewayStatusAddress(svcMetadataObj lib.ServiceMetadataObj, key string) error {
 	gwNSName := strings.Split(svcMetadataObj.Gateway, "/")
 	if lib.GetAdvancedL4() {
 		gw, err := lib.AKOControlConfig().AdvL4Clientset().NetworkingV1alpha1pre1().Gateways(gwNSName[0]).Get(context.TODO(), gwNSName[1], metav1.GetOptions{})

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -39,7 +39,7 @@ type UpdateOptions struct {
 	// IngSvc format: namespace/name, not supposed to be provided by the caller
 	IngSvc             string
 	Vip                []string
-	ServiceMetadata    avicache.ServiceMetadataObj
+	ServiceMetadata    lib.ServiceMetadataObj
 	Key                string
 	VirtualServiceUUID string
 	VSName             string
@@ -84,7 +84,7 @@ func UpdateIngressStatus(options []UpdateOptions, bulk bool) {
 				hostnames = append(hostnames, rule.Host)
 			}
 			DeleteIngressStatus([]UpdateOptions{{
-				ServiceMetadata: avicache.ServiceMetadataObj{
+				ServiceMetadata: lib.ServiceMetadataObj{
 					NamespaceIngressName: []string{ingNSName},
 					HostNames:            hostnames,
 				},
@@ -403,7 +403,7 @@ func deleteObject(option UpdateOptions, key string, isVSDelete bool, retryNum ..
 	return nil
 }
 
-func deleteIngressAnnotation(ingObj *networkingv1.Ingress, svcMeta avicache.ServiceMetadataObj, isVSDelete bool,
+func deleteIngressAnnotation(ingObj *networkingv1.Ingress, svcMeta lib.ServiceMetadataObj, isVSDelete bool,
 	key string, mClient kubernetes.Interface, oldIng *networkingv1.Ingress,
 	ingHostList []string, retryNum ...int) error {
 	if ingObj == nil {

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -144,7 +143,7 @@ func UpdateRouteStatus(options []UpdateOptions, bulk bool) {
 				continue
 			}
 			DeleteRouteStatus([]UpdateOptions{{
-				ServiceMetadata: avicache.ServiceMetadataObj{
+				ServiceMetadata: lib.ServiceMetadataObj{
 					NamespaceIngressName: []string{routeNSName},
 					HostNames:            []string{route.Spec.Host},
 				},
@@ -588,7 +587,7 @@ func deleteRouteObject(option UpdateOptions, key string, isVSDelete bool, retryN
 	return deleteRouteAnnotation(updatedRoute, option.ServiceMetadata, isVSDelete, mRoute.Spec.Host, key, mRoute)
 }
 
-func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta avicache.ServiceMetadataObj, isVSDelete bool,
+func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta lib.ServiceMetadataObj, isVSDelete bool,
 	routeHost string, key string, oldRoute *routev1.Route, retryNum ...int) error {
 	if routeObj == nil {
 		routeObj = oldRoute

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -105,7 +105,7 @@ func UpdateL4LBStatus(options []UpdateOptions, bulk bool) {
 			if val, ok := skipDelete[svcNSName]; ok && val {
 				continue
 			}
-			DeleteL4LBStatus(avicache.ServiceMetadataObj{
+			DeleteL4LBStatus(lib.ServiceMetadataObj{
 				NamespaceServiceName: []string{svcNSName},
 			}, "", lib.SyncStatusKey)
 		}
@@ -154,7 +154,7 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 	return nil
 }
 
-func DeleteL4LBStatus(svc_mdata_obj avicache.ServiceMetadataObj, vsName, key string) error {
+func DeleteL4LBStatus(svc_mdata_obj lib.ServiceMetadataObj, vsName, key string) error {
 	serviceMap := getServices(svc_mdata_obj.NamespaceServiceName, false)
 	for _, service := range svc_mdata_obj.NamespaceServiceName {
 		serviceNSName := strings.Split(service, "/")

--- a/internal/status/svcapi_status.go
+++ b/internal/status/svcapi_status.go
@@ -23,7 +23,6 @@ import (
 
 	svcapiv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -75,7 +74,7 @@ func UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool) {
 			if val, ok := skipDelete[gwNSName]; ok && val {
 				continue
 			}
-			DeleteSvcApiGatewayStatusAddress("", avicache.ServiceMetadataObj{
+			DeleteSvcApiGatewayStatusAddress("", lib.ServiceMetadataObj{
 				Gateway: gwNSName,
 			})
 		}
@@ -159,7 +158,7 @@ func getSvcApiGateways(gwNSNames []string, bulk bool, retryNum ...int) map[strin
 	return gwMap
 }
 
-func DeleteSvcApiGatewayStatusAddress(key string, svcMetadataObj avicache.ServiceMetadataObj) error {
+func DeleteSvcApiGatewayStatusAddress(key string, svcMetadataObj lib.ServiceMetadataObj) error {
 	gwNSName := strings.Split(svcMetadataObj.Gateway, "/")
 	gw, err := lib.AKOControlConfig().ServicesAPIClientset().NetworkingV1alpha1().Gateways(gwNSName[0]).Get(context.TODO(), gwNSName[1], metav1.GetOptions{})
 	if err != nil {
@@ -186,7 +185,7 @@ func DeleteSvcApiGatewayStatusAddress(key string, svcMetadataObj avicache.Servic
 	return nil
 }
 
-func DeleteSvcApiStatus(key string, svcMetadataObj avicache.ServiceMetadataObj) error {
+func DeleteSvcApiStatus(key string, svcMetadataObj lib.ServiceMetadataObj) error {
 	gwNSName := strings.Split(svcMetadataObj.Gateway, "/")
 	gw, err := lib.AKOControlConfig().ServicesAPIClientset().NetworkingV1alpha1().Gateways(gwNSName[0]).Get(context.TODO(), gwNSName[1], metav1.GetOptions{})
 	if err != nil {

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -383,7 +383,7 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		return nodes[0].EvhNodes[0].SSLKeyCertAviRef
-	}, 30*time.Second).Should(gomega.ContainSubstring("thisisaviref"))
+	}, 50*time.Second).Should(gomega.ContainSubstring("thisisaviref"))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -1657,7 +1657,7 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 		g.Eventually(func() int {
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 			return len(nodes[0].EvhNodes)
-		}, 15*time.Second).Should(gomega.Equal(1))
+		}, 30*time.Second).Should(gomega.Equal(1))
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}

--- a/tests/ingresstests/l7_rest_test.go
+++ b/tests/ingresstests/l7_rest_test.go
@@ -373,7 +373,7 @@ func TestCreateSNICacheSync(t *testing.T) {
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 		return found
-	}, 10*time.Second).Should(gomega.Equal(true))
+	}, 20*time.Second).Should(gomega.Equal(true))
 	parentCache, _ := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
 	parentCacheObj, _ := parentCache.(*cache.AviVsCache)
 	g.Expect(parentCacheObj.SNIChildCollection).To(gomega.HaveLen(1))


### PR DESCRIPTION
This commit simplifies switching mechanisms for status updates
based on the serviceMetadata information, and helps identify
corresponding to which object the status update is bound for.
Fixes include - not allowing status update for SNI VS pools,
correct status update logic in case of vsvip updates.
Fixes: AV-128633