### PR TITLE
Handling non admin tenant with SE_in_provider_context set

### DIFF
--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -119,6 +119,7 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 }
 
 func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
+
 	err, seGroup := lib.FetchSEGroupWithMarkerSet(a.AviRestClients.AviClient[0])
 	if err == nil && seGroup != "" {
 		utils.AviLog.Infof("SE Group: %s already configured with the marker labels: %s", seGroup, lib.GetClusterID())
@@ -130,9 +131,11 @@ func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
 	}
 	utils.AviLog.Infof("Obtained matching cloud to be used: %s", cloudName)
 	utils.SetCloudName(cloudName)
+
 	if checkSeGroup(a.AviRestClients.AviClient[0], cloudName) {
 		return true
 	}
+
 	var uri string
 	if segUuid == "" {
 		// The cloud does not have a SEG template set, use `Default-Group`
@@ -142,10 +145,18 @@ func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
 		// The cloud does not have a SEG template set, use `Default-Group`
 		uri = "/api/serviceenginegroup/" + segUuid
 	}
-	result, err := lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
+	var result session.AviCollectionResult
+	result, err = lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
 	if err != nil {
-		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
-		return false
+		SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+		SetTenant := session.SetTenant(lib.GetTenant())
+		SetAdminTenant(a.AviRestClients.AviClient[0].AviSession)
+		defer SetTenant(a.AviRestClients.AviClient[0].AviSession)
+		result, err = lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
+		if err != nil {
+			utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+			return false
+		}
 	}
 	// Construct an SE group based on parameters in the `Default-Group`
 	elems := make([]json.RawMessage, result.Count)
@@ -178,18 +189,23 @@ func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGr
 	// Add the labels.
 	seGroup.Labels = lib.GetLabels()
 	response := models.ServiceEngineGroupAPIResponse{}
+	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+	SetTenant := session.SetTenant(lib.GetTenant())
 	// If tenants per cluster is enabled then the X-Avi-Tenant needs to be set to admin for vrfcontext and segroup updates
 	if lib.GetTenantsPerCluster() && lib.IsCloudInAdminTenant {
-		SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
-		SetTenant := session.SetTenant(lib.GetTenant())
 		SetAdminTenant(client.AviSession)
 		defer SetTenant(client.AviSession)
 	}
 
 	err := lib.AviPost(client, uri, seGroup, response)
 	if err != nil {
-		utils.AviLog.Warnf("Error during POST call to create the SE group :%v", err.Error())
-		return false
+		SetAdminTenant(client.AviSession)
+		defer SetTenant(client.AviSession)
+		err := lib.AviPost(client, uri, seGroup, response)
+		if err != nil {
+			utils.AviLog.Warnf("Error during POST call to create the SE group :%v", err.Error())
+			return false
+		}
 	}
 	utils.AviLog.Infof("labels: %v set on Service Engine Group :%v", utils.Stringify(lib.GetLabels()), *seGroup.Name)
 	return true
@@ -203,8 +219,15 @@ func checkSeGroup(client *clients.AviClient, cloudName string) bool {
 	response := models.ServiceEngineGroupAPIResponse{}
 	err := lib.AviGet(client, uri, &response)
 	if err != nil {
-		utils.AviLog.Warnf("Error during Get call for the SE group :%v", err.Error())
-		return false
+		SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+		SetTenant := session.SetTenant(lib.GetTenant())
+		SetAdminTenant(client.AviSession)
+		defer SetTenant(client.AviSession)
+		err := lib.AviGet(client, uri, &response)
+		if err != nil {
+			utils.AviLog.Warnf("Error during Get call for the SE group :%v", err.Error())
+			return false
+		}
 	}
 	utils.AviLog.Infof("Found Service Engine Group :%v", segroupName)
 	return true

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2599,12 +2599,21 @@ func validateAndConfigureSeGroup(client *clients.AviClient, returnErr *error) bo
 	}
 	seGroupSet.Insert(lib.GetSEGName())
 
+	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+	SetTenant := session.SetTenant(lib.GetTenant())
+
 	// This assumes that a single cluster won't use more than 100 distinct SEGroups.
 	uri := "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName + "&name.in=" + strings.Join(seGroupSet.List(), ",")
+	var result session.AviCollectionResult
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
-		*returnErr = fmt.Errorf("Get uri %v returned err %v", uri, err)
-		return false
+		SetAdminTenant(client.AviSession)
+		defer SetTenant(client.AviSession)
+		result, err = lib.AviGetCollectionRaw(client, uri)
+		if err != nil {
+			*returnErr = fmt.Errorf("Get uri %v returned err %v", uri, err)
+			return false
+		}
 	}
 
 	elems := make([]json.RawMessage, result.Count)
