### PR TITLE
Status update push to queue fixes, ingress/svc/route update check enhancements

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -132,9 +132,19 @@ func isIngressUpdated(oldIngress, newIngress *networkingv1.Ingress) bool {
 	}
 
 	oldSpecHash := utils.Hash(utils.Stringify(oldIngress.Spec))
-	oldAnnotationHash := utils.Hash(utils.Stringify(oldIngress.Annotations))
 	newSpecHash := utils.Hash(utils.Stringify(newIngress.Spec))
-	newAnnotationHash := utils.Hash(utils.Stringify(newIngress.Annotations))
+
+	// Check for annotation change apart from the ones AKO fills in
+	// after status update
+	oldAnnotation := oldIngress.DeepCopy().Annotations
+	delete(oldAnnotation, lib.VSAnnotation)
+	delete(oldAnnotation, lib.ControllerAnnotation)
+	newAnnotation := newIngress.DeepCopy().Annotations
+	delete(newAnnotation, lib.VSAnnotation)
+	delete(newAnnotation, lib.ControllerAnnotation)
+
+	oldAnnotationHash := utils.Hash(utils.Stringify(oldAnnotation))
+	newAnnotationHash := utils.Hash(utils.Stringify(newAnnotation))
 
 	if oldSpecHash != newSpecHash || oldAnnotationHash != newAnnotationHash {
 		return true

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -202,6 +202,8 @@ const (
 	StaticRouteAnnotation          = "ako.vmware.com/pod-cidrs"
 	WCPSEGroup                     = "ako.vmware.com/wcp-se-group"
 	WCPCloud                       = "ako.vmware.com/wcp-cloud-name"
+	VSAnnotation                   = "ako.vmware.com/host-fqdn-vs-uuid-map"
+	ControllerAnnotation           = "ako.vmware.com/controller-cluster-uuid"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -419,7 +419,7 @@ func handleL4Service(key string, fullsync bool) {
 					Namespace: namespace,
 					Key:       key,
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", name, utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", name, utils.Stringify(statusOption))
 				status.PublishToStatusQueue(name, statusOption)
 				return
 			}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -303,7 +303,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 							Op:      lib.UpdateStatus,
 							Options: &updateOptions,
 						}
-						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
+						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
 						status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
 					case lib.SNIInsecureOrEVHPool:
 						updateOptions := status.UpdateOptions{
@@ -321,7 +321,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 						if utils.GetInformers().RouteInformer != nil {
 							statusOption.ObjType = utils.OshiftRoute
 						}
-						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
 						status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 					}
 				}
@@ -383,7 +383,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					Op:      lib.DeleteStatus,
 					Options: &updateOptions,
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
 				status.PublishToStatusQueue(pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
 			case lib.SNIInsecureOrEVHPool:
 				updateOptions := status.UpdateOptions{
@@ -400,7 +400,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				if utils.GetInformers().RouteInformer != nil {
 					statusOption.ObjType = utils.OshiftRoute
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
 				status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 			}
 		}

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -540,6 +541,16 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		if ok {
 			vs_cache_obj, found := vs_cache.(*avicache.AviVsCache)
 			if found {
+				oldVsVipCache, oldVsVipFound := rest.cache.VSVIPCache.AviCacheGet(k)
+				var oldVsVips, oldVsFips []string
+				if oldVsVipFound {
+					oldVsVipCacheObj, ok := oldVsVipCache.(*avicache.AviVSVIPCache)
+					if ok {
+						oldVsVips = oldVsVipCacheObj.Vips
+						oldVsFips = oldVsVipCacheObj.Fips
+					}
+				}
+
 				vs_cache_obj.AddToVSVipKeyCollection(k)
 				utils.AviLog.Debugf("key: %s, msg: modified the VS cache object for VSVIP collection. The cache now is :%v", key, utils.Stringify(vs_cache_obj))
 				if rest_op.Method == utils.RestPut {
@@ -551,14 +562,18 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 								childObj, _ := rest.cache.VsCacheMeta.AviCacheGet(childVSKey)
 								child_cache_obj, vs_found := childObj.(*avicache.AviVsCache)
 								if vs_found {
-									rest.StatusUpdateForPool(rest_op.Method, child_cache_obj, key)
-									rest.StatusUpdateForVS(child_cache_obj, key)
+									if !reflect.DeepEqual(vsvip_cache_obj.Vips, oldVsVips) || !reflect.DeepEqual(vsvip_cache_obj.Fips, oldVsFips) {
+										rest.StatusUpdateForPool(rest_op.Method, child_cache_obj, key)
+										// rest.StatusUpdateForVS(child_cache_obj, key)
+									}
 								}
 							}
 						}
 					}
-					rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
-					rest.StatusUpdateForVS(vs_cache_obj, key)
+					if !reflect.DeepEqual(vsvip_cache_obj.Vips, oldVsVips) || !reflect.DeepEqual(vsvip_cache_obj.Fips, oldVsFips) {
+						rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
+						// rest.StatusUpdateForVS(vs_cache_obj, key)
+					}
 				}
 			}
 
