### PR TITLE
Public IP and Status Update Fixes

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1859,7 +1859,7 @@ func buildWithInfraSettingForEvh(key string, vs *AviEvhVsNode, vsvip *AviVSVIPNo
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
-		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
+		if lib.IsPublicCloud() {
 			vsvip.EnablePublicIP = infraSetting.Spec.Network.EnablePublicIP
 		}
 		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -616,7 +616,7 @@ func buildWithInfraSetting(key string, vs *AviVsNode, vsvip *AviVSVIPNode, infra
 		} else {
 			vsvip.VipNetworks = lib.GetVipNetworkList()
 		}
-		if infraSetting.Spec.Network.EnablePublicIP != nil && lib.IsPublicCloud() {
+		if lib.IsPublicCloud() {
 			vsvip.EnablePublicIP = infraSetting.Spec.Network.EnablePublicIP
 		}
 		utils.AviLog.Debugf("key: %s, msg: Applied AviInfraSetting configuration over VSNode %s", key, vs.Name)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -407,7 +407,7 @@ func AviVsHttpPSAdd(vs_meta interface{}, isEVH bool) []*avimodels.HTTPPolicies {
 }
 
 func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_cache_obj *avicache.AviVsCache, key string) {
-	if restMethod == utils.RestPost || restMethod == utils.RestDelete {
+	if restMethod == utils.RestPost || restMethod == utils.RestDelete || restMethod == utils.RestPut {
 		for _, poolkey := range vs_cache_obj.PoolKeyCollection {
 			// Fetch the pool object from cache and check the service metadata
 			pool_cache, ok := rest.cache.PoolCache.AviCacheGet(poolkey)

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -505,6 +505,20 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 				vs_cache_obj.AddToVSVipKeyCollection(k)
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for VSVIP collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				if rest_op.Method == utils.RestPut {
+					if len(vs_cache_obj.SNIChildCollection) > 0 {
+						for _, childUuid := range vs_cache_obj.SNIChildCollection {
+							childKey, childFound := rest.cache.VsCacheMeta.AviCacheGetKeyByUuid(childUuid)
+							if childFound {
+								childVSKey := childKey.(avicache.NamespaceName)
+								childObj, _ := rest.cache.VsCacheMeta.AviCacheGet(childVSKey)
+								child_cache_obj, vs_found := childObj.(*avicache.AviVsCache)
+								if vs_found {
+									rest.StatusUpdateForPool(rest_op.Method, child_cache_obj, key)
+									rest.StatusUpdateForVS(child_cache_obj, key)
+								}
+							}
+						}
+					}
 					rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
 					rest.StatusUpdateForVS(vs_cache_obj, key)
 				}
@@ -516,6 +530,20 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey,
 				vs_cache_obj))
 			if rest_op.Method == utils.RestPut {
+				if len(vs_cache_obj.SNIChildCollection) > 0 {
+					for _, childUuid := range vs_cache_obj.SNIChildCollection {
+						childKey, childFound := rest.cache.VsCacheMeta.AviCacheGetKeyByUuid(childUuid)
+						if childFound {
+							childVSKey := childKey.(avicache.NamespaceName)
+							childObj, _ := rest.cache.VsCacheMeta.AviCacheGet(childVSKey)
+							child_cache_obj, vs_found := childObj.(*avicache.AviVsCache)
+							if vs_found {
+								rest.StatusUpdateForPool(rest_op.Method, child_cache_obj, key)
+								rest.StatusUpdateForVS(child_cache_obj, key)
+							}
+						}
+					}
+				}
 				rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
 				rest.StatusUpdateForVS(vs_cache_obj, key)
 			}


### PR DESCRIPTION
1. Allow status update with pools with PUT calls
2. Update status for SNI child
3. Fix public ip not removed when enablePublicIP unset in aviinfrasetting.