@@ -2636,22 +2645,25 @@ func validateAndConfigureSeGroup(client *clients.AviClient, returnErr *error) bo
 func ConfigureSeGroupLabels(client *clients.AviClient, seGroup *models.ServiceEngineGroup) error {
 	labels := seGroup.Labels
 	segName := *seGroup.Name
-
+	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+	SetTenant := session.SetTenant(lib.GetTenant())
 	if len(labels) == 0 {
 		uri := "/api/serviceenginegroup/" + *seGroup.UUID
 		seGroup.Labels = lib.GetLabels()
 		response := models.ServiceEngineGroupAPIResponse{}
 		// If tenants per cluster is enabled then the X-Avi-Tenant needs to be set to admin for vrfcontext and segroup updates
 		if lib.GetTenantsPerCluster() && lib.IsCloudInAdminTenant {
-			SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
-			SetTenant := session.SetTenant(lib.GetTenant())
 			SetAdminTenant(client.AviSession)
 			defer SetTenant(client.AviSession)
 		}
-
 		err := lib.AviPut(client, uri, seGroup, response)
 		if err != nil {
-			return fmt.Errorf("Setting labels on Service Engine Group :%v failed with error :%v. Expected Labels: %v", segName, err.Error(), utils.Stringify(lib.GetLabels()))
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			err := lib.AviPut(client, uri, seGroup, response)
+			if err != nil {
+				return fmt.Errorf("Setting labels on Service Engine Group :%v failed with error :%v. Expected Labels: %v", segName, err.Error(), utils.Stringify(lib.GetLabels()))
+			}
 		}
 		utils.AviLog.Infof("labels: %v set on Service Engine Group :%v", utils.Stringify(lib.GetLabels()), segName)
 		return nil
@@ -2674,6 +2686,8 @@ func DeConfigureSeGroupLabels() {
 	clients := SharedAVIClients()
 	aviClientLen := lib.GetshardSize()
 	client := clients.AviClient[aviClientLen-1]
+	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+	SetTenant := session.SetTenant(lib.GetTenant())
 	seGroup, err := GetAviSeGroup(client, segName)
 	if err != nil {
 		utils.AviLog.Error(err)
@@ -2689,27 +2703,39 @@ func DeConfigureSeGroupLabels() {
 	utils.AviLog.Infof("Updating the following labels: %v, on the SE Group", utils.Stringify(seGroup.Labels))
 	uri := "/api/serviceenginegroup/" + *seGroup.UUID
 	response := models.ServiceEngineGroupAPIResponse{}
+
 	// If tenants per cluster is enabled then the X-Avi-Tenant needs to be set to admin for vrfcontext and segroup updates
 	if lib.GetTenantsPerCluster() && lib.IsCloudInAdminTenant {
-		SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
-		SetTenant := session.SetTenant(lib.GetTenant())
 		SetAdminTenant(client.AviSession)
 		defer SetTenant(client.AviSession)
 	}
 
 	err = lib.AviPut(client, uri, seGroup, response)
 	if err != nil {
-		utils.AviLog.Warnf("Deconfiguring SE Group labels failed on %v with error %v", segName, err.Error())
-		return
+		SetAdminTenant(client.AviSession)
+		defer SetTenant(client.AviSession)
+		err = lib.AviPut(client, uri, seGroup, response)
+		if err != nil {
+			utils.AviLog.Warnf("Deconfiguring SE Group labels failed on %v with error %v", segName, err.Error())
+			return
+		}
 	}
 	utils.AviLog.Infof("Successfully deconfigured SE Group labels  on %v", segName)
 }
 
 func GetAviSeGroup(client *clients.AviClient, segName string) (*models.ServiceEngineGroup, error) {
+	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+	SetTenant := session.SetTenant(lib.GetTenant())
 	uri := "/api/serviceenginegroup/?include_name&name=" + segName + "&cloud_ref.name=" + utils.CloudName
+	var result session.AviCollectionResult
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
-		return nil, fmt.Errorf("Get uri %v returned err %v", uri, err)
+		SetAdminTenant(client.AviSession)
+		defer SetTenant(client.AviSession)
+		result, err = lib.AviGetCollectionRaw(client, uri)
+		if err != nil {
+			return nil, fmt.Errorf("Get uri %v returned err %v", uri, err)
+		}
 	}
 
 	if result.Count != 1 {

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -44,7 +44,9 @@ func AviGetCollectionRaw(client *clients.AviClient, uri string, retryNum ...int)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to fetch collection data from uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
-		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			return session.AviCollectionResult{}, err
+		}
 		return AviGetCollectionRaw(client, uri, retry+1)
 	}
 
@@ -67,6 +69,9 @@ func AviGet(client *clients.AviClient, uri string, response interface{}, retryNu
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			return err
+		}
 		return AviGet(client, uri, response, retry+1)
 	}
 
@@ -89,6 +94,9 @@ func AviGetRaw(client *clients.AviClient, uri string, retryNum ...int) ([]byte, 
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			return nil, err
+		}
 		return AviGetRaw(client, uri, retry+1)
 	}
 
@@ -111,6 +119,9 @@ func AviPut(client *clients.AviClient, uri string, payload interface{}, response
 		utils.AviLog.Warnf("msg: Unable to execute Put on uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 400 {
+			return err
+		}
 		return AviPut(client, uri, payload, response, retry+1)
 	}
 
@@ -133,6 +144,9 @@ func AviPost(client *clients.AviClient, uri string, payload interface{}, respons
 		utils.AviLog.Warnf("msg: Unable to execute Post on uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			return err
+		}
 		return AviPost(client, uri, payload, response, retry+1)
 	}
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -693,12 +693,20 @@ func FetchSEGroupWithMarkerSet(client *clients.AviClient, overrideUri ...NextPag
 	var result session.AviCollectionResult
 	result, err := AviGetCollectionRaw(client, uri)
 	if err != nil {
-		SetAdminTenant := session.SetTenant(GetAdminTenant())
-		SetTenant := session.SetTenant(GetTenant())
-		SetAdminTenant(client.AviSession)
-		defer SetTenant(client.AviSession)
-		result, err = AviGetCollectionRaw(client, uri)
-		if err != nil {
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			//SE in provider context no read access
+			utils.AviLog.Debugf("Switching to admin context from  %s", GetTenant())
+			SetAdminTenant := session.SetTenant(GetAdminTenant())
+			SetTenant := session.SetTenant(GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			result, err = AviGetCollectionRaw(client, uri)
+			if err != nil {
+				utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+				return err, ""
+
+			}
+		} else {
 			utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
 			return err, ""
 		}


### PR DESCRIPTION
When any SE group related op fails with provided tenant(GET/PUT), an assumption is made that the tenant is configured with se_in_provider_context set to True on the AVI controller.
A context switch is then done for the session and the operation is retried.