### PR TITLE
test cases for ako-infra boostrapconditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,16 @@ dedicatedvstests:
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
 	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/dedicatedvstests -failfast
 
+.PHONY: infratests
+infratests:
+	sudo docker run \
+	-w=/go/src/$(PACKAGE_PATH_AKO) \
+	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/infratests -failfast
+
 .PHONY: int_test
 int_test:
-	make -j 1 k8stest integrationtest ingresstests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests evhtests misc vcftests dedicatedvstests
+	make -j 1 k8stest integrationtest ingresstests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests evhtests misc vcftests dedicatedvstests infratests
 
 .PHONY: scale_test
 scale_test:
@@ -280,4 +287,3 @@ golangci: .golangci-bin
 golangci-fix: .golangci-bin
 	@echo "Running golangci-fix"
 	@GOOS=linux .golangci-bin/golangci-lint run -c .golangci.yml --fix
-

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -50,6 +50,11 @@ func SyncLSLRNetwork() {
 		return
 	}
 
+	if cloudModel.NsxtConfiguration == nil {
+		utils.AviLog.Warnf("NSX-T config not set in cloud, LS-LR mapping won't be updated")
+		return
+	}
+
 	if len(cloudModel.NsxtConfiguration.DataNetworkConfig.VlanSegments) != 0 {
 		utils.AviLog.Infof("NSX-T cloud is using Vlan Segments, LS-LR mapping won't be updated")
 		return
@@ -106,6 +111,12 @@ func AddSegment(obj interface{}) bool {
 		utils.AviLog.Fatalf("key: %s, Failed to get Cloud data from cache", objKey)
 		return false
 	}
+
+	if cloudModel.NsxtConfiguration == nil {
+		utils.AviLog.Warnf("key: %s, NSX-T config not set in cloud, segment won't be added", objKey)
+		return false
+	}
+
 	updateRequired, lslrList := addSegmentInCloud(cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs, lr, ls)
 	if updateRequired {
 		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = lslrList
@@ -156,6 +167,12 @@ func DeleteSegment(obj interface{}) {
 		utils.AviLog.Warnf("key: %s, Failed to get Cloud data from cache", objKey)
 		return
 	}
+
+	if cloudModel.NsxtConfiguration == nil {
+		utils.AviLog.Warnf("key: %s, NSX-T config not set in cloud, segment won't be deleted", objKey)
+		return
+	}
+
 	updateRequired, lslrList := delSegmentInCloud(cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs, lr, ls)
 	if updateRequired {
 		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = lslrList

--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -36,10 +36,10 @@ import (
 
 type AviControllerInfra struct {
 	AviRestClients *utils.AviRestClientPool
-	cs             *kubernetes.Clientset
+	cs             kubernetes.Interface
 }
 
-func NewAviControllerInfra(cs *kubernetes.Clientset) *AviControllerInfra {
+func NewAviControllerInfra(cs kubernetes.Interface) *AviControllerInfra {
 	PopulateControllerProperties(cs)
 	AviRestClientsPool := avicache.SharedAVIClients()
 	return &AviControllerInfra{AviRestClients: AviRestClientsPool, cs: cs}

--- a/ako-infra/ingestion/vcf_k8s_controller.go
+++ b/ako-infra/ingestion/vcf_k8s_controller.go
@@ -198,7 +198,7 @@ func (c *VCFK8sController) AddNetworkInfoEventHandler(k8sinfo K8sinformers, stop
 // AVI Controller. If there is any failure, we would look at Bootstrap CR used by NCP to communicate with AKO.
 // If Bootstrap CR is not found, AKO would wait for it to be created. If the authtoken from Bootstrap CR
 // can be used to connect to the AVI Controller, then avi-secret would be created with that token.
-func (c *VCFK8sController) HandleVCF(informers K8sinformers, stopCh <-chan struct{}, ctrlCh chan struct{}) string {
+func (c *VCFK8sController) HandleVCF(informers K8sinformers, stopCh <-chan struct{}, ctrlCh chan struct{}, skipAviClient ...bool) string {
 	cs := c.informers.ClientSet
 	aviSecret, err := cs.CoreV1().Secrets(utils.GetAKONamespace()).Get(context.TODO(), lib.AviSecret, metav1.GetOptions{})
 	ctrlIP := lib.GetControllerURLFromBootstrapCR()
@@ -212,7 +212,7 @@ func (c *VCFK8sController) HandleVCF(informers K8sinformers, stopCh <-chan struc
 			session.SetNoControllerStatusCheck, session.SetTransport(transport),
 			session.SetInsecure,
 		)
-		if err == nil {
+		if err == nil || len(skipAviClient) == 1 {
 			utils.AviLog.Infof("Successfully connected to AVI controller using existing AKO secret")
 			boostrapdata, ok := lib.GetBootstrapCRData()
 			if ok {

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -147,6 +147,10 @@ func NewVCFDynamicClientSet(config *rest.Config) (dynamic.Interface, error) {
 	return vcfDynamicClientSet, nil
 }
 
+func SetVCFVCFDynamicClientSet(dc dynamic.Interface) {
+	vcfDynamicClientSet = dc
+}
+
 func GetVCFDynamicClientSet() dynamic.Interface {
 	if vcfDynamicClientSet == nil {
 		utils.AviLog.Warn("Cannot retrieve the dynamic informers since it's not initialized yet.")
@@ -195,9 +199,21 @@ func GetBootstrapCRData() (BootstrapCRData, bool) {
 	}
 
 	obj := crdList.Items[0]
-	spec := obj.Object["spec"].(map[string]interface{})
-	secretref := spec["albCredentialSecretRef"].(map[string]interface{})
-	albtoken := spec["albTokenProperty"].(map[string]interface{})
+	spec, ok := obj.Object["spec"].(map[string]interface{})
+	if !ok {
+		utils.AviLog.Errorf("spec is not found in NCP bootstrap object")
+		return boostrapdata, false
+	}
+	secretref, ok := spec["albCredentialSecretRef"].(map[string]interface{})
+	if !ok {
+		utils.AviLog.Errorf("albCredentialSecretRef is not found in NCP bootstrap object")
+		return boostrapdata, false
+	}
+	albtoken, ok := spec["albTokenProperty"].(map[string]interface{})
+	if !ok {
+		utils.AviLog.Errorf("albTokenProperty is not found in NCP bootstrap object")
+		return boostrapdata, false
+	}
 
 	secretName, ok := secretref["name"].(string)
 	if !ok {

--- a/tests/avimockobjects/CLOUD_NSXT_mock.json
+++ b/tests/avimockobjects/CLOUD_NSXT_mock.json
@@ -1,0 +1,61 @@
+{
+  "count": 1,
+  "results": [
+    {
+      "url": "https://10.50.63.199/api/cloud/cloud-886945b9-9ed7-439e-9a62-797de541c329",
+      "uuid": "cloud-886945b9-9ed7-439e-9a62-797de541c329",
+      "name": "CLOUD_NSXT",
+      "tenant_ref": "https://10.50.63.199/api/tenant/admin",
+      "_last_modified": "1637130116495634",
+      "vtype": "CLOUD_NSXT",
+      "apic_mode": false,
+      "nsxt_configuration": {
+        "nsxt_url": "10.50.62.110",
+        "site_id": "default",
+        "enforcementpoint_id": "default",
+        "domain_id": "default",
+        "automate_dfw_rules": false,
+        "management_network_config": {
+          "tz_type": "OVERLAY",
+          "transport_zone": "/infra/sites/default/enforcement-points/default/transport-zones/1b3a2f36-bfd1-443e-a0f6-4de01abc963e",
+          "overlay_segment": {
+            "tier1_lr_id": "/infra/tier-1s/ako-dev-k8s-1",
+            "segment_id": "/infra/segments/seg-ako-dev-k8s-1"
+          }
+        },
+        "data_network_config": {
+          "tz_type": "OVERLAY",
+          "transport_zone": "/infra/sites/default/enforcement-points/default/transport-zones/1b3a2f36-bfd1-443e-a0f6-4de01abc963e",
+          "tier1_segment_config": {
+            "segment_config_mode": "TIER1_SEGMENT_MANUAL",
+            "manual": {
+              "tier1_lrs": [
+                {
+                  "tier1_lr_id": "/infra/tier-1s/ako-dev-k8s-1",
+                  "segment_id": "/infra/segments/seg-ako-dev-k8s-1"
+                }
+              ]
+            }
+          }
+        },
+        "nsxt_credentials_ref": "https://10.50.63.199/api/cloudconnectoruser/cloudconnectoruser-d21e701b-fd91-4cbf-841e-d21e2e52526f"
+      },
+      "dhcp_enabled": true,
+      "mtu": 1500,
+      "prefer_static_routes": false,
+      "enable_vip_static_routes": false,
+      "obj_name_prefix": "nsxt",
+      "license_type": "LIC_CORES",
+      "state_based_dns_registration": true,
+      "ip6_autocfg_enabled": false,
+      "dns_resolution_on_se": false,
+      "enable_vip_on_all_interfaces": false,
+      "maintenance_mode": false,
+      "license_tier": "ENTERPRISE",
+      "autoscale_polling_interval": 60,
+      "vmc_deployment": false,
+      "ipam_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-3abd2780-ee6d-4435-9616-5066f0f1909a",
+      "dns_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-dd704396-053a-4c43-9d88-fa211cfd8f58"
+    }
+  ]
+}

--- a/tests/infratests/akoinfra_test.go
+++ b/tests/infratests/akoinfra_test.go
@@ -1,0 +1,415 @@
+package infratests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-infra/ingestion"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var kubeClient *k8sfake.Clientset
+var dynamicClient *dynamicfake.FakeDynamicClient
+var keyChan chan bool
+
+func TestMain(m *testing.M) {
+	os.Setenv("CLOUD_NAME", "CLOUD_NSXT")
+	utils.SetCloudName("CLOUD_NSXT")
+	keyChan = make(chan bool)
+
+	kubeClient = k8sfake.NewSimpleClientset()
+	data := map[string][]byte{
+		"username":  []byte("admin"),
+		"authtoken": []byte("admin"),
+	}
+	object := metav1.ObjectMeta{Name: "avi-secret", Namespace: utils.GetAKONamespace()}
+	secret := &corev1.Secret{Data: data, ObjectMeta: object}
+	kubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Create(context.TODO(), secret, metav1.CreateOptions{})
+	kubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Get(context.TODO(), "avi-secret", metav1.GetOptions{})
+
+	os.Exit(m.Run())
+}
+
+func waitAndverify(t *testing.T, expectTimeout bool) {
+	waitChan := make(chan int)
+	go func() {
+		time.Sleep(10 * time.Second)
+		waitChan <- 1
+	}()
+
+	select {
+	case _ = <-keyChan:
+		if expectTimeout {
+			t.Fatalf("expected timeout, but got valid data")
+		}
+	case _ = <-waitChan:
+		if !expectTimeout {
+			t.Fatalf("timed out waiting")
+		}
+	}
+}
+
+func initInfraTest(testData []*unstructured.Unstructured) {
+	gvrToKind := make(map[schema.GroupVersionResource]string)
+	gvrToKind[lib.NetworkInfoGVR] = "namespacenetworkinfosList"
+	gvrToKind[lib.BootstrapGVR] = "akobootstrapconditionsList"
+
+	dynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToKind, testData[0], testData[1])
+	dynamicClient.Resource(lib.BootstrapGVR).Namespace("default").Create(context.TODO(), testData[0], v1.CreateOptions{})
+	dynamicClient.Resource(lib.NetworkInfoGVR).Namespace("default").Create(context.TODO(), testData[1], v1.CreateOptions{})
+	lib.SetVCFVCFDynamicClientSet(dynamicClient)
+
+	registeredInformers := []string{
+		utils.SecretInformer,
+	}
+	informersArg := make(map[string]interface{})
+
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
+	lib.NewVCFDynamicInformers(dynamicClient)
+
+}
+
+// TestBoostrapNoALBEndpoint adds an akobootstrapconditions object with no albEndpoint.
+// In this condition HandleVCF should wait.
+func TestBoostrapNoALBEndpoint(t *testing.T) {
+	var testData []*unstructured.Unstructured
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[0].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "ncp.vmware.com/v1alpha1",
+		"kind":       "akobootstrapconditions",
+		"metadata": map[string]interface{}{
+			"name":      "testbs",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"albCredentialSecretRef": map[string]interface{}{
+				"name":      "avi-secret",
+				"namespace": "avi-system",
+			},
+			"albTokenProperty": map[string]interface{}{
+				"userName": "admin",
+			},
+		},
+		"status": map[string]interface{}{
+			/*"albEndpoint": map[string]interface{}{
+				"hostUrl": "10.50.63.199",
+			},*/
+			"transportZone": map[string]interface{}{
+				"path": "testpath",
+			},
+		},
+	})
+
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[1].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "nsx.vmware.com/v1alpha1",
+		"kind":       "namespacenetworkinfos",
+		"metadata": map[string]interface{}{
+			"name":      "testnetinfo",
+			"namespace": "default",
+		},
+		"topology": map[string]interface{}{
+			"aviSegmentPath": "testSeg",
+			"gatewayPath":    "testGW",
+			"ingressCIDRs": []interface{}{
+				"10.20.30.0/24",
+			},
+		},
+	})
+
+	initInfraTest(testData)
+	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
+	c := ingestion.SharedVCFK8sController()
+	stopCh := make(chan struct{})
+	ctrlCh := make(chan struct{})
+
+	integrationtest.NewAviFakeClientInstance(kubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	go func() {
+		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+
+		lib.VCFInitialized = true
+		keyChan <- true
+	}()
+	waitAndverify(t, true)
+}
+
+// TestBoostrapNoTransportZone adds an akobootstrapconditions object with no transportZone.
+// In this condition HandleVCF should wait.
+func TestBoostrapNoTransportZone(t *testing.T) {
+	var testData []*unstructured.Unstructured
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[0].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "ncp.vmware.com/v1alpha1",
+		"kind":       "akobootstrapconditions",
+		"metadata": map[string]interface{}{
+			"name":      "testbs",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"albCredentialSecretRef": map[string]interface{}{
+				"name":      "avi-secret",
+				"namespace": "avi-system",
+			},
+			"albTokenProperty": map[string]interface{}{
+				"userName": "admin",
+			},
+		},
+		"status": map[string]interface{}{
+			"albEndpoint": map[string]interface{}{
+				"hostUrl": "10.50.63.199",
+			},
+			/*"transportZone": map[string]interface{}{
+				"path": "testpath",
+			},*/
+		},
+	})
+
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[1].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "nsx.vmware.com/v1alpha1",
+		"kind":       "namespacenetworkinfos",
+		"metadata": map[string]interface{}{
+			"name":      "testnetinfo",
+			"namespace": "default",
+		},
+		"topology": map[string]interface{}{
+			"aviSegmentPath": "testSeg",
+			"gatewayPath":    "testGW",
+			"ingressCIDRs": []interface{}{
+				"10.20.30.0/24",
+			},
+		},
+	})
+
+	initInfraTest(testData)
+	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
+	c := ingestion.SharedVCFK8sController()
+	stopCh := make(chan struct{})
+
+	ctrlCh := make(chan struct{})
+
+	integrationtest.NewAviFakeClientInstance(kubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	go func() {
+		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+
+		lib.VCFInitialized = true
+		keyChan <- true
+	}()
+	waitAndverify(t, true)
+}
+
+// TestBoostrapNoSecretRef adds an akobootstrapconditions object with no albCredentialSecretRef.
+// In this condition HandleVCF should wait.
+func TestBoostrapNoSecretRef(t *testing.T) {
+	var testData []*unstructured.Unstructured
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[0].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "ncp.vmware.com/v1alpha1",
+		"kind":       "akobootstrapconditions",
+		"metadata": map[string]interface{}{
+			"name":      "testbs",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			/*"albCredentialSecretRef": map[string]interface{}{
+				"name":      "avi-secret",
+				"namespace": "avi-system",
+			},*/
+			"albTokenProperty": map[string]interface{}{
+				"userName": "admin",
+			},
+		},
+		"status": map[string]interface{}{
+			"albEndpoint": map[string]interface{}{
+				"hostUrl": "10.50.63.199",
+			},
+			"transportZone": map[string]interface{}{
+				"path": "testpath",
+			},
+		},
+	})
+
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[1].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "nsx.vmware.com/v1alpha1",
+		"kind":       "namespacenetworkinfos",
+		"metadata": map[string]interface{}{
+			"name":      "testnetinfo",
+			"namespace": "default",
+		},
+		"topology": map[string]interface{}{
+			"aviSegmentPath": "testSeg",
+			"gatewayPath":    "testGW",
+			"ingressCIDRs": []interface{}{
+				"10.20.30.0/24",
+			},
+		},
+	})
+
+	initInfraTest(testData)
+	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
+	c := ingestion.SharedVCFK8sController()
+	stopCh := make(chan struct{})
+
+	ctrlCh := make(chan struct{})
+
+	integrationtest.NewAviFakeClientInstance(kubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	go func() {
+		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+
+		lib.VCFInitialized = true
+		keyChan <- true
+	}()
+	waitAndverify(t, true)
+}
+
+// TestBoostrapNoUserName adds an akobootstrapconditions object with no albTokenProperty.
+// In this condition HandleVCF should wait.
+func TestBoostrapNoUserName(t *testing.T) {
+	var testData []*unstructured.Unstructured
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[0].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "ncp.vmware.com/v1alpha1",
+		"kind":       "akobootstrapconditions",
+		"metadata": map[string]interface{}{
+			"name":      "testbs",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"albCredentialSecretRef": map[string]interface{}{
+				"name":      "avi-secret",
+				"namespace": "avi-system",
+			},
+			/*"albTokenProperty": map[string]interface{}{
+				"userName": "admin",
+			},*/
+		},
+		"status": map[string]interface{}{
+			"albEndpoint": map[string]interface{}{
+				"hostUrl": "10.50.63.199",
+			},
+			"transportZone": map[string]interface{}{
+				"path": "testpath",
+			},
+		},
+	})
+
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[1].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "nsx.vmware.com/v1alpha1",
+		"kind":       "namespacenetworkinfos",
+		"metadata": map[string]interface{}{
+			"name":      "testnetinfo",
+			"namespace": "default",
+		},
+		"topology": map[string]interface{}{
+			"aviSegmentPath": "testSeg",
+			"gatewayPath":    "testGW",
+			"ingressCIDRs": []interface{}{
+				"10.20.30.0/24",
+			},
+		},
+	})
+
+	initInfraTest(testData)
+	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
+	c := ingestion.SharedVCFK8sController()
+	stopCh := make(chan struct{})
+
+	ctrlCh := make(chan struct{})
+
+	integrationtest.NewAviFakeClientInstance(kubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	go func() {
+		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+
+		lib.VCFInitialized = true
+		keyChan <- true
+	}()
+	waitAndverify(t, true)
+}
+
+func TestValidBootstrapData(t *testing.T) {
+	var testData []*unstructured.Unstructured
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[0].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "ncp.vmware.com/v1alpha1",
+		"kind":       "akobootstrapconditions",
+		"metadata": map[string]interface{}{
+			"name":      "testbs",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"albCredentialSecretRef": map[string]interface{}{
+				"name":      "avi-secret",
+				"namespace": "avi-system",
+			},
+			"albTokenProperty": map[string]interface{}{
+				"userName": "admin",
+			},
+		},
+		"status": map[string]interface{}{
+			"albEndpoint": map[string]interface{}{
+				"hostUrl": "10.50.63.199",
+			},
+			"transportZone": map[string]interface{}{
+				"path": "testpath",
+			},
+		},
+	})
+
+	testData = append(testData, &unstructured.Unstructured{})
+	testData[1].SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "nsx.vmware.com/v1alpha1",
+		"kind":       "namespacenetworkinfos",
+		"metadata": map[string]interface{}{
+			"name":      "testnetinfo",
+			"namespace": "default",
+		},
+		"topology": map[string]interface{}{
+			"aviSegmentPath": "testSeg",
+			"gatewayPath":    "testGW",
+			"ingressCIDRs": []interface{}{
+				"10.20.30.0/24",
+			},
+		},
+	})
+
+	initInfraTest(testData)
+	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
+	c := ingestion.SharedVCFK8sController()
+	stopCh := make(chan struct{})
+
+	ctrlCh := make(chan struct{})
+
+	integrationtest.NewAviFakeClientInstance(kubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	go func() {
+		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+
+		lib.VCFInitialized = true
+		keyChan <- true
+	}()
+	waitAndverify(t, false)
+}

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1164,6 +1164,8 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 			data, _ = ioutil.ReadFile(fmt.Sprintf("%s/%s_mock.json", mockFilePath, "CLOUD_AZURE"))
 		} else if strings.HasSuffix(r.URL.RawQuery, "CLOUD_AWS") {
 			data, _ = ioutil.ReadFile(fmt.Sprintf("%s/%s_mock.json", mockFilePath, "CLOUD_AWS"))
+		} else if strings.HasSuffix(r.URL.RawQuery, "CLOUD_NSXT") {
+			data, _ = ioutil.ReadFile(fmt.Sprintf("%s/%s_mock.json", mockFilePath, "CLOUD_NSXT"))
 		} else {
 			data, _ = ioutil.ReadFile(fmt.Sprintf("%s/%s_mock.json", mockFilePath, "CLOUD_VCENTER"))
 		}
@@ -1182,7 +1184,10 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 		w.Write([]byte(`{"version": {"Version": "20.1.2"}}`))
 	} else if strings.Contains(url, "/api/cluster/runtime") {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"node_states": [{"name": "10.79.169.60","role": "CLUSTER_LEADER","up_since": "2020-10-28 04:58:48"}]}`))
+		w.Write([]byte(`{"node_states": [{"name": "10.79.169.60","role": "CLUSTER_LEADER","up_since": "2020-10-28 04:58:48"}],"cluster_state": {"state": "CLUSTER_UP_NO_HA"}}`))
+	} else if strings.Contains(url, "/api/systemconfiguration") {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"default_license_tier": "ENTERPRISE"}`))
 	}
 }
 


### PR DESCRIPTION
Testcases to validate that ako-infra waits for correct Boostrapcondtion objects.
More tets cases regarding networkinfo cr validation and annotation update would be handled in subsequent PRs.