@@ -577,13 +592,13 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 							child_cache_obj, vs_found := childObj.(*avicache.AviVsCache)
 							if vs_found {
 								rest.StatusUpdateForPool(rest_op.Method, child_cache_obj, key)
-								rest.StatusUpdateForVS(child_cache_obj, key)
+								// rest.StatusUpdateForVS(child_cache_obj, key)
 							}
 						}
 					}
 				}
 				rest.StatusUpdateForPool(rest_op.Method, vs_cache_obj, key)
-				rest.StatusUpdateForVS(vs_cache_obj, key)
+				// rest.StatusUpdateForVS(vs_cache_obj, key)
 			}
 		}
 		utils.AviLog.Info(spew.Sprintf("key: %s, msg: added vsvip cache k %v val %v", key, k,

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -45,11 +45,6 @@ type UpdateOptions struct {
 	VSName             string
 }
 
-const (
-	VSAnnotation         = "ako.vmware.com/host-fqdn-vs-uuid-map"
-	ControllerAnnotation = "ako.vmware.com/controller-cluster-uuid"
-)
-
 // VSUuidAnnotation is maps a hostname to the UUID of the virtual service where it is placed.
 
 func UpdateIngressStatus(options []UpdateOptions, bulk bool) {
@@ -194,7 +189,7 @@ func updateIngAnnotations(mClient kubernetes.Interface, ingObj *networkingv1.Ing
 	var err error
 	vsAnnotations := make(map[string]string)
 
-	if value, ok := ingObj.Annotations[VSAnnotation]; ok {
+	if value, ok := ingObj.Annotations[lib.VSAnnotation]; ok {
 		if err := json.Unmarshal([]byte(value), &vsAnnotations); err != nil {
 			// just print an error and continue, this will be taken care of during the update
 			utils.AviLog.Errorf("key: %s, error in unmarshalling Ingress %s/%s annotations for VS: %v",
@@ -234,7 +229,7 @@ func updateIngAnnotations(mClient kubernetes.Interface, ingObj *networkingv1.Ing
 }
 
 func isAnnotationsUpdateRequired(ingAnnotations map[string]string, newVSAnnotations map[string]string) bool {
-	oldVSAnnotationsStr, ok := ingAnnotations[VSAnnotation]
+	oldVSAnnotationsStr, ok := ingAnnotations[lib.VSAnnotation]
 	if !ok {
 		if len(newVSAnnotations) > 0 {
 			return true
@@ -279,8 +274,8 @@ func getAnnotationsPayload(vsAnnotations map[string]string, existingAnnotations 
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]*string{
 			"annotations": {
-				VSAnnotation:         vsAnnotationVal,
-				ControllerAnnotation: ctrlAnnotationVal,
+				lib.VSAnnotation:         vsAnnotationVal,
+				lib.ControllerAnnotation: ctrlAnnotationVal,
 			},
 		},
 	}
@@ -363,7 +358,7 @@ func deleteObject(option UpdateOptions, key string, isVSDelete bool, retryNum ..
 			if !lib.ValidateIngressForClass(key, mIngress) || !utils.CheckIfNamespaceAccepted(option.ServiceMetadata.Namespace) || !utils.HasElem(hostListIng, host) || isVSDelete {
 				mIngress.Status.LoadBalancer.Ingress = append(mIngress.Status.LoadBalancer.Ingress[:i], mIngress.Status.LoadBalancer.Ingress[i+1:]...)
 			} else {
-				utils.AviLog.Infof("key: %s, msg: skipping status deletion since host is present in the ingress: %v", key, host)
+				utils.AviLog.Debugf("key: %s, msg: skipping status deletion since host is present in the ingress: %v", key, host)
 			}
 		}
 	}
@@ -418,7 +413,7 @@ func deleteIngressAnnotation(ingObj *networkingv1.Ingress, svcMeta lib.ServiceMe
 		}
 	}
 	existingAnnotations := make(map[string]string)
-	if annotations, exists := ingObj.Annotations[VSAnnotation]; exists {
+	if annotations, exists := ingObj.Annotations[lib.VSAnnotation]; exists {
 		if err := json.Unmarshal([]byte(annotations), &existingAnnotations); err != nil {
 			return fmt.Errorf("error in unmarshalling annotations for ingress: %v", err)
 		}

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -386,7 +386,7 @@ func updateRouteAnnotations(mRoute *routev1.Route, updateOption UpdateOptions, o
 	}
 
 	vsAnnotations := make(map[string]string)
-	if value, ok := mRoute.Annotations[VSAnnotation]; ok {
+	if value, ok := mRoute.Annotations[lib.VSAnnotation]; ok {
 		if err := json.Unmarshal([]byte(value), &vsAnnotations); err != nil {
 			utils.AviLog.Errorf("key: %s, msg: error in unmarshalling route annotations: %v", key, err)
 			// nothing else to be done, invalid annotations will be taken care of in the update call
@@ -607,7 +607,7 @@ func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta lib.ServiceMetadataO
 		}
 	}
 	existingAnnotations := make(map[string]string)
-	if annotations, exists := routeObj.Annotations[VSAnnotation]; exists {
+	if annotations, exists := routeObj.Annotations[lib.VSAnnotation]; exists {
 		if err := json.Unmarshal([]byte(annotations), &existingAnnotations); err != nil {
 			return fmt.Errorf("error in unmarshalling annotations %s, %v", annotations, err)
 		}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -138,8 +138,8 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 	if len(annotations) == 0 {
 		annotations = map[string]string{}
 	}
-	annotations[VSAnnotation] = string(vsAnnotationsStr)
-	annotations[ControllerAnnotation] = avicache.GetControllerClusterUUID()
+	annotations[lib.VSAnnotation] = string(vsAnnotationsStr)
+	annotations[lib.ControllerAnnotation] = avicache.GetControllerClusterUUID()
 
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]string{
@@ -188,8 +188,8 @@ func deleteSvcAnnotation(svc *corev1.Service) error {
 	payloadData := map[string]interface{}{
 		"metadata": map[string]map[string]*string{
 			"annotations": {
-				VSAnnotation:         nil,
-				ControllerAnnotation: nil,
+				lib.VSAnnotation:         nil,
+				lib.ControllerAnnotation: nil,
 			},
 		},
 	}


### PR DESCRIPTION
This commit fixes issues in pushing to the Status queue
which were happening multiple times for certain object updates
like VS and VSVIP.
Annotation addition from AKO updates the resourceVersion leading to
redundant work for the graph layer. The commit enhances checks
for ingress/svc/route diff during Update.