### PR TITLE
Doc: Documentation for the new field aliases in hostrule CRD

### DIFF
--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -44,6 +44,9 @@ A sample HostRule CRD looks like this:
           - port: 6443
             enableSSL: true
           loadBalancerIP: 10.10.10.1
+        aliases: # optional
+        -  bar.com
+        -  baz.com
 
 
 ### Specific usage of HostRule CRD
@@ -213,10 +216,22 @@ Where dedicated VSes are created corresponding to a single application, Shared V
         fqdnType: Contains
         tcpSetting:
           loadBalancerIP: 10.10.10.1
+#### Configure aliases for FQDN
+
+The Aliases field adds the ability to have multiple FQDNs configured under a specific route/ingress for the child VS instead of creating the route/ingress multiple times.
+
+        aliases:
+        - bar.com
+        - baz.com
+
+This list of FQDNs inherits all the properties of the root FQDN specified under the `virtualHost` section.
+DNS will arrive with the host header as bar.com to the VIP hosting foo.com and this CRD property would ensure that the request is routed appropriately to the backend service of `foo.com`.
+
+Aliases field must contain unique FQDNs and must not contain GSLB FQDN or the root FQDN. Users must ensure that the `fqdnType` is set as `Exact` before setting this field.
 
 #### Status Messages
 
-The status messages are used to give instanteneous feedback to the users about the reference objects specified in the HostRule CRD.
+The status messages are used to give instantaneous feedback to the users about the reference objects specified in the HostRule CRD.
 
 Following are some of the sample status messages:
 

--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -225,7 +225,7 @@ The Aliases field adds the ability to have multiple FQDNs configured under a spe
         - baz.com
 
 This list of FQDNs inherits all the properties of the root FQDN specified under the `virtualHost` section.
-DNS will arrive with the host header as bar.com to the VIP hosting foo.com and this CRD property would ensure that the request is routed appropriately to the backend service of `foo.com`.
+DNS will arrive with the host header as bar.com to the VIP hosting foo.region1.com and this CRD property would ensure that the request is routed appropriately to the backend service of `foo.region1.com`.
 
 Aliases field must contain unique FQDNs and must not contain GSLB FQDN or the root FQDN. Users must ensure that the `fqdnType` is set as `Exact` before setting this field.
 

--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -216,6 +216,7 @@ Where dedicated VSes are created corresponding to a single application, Shared V
         fqdnType: Contains
         tcpSetting:
           loadBalancerIP: 10.10.10.1
+
 #### Configure aliases for FQDN
 
 The Aliases field adds the ability to have multiple FQDNs configured under a specific route/ingress for the child VS instead of creating the route/ingress multiple times.

--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -225,7 +225,7 @@ The Aliases field adds the ability to have multiple FQDNs configured under a spe
         - baz.com
 
 This list of FQDNs inherits all the properties of the root FQDN specified under the `virtualHost` section.
-DNS will arrive with the host header as bar.com to the VIP hosting foo.region1.com and this CRD property would ensure that the request is routed appropriately to the backend service of `foo.region1.com`.
+Traffic would arrive with the host header as bar.com to the VIP hosting foo.region1.com and this CRD property would ensure that the request is routed appropriately to the backend service of `foo.region1.com`.
 
 Aliases field must contain unique FQDNs and must not contain GSLB FQDN or the root FQDN. Users must ensure that the `fqdnType` is set as `Exact` before setting this field.
 

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -588,7 +588,7 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 			aliases := cachedAliases.([]string)
 			for _, alias := range hostrule.Spec.VirtualHost.Aliases {
 				if utils.HasElem(aliases, alias) {
-					err = fmt.Errorf("%s is already in use", alias)
+					err = fmt.Errorf("%s is already in use by hostrule %s", alias, cachedFQDN)
 					status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
 					return err
 				}

--- a/tests/dedicatedvstests/l7_dedicated_crd_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_crd_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2020-2021 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2020-2021 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds documentation for the new field aliases in hostrule CRD. It also includes code that addresses some minor comments given by @chauhanshubham in the PR [#706](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/706)