### PR TITLE
Bringing back syncNamespace and advancedL4 in akoconfig CRD for 1.6.1

### DIFF
--- a/ako-operator/api/v1alpha1/akoconfig_types.go
+++ b/ako-operator/api/v1alpha1/akoconfig_types.go
@@ -106,12 +106,16 @@ type L7Settings struct {
 	ShardVSSize VSSize `json:"shardVSSize,omitempty"`
 	// PassthroughShardSize specifies the number of shard VSs to be created for passthrough routes
 	PassthroughShardSize PassthroughVSSize `json:"passthroughShardSize,omitempty"`
+	// SyncNamespace takes in a namespace from which AKO will sync the objects
+	SyncNamespace string `json:"syncNamespace,omitempty"`
 	// NoPGForSNI removes Avi PoolGroups from SNI VSes
 	NoPGForSNI bool `json:"noPGForSNI,omitempty"`
 }
 
 // L4Settings defines the L4 configuration for the AKO controller
 type L4Settings struct {
+	// AdvancedL4 specifies whether the AKO controller should listen for the Gateway objects
+	AdvancedL4 bool `json:"advancedL4,omitempty"`
 	// DefaultDomain is the default domain
 	DefaultDomain string `json:"defaultDomain,omitempty"`
 	//Specifies the FQDN pattern - default, flat or disabled

--- a/ako-operator/bundle/manifests/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/bundle/manifests/ako.vmware.com_akoconfigs.yaml
@@ -126,6 +126,10 @@ spec:
               l4Settings:
                 description: L4Settings defines the L4 configuration for the AKO controller
                 properties:
+                  advancedL4:
+                    description: AdvancedL4 specifies whether the AKO controller should
+                      listen for the Gateway objects
+                    type: boolean
                   autoFQDN:
                     description: Specifies the FQDN pattern - default, flat or disabled
                     type: string
@@ -166,6 +170,10 @@ spec:
                     - LARGE
                     - MEDIUM
                     - SMALL
+                    type: string
+                  syncNamespace:
+                    description: SyncNamespace takes in a namespace from which AKO
+                      will sync the objects
                     type: string
                 type: object
               logFile:

--- a/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/config/crd/bases/ako.vmware.com_akoconfigs.yaml
@@ -132,6 +132,10 @@ spec:
               l4Settings:
                 description: L4Settings defines the L4 configuration for the AKO controller
                 properties:
+                  advancedL4:
+                    description: AdvancedL4 specifies whether the AKO controller should
+                      listen for the Gateway objects
+                    type: boolean
                   autoFQDN:
                     description: Specifies the FQDN pattern - default, flat or disabled
                     type: string
@@ -173,6 +177,10 @@ spec:
                     - MEDIUM
                     - SMALL
                     - DEDICATED
+                    type: string
+                  syncNamespace:
+                    description: SyncNamespace takes in a namespace from which AKO
+                      will sync the objects
                     type: string
                 type: object
               logFile:

--- a/ako-operator/controllers/akoconfig_controller.go
+++ b/ako-operator/controllers/akoconfig_controller.go
@@ -153,6 +153,9 @@ func (r *AKOConfigReconciler) ReconcileAllArtifacts(ctx context.Context, ako ako
 		log.Error(err, "secret named avi-secret is must for starting AKO controller")
 		return err
 	}
+
+	checkDeprecatedFields(ako, log)
+
 	// reconcile all the required artifacts for AKO
 	err = createOrUpdateConfigMap(ctx, ako, log, r)
 	if err != nil {

--- a/ako-operator/controllers/configmap.go
+++ b/ako-operator/controllers/configmap.go
@@ -256,3 +256,13 @@ func BuildConfigMap(ako akov1alpha1.AKOConfig) (corev1.ConfigMap, error) {
 
 	return cm, nil
 }
+
+func checkDeprecatedFields(ako akov1alpha1.AKOConfig, log logr.Logger) {
+	if ako.Spec.L4Settings.AdvancedL4 {
+		log.V(0).Info("", "WARN: ", "akoconfig.Spec.L4Settings.AdvancedL4 will be deprecated")
+	}
+
+	if ako.Spec.L7Settings.SyncNamespace != "" {
+		log.V(0).Info("", "WARN: ", "akoconfig.Spec.L7Settings.SyncNamespace will be deprecated")
+	}
+}

--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_akoconfigs.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_akoconfigs.yaml
@@ -128,6 +128,10 @@ spec:
               l4Settings:
                 description: L4Settings defines the L4 configuration for the AKO controller
                 properties:
+                  advancedL4:
+                    description: AdvancedL4 specifies whether the AKO controller should
+                      listen for the Gateway objects
+                    type: boolean
                   autoFQDN:
                     description: Specifies the FQDN pattern - default, flat or disabled
                     type: string
@@ -169,6 +173,10 @@ spec:
                     - MEDIUM
                     - SMALL
                     - DEDICATED
+                    type: string
+                  syncNamespace:
+                    description: SyncNamespace takes in a namespace from which AKO
+                      will sync the objects
                     type: string
                 type: object
               logFile:


### PR DESCRIPTION
This commit adds `syncNamespace` and `advancedL4` fields back into the akoconfigs CRD with a warning message.
This is done to avoid any API Version upgrade or introducing admissions controllers for the AKO Operator 1.6.1 release.

