### PR TITLE
AV-136288: Ingresses are not getting synced to AVI After changing deleteconfig value from True to False

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -99,13 +99,15 @@ func PopulateControllerProperties(cs kubernetes.Interface) error {
 }
 
 func delConfigFromData(data map[string]string) bool {
+	var delConf bool
 	if val, ok := data[lib.DeleteConfig]; ok {
 		if val == "true" {
 			utils.AviLog.Infof("deleteConfig set in configmap, sync would be disabled")
-			return true
+			delConf = true
 		}
 	}
-	return false
+	lib.SetDeleteConfigMap(delConf)
+	return delConf
 }
 
 func deleteConfigFromConfigmap(cs kubernetes.Interface) bool {
@@ -306,10 +308,11 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 			if err != nil {
 				utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 			}
-			c.DisableSync = !isValidUserInput || delConfigFromData(cm.Data)
+			delModels := delConfigFromData(cm.Data)
+			c.DisableSync = !isValidUserInput || delModels
 			lib.SetDisableSync(c.DisableSync)
 			if isValidUserInput {
-				if delConfigFromData(cm.Data) {
+				if delModels {
 					c.DeleteModels()
 					if lib.GetServiceType() == "ClusterIP" {
 						avicache.DeConfigureSeGroupLabels()

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -172,6 +172,7 @@ var DisableSync bool
 var layer7Only bool
 var noPGForSNI, gRBAC bool
 var NsxTTzType string
+var deleteConfigMap bool
 
 func SetNSXTTransportZone(tzType string) {
 	NsxTTzType = tzType
@@ -220,7 +221,10 @@ func SetDisableSync(state bool) {
 	DisableSync = state
 	utils.AviLog.Infof("Setting Disable Sync to: %v", state)
 }
-
+func SetDeleteConfigMap(deleteCMFlag bool) {
+	deleteConfigMap = deleteCMFlag
+	utils.AviLog.Debugf("Setting deleteConfigMap flag to: [%v]", deleteConfigMap)
+}
 func SetLayer7Only(val string) {
 	if boolVal, err := strconv.ParseBool(val); err == nil {
 		layer7Only = boolVal
@@ -246,6 +250,10 @@ func SetGRBACSupport() {
 }
 
 func IsShardVS(vsName string) bool {
+	if deleteConfigMap {
+		//delete configmap is set, do not save anything
+		return false
+	}
 	if GetshardSize() == 0 {
 		//Dedicated mode
 		return false


### PR DESCRIPTION
This regression is caused because of retaining shared vs vip during AKO reboot. Now we have added check if deleteConfigMap is set to true, we should not save anything.