### PR TITLE
cherrypick: Donot create dedicated VS if gateway labels are present on the service 

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -867,6 +867,17 @@ func PopulateAdvL4PoolNodeMarkers(namespace, svcName, gatewayName string, port i
 	markers.Port = strconv.Itoa(port)
 	return markers
 }
+
+func PopulateSvcApiL4PoolNodeMarkers(namespace, svcName, gatewayName, protocol string, port int) utils.AviObjectMarkers {
+	var markers utils.AviObjectMarkers
+	markers.Namespace = namespace
+	markers.GatewayName = gatewayName
+	markers.ServiceName = svcName
+	markers.Protocol = protocol
+	markers.Port = strconv.Itoa(port)
+	return markers
+}
+
 func PopulatePGNodeMarkers(namespace, host, infraSettingName string, ingName, path []string) utils.AviObjectMarkers {
 	var markers utils.AviObjectMarkers
 	markers.Namespace = namespace

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -231,6 +231,11 @@ func GetAdvL4PoolName(svcName, namespace, gwName string, port int32) string {
 	return Encode(poolName, L4AdvPool)
 }
 
+func GetSvcApiL4PoolName(svcName, namespace, gwName, protocol string, port int32) string {
+	poolName := NamePrefix + namespace + "-" + svcName + "-" + gwName + "-" + protocol + "-" + strconv.Itoa(int(port))
+	return Encode(poolName, L4AdvPool)
+}
+
 // All L7 object names.
 func GetVsVipName(vsName string) string {
 	vsVipName := vsName

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -293,8 +293,12 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			svcFQDN = getAutoFQDNForService(svcNSName[0], svcNSName[1])
 		}
 
+		poolName := lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port))
+		if lib.UseServicesAPI() {
+			poolName = lib.GetSvcApiL4PoolName(svcNSName[1], namespace, gwName, portProto[0], int32(port))
+		}
 		poolNode := &AviPoolNode{
-			Name:     lib.GetAdvL4PoolName(svcNSName[1], namespace, gwName, int32(port)),
+			Name:     poolName,
 			Tenant:   lib.GetTenant(),
 			Protocol: portProto[0],
 			PortName: "",

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -339,7 +339,13 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 				poolNode.Servers = servers
 			}
 		}
-		poolNode.AviMarkers = lib.PopulateAdvL4PoolNodeMarkers(namespace, svcNSName[1], gwName, port)
+
+		if lib.UseServicesAPI() {
+			poolNode.AviMarkers = lib.PopulateSvcApiL4PoolNodeMarkers(namespace, svcNSName[1], gwName, portProto[0], port)
+		} else {
+			poolNode.AviMarkers = lib.PopulateAdvL4PoolNodeMarkers(namespace, svcNSName[1], gwName, port)
+		}
+
 		pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
 		portPool := AviHostPathPortPoolPG{
 			Port:     uint32(port),

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -207,6 +207,7 @@ type AviObjectMarkers struct {
 	ServiceName      string
 	Path             []string
 	Port             string
+	Protocol         string
 	IngressName      []string
 	GatewayName      string
 }

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -762,8 +762,11 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 		g.Eventually(func() string {
 			_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-			return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
-		}, 10*time.Second).Should(gomega.Equal("2.2.2.1"))
+			if len(nodes) > 0 && len(nodes[0].EvhNodes) > 0 && len(nodes[0].EvhNodes[0].PoolRefs) > 0 {
+				return *nodes[0].EvhNodes[0].PoolRefs[0].Servers[0].Ip.Addr
+			}
+			return ""
+		}, 15*time.Second).Should(gomega.Equal("2.2.2.1"))
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 	} else {

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -359,7 +359,7 @@ func TestServicesAPINamingConvention(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--default-my-gateway"))
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-svc-my-gateway--8081"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-svc-my-gateway-TCP-8081"))
 	g.Expect(nodes[0].L4PolicyRefs[0].Name).To(gomega.Equal("cluster--default-my-gateway"))
 
 	TeardownGatewayClass(t, gwClassName)


### PR DESCRIPTION
This commit avoids creating an extra dedicated VS, when services API is
being used and a gateway frontends the service of type LB. This would mean
an either/or workflow, decided by the presence of labesl on the k8s Service.