### PR TITLE
Introduce fqdnType (Exact/Contains/Wildcard) in HostRule

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -34,6 +34,13 @@ spec:
                     type: string
                   fqdn:
                     type: string
+                  fqdnType:
+                    type: string
+                    enum:
+                    - Exact
+                    - Wildcard
+                    - Contains
+                    default: Exact
                   datascripts:
                     items:
                       type: string
@@ -104,6 +111,8 @@ spec:
                           properties:
                             port:
                               type: integer
+                              minimum: 1
+                              maximum: 65535
                             enableSSL:
                               type: boolean
                           type: object
@@ -113,6 +122,7 @@ spec:
                     type: object
                 required:
                 - fqdn
+                - fqdnType
                 type: object
             required:
             - virtualhost

--- a/helm/ako/crds/ako.vmware.com_hostrules.yaml
+++ b/helm/ako/crds/ako.vmware.com_hostrules.yaml
@@ -34,6 +34,13 @@ spec:
                     type: string
                   fqdn:
                     type: string
+                  fqdnType:
+                    type: string
+                    enum:
+                    - Exact
+                    - Wildcard
+                    - Contains
+                    default: Exact
                   datascripts:
                     items:
                       type: string
@@ -104,6 +111,8 @@ spec:
                           properties:
                             port:
                               type: integer
+                              minimum: 1
+                              maximum: 65535
                             enableSSL:
                               type: boolean
                           type: object
@@ -113,6 +122,7 @@ spec:
                     type: object
                 required:
                 - fqdn
