### PR TITLE
Do not overwrite the ipam network subnet config in Vip before PUT

### DIFF
--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -57,6 +57,7 @@ type AviDSCache struct {
 type AviCloudPropertyCache struct {
 	Name      string
 	VType     string
+	IPAMType  string
 	NSIpamDNS []string
 }
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2417,7 +2417,10 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	}
 	cloud_obj := &AviCloudPropertyCache{Name: cloudName, VType: vtype}
 
-	ipamType := c.AviIPAMPropertyPopulate(client, *cloud.IPAMProviderRef)
+	ipamType := ""
+	if cloud.IPAMProviderRef != nil && *cloud.IPAMProviderRef != "" {
+		ipamType = c.AviIPAMPropertyPopulate(client, *cloud.IPAMProviderRef)
+	}
 	cloud_obj.IPAMType = ipamType
 	utils.AviLog.Infof("IPAM Provider type configured as %s for Cloud %s", cloud_obj.IPAMType, cloud_obj.Name)
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2379,7 +2379,7 @@ func (c *AviObjCache) AviClusterStatusPopulate(client *clients.AviClient) error 
 }
 
 func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, cloudName string) error {
-	uri := "/api/cloud/?name=" + cloudName
+	uri := "/api/cloud/?include_name&name=" + cloudName
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("CloudProperties Get uri %v returned err %v", uri, err)
@@ -2417,12 +2417,15 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	}
 	cloud_obj := &AviCloudPropertyCache{Name: cloudName, VType: vtype}
 
+	ipamType := c.AviIPAMPropertyPopulate(client, *cloud.IPAMProviderRef)
+	cloud_obj.IPAMType = ipamType
+	utils.AviLog.Infof("IPAM Provider type configured as %s for Cloud %s", cloud_obj.IPAMType, cloud_obj.Name)
+
 	subdomains := c.AviDNSPropertyPopulate(client, *cloud.UUID)
 	if len(subdomains) == 0 {
 		utils.AviLog.Warnf("Cloud: %v does not have a dns provider configured", cloudName)
 		return nil
 	}
-
 	if subdomains != nil {
 		cloud_obj.NSIpamDNS = subdomains
 	}
@@ -2430,6 +2433,38 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	c.CloudKeyCache.AviCacheAdd(cloudName, cloud_obj)
 	utils.AviLog.Infof("Added CloudKeyCache cache key %v val %v", cloudName, cloud_obj)
 	return nil
