### PR TITLE
[cherry-pick]: Status update push to queue fixes, ingress/svc/route update check enhancements

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -132,9 +132,19 @@ func isIngressUpdated(oldIngress, newIngress *networkingv1.Ingress) bool {
 	}
 
 	oldSpecHash := utils.Hash(utils.Stringify(oldIngress.Spec))
-	oldAnnotationHash := utils.Hash(utils.Stringify(oldIngress.Annotations))
 	newSpecHash := utils.Hash(utils.Stringify(newIngress.Spec))
-	newAnnotationHash := utils.Hash(utils.Stringify(newIngress.Annotations))
+
+	// Check for annotation change apart from the ones AKO fills in
+	// after status update
+	oldAnnotation := oldIngress.DeepCopy().Annotations
+	delete(oldAnnotation, lib.VSAnnotation)
+	delete(oldAnnotation, lib.ControllerAnnotation)
+	newAnnotation := newIngress.DeepCopy().Annotations
+	delete(newAnnotation, lib.VSAnnotation)
+	delete(newAnnotation, lib.ControllerAnnotation)
+
+	oldAnnotationHash := utils.Hash(utils.Stringify(oldAnnotation))
+	newAnnotationHash := utils.Hash(utils.Stringify(newAnnotation))
 
 	if oldSpecHash != newSpecHash || oldAnnotationHash != newAnnotationHash {
 		return true

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -206,6 +206,8 @@ const (
 	StaticRouteAnnotation          = "ako.vmware.com/pod-cidrs"
 	WCPSEGroup                     = "ako.vmware.com/wcp-se-group"
 	WCPCloud                       = "ako.vmware.com/wcp-cloud-name"
+	VSAnnotation                   = "ako.vmware.com/host-fqdn-vs-uuid-map"
+	ControllerAnnotation           = "ako.vmware.com/controller-cluster-uuid"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -426,7 +426,7 @@ func handleL4Service(key string, fullsync bool) {
 					Namespace: namespace,
 					Key:       key,
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", name, utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", name, utils.Stringify(statusOption))
 				status.PublishToStatusQueue(name, statusOption)
 				return
 			}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -308,7 +308,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 							Op:      lib.UpdateStatus,
 							Options: &updateOptions,
 						}
-						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
+						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
 						status.PublishToStatusQueue(updateOptions.ServiceMetadata.NamespaceServiceName[0], statusOption)
 					case lib.SNIInsecureOrEVHPool:
 						updateOptions := status.UpdateOptions{
@@ -326,7 +326,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 						if utils.GetInformers().RouteInformer != nil {
 							statusOption.ObjType = utils.OshiftRoute
 						}
-						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
 						status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 					}
 				}
@@ -387,7 +387,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					Op:      lib.DeleteStatus,
 					Options: &updateOptions,
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
 				status.PublishToStatusQueue(pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
 			case lib.SNIInsecureOrEVHPool:
 				updateOptions := status.UpdateOptions{
@@ -404,7 +404,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				if utils.GetInformers().RouteInformer != nil {
 					statusOption.ObjType = utils.OshiftRoute
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
 				status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 			}
 		}

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -388,7 +388,7 @@ func updateRouteAnnotations(mRoute *routev1.Route, updateOption UpdateOptions, o
 	}
 
 	vsAnnotations := make(map[string]string)
-	if value, ok := mRoute.Annotations[VSAnnotation]; ok {
+	if value, ok := mRoute.Annotations[lib.VSAnnotation]; ok {
 		if err := json.Unmarshal([]byte(value), &vsAnnotations); err != nil {
 			utils.AviLog.Errorf("key: %s, msg: error in unmarshalling route annotations: %v", key, err)
 			// nothing else to be done, invalid annotations will be taken care of in the update call
@@ -610,7 +610,7 @@ func deleteRouteAnnotation(routeObj *routev1.Route, svcMeta lib.ServiceMetadataO
 		}
 	}
 	existingAnnotations := make(map[string]string)
-	if annotations, exists := routeObj.Annotations[VSAnnotation]; exists {
+	if annotations, exists := routeObj.Annotations[lib.VSAnnotation]; exists {
 		if err := json.Unmarshal([]byte(annotations), &existingAnnotations); err != nil {
 			return fmt.Errorf("error in unmarshalling annotations %s, %v", annotations, err)
 		}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -139,8 +139,8 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 	if len(annotations) == 0 {
 		annotations = map[string]string{}
 	}
-	annotations[VSAnnotation] = string(vsAnnotationsStr)
-	annotations[ControllerAnnotation] = avicache.GetControllerClusterUUID()
+	annotations[lib.VSAnnotation] = string(vsAnnotationsStr)
+	annotations[lib.ControllerAnnotation] = avicache.GetControllerClusterUUID()
 
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]string{
@@ -189,8 +189,8 @@ func deleteSvcAnnotation(svc *corev1.Service) error {
 	payloadData := map[string]interface{}{
 		"metadata": map[string]map[string]*string{
 			"annotations": {
-				VSAnnotation:         nil,
-				ControllerAnnotation: nil,
+				lib.VSAnnotation:         nil,
+				lib.ControllerAnnotation: nil,
 			},
 		},
 	}


### PR DESCRIPTION
This commit fixes issues in pushing to the Status queue
which were happening multiple times for certain object updates
like VS and VSVIP.
Annotation addition from AKO updates the resourceVersion leading to
redundant work for the graph layer. The commit enhances checks
for ingress/svc/route diff during Update.