### PR TITLE
Fix: VSes not getting deleted from AVI Controller after Route deletion from cluster

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -954,18 +954,6 @@ func (c *AviController) FullSyncK8s() error {
 	syncNamespace := lib.GetNamespaceToSync()
 	for _, vsCacheKey := range vsKeys {
 		modelName := vsCacheKey.Namespace + "/" + vsCacheKey.Name
-		ok, _ := objects.SharedAviGraphLister().Get(modelName)
-		if !ok {
-			utils.AviLog.Warnf("key: %s, msg: no model found for the key", modelName)
-			// In the case of L7 shared VS, the following condition check makes sure the
-			// VIPs persist over AKO reboot.
-			if lib.IsShardVS(modelName) {
-				// Save the model in the cache as it is required when the user
-				// sets the deleteconfig flag to `true`.
-				objects.SharedAviGraphLister().Save(modelName, nil)
-				continue
-			}
-		}
 		// Reverse map the model key from this.
 		if syncNamespace != "" {
 			shardVsPrefix := lib.ShardVSPrefix

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -72,6 +72,9 @@ func (rest *RestOperations) DequeueNodes(key string) {
 			// In the case of L7 shared VS, the following condition check makes sure the
 			// VIPs persist over AKO reboot.
 			if lib.IsShardVS(key) && !lib.DisableSync {
+				// Save the model in the cache as it is required when the user
+				// sets the deleteconfig flag to `true`.
+				objects.SharedAviGraphLister().Save(key, nil)
 				utils.AviLog.Infof("key: %s, VIPs needs to be retained, not performing vs deletion", key)
 				return
 			}

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -69,6 +69,12 @@ func (rest *RestOperations) DequeueNodes(key string) {
 		}
 		if vs_cache_obj != nil {
 			utils.AviLog.Infof("key: %s, msg: nil model found, this is a vs deletion case", key)
+			// In the case of L7 shared VS, the following condition check makes sure the
+			// VIPs persist over AKO reboot.
+			if lib.IsShardVS(key) && !lib.DisableSync {
+				utils.AviLog.Infof("key: %s, VIPs needs to be retained, not performing vs deletion", key)
+				return
+			}
 			rest.deleteVSOper(vsKey, vs_cache_obj, namespace, key, false, false)
 		}
 	} else if ok && avimodelIntf != nil {


### PR DESCRIPTION
This PR fixes the issue of VSes not getting deleted from AVI Controller after Route deletion from the cluster.