+}
+
+func (c *AviObjCache) AviIPAMPropertyPopulate(client *clients.AviClient, ipamRef string) string {
+	ipamName := strings.Split(ipamRef, "#")[1]
+	uri := "/api/ipamdnsproviderprofile/?include_name&name=" + ipamName
+	result, err := lib.AviGetCollectionRaw(client, uri)
+	if err != nil {
+		utils.AviLog.Warnf("IPAMProvider Get uri %v returned err %v", uri, err)
+		return ""
+	}
+
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
+		return ""
+	}
+
+	if result.Count != 1 {
+		utils.AviLog.Errorf("IPAM details not found for cloud name: %s", ipamName)
+	}
+
+	ipam := models.IPAMDNSProviderProfile{}
+	if err = json.Unmarshal(elems[0], &ipam); err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal ipam provider data, err: %v", err)
+		return ""
+	}
+
+	if ipam.Type == nil {
+		return ""
+	}
+	return *ipam.Type
 }
 
 func (c *AviObjCache) AviDNSPropertyPopulate(client *clients.AviClient, cloudUUID string) []string {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -162,6 +162,7 @@ const (
 	CRDActive                                  = "ACTIVE"
 	CRDInactive                                = "INACTIVE"
 	SSLPort                                    = 443
+	IPAMProviderInfoblox                       = "IPAMDNS_TYPE_INFOBLOX"
 
 	// AKO Event constants
 	AKOEventComponent  = "avi-kubernetes-operator"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -163,6 +163,7 @@ const (
 	CRDInactive                                = "INACTIVE"
 	SSLPort                                    = 443
 	IPAMProviderInfoblox                       = "IPAMDNS_TYPE_INFOBLOX"
+	IPAMProviderCustom                         = "IPAMDNS_TYPE_CUSTOM"
 
 	// AKO Event constants
 	AKOEventComponent  = "avi-kubernetes-operator"

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -35,6 +35,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func GetIPAMProviderType() string {
+	cache := avicache.SharedAviObjCache()
+	cloud, ok := cache.CloudKeyCache.AviCacheGet(utils.CloudName)
+	if !ok || cloud == nil {
+		utils.AviLog.Warnf("Cloud object %s not found in cache", utils.CloudName)
+		return ""
+	}
+	cloudProperty, ok := cloud.(*avicache.AviCloudPropertyCache)
+	if !ok {
+		utils.AviLog.Warnf("Cloud property object not found")
+		return ""
+	}
+	return cloudProperty.IPAMType
+}
+
 func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCache *avicache.AviVsCache, cache_obj *avicache.AviVSVIPCache, key string) (*utils.RestOp, error) {
 	if lib.CheckObjectNameLength(vsvip_meta.Name, lib.VIP) {
 		utils.AviLog.Warnf("key: %s not processing VSVIP object", key)
@@ -76,44 +91,47 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 		vsvip.VsvipCloudConfigCksum = &cksumstr
 
 		// handling static IP and networkName (infraSetting) updates.
-		vip := &avimodels.Vip{
-			VipID:                  &vipId,
-			AutoAllocateIP:         &autoAllocate,
-			AutoAllocateFloatingIP: vsvip_meta.EnablePublicIP,
-		}
+		if GetIPAMProviderType() != lib.IPAMProviderInfoblox {
+			vip := &avimodels.Vip{
+				VipID:                  &vipId,
+				AutoAllocateIP:         &autoAllocate,
+				AutoAllocateFloatingIP: vsvip_meta.EnablePublicIP,
+			}
 
-		// This would throw an error for advl4 the error is propagated to the gateway status.
-		if vsvip_meta.IPAddress != "" {
-			vip.IPAddress = &avimodels.IPAddr{Type: &ipType, Addr: &vsvip_meta.IPAddress}
-		}
+			// This would throw an error for advl4 the error is propagated to the gateway status.
+			if vsvip_meta.IPAddress != "" {
+				vip.IPAddress = &avimodels.IPAddr{Type: &ipType, Addr: &vsvip_meta.IPAddress}
+			}
 
-		if lib.IsPublicCloud() && lib.GetCloudType() != lib.CLOUD_GCP {
-			vips := networkNamesToVips(vsvip_meta.VipNetworks, vsvip_meta.EnablePublicIP)
-			vsvip.Vip = []*avimodels.Vip{}
-			vsvip.Vip = append(vsvip.Vip, vips...)
-		} else {
-			// Set the IPAM network subnet for all clouds except AWS and Azure
-			if len(vsvip_meta.VipNetworks) != 0 {
-				if vip.IPAMNetworkSubnet == nil {
-					vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{}
+			if lib.IsPublicCloud() && lib.GetCloudType() != lib.CLOUD_GCP {
+				vips := networkNamesToVips(vsvip_meta.VipNetworks, vsvip_meta.EnablePublicIP)
+				vsvip.Vip = []*avimodels.Vip{}
+				vsvip.Vip = append(vsvip.Vip, vips...)
+			} else {
+				// Set the IPAM network subnet for all clouds except AWS and Azure
+				if len(vsvip_meta.VipNetworks) != 0 {
+					if len(vsvip.Vip) == 1 && vsvip.Vip[0].IPAMNetworkSubnet == nil {
+						vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{}
+					}
+					networkRef := "/api/network/?name=" + vsvip_meta.VipNetworks[0].NetworkName
+					vip.IPAMNetworkSubnet.NetworkRef = &networkRef
+					vsvip.Vip = []*avimodels.Vip{vip}
 				}
-				networkRef := "/api/network/?name=" + vsvip_meta.VipNetworks[0].NetworkName
-				vip.IPAMNetworkSubnet.NetworkRef = &networkRef
-				vsvip.Vip = []*avimodels.Vip{vip}
+			}
+
+			if vsCache != nil && !vsCache.EnableRhi && len(vsvip_meta.BGPPeerLabels) > 0 {
+				err = fmt.Errorf("to use selective vip advertisement, %s VS must advertise vips via BGP. Please recreate the VS", vsCache.Name)
+				utils.AviLog.Error(err)
+				return nil, err
+			}
+
+			if len(vsvip_meta.BGPPeerLabels) > 0 {
+				vsvip.BgpPeerLabels = vsvip_meta.BGPPeerLabels
+			} else {
+				vsvip.BgpPeerLabels = nil
 			}
 		}
 
-		if vsCache != nil && !vsCache.EnableRhi && len(vsvip_meta.BGPPeerLabels) > 0 {
-			err = fmt.Errorf("to use selective vip advertisement, %s VS must advertise vips via BGP. Please recreate the VS", vsCache.Name)
-			utils.AviLog.Error(err)
-			return nil, err
-		}
-
-		if len(vsvip_meta.BGPPeerLabels) > 0 {
-			vsvip.BgpPeerLabels = vsvip_meta.BGPPeerLabels
-		} else {
-			vsvip.BgpPeerLabels = nil
-		}
 		if lib.GetGRBACSupport() {
 			vsvip.Markers = lib.GetMarkers()
 		}
@@ -590,6 +608,7 @@ func (rest *RestOperations) AviVsVipCacheDel(rest_op *utils.RestOp, vsKey avicac
 func networkNamesToVips(vipNetworks []akov1alpha1.AviInfraSettingVipNetwork, enablePublicIP *bool) []*avimodels.Vip {
 	var vipList []*avimodels.Vip
 	autoAllocate := true
+
 	for vipIDInt, vipNetwork := range vipNetworks {
 		vipID := strconv.Itoa(vipIDInt + 1)
 		newVip := &avimodels.Vip{
@@ -600,5 +619,6 @@ func networkNamesToVips(vipNetworks []akov1alpha1.AviInfraSettingVipNetwork, ena
 		newVip.SubnetUUID = proto.String(vipNetwork.NetworkName)
 		vipList = append(vipList, newVip)
 	}
+
 	return vipList
 }

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -535,7 +535,6 @@ func deleteRouteObject(option UpdateOptions, key string, isVSDelete bool, retryN
 	}
 
 	mRoute, err := utils.GetInformers().RouteInformer.Lister().Routes(option.ServiceMetadata.Namespace).Get(option.ServiceMetadata.IngressName)
-
 	if err != nil {
 		utils.AviLog.Warnf("key: %s, msg: Could not get the Route object for DeleteStatus: %s", key, err)
 		return err

--- a/tests/avimockobjects/CLOUD_NSXT_mock.json
+++ b/tests/avimockobjects/CLOUD_NSXT_mock.json
@@ -54,8 +54,8 @@
       "license_tier": "ENTERPRISE",
       "autoscale_polling_interval": 60,
       "vmc_deployment": false,
-      "ipam_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-3abd2780-ee6d-4435-9616-5066f0f1909a",
-      "dns_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-dd704396-053a-4c43-9d88-fa211cfd8f58"
+      "ipam_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-3abd2780-ee6d-4435-9616-5066f0f1909a#avi-ipam",
+      "dns_provider_ref": "https://10.50.63.199/api/ipamdnsproviderprofile/ipamdnsproviderprofile-dd704396-053a-4c43-9d88-fa211cfd8f58#avi-dns"
     }
   ]
 }

--- a/tests/avimockobjects/CLOUD_VCENTER_mock.json
+++ b/tests/avimockobjects/CLOUD_VCENTER_mock.json
@@ -4,7 +4,7 @@
       {
         "uuid": "cloud-8fb8b8fa-5aa3-418e-9099-c3ec29196d08",
         "vtype": "CLOUD_VCENTER",
-        "ipam_provider_ref": "https://10.79.168.232/api/ipamdnsproviderprofile/ipamdnsproviderprofile-b970467a-e70d-4bba-a7e2-e3a9d3b535a7",
+        "ipam_provider_ref": "https://10.79.168.232/api/ipamdnsproviderprofile/ipamdnsproviderprofile-b970467a-e70d-4bba-a7e2-e3a9d3b535a7#avi-ipam",
         "_last_modified": "1598531961880147",
         "name": "CLOUD_VCENTER",
         "url": "https://10.79.168.232/api/cloud/cloud-8fb8b8fa-5aa3-418e-9099-c3ec29196d08",

--- a/tests/avimockobjects/ipamdnsproviderprofile_uuid_mock.json
+++ b/tests/avimockobjects/ipamdnsproviderprofile_uuid_mock.json
@@ -30,5 +30,5 @@
   },
   "uuid": "ipamdnsproviderprofile-19a05809-a373-4892-a318-74702c2237ca",
   "type": "IPAMDNS_TYPE_INTERNAL_DNS",
-  "name": "avi-dns"
+  "name": "avi-ipam"
 }

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -933,7 +933,10 @@ func TestUpdateBackendService(t *testing.T) {
 		g.Eventually(func() string {
 			_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 			nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-			return *nodes[0].PoolRefs[0].Servers[0].Ip.Addr
+			if len(nodes) > 0 && len(nodes[0].PoolRefs) > 0 && len(nodes[0].PoolRefs[0].Servers) > 0 {
+				return *nodes[0].PoolRefs[0].Servers[0].Ip.Addr
+			}
+			return ""
 		}, 10*time.Second).Should(gomega.Equal("2.2.2.1"))
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(1))


### PR DESCRIPTION
This prevents AKO to overwrite the ipam network subnet configuration
in the Vip while doing a PUT VSVIP call.
Resolves AV-132243