### PR TITLE
Fix route status update while deleting entry from status

### DIFF
--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -442,6 +442,7 @@ func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) (bool, stri
 	// Route would essentially consist of single hosts.
 	var beforeHost, afterHost string
 	var diff *bool
+
 	for _, status := range oldStatus {
 		if status.RouterName != lib.AKOUser {
 			continue
@@ -480,6 +481,10 @@ func compareRouteStatus(oldStatus, newStatus []routev1.RouteIngress) (bool, stri
 		}
 		afterHost = status.Host
 		break
+	}
+
+	if len(oldStatus) != len(newStatus) {
+		diff = proto.Bool(false)
 	}
 
 	if diff == nil {
@@ -550,7 +555,7 @@ func deleteRouteObject(option UpdateOptions, key string, isVSDelete bool, retryN
 		}
 		// Check if this host is still present in the spec, if so - don't delete it
 		// NS migration case: if false -> ns invalid event happened so remove status
-		if mRoute.Spec.Host != svcMdataHostname || isVSDelete || !utils.CheckIfNamespaceAccepted(option.ServiceMetadata.Namespace) {
+		if mRoute.Status.Ingress[i].RouterName == lib.AKOUser && (mRoute.Spec.Host != svcMdataHostname || isVSDelete || !utils.CheckIfNamespaceAccepted(option.ServiceMetadata.Namespace)) {
 			mRoute.Status.Ingress = append(mRoute.Status.Ingress[:i], mRoute.Status.Ingress[i+1:]...)
 		} else {
 			utils.AviLog.Debugf("key: %s, msg: skipping status update since host is present in the route: %v", key, svcMdataHostname)

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -782,7 +782,7 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 		g.Eventually(func() string {
 			_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-			if len(nodes) > 0 && len(nodes[0].EvhNodes) > 0 && len(nodes[0].EvhNodes[0].PoolRefs) > 0 {
+			if len(nodes) > 0 && len(nodes[0].EvhNodes) > 0 && len(nodes[0].EvhNodes[0].PoolRefs) > 0 && len(nodes[0].EvhNodes[0].PoolRefs[0].Servers) > 0 {
 				return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
 			}
 			return ""


### PR DESCRIPTION
This commit fixes a faulty route status check issue, that was
returning a wrong comparison between old/new route statuses.
Fixes - AV-131326