### PR TITLE
Donot create dedicated VS if gateway labels are present on the service

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -349,6 +349,11 @@ func GetAdvL4PoolName(svcName, namespace, gwName string, port int32) string {
 	return Encode(poolName, L4AdvPool)
 }
 
+func GetSvcApiL4PoolName(svcName, namespace, gwName, protocol string, port int32) string {
+	poolName := NamePrefix + namespace + "-" + svcName + "-" + gwName + "-" + protocol + "-" + strconv.Itoa(int(port))
+	return Encode(poolName, L4AdvPool)
+}
+
 // All L7 object names.
 func GetVsVipName(vsName string) string {
 	vsVipName := vsName

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -292,8 +292,12 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			svcFQDN = getAutoFQDNForService(svcNSName[0], svcNSName[1])
 		}
 
+		poolName := lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port))
+		if lib.UseServicesAPI() {
+			poolName = lib.GetSvcApiL4PoolName(svcNSName[1], namespace, gwName, portProto[0], int32(port))
+		}
 		poolNode := &AviPoolNode{
-			Name:     lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port)),
+			Name:     poolName,
 			Tenant:   lib.GetTenant(),
 			Protocol: portProto[0],
 			PortName: "",

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -150,7 +150,7 @@ func DequeueIngestion(key string, fullsync bool) {
 
 	// handle the services APIs
 	if (lib.GetAdvancedL4() && objType == utils.L4LBService) ||
-		(lib.UseServicesAPI() && objType == utils.Service) ||
+		(lib.UseServicesAPI() && (objType == utils.Service || objType == utils.L4LBService)) ||
 		((lib.GetAdvancedL4() || lib.UseServicesAPI()) && (objType == lib.Gateway || objType == lib.GatewayClass || objType == utils.Endpoints || objType == lib.AviInfraSetting)) {
 		if !valid && objType == utils.L4LBService {
 			// Required for advl4 schemas.
@@ -543,13 +543,29 @@ func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.Work
 
 func isServiceDelete(svcName string, namespace string, key string) bool {
 	// If the service is not found we return true.
-	_, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
+	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
 	if err != nil {
 		utils.AviLog.Warnf("key: %s, msg: could not retrieve the object for service: %s", key, err)
 		if errors.IsNotFound(err) {
 			return true
 		}
 	}
+
+	var gwNameLabel, gwNamespaceLabel string
+	if lib.GetAdvancedL4() {
+		gwNameLabel = lib.GatewayNameLabelKey
+		gwNamespaceLabel = lib.GatewayNamespaceLabelKey
+	} else if lib.UseServicesAPI() {
+		gwNameLabel = lib.SvcApiGatewayNameLabelKey
+		gwNamespaceLabel = lib.SvcApiGatewayNamespaceLabelKey
+	}
+
+	_, nok := service.Labels[gwNameLabel]
+	_, nsok := service.Labels[gwNamespaceLabel]
+	if nsok || nok {
+		return true
+	}
+
 	return false
 }
 

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -782,8 +782,11 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 		g.Eventually(func() string {
 			_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-			return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
-		}, 10*time.Second).Should(gomega.Equal("2.2.2.1"))
+			if len(nodes) > 0 && len(nodes[0].EvhNodes) > 0 && len(nodes[0].EvhNodes[0].PoolRefs) > 0 {
+				return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
+			}
+			return ""
+		}, 15*time.Second).Should(gomega.Equal("2.2.2.1"))
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 	} else {

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -362,7 +362,7 @@ func TestServicesAPINamingConvention(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--default-my-gateway"))
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-svc-my-gateway--8081"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-svc-my-gateway-TCP-8081"))
 	g.Expect(nodes[0].L4PolicyRefs[0].Name).To(gomega.Equal("cluster--default-my-gateway"))
 
 	TeardownGatewayClass(t, gwClassName)


### PR DESCRIPTION
This commit avoids creating an extra dedicated VS, when services API is
being used and a gateway frontends the service of type LB. This would mean
an either/or workflow, decided by the presence of labesl on the k8s Service.