### PR TITLE
kube-builder tags to access CRDs for VCF

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -42,9 +42,11 @@ var ctrlonce sync.Once
 
 // These tags below are only applicable in case of advanced L4 features at the moment.
 
+// +kubebuilder:rbac:groups=ncp.vmware.com,resources=akobootstrapconditions;akobootstrapconditions/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nsx.vmware.com,resources=namespacenetworkinfos;namespacenetworkinfos/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gateways;gateways/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses;gatewayclasses/status,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=core,resources=services;services/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;


### PR DESCRIPTION
in VCF cluster, ako needs permission to access namespacenetworkinfos and akobootstrapconditions