### PR TITLE
Analytics policy support to parent VS's Hostrule CRD

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -77,6 +77,26 @@ spec:
                     type: object
                   wafPolicy:
                     type: string
+                  analyticsPolicy:
+                    properties:
+                      fullClientLogs:
+                        properties:
+                          enabled:
+                            type: boolean
+                            default: false
+                          throttle:
+                            enum:
+                            - LOW
+                            - MEDIUM
+                            - HIGH
+                            - DISABLED
+                            default: HIGH
+                            type: string
+                        type: object
+                      logAllHeaders:
+                        type: boolean
+                        default: false
+                    type: object
                 required:
                 - fqdn
                 type: object

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -346,6 +346,8 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 			vsDownOnPoolDown := true
 			vs.RemoveListeningPortOnVsDown = &vsDownOnPoolDown
 		}
+		vs.AnalyticsPolicy = vs_meta.GetAnalyticsPolicy()
+
 		var rest_ops []*utils.RestOp
 
 		var rest_op utils.RestOp

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -180,6 +180,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			}
 			vs.L4Policies = l4Policies
 		}
+		vs.AnalyticsPolicy = vs_meta.GetAnalyticsPolicy()
 
 		var rest_ops []*utils.RestOp
 


### PR DESCRIPTION
This commits adds analytics policy support to parent VS's Hostrule CRD.