### PR TITLE
Read Avi Controller IP from bootstrap CR in VCF environment

### DIFF
--- a/Dockerfile.ako-infra
+++ b/Dockerfile.ako-infra
@@ -1,0 +1,23 @@
+ARG golang_src_repo=golang:latest
+ARG photon_src_repo=photon:latest
+FROM ${golang_src_repo} as build
+ARG AKO_LDFLAGS=
+ENV BUILD_PATH="github.com/vmware/load-balancer-and-ingress-services-for-kubernetes"
+RUN mkdir -p $GOPATH/src/$BUILD_PATH
+
+COPY . $GOPATH/src/$BUILD_PATH
+WORKDIR $GOPATH/src/$BUILD_PATH
+
+RUN GOARCH=amd64 \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    go build -o $GOPATH/bin/ako-infra \
+    -ldflags "$AKO_LDFLAGS" \
+    -mod=vendor \
+    $BUILD_PATH/cmd/infra-main
+
+FROM ${photon_src_repo}
+RUN yum install -y tar.x86_64
+COPY --from=build /go/bin/ako-infra .
+EXPOSE 8080
+ENTRYPOINT ["./ako-infra"]

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,15 @@ docker: glob-vars
 	$(BUILD_ARG_GOLANG) $(BUILD_ARG_PHOTON) $(BUILD_ARG_AKO_LDFLAGS) \
 	-f Dockerfile.ako .
 
+.PHONY: ako-infra-docker
+ako-infra-docker: glob-vars
+	sudo docker build \
+	-t $(BINARY_NAME_AKO_INFRA):latest \
+	--label "BUILD_TAG=$(BUILD_TAG)" \
+	--label "BUILD_TIME=$(BUILD_TIME)" \
+	$(BUILD_ARG_GOLANG) $(BUILD_ARG_PHOTON) $(BUILD_ARG_AKO_LDFLAGS) \
+	-f Dockerfile.ako-infra .
+
 .PHONY: ako-operator-docker
 ako-operator-docker: glob-vars
 	sudo docker build \

--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -15,8 +15,6 @@
 package cache
 
 import (
-	"os"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -36,7 +34,7 @@ func SharedAVIClients() *utils.AviRestClientPool {
 	ctrlUsername := ctrlProp[utils.ENV_CTRL_USERNAME]
 	ctrlPassword := ctrlProp[utils.ENV_CTRL_PASSWORD]
 	ctrlAuthToken := ctrlProp[utils.ENV_CTRL_AUTHTOKEN]
-	ctrlIpAddress := os.Getenv(utils.ENV_CTRL_IPADDRESS)
+	ctrlIpAddress := lib.GetControllerIP()
 	if ctrlUsername == "" || (ctrlPassword == "" && ctrlAuthToken == "") || ctrlIpAddress == "" {
 		var passwordLog, authTokenLog string
 		if ctrlPassword != "" {

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -162,7 +162,7 @@ func NewAviRestClientWithToken(api_ep string, username string, authToken string)
 	var transport *http.Transport
 	var err error
 
-	ctrlIpAddress := os.Getenv(utils.ENV_CTRL_IPADDRESS)
+	ctrlIpAddress := GetControllerIP()
 	if username == "" || authToken == "" || ctrlIpAddress == "" {
 		var authTokenLog string
 		if authToken != "" {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1410,7 +1410,7 @@ func RefreshAuthToken(kc kubernetes.Interface) {
 	ctrlProp := utils.SharedCtrlProp().GetAllCtrlProp()
 	ctrlUsername := ctrlProp[utils.ENV_CTRL_USERNAME]
 	ctrlAuthToken := ctrlProp[utils.ENV_CTRL_AUTHTOKEN]
-	ctrlIpAddress := os.Getenv(utils.ENV_CTRL_IPADDRESS)
+	ctrlIpAddress := GetControllerIP()
 
 	aviClient := NewAviRestClientWithToken(ctrlIpAddress, ctrlUsername, ctrlAuthToken)
 	if aviClient == nil {
@@ -1512,6 +1512,19 @@ func GetK8sMaxSupportedVersion() string {
 func VIPPerNamespace() bool {
 	vipPerNS := os.Getenv(VIP_PER_NAMESPACE)
 	return vipPerNS == "true"
+}
+
+var controllerIP string
+
+func GetControllerIP() string {
+	if controllerIP == "" {
+		SetControllerIP(os.Getenv(utils.ENV_CTRL_IPADDRESS))
+	}
+	return controllerIP
+}
+
+func SetControllerIP(ctrlIP string) {
+	controllerIP = ctrlIP
 }
 
 var VCFInitialized bool


### PR DESCRIPTION
In VCF controller details won't be provided through configmap, instead
it would be provided via bootstrap CRD. Added neccessary changes.

Also added makefile changes to build ako-infra docker container.