### PR TITLE
Fix for child FQDNs not getting removed from parent VS

### DIFF
--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -428,6 +428,7 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 		if len(ingressHostMap.GetIngressesForHostName(sniHost)) == 0 {
 			RemoveSniInModel(sniNode.Name, vsNode, key)
 			RemoveRedirectHTTPPolicyInModel(vsNode[0], sniHostToRemove, key)
+			RemoveFQDNsFromModel(vsNode[0], sniHosts, key)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the issue of child FQDNs not getting removed from parent VSes when the secret is removed from the k8s.