### PR TITLE
Sets the non significant log duration as infinite by default

### DIFF
--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -143,8 +143,10 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 		}
 
 		if hostrule.Spec.VirtualHost.AnalyticsPolicy != nil {
+			var infinite int32 = 0 // Special value to set log duration as infinite
 			analyticsPolicy = &models.AnalyticsPolicy{
 				FullClientLogs: &models.FullClientLogs{
+					Duration: &infinite,
 					Enabled:  hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Enabled,
 					Throttle: lib.GetThrottle(hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Throttle),
 				},


### PR DESCRIPTION
This PR fixes the issue of non-significant logs duration not coming as infinite by default.