### PR TITLE
Hostrule fixes relating to fqdnType Wildcard and changes between fqdnTypes

### DIFF
--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -99,7 +99,7 @@ func validateRouteSpecFromHostnameCache(key, ns, routeName string, routeSpec rou
 
 func findHostRuleMappingForFqdn(key, host string) (bool, *v1alpha1.HostRule) {
 	// from host check if hostrule is present
-	found, hrNSNameStr := objects.SharedCRDLister().GetFQDNToHostruleMapping(host)
+	found, hrNSNameStr := objects.SharedCRDLister().GetFQDNToHostruleMappingWithType(host)
 	if !found {
 		utils.AviLog.Debugf("key: %s, msg: Couldn't find fqdn %s to hostrule mapping in cache", key, host)
 		return false, nil

--- a/internal/objects/crdrules.go
+++ b/internal/objects/crdrules.go
@@ -175,12 +175,12 @@ func (c *CRDLister) UpdateFQDNHostruleMapping(fqdn string, hostrule string) {
 	c.HostRuleFQDNCache.AddOrUpdate(hostrule, fqdn)
 }
 
-func (c *CRDLister) GetFQDNFQDNTypeMapping(fqdn string) (bool, string) {
+func (c *CRDLister) GetFQDNFQDNTypeMapping(fqdn string) string {
 	found, fqdnType := c.FqdnFqdnTypeCache.Get(fqdn)
 	if !found {
-		return false, ""
+		return string(akov1alpha1.Exact)
 	}
-	return true, fqdnType.(string)
+	return fqdnType.(string)
 }
 
 func (c *CRDLister) DeleteFQDNFQDNTypeMapping(fqdn string) bool {
@@ -241,12 +241,7 @@ func (c *CRDLister) UpdateFqdnHTTPRulesMappings(fqdn, path, httprule string) {
 }
 
 // FqdnSharedVSModelCache/SharedVSModelFqdnCache
-func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn string) (bool, []string) {
-	oktype, fqdnType := c.FqdnFqdnTypeCache.Get(fqdn)
-	if !oktype || fqdnType == "" {
-		fqdnType = string(akov1alpha1.Exact)
-	}
-
+func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn, fqdnType string) (bool, []string) {
 	allFqdns := c.FqdnSharedVSModelCache.GetAllKeys()
 	returnModelNames := []string{}
 	for _, mFqdn := range allFqdns {

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -305,7 +305,6 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	}, 25*time.Second).Should(gomega.Equal(false))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
@@ -385,7 +384,6 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 	g.Expect(ports[2]).To(gomega.Equal(8083))
 
 	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].Enabled).To(gomega.BeNil())


### PR DESCRIPTION
This commit fixes the following problems in the object cache mapping
- solves a problem with Wildcard based fqdnType hostrules, that was not
returning all Ingresses in which the host the wildcard fqdn.
- solves a problem with `Contains` based fqdnType hostrules, that was not
correctly returning all Shared VS models, particularly in case of
create-delete-create workflows.
- solves problems related to fqdnType switching.