### PR TITLE
Retain the shared VS VIP on ako reboot

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -361,6 +361,10 @@ func (c *AviObjCache) DeleteUnmarked(childCollection []string) {
 	for _, objkey := range c.VSVIPCache.AviGetAllKeys() {
 		intf, _ := c.VSVIPCache.AviCacheGet(objkey)
 		if obj, ok := intf.(*AviVSVIPCache); ok {
+			if lib.IsShardVS(obj.Name) {
+				utils.AviLog.Infof("Retaining the vsvip: %s", obj.Name)
+				continue
+			}
 			if obj.HasReference == false {
 				utils.AviLog.Infof("Reference Not found for vsvip: %s", objkey)
 				vsVipKeys = append(vsVipKeys, objkey)

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -325,6 +325,22 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 	return &rest_op
 }
 
+func (rest *RestOperations) AviVsVipPut(vsvipObj *avimodels.VsVip, tenant string, key string) *utils.RestOp {
+	path := "/api/vsvip/" + *vsvipObj.UUID
+	rest_op := utils.RestOp{
+		ObjName: *vsvipObj.Name,
+		Path:    path,
+		Method:  utils.RestPut,
+		Obj:     vsvipObj,
+		Tenant:  tenant,
+		Model:   "VsVip",
+		Version: utils.CtrlVersion,
+	}
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VSVIP PUT Restop %v ", key,
+		utils.Stringify(rest_op)))
+	return &rest_op
+}
+
 func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicache.NamespaceName, key string) error {
 	if (rest_op.Err != nil) || (rest_op.Response == nil) {
 		if rest_op.Message == "" {

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -325,10 +325,9 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 	return &rest_op
 }
 
-func (rest *RestOperations) AviVsVipPut(vsvipObj *avimodels.VsVip, tenant string, key string) *utils.RestOp {
-	path := "/api/vsvip/" + *vsvipObj.UUID
+func (rest *RestOperations) AviVsVipPut(uuid string, vsvipObj *avimodels.VsVip, tenant string, key string) *utils.RestOp {
+	path := "/api/vsvip/" + uuid
 	rest_op := utils.RestOp{
-		ObjName: *vsvipObj.Name,
 		Path:    path,
 		Method:  utils.RestPut,
 		Obj:     vsvipObj,

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -69,7 +69,7 @@ func (rest *RestOperations) DequeueNodes(key string) {
 		}
 		if vs_cache_obj != nil {
 			utils.AviLog.Infof("key: %s, msg: nil model found, this is a vs deletion case", key)
-			rest.deleteVSOper(vsKey, vs_cache_obj, namespace, key, false, lib.IsShardVS(key))
+			rest.deleteVSOper(vsKey, vs_cache_obj, namespace, key, false, false)
 		}
 	} else if ok && avimodelIntf != nil {
 		avimodel := avimodelIntf.(*nodes.AviObjectGraph)
@@ -1049,7 +1049,18 @@ func (rest *RestOperations) VSVipDelete(vsvip_to_delete []avicache.NamespaceName
 		vsvip_cache, ok := rest.cache.VSVIPCache.AviCacheGet(vsvip_key)
 		if ok {
 			vsvip_cache_obj, _ := vsvip_cache.(*avicache.AviVSVIPCache)
-			restOp := rest.AviVsVipDel(vsvip_cache_obj.Uuid, namespace, key)
+			var restOp *utils.RestOp
+			if lib.IsShardVS(del_vsvip.Name) {
+				vsvip_avi, err := rest.AviVsVipGet(key, vsvip_cache_obj.Uuid, del_vsvip.Name)
+				if err != nil {
+					utils.AviLog.Errorf("key: %s, msg: failed to get VS VIP %s", key, del_vsvip.Name)
+					return rest_ops
+				}
+				vsvip_avi.DNSInfo = nil
+				restOp = rest.AviVsVipPut(vsvip_avi, namespace, key)
+			} else {
+				restOp = rest.AviVsVipDel(vsvip_cache_obj.Uuid, namespace, key)
+			}
 			restOp.ObjName = del_vsvip.Name
 			rest_ops = append(rest_ops, restOp)
 		}

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1057,7 +1057,7 @@ func (rest *RestOperations) VSVipDelete(vsvip_to_delete []avicache.NamespaceName
 					return rest_ops
 				}
 				vsvip_avi.DNSInfo = nil
-				restOp = rest.AviVsVipPut(vsvip_avi, namespace, key)
+				restOp = rest.AviVsVipPut(vsvip_cache_obj.Uuid, vsvip_avi, namespace, key)
 			} else {
 				restOp = rest.AviVsVipDel(vsvip_cache_obj.Uuid, namespace, key)
 			}

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -69,7 +69,7 @@ func (rest *RestOperations) DequeueNodes(key string) {
 		}
 		if vs_cache_obj != nil {
 			utils.AviLog.Infof("key: %s, msg: nil model found, this is a vs deletion case", key)
-			rest.deleteVSOper(vsKey, vs_cache_obj, namespace, key, false, false)
+			rest.deleteVSOper(vsKey, vs_cache_obj, namespace, key, false, lib.IsShardVS(key))
 		}
 	} else if ok && avimodelIntf != nil {
 		avimodel := avimodelIntf.(*nodes.AviObjectGraph)

--- a/tests/ingresstests/l7_rest_test.go
+++ b/tests/ingresstests/l7_rest_test.go
@@ -77,9 +77,17 @@ func TearDownIngressForCacheSyncCheck(t *testing.T, modelName string) {
 	TearDownTestForIngress(t, modelName)
 }
 
+func CleanupCache(vsName string) {
+	mcache := cache.SharedAviObjCache()
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
+	mcache.VsCacheMeta.AviCacheDelete(vsKey)
+}
+
 func TestCreateIngressCacheSync(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var found bool
+
+	CleanupCache("cluster--Shared-L7-0")
 
 	modelName := "admin/cluster--Shared-L7-0"
 	SetUpIngressForCacheSyncCheck(t, false, false, modelName)


### PR DESCRIPTION
This PR adds support to retain shared VS VIP on AKO reboots.

The following approaches have to be taken by the user to remove the shared VS VIP after this PR.

1. Toggle the `enableEVH` flag in config map and reboot the ako
2. Manually delete from the UI or shell.