### PR TITLE
Update annotation in AKO statefulset after avi object deletion through deleteConfig

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -151,7 +151,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			lib.SetGRBACSupport()
 			delModels := delConfigFromData(cm.Data)
 			if !delModels {
-				status.ResetStatefulSetStatus()
+				status.ResetStatefulSetAnnotation()
 			}
 			c.DisableSync = !avicache.ValidateUserInput(aviclient) || delModels
 			lib.SetDisableSync(c.DisableSync)
@@ -184,7 +184,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 						avicache.DeConfigureSeGroupLabels()
 					}
 				} else {
-					status.ResetStatefulSetStatus()
+					status.ResetStatefulSetAnnotation()
 					quickSyncCh <- struct{}{}
 				}
 			}
@@ -856,12 +856,12 @@ func (c *AviController) FullSyncK8s() error {
 // The rest layer would pick up the model key and delete the objects in Avi
 func (c *AviController) DeleteModels() {
 	utils.AviLog.Infof("Deletion of all avi objects triggered")
-	status.AddStatefulSetStatus(lib.ObjectDeletionStartStatus, corev1.ConditionTrue)
+	status.AddStatefulSetAnnotation(lib.ObjectDeletionStartStatus)
 	allModels := objects.SharedAviGraphLister().GetAll()
 	allModelsMap := allModels.(map[string]interface{})
 	if len(allModelsMap) == 0 {
 		utils.AviLog.Infof("No Avi Object to delete, status would be updated in Statefulset")
-		status.AddStatefulSetStatus(lib.ObjectDeletionDoneStatus, corev1.ConditionFalse)
+		status.AddStatefulSetAnnotation(lib.ObjectDeletionDoneStatus)
 		return
 	}
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
@@ -895,10 +895,10 @@ func (c *AviController) DeleteModels() {
 	lib.SetConfigDeleteSyncChan()
 	select {
 	case <-lib.ConfigDeleteSyncChan:
-		status.AddStatefulSetStatus(lib.ObjectDeletionDoneStatus, corev1.ConditionFalse)
+		status.AddStatefulSetAnnotation(lib.ObjectDeletionDoneStatus)
 		utils.AviLog.Infof("Processing done for deleteConfig, user would be notified through statefulset update")
 	case <-timeout:
-		status.AddStatefulSetStatus(lib.ObjectDeletionTimeoutStatus, corev1.ConditionUnknown)
+		status.AddStatefulSetAnnotation(lib.ObjectDeletionTimeoutStatus)
 		utils.AviLog.Warnf("Timed out while waiting for rest layer to respond for delete config")
 	}
 

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -16,29 +16,16 @@ package status
 
 import (
 	"context"
+	"encoding/json"
 
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-var msgForReason = map[string]string{
-	lib.ObjectDeletionStartStatus:   "Started deleting objects",
-	lib.ObjectDeletionDoneStatus:    "Successfully deleted all objects",
-	lib.ObjectDeletionTimeoutStatus: "Error, timed out while deleting objects",
-}
-
-func msgFoundInStatus(conditions []appsv1.StatefulSetCondition, msg string) bool {
-	for _, c := range conditions {
-		if c.Type == lib.AKOConditionType && c.Message == msg {
-			return true
-		}
-	}
-	return false
-}
+const ObjectDeletionStatus = "AviObjectDeletionStatus"
 
 // ResetStatefulSetStatus removes the condition set by AKO from AKO statefulset
 func ResetStatefulSetStatus() {
@@ -68,52 +55,69 @@ func ResetStatefulSetStatus() {
 	utils.AviLog.Debugf("Successfully reset ako statefulset: %v", u)
 }
 
-// AddStatefulSetStatus sets a condition in status of AKO statefulset to the desired value
-func AddStatefulSetStatus(reason string, statusCondition v1.ConditionStatus) {
+func ResetStatefulSetAnnotation() {
+	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
+	if err != nil {
+		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
+		return
+	}
+	ann := ss.GetAnnotations()
+	if ann == nil {
+		return
+	}
+	if _, ok := ann[ObjectDeletionStatus]; !ok {
+		return
+	}
+	payloadValue := make(map[string]*string)
+	// To delete an annotation with patch call, the value has to be set to nil
+	payloadValue[ObjectDeletionStatus] = nil
+
+	patchPayload := map[string]interface{}{
+		"metadata": map[string]map[string]*string{
+			"annotations": payloadValue,
+		},
+	}
+	payloadBytes, _ := json.Marshal(patchPayload)
+	_, err = utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Patch(context.TODO(), ss.Name, types.MergePatchType, payloadBytes, metav1.PatchOptions{})
+
+	if err != nil {
+		utils.AviLog.Warnf("Error in patching ako statefulset: %v", err)
+		return
+	}
+	utils.AviLog.Infof("Successfully removed annotation %s from ako statefulset", ObjectDeletionStatus)
+
+	//Remove any status from previous versions of AKO
+	ResetStatefulSetStatus()
+}
+
+func AddStatefulSetAnnotation(reason string) {
 	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
 		return
 	}
 
-	msg, ok := msgForReason[reason]
-	if !ok {
-		utils.AviLog.Warnf("Unknown reason %s for statefulset status", reason)
-		return
+	ann := ss.GetAnnotations()
+	if ann == nil {
+		ann = make(map[string]string)
 	}
-
-	if msgFoundInStatus(ss.Status.Conditions, msg) {
-		return
-	}
-
-	var foundCondition bool
-	currentTime := metav1.Now()
-	for i, c := range ss.Status.Conditions {
-		if c.Type == lib.AKOConditionType {
-			ss.Status.Conditions[i].Reason = reason
-			ss.Status.Conditions[i].Message = msg
-			ss.Status.Conditions[i].Status = statusCondition
-			ss.Status.Conditions[i].LastTransitionTime = currentTime
-			foundCondition = true
-			break
+	if val, ok := ann[ObjectDeletionStatus]; ok {
+		if val == reason {
+			return
 		}
 	}
-
-	if !foundCondition {
-		cond := appsv1.StatefulSetCondition{
-			Type:               lib.AKOConditionType,
-			Status:             statusCondition,
-			Reason:             reason,
-			Message:            msg,
-			LastTransitionTime: currentTime,
-		}
-		ss.Status.Conditions = append(ss.Status.Conditions, cond)
+	ann[ObjectDeletionStatus] = reason
+	patchPayload := map[string]interface{}{
+		"metadata": map[string]map[string]string{
+			"annotations": ann,
+		},
 	}
+	payloadBytes, _ := json.Marshal(patchPayload)
+	_, err = utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Patch(context.TODO(), ss.Name, types.MergePatchType, payloadBytes, metav1.PatchOptions{})
 
-	u, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).UpdateStatus(context.TODO(), ss, metav1.UpdateOptions{})
 	if err != nil {
-		utils.AviLog.Warnf("Error in patching ako statefulset: %v", err)
+		utils.AviLog.Warnf("Error in patching ako statefulset annotation: %v", err)
 		return
 	}
-	utils.AviLog.Debugf("Successfully updated ako statefulset: %v", u)
+	utils.AviLog.Debugf("Successfully updated annotation %s in ako statefulset", ObjectDeletionStatus)
 }


### PR DESCRIPTION
Currently status of ako statefulset is updated with condition values after objects are deleted
by setting deleteConfig to true. However, in kubernetes 1.22 this can not be done because kubernetes
automatically removes this status. To get around this problem annotation of the statefulset would be
updated instead of status.

When object deletion starts we would set the annotation as:
  annotations:
    ObjectDeletionStatus: Started

After object deletion is completed, this would be changed to
    ObjectDeletionStatus: Done