### PR TITLE
Control AKO Event broadcasting using ConfigMap `enableEvents`

### DIFF
--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -44,6 +44,8 @@ type NamespaceSelector struct {
 type AKOSettings struct {
 	// LogLevel defines the log level to be used by the AKO controller
 	LogLevel LogLevelType `json:"logLevel,omitempty"`
+	// EnableEvents controls whether AKO broadcasts Events in the cluster or not
+	EnableEvents bool `json:"enableEvents,omitempty"`
 	// FullSyncFrequency defines the interval at which full sync is carried out by the AKO controller
 	FullSyncFrequency string `json:"fullSyncFrequency,omitempty"`
 	// APIServerPort is the port at which the AKO API server runs

--- a/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
+++ b/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
               "fullSyncFrequency": "1800",
               "layer7Only": false,
               "logLevel": "INFO",
+              "enableEvents": "true",
               "namespaceSelector": {
                 "labelKey": "",
                 "labelValue": ""

--- a/ako-operator/bundle/manifests/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/bundle/manifests/ako.vmware.com_akoconfigs.yaml
@@ -67,6 +67,10 @@ spec:
                     description: Layer7Only flag, if set to true, then AKO controller
                       will only do layer 7 loadbalancing
                     type: boolean
+                  enableEvents:
+                    description: EnableEvents controls whether AKO broadcasts Events in 
+                      the cluster or not
+                    type: boolean
                   logLevel:
                     description: LogLevel defines the log level to be used by the
                       AKO controller

--- a/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
@@ -69,6 +69,10 @@ spec:
                     description: Layer7Only enables AKO to do Layer 7 loadbalancing
                       only
                     type: boolean
+                  enableEvents:
+                    description: EnableEvents controls whether AKO broadcasts Events in 
+                      the cluster or not
+                    type: boolean
                   logLevel:
                     description: LogLevel defines the log level to be used by the
                       AKO controller

--- a/ako-operator/controllers/configmap_test.go
+++ b/ako-operator/controllers/configmap_test.go
@@ -53,6 +53,7 @@ var cmJson = `
 		"deleteConfig": "false",
 		"disableStaticRouteSync": "false",
 		"fullSyncFrequency": "1800",
+		"enableEvents": "true",
 		"logLevel": "INFO",
 		"networkName": "test-nw",
 		"nodeKey": "key",

--- a/ako-operator/controllers/utils.go
+++ b/ako-operator/controllers/utils.go
@@ -46,6 +46,7 @@ const (
 	DefaultIngController   = "defaultIngController"
 	VipNetworkList         = "vipNetworkList"
 	BgpPeerLabels          = "bgpPeerLabels"
+	EnableEvents           = "enableEvents"
 	LogLevel               = "logLevel"
 	DeleteConfig           = "deleteConfig"
 	AutoFQDN               = "autoFQDN"

--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_akoconfigs.yaml
@@ -66,6 +66,10 @@ spec:
                     description: Layer7Only enables AKO to do Layer 7 loadbalancing
                       only
                     type: boolean
+                  enableEvents:
+                    description: EnableEvents controls whether AKO broadcasts Events in 
+                      the cluster or not
+                    type: boolean
                   logLevel:
                     description: LogLevel defines the log level to be used by the
                       AKO controller

--- a/ako-operator/helm/ako-operator/templates/akoconfig.yaml
+++ b/ako-operator/helm/ako-operator/templates/akoconfig.yaml
@@ -9,6 +9,7 @@ spec:
   imageRepository: {{ .Values.akoImage.repository }}
   imagePullPolicy: {{ .Values.akoImage.pullPolicy }}
   akoSettings:
+    enableEvents: {{ .Values.AKOSettings.enableEvents }}
     logLevel: {{ .Values.AKOSettings.logLevel }}
     fullSyncFrequency: {{ .Values.AKOSettings.fullSyncFrequency | quote }}
     apiServerPort: {{ .Values.AKOSettings.apiServerPort }}

--- a/ako-operator/helm/ako-operator/values.yaml
+++ b/ako-operator/helm/ako-operator/values.yaml
@@ -16,6 +16,7 @@ akoImage:
 
 ### This section outlines the generic AKO controller settings
 AKOSettings:
+  enableEvents: "true" # Enables/disables Event broadcasting via AKO  
   logLevel: "INFO" #enum: INFO|DEBUG|WARN|ERROR
   fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.
   apiServerPort: 8080 # Specify the port for the API server, default is set as 8080 // EmptyAllowed: false

--- a/docs/ako_operator.md
+++ b/docs/ako_operator.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `L4Settings.defaultDomain` | Specify a default sub-domain for L4 LB services | First domainname found in cloud's dnsprofile |
 | `L7Settings.l7ShardingScheme` | Sharding scheme enum values: hostname, namespace | hostname |
 | `AKOSettings.cniPlugin` | CNI Plugin being used in kubernetes cluster. Specify one of: calico, canal, flannel | **required** for calico setups |
+| `AKOSettings.enableEvents` | enableEvents can be changed dynamically from the configmap | true |
 | `AKOSettings.logLevel` | logLevel enum values: INFO, DEBUG, WARN, ERROR. logLevel can be changed dynamically from the configmap | INFO |
 | `AKOSettings.deleteConfig` | set to true if user wants to delete AKO created objects from Avi. deleteConfig can be changed dynamically from the configmap | false |
 | `AKOSettings.disableStaticRouteSync` | Disables static route syncing if set to true | false |

--- a/docs/akoconfig.md
+++ b/docs/akoconfig.md
@@ -13,6 +13,7 @@ spec:
   imageRepository: "ako:latest"
   imagePullPolicy: "IfNotPresent"
   akoSettings:
+    enableEvents: "true"
     logLevel: "WARN"
     fullSyncFrequency: "1800"
     apiServerPort: 8080

--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -152,6 +152,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `L7Settings.noPGForSNI`  | Skip using Pool Groups for SNI children | false |  
 | `L7Settings.l7ShardingScheme` | Sharding scheme enum values: hostname, namespace | hostname |
 | `AKOSettings.cniPlugin` | CNI Plugin being used in kubernetes cluster. Specify one of: calico, canal, flannel, ncp | **required** for calico, ncp setups |
+| `AKOSettings.enableEvents` | enableEvents can be changed dynamically from the configmap | true |
 | `AKOSettings.logLevel` | logLevel enum values: INFO, DEBUG, WARN, ERROR. logLevel can be changed dynamically from the configmap | INFO |
 | `AKOSettings.deleteConfig` | set to true if user wants to delete AKO created objects from Avi. deleteConfig can be changed dynamically from the configmap | false |
 | `AKOSettings.disableStaticRouteSync` | Disables static route syncing if set to true | false |

--- a/docs/install/operator.md
+++ b/docs/install/operator.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `L4Settings.defaultDomain` | Specify a default sub-domain for L4 LB services | First domainname found in cloud's dnsprofile |
 | `L7Settings.l7ShardingScheme` | Sharding scheme enum values: hostname, namespace | hostname |
 | `AKOSettings.cniPlugin` | CNI Plugin being used in kubernetes cluster. Specify one of: calico, canal, flannel | **required** for calico setups |
+| `AKOSettings.enableEvents` | enableEvents can be changed dynamically from the configmap | true |
 | `AKOSettings.logLevel` | logLevel enum values: INFO, DEBUG, WARN, ERROR. logLevel can be changed dynamically from the configmap | INFO |
 | `AKOSettings.deleteConfig` | set to true if user wants to delete AKO created objects from Avi. deleteConfig can be changed dynamically from the configmap | false |
 | `AKOSettings.disableStaticRouteSync` | Disables static route syncing if set to true | false |

--- a/docs/troubleshooting/events.md
+++ b/docs/troubleshooting/events.md
@@ -9,6 +9,7 @@ Avi Kubernetes Operator broadcasts events in order to -
 - use events for better error reporting, for support and engineering team to report issue after analyzing event timeline.
 - provide granular debugging on Ingress/Routes/SvcLB/Gateways and show their relationship with Avi virtual services, that AKO creates.
 
+AKO Event broadcasting can be controlled by setting the `enableEvents` flag in the ConfigMap appropriately. By default the Event broadcasting is enabled, but can be switched off by updating the ConfigMap, which comes into affect without rebooting AKO.
 
 ## Event Types
 
@@ -41,6 +42,8 @@ A few examples of a `Warning` events are:
 ```
 23s         Warning   AKOShutdown          pod/ako-0   Invalid user input [No user input detected for vipNetworkList]
 ```
+
+**Note**: Regardless of the `enableEvents` setting in the ConfigMap, Warning Events are always broadcasted via AKO.
 
 ## Event Categories
 

--- a/docs/values.md
+++ b/docs/values.md
@@ -10,6 +10,10 @@ This field is used to set a frequency of consitency checks in AKO. Typically inc
 of band w.r.t AKO. For example, a pool is deleted by the user from the UI of the Avi Controller. The full sync frequency is used
 to ensure that the models are re-conciled and the corresponding Avi objects are restored to the original state.
 
+### AKOSettings.enableEvents *(editable)*
+
+This flag provides the ability to enable/disable Event broadcasting from AKO. The value specified here gets populated in the ConfigMap and can be edited at any time while AKO is running. AKO picks up the change in the param value and enables/disables Event broadcasting in the cluster at runtime, so AKO pod restart is not required.
+
 ### AKOSettings.logLevel *(editable)*
 
 This flag defines the logLevel for logging and can be set to one of `DEBUG`, `INFO`, `WARN`, `ERROR` (case sensitive).

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
   noPGForSNI: {{ .Values.L7Settings.noPGForSNI | quote }}
   enableRHI: {{ .Values.NetworkSettings.enableRHI | quote }}
   nsxtT1LR: {{ .Values.NetworkSettings.nsxtT1LR | quote }}
+  enableEvents: {{ .Values.AKOSettings.enableEvents | quote }}
   logLevel: {{ .Values.AKOSettings.logLevel | quote }}
   deleteConfig: {{ .Values.AKOSettings.deleteConfig | quote }}
   autoFQDN: {{ .Values.L4Settings.autoFQDN | quote }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -10,6 +10,7 @@ image:
 
 ### This section outlines the generic AKO settings
 AKOSettings:
+  enableEvents: "true" # Enables/disables Event broadcasting via AKO 
   logLevel: "WARN" # enum: INFO|DEBUG|WARN|ERROR
   fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.
   apiServerPort: 8080 # Internal port for AKO's API server for the liveness probe of the AKO pod default=8080

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -265,6 +265,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			}
 			utils.AviLog.Infof("avi k8s configmap created")
 			utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
+			lib.AKOControlConfig().EventsSetEnabled(cm.Data[lib.EnableEvents])
 			// Check if AKO is configured to only use Ingress. This value can be only set during bootup and can't be edited dynamically.
 			lib.SetLayer7Only(cm.Data[lib.LAYER7_ONLY])
 			// Check if we need to use PGs for SNIs or not.
@@ -296,6 +297,10 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			// if resourceversions and loglevel change, set new loglevel
 			if oldcm.Data[lib.LOG_LEVEL] != cm.Data[lib.LOG_LEVEL] {
 				utils.AviLog.SetLevel(cm.Data[lib.LOG_LEVEL])
+			}
+
+			if oldcm.Data[lib.EnableEvents] != cm.Data[lib.EnableEvents] {
+				lib.AKOControlConfig().EventsSetEnabled(cm.Data[lib.EnableEvents])
 			}
 
 			if oldcm.Data[lib.DeleteConfig] == cm.Data[lib.DeleteConfig] {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -61,6 +61,7 @@ const (
 	IS_IN                                      = "IS_IN"
 	SLOW_SYNC_TIME                             = 90 // seconds
 	LOG_LEVEL                                  = "logLevel"
+	EnableEvents                               = "enableEvents"
 	LAYER7_ONLY                                = "layer7Only"
 	NO_PG_FOR_SNI                              = "noPGForSNI"
 	SERVICE_TYPE                               = "SERVICE_TYPE"

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -215,6 +215,16 @@ func (c *akoControlConfig) SetEventRecorder(id string, client kubernetes.Interfa
 	c.akoEventRecorder = utils.NewEventRecorder(id, client, fake)
 }
 
+func (c *akoControlConfig) EventsSetEnabled(enable string) {
+	if enable == "true" {
+		utils.AviLog.Infof("Enabling event broadcasting via AKO.")
+		c.akoEventRecorder.Enabled = true
+	} else {
+		utils.AviLog.Infof("Disabling event broadcasting via AKO.")
+		c.akoEventRecorder.Enabled = false
+	}
+}
+
 func (c *akoControlConfig) EventRecorder() *utils.EventRecorder {
 	return c.akoEventRecorder
 }


### PR DESCRIPTION
Introduce a flag in the AKO Configmap that allows users to disable
AKO event broadcasting. Any changes in the parameter value takes affect
during runtime, without requiring AKO reboot. By default Events are
enabled and needs explicit user intent to disable. AKO Warning events
are never disabled regardless of the `enableEvents` flag.