+                - fqdnType
                 type: object
             required:
             - virtualhost

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -799,6 +799,9 @@ func (c *AviController) FullSyncK8s() error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
+				if err := validateHostRuleObj(key, hostRuleObj); err != nil {
+					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -814,6 +817,9 @@ func (c *AviController) FullSyncK8s() error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
+				if err := validateHTTPRuleObj(key, httpRuleObj); err != nil {
+					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HTTPRule: %v", key, err)
+				}
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -828,6 +834,9 @@ func (c *AviController) FullSyncK8s() error {
 				if err == nil {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
+				}
+				if err := validateAviInfraSetting(key, aviInfraObj); err != nil {
+					utils.AviLog.Warnf("key: %s, Error retrieved during validation of AviInfraSetting: %v", key, err)
 				}
 				nodes.DequeueIngestion(key, true)
 			}

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"strings"
 	"time"
 
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -517,11 +516,12 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 
 	// If it is not a Shared VS but TCP Settings are provided, then we reject it since these
 	// TCP settings are not valid for the child VS.
-	if !strings.Contains(fqdn, lib.ShardVSSubstring) && hostrule.Spec.VirtualHost.TCPSettings != nil {
-		err = fmt.Errorf("Hostrule tcpSettings with fqdn %s cannot be applied to child Virtualservices", fqdn)
-		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-		return err
-	}
+	// TODO: move to translator?
+	// if !strings.Contains(fqdn, lib.ShardVSSubstring) && hostrule.Spec.VirtualHost.TCPSettings != nil {
+	// 	err = fmt.Errorf("Hostrule tcpSettings with fqdn %s cannot be applied to child Virtualservices", fqdn)
+	// 	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+	// 	return err
+	// }
 
 	if hostrule.Spec.VirtualHost.TCPSettings != nil && hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP != "" {
 		re := regexp.MustCompile(lib.IPRegex)

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -41,6 +41,7 @@ type AviVsEvhSniModel interface {
 	SetName(string)
 
 	IsSharedVS() bool
+	IsDedicatedVS() bool
 
 	GetPortProtocols() []AviPortHostProtocol
 	SetPortProtocols([]AviPortHostProtocol)
@@ -151,6 +152,10 @@ func (v *AviEvhVsNode) SetName(name string) {
 
 func (v *AviEvhVsNode) IsSharedVS() bool {
 	return v.SharedVS
+}
+
+func (v *AviEvhVsNode) IsDedicatedVS() bool {
+	return v.Dedicated
 }
 
 func (v *AviEvhVsNode) GetPortProtocols() []AviPortHostProtocol {

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -403,6 +403,10 @@ func (v *AviVsNode) IsSharedVS() bool {
 	return v.SharedVS
 }
 
+func (v *AviVsNode) IsDedicatedVS() bool {
+	return v.Dedicated
+}
+
 func (v *AviVsNode) GetPortProtocols() []AviPortHostProtocol {
 	return v.PortProto
 }

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -31,7 +31,7 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 	// use host to find out HostRule CRD if it exists
 	// The host that comes here will have a proper FQDN, either from the Ingress/Route (foo.com)
 	// or the SharedVS FQDN (Shared-L7-1.com).
-	found, hrNamespaceName := objects.SharedCRDLister().GetFQDNToHostruleMappingV2(host)
+	found, hrNamespaceName := objects.SharedCRDLister().GetFQDNToHostruleMappingWithType(host)
 	deleteCase := false
 	if !found {
 		utils.AviLog.Debugf("key: %s, msg: No HostRule found for virtualhost: %s in Cache", key, host)
@@ -111,7 +111,7 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 			}
 		}
 
-		if vsNode.IsSharedVS() {
+		if vsNode.IsSharedVS() || vsNode.IsDedicatedVS() {
 			portProtocols = []AviPortHostProtocol{}
 			for _, listener := range hostrule.Spec.VirtualHost.TCPSettings.Listeners {
 				portProtocol := AviPortHostProtocol{

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -29,7 +29,9 @@ import (
 
 func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 	// use host to find out HostRule CRD if it exists
-	found, hrNamespaceName := objects.SharedCRDLister().GetFQDNToHostruleMapping(host)
+	// The host that comes here will have a proper FQDN, either from the Ingress/Route (foo.com)
+	// or the SharedVS FQDN (Shared-L7-1.com).
+	found, hrNamespaceName := objects.SharedCRDLister().GetFQDNToHostruleMappingV2(host)
 	deleteCase := false
 	if !found {
 		utils.AviLog.Debugf("key: %s, msg: No HostRule found for virtualhost: %s in Cache", key, host)

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -549,6 +549,7 @@ func HostRuleToIng(hrname string, namespace string, key string) ([]string, bool)
 		_, fqdn = objects.SharedCRDLister().GetHostruleToFQDNMapping(namespace + "/" + hrname)
 		if !strings.Contains(fqdn, lib.ShardVSSubstring) {
 			objects.SharedCRDLister().DeleteHostruleFQDNMapping(namespace + "/" + hrname)
+			objects.SharedCRDLister().DeleteFQDNFQDNTypeMapping(fqdn)
 		}
 	} else if err != nil {
 		utils.AviLog.Errorf("key: %s, msg: Error getting hostrule: %v", key, err)
@@ -564,6 +565,7 @@ func HostRuleToIng(hrname string, namespace string, key string) ([]string, bool)
 		}
 		if !strings.Contains(fqdn, lib.ShardVSSubstring) {
 			objects.SharedCRDLister().UpdateFQDNHostruleMapping(fqdn, namespace+"/"+hrname)
+			objects.SharedCRDLister().UpdateFQDNFQDNTypeMapping(fqdn, string(hostrule.Spec.VirtualHost.FqdnType))
 		}
 	}
 

--- a/internal/objects/crdrules.go
+++ b/internal/objects/crdrules.go
@@ -82,10 +82,7 @@ func (c *CRDLister) GetFQDNToHostruleMapping(fqdn string) (bool, string) {
 	return true, hostrule.(string)
 }
 
-func (c *CRDLister) GetFQDNToHostruleMappingV2(fqdn string) (bool, string) {
-	// c.NSLock.Lock()
-	// defer c.NSLock.Unlock()
-
+func (c *CRDLister) GetFQDNToHostruleMappingWithType(fqdn string) (bool, string) {
 	// not exact fqdns
 	allFqdns := c.FqdnHostRuleCache.GetAllKeys()
 	returnHostrules := []string{}
@@ -241,10 +238,8 @@ func (c *CRDLister) UpdateFqdnHTTPRulesMappings(fqdn, path, httprule string) {
 
 // FqdnSharedVSModelCache/SharedVSModelFqdnCache
 func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn string) (bool, []string) {
-	// c.NSLock.Lock()
-	// defer c.NSLock.Unlock()
 	oktype, fqdnType := c.FqdnFqdnTypeCache.Get(fqdn)
-	if !oktype {
+	if !oktype || fqdnType == "" {
 		fqdnType = string(akov1alpha1.Exact)
 	}
 
@@ -270,7 +265,10 @@ func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn string) (bool, []string) 
 		}
 	}
 
-	return true, returnModelNames
+	if len(returnModelNames) > 0 {
+		return true, returnModelNames
+	}
+	return false, returnModelNames
 }
 
 func (c *CRDLister) GetSharedVSModelFQDNMapping(modelName string) (bool, string) {

--- a/internal/objects/store.go
+++ b/internal/objects/store.go
@@ -123,6 +123,16 @@ func (o *ObjectMapStore) GetAllObjectNames() map[string]interface{} {
 
 }
 
+func (o *ObjectMapStore) GetAllKeys() []string {
+	o.ObjLock.RLock()
+	defer o.ObjLock.RUnlock()
+	allKeys := []string{}
+	for k := range o.ObjectMap {
+		allKeys = append(allKeys, k)
+	}
+	return allKeys
+}
+
 func (o *ObjectMapStore) CopyAllObjects() map[string]interface{} {
 	o.ObjLock.RLock()
 	defer o.ObjLock.RUnlock()

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -454,6 +454,7 @@ func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) (bool, stri
 			if diff == nil {
 				diff = proto.Bool(false)
 			}
+			beforeHost = status.Host
 			continue
 		}
 		ip := status.Conditions[0].Message
@@ -475,6 +476,7 @@ func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) (bool, stri
 		if !exists.Has(ip + ":" + status.Host + ":" + status.RouterName + ":" + reason) {
 			if diff == nil {
 				diff = proto.Bool(false)
+				afterHost = status.Host
 			}
 			continue
 		}

--- a/pkg/apis/ako/v1alpha1/hostrule.go
+++ b/pkg/apis/ako/v1alpha1/hostrule.go
@@ -116,7 +116,7 @@ type HostRuleGSLB struct {
 // HostRuleStatus holds the status of the HostRule
 type HostRuleStatus struct {
 	Status string `json:"status,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Error  string `json:"error"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/ako/v1alpha1/hostrule.go
+++ b/pkg/apis/ako/v1alpha1/hostrule.go
@@ -38,6 +38,26 @@ type HostRuleSpec struct {
 	VirtualHost HostRuleVirtualHost `json:"virtualhost,omitempty"`
 }
 
+type FqdnType string
+
+const (
+	// Matches the string character by character to the VS FQDNs,
+	// in an exact match fashion.
+	Exact FqdnType = "Exact"
+
+	// Matches the string to multiple VS FQDNs, and matches the FQDNs
+	// with the provided string as the suffix. The string must start with
+	// a '*' to qualify for wildcard matching.
+	// fqdn: *.alb.vmware.com
+	Wildcard FqdnType = "Wildcard"
+
+	// Matches the string to multiple VS FQDNs, and matches the FQDNs
+	// with the provided string as a substring of any possible FQDNs
+	// programmed by AKO.
+	// fqdn: Shared-VS-1
+	Contains FqdnType = "Contains"
+)
+
 // HostRuleVirtualHost defines properties for a host
 type HostRuleVirtualHost struct {
 	AnalyticsProfile   string                   `json:"analyticsProfile,omitempty"`
@@ -46,6 +66,7 @@ type HostRuleVirtualHost struct {
 	EnableVirtualHost  *bool                    `json:"enableVirtualHost,omitempty"`
 	ErrorPageProfile   string                   `json:"errorPageProfile,omitempty"`
 	Fqdn               string                   `json:"fqdn,omitempty"`
+	FqdnType           FqdnType                 `json:"fqdnType,omitempty"`
 	HTTPPolicy         HostRuleHTTPPolicy       `json:"httpPolicy,omitempty"`
 	Gslb               HostRuleGSLB             `json:"gslb,omitempty"`
 	TLS                HostRuleTLS              `json:"tls,omitempty"`


### PR DESCRIPTION
The field fqdnType determines the interpretation of the fqdn matching.
fqdnType can be one of the following:
Exact - matches the fqdn exactly
Contains - considers the value specified in `fqdn` for a substring match
Wildcard - matches based on fqdn suffix, this must contain a `*` as a prefix
(for instance: *.tenant.com)
This implementation also helps in **easily** specifying the Hostrule for parent VSes
for which AKO programs the fqdn automatically (without user input). The users
can specify a substring of the parent VS name, to attach the hostrule to that VS.