### PR TITLE
Validate enableSSL on listener Port only when listener settings are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,5 +207,6 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Bugs fixed
  - Problem in creating VSVip for Passthrough routes.
- - Problem in correctly saving ipamType in AKO when no DNS providers are set in the Cloud
+ - Problem in correctly saving ipamType in AKO when no DNS providers are set in the Cloud.
  - Fixes related to fqdnType Contains/Wildcard in HostRules.
+ - Fixes validation related to tcpSettings listener ports in HostRules.

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -540,7 +540,7 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 		}
 	}
 
-	if hostrule.Spec.VirtualHost.TCPSettings != nil {
+	if hostrule.Spec.VirtualHost.TCPSettings != nil && len(hostrule.Spec.VirtualHost.TCPSettings.Listeners) > 0 {
 		sslEnabled := false
 		for _, listener := range hostrule.Spec.VirtualHost.TCPSettings.Listeners {
 			if listener.EnableSSL {


### PR DESCRIPTION
This commit corrects the validation on tcpSettings while specifying listeners.