### PR TITLE
Remove advanced_l4 from helm

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -27,11 +27,7 @@ data:
   nsxtT1LR: {{ .Values.NetworkSettings.nsxtT1LR | quote }}
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
-  advancedL4: {{ .Values.L4Settings.advancedL4 | quote }}
   autoFQDN: {{ .Values.L4Settings.autoFQDN | quote }}
-  {{ if .Values.AKOSettings.syncNamespace  }}
-  syncNamespace: {{ .Values.AKOSettings.syncNamespace | quote }}
-  {{ end }}
   nsSyncLabelKey: {{ .Values.AKOSettings.namespaceSelector.labelKey | quote }}
   nsSyncLabelValue: {{ .Values.AKOSettings.namespaceSelector.labelValue | quote }}
   serviceType:  {{ .Values.L7Settings.serviceType | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -133,13 +133,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: disableStaticRouteSync
-           {{ if .Values.AKOSettings.syncNamespace  }}
-          - name: SYNC_NAMESPACE
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: syncNamespace
-          {{ end }}
            {{ if .Values.NetworkSettings.nsxtT1LR }}
           - name: NSXT_T1_LR
             valueFrom:
@@ -204,11 +197,6 @@ spec:
                 name: avi-k8s-config
                 key: nodeValue
           {{ end }}
-          - name: ADVANCED_L4
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: advancedL4
           - name: AUTO_L4_FQDN
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -60,7 +60,6 @@ L7Settings:
 
 ### This section outlines all the knobs  used to control Layer 4 loadbalancing settings in AKO.
 L4Settings:
-  advancedL4: "false" # Use this knob to control the settings for the services API usage. Default to not using services APIs: https://github.com/kubernetes-sigs/service-apis
   defaultDomain: "" # If multiple sub-domains are configured in the cloud, use this knob to set the default sub-domain to use for L4 VSes.
   autoFQDN: "default" # ENUM: default(<svc>.<ns>.<subdomain>), flat (<svc>-<ns>.<subdomain>), "disabled" If the value is disabled then the FQDN generation is disabled.
 


### PR DESCRIPTION
This commit removes the advancedL4 flag from helm. This flag is used
internally and need not be exposed to the end user.

The servicesAPI flag under AKOSettings can be used for Services API
use.