### PR TITLE
[cherry-picks]: hostrule and cloud cache fixes

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2427,7 +2427,6 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	subdomains := c.AviDNSPropertyPopulate(client, *cloud.UUID)
 	if len(subdomains) == 0 {
 		utils.AviLog.Warnf("Cloud: %v does not have a dns provider configured", cloudName)
-		return nil
 	}
 	if subdomains != nil {
 		cloud_obj.NSIpamDNS = subdomains

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -96,7 +96,7 @@ func validateRouteSpecFromHostnameCache(key, ns, routeName string, routeSpec rou
 
 func findHostRuleMappingForFqdn(key, host string) (bool, *v1alpha1.HostRule) {
 	// from host check if hostrule is present
-	found, hrNSNameStr := objects.SharedCRDLister().GetFQDNToHostruleMapping(host)
+	found, hrNSNameStr := objects.SharedCRDLister().GetFQDNToHostruleMappingWithType(host)
 	if !found {
 		utils.AviLog.Debugf("key: %s, msg: Couldn't find fqdn %s to hostrule mapping in cache", key, host)
 		return false, nil

--- a/internal/objects/crdrules.go
+++ b/internal/objects/crdrules.go
@@ -175,12 +175,12 @@ func (c *CRDLister) UpdateFQDNHostruleMapping(fqdn string, hostrule string) {
 	c.HostRuleFQDNCache.AddOrUpdate(hostrule, fqdn)
 }
 
-func (c *CRDLister) GetFQDNFQDNTypeMapping(fqdn string) (bool, string) {
+func (c *CRDLister) GetFQDNFQDNTypeMapping(fqdn string) string {
 	found, fqdnType := c.FqdnFqdnTypeCache.Get(fqdn)
 	if !found {
-		return false, ""
+		return string(akov1alpha1.Exact)
 	}
-	return true, fqdnType.(string)
+	return fqdnType.(string)
 }
 
 func (c *CRDLister) DeleteFQDNFQDNTypeMapping(fqdn string) bool {
@@ -241,12 +241,7 @@ func (c *CRDLister) UpdateFqdnHTTPRulesMappings(fqdn, path, httprule string) {
 }
 
 // FqdnSharedVSModelCache/SharedVSModelFqdnCache
-func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn string) (bool, []string) {
-	oktype, fqdnType := c.FqdnFqdnTypeCache.Get(fqdn)
-	if !oktype || fqdnType == "" {
-		fqdnType = string(akov1alpha1.Exact)
-	}
-
+func (c *CRDLister) GetFQDNToSharedVSModelMapping(fqdn, fqdnType string) (bool, []string) {
 	allFqdns := c.FqdnSharedVSModelCache.GetAllKeys()
 	returnModelNames := []string{}
 	for _, mFqdn := range allFqdns {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -333,8 +333,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 			utils.AviLog.Debug(spew.Sprintf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey,
 				vs_cache_obj))
 		}
-		utils.AviLog.Info(spew.Sprintf("key: %s, msg: Added Pool cache k %v val %v", key, k,
-			pool_cache_obj))
+		utils.AviLog.Info("key: %s, msg: Added Pool cache k %v val %v", key, k, utils.Stringify(pool_cache_obj))
 	}
 
 	return nil

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -164,8 +164,7 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			} else {
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 				vs_cache_obj.AddToSSLKeyCertCollection(k)
-				utils.AviLog.Info(spew.Sprintf("Added VS cache key during SSLKeyCert update %v val %v", vsKey,
-					vs_cache_obj))
+				utils.AviLog.Info("Added VS cache key during SSLKeyCert update %v val %v", vsKey, utils.Stringify(vs_cache_obj))
 			}
 			utils.AviLog.Info(spew.Sprintf("Added SSLKeyCert cache k %v val %v", k,
 				ssl_cache_obj))

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -305,7 +305,6 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	}, 25*time.Second).Should(gomega.Equal(false))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
@@ -385,7 +384,6 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 	g.Expect(ports[2]).To(gomega.Equal(8083))
 
 	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].Enabled).To(gomega.BeNil())


### PR DESCRIPTION
Save cloud properties in cache if dns provider not set


Hostrule fixes relating to fqdnType Wildcard and changes between fqdnTypes
This commit fixes the following problems in the object cache mapping
- solves a problem with Wildcard based fqdnType hostrules, that was not
returning all Ingresses in which the host the wildcard fqdn.
- solves a problem with `Contains` based fqdnType hostrules, that was not
correctly returning all Shared VS models, particularly in case of
create-delete-create workflows.
- solves problems related to fqdnType switching.