### PR TITLE
Update deconfiguration logic by watching over Workload namespace

### DIFF
--- a/ako-infra/ingestion/constants.go
+++ b/ako-infra/ingestion/constants.go
@@ -15,5 +15,6 @@
 package ingestion
 
 const (
-	AVI_ENTERPRISE = "ENTERPRISE"
+	AVI_ENTERPRISE           = "ENTERPRISE"
+	VSphereClusterIDLabelKey = "vSphereClusterID"
 )

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -154,7 +154,7 @@ func InitializeAKC() {
 		utils.AviLog.Warnf("Error in creating openshift clientset")
 	}
 
-	registeredInformers, err := lib.InformersToRegister(kubeClient, oshiftClient)
+	registeredInformers, err := lib.InformersToRegister(kubeClient, oshiftClient, false)
 	if err != nil {
 		utils.AviLog.Fatalf("Failed to initialize informers: %v, shutting down AKO, going to reboot", err)
 	}

--- a/cmd/infra-main/main.go
+++ b/cmd/infra-main/main.go
@@ -75,7 +75,7 @@ func InitializeAKOInfra() {
 
 	utils.AviLog.Infof("Successfully created kube client for ako-infra")
 
-	registeredInformers, err := lib.InformersToRegister(kubeClient, nil)
+	registeredInformers, err := lib.InformersToRegister(kubeClient, nil, true)
 	if err != nil {
 		utils.AviLog.Fatalf("Failed to initialize informers: %v, shutting down AKO-Infra, going to reboot", err)
 	}
@@ -113,7 +113,7 @@ func InitializeAKOInfra() {
 	avirest.SyncLSLRNetwork()
 	a.AnnotateSystemNamespace(lib.GetClusterID(), utils.CloudName)
 	c.AddNetworkInfoEventHandler(informers, stopCh)
-	c.AddNSXNetworkConfigEventHandler(informers, stopCh)
+	c.AddNamespaceEventHandler(informers, stopCh)
 
 	<-stopCh
 	close(ctrlCh)

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -64,12 +64,6 @@ var (
 		Version:  "v1alpha1",
 		Resource: "namespacenetworkinfos",
 	}
-
-	NSXNetworkConfigGVR = schema.GroupVersionResource{
-		Group:    "nsx.vmware.com",
-		Version:  "v1alpha1",
-		Resource: "nsxnetworkconfigurations",
-	}
 )
 
 type BootstrapCRData struct {
@@ -166,9 +160,8 @@ func GetVCFDynamicClientSet() dynamic.Interface {
 }
 
 type VCFDynamicInformers struct {
-	NCPBootstrapInformer     informers.GenericInformer
-	NetworkInfoInformer      informers.GenericInformer
-	NSXNetworkConfigInformer informers.GenericInformer
+	NCPBootstrapInformer informers.GenericInformer
+	NetworkInfoInformer  informers.GenericInformer
 }
 
 func NewVCFDynamicInformers(client dynamic.Interface) *VCFDynamicInformers {
@@ -177,7 +170,6 @@ func NewVCFDynamicInformers(client dynamic.Interface) *VCFDynamicInformers {
 
 	informers.NCPBootstrapInformer = f.ForResource(BootstrapGVR)
 	informers.NetworkInfoInformer = f.ForResource(NetworkInfoGVR)
-	informers.NSXNetworkConfigInformer = f.ForResource(NSXNetworkConfigGVR)
 
 	vcfDynamicInformerInstance = informers
 	return vcfDynamicInformerInstance

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1146,7 +1146,7 @@ func PopulatePassthroughPoolMarkers(host, svcName string) utils.AviObjectMarkers
 	return markers
 }
 
-func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Clientset) ([]string, error) {
+func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Clientset, akoInfra bool) ([]string, error) {
 	var isOshift bool
 	allInformers := []string{
 		utils.ServiceInformer,
@@ -1188,6 +1188,11 @@ func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Cl
 			allInformers = append(allInformers, utils.ServiceImportInformer)
 		}
 	}
+
+	if akoInfra {
+		allInformers = append(allInformers, utils.NSInformer)
+	}
+
 	return allInformers, nil
 }
 


### PR DESCRIPTION
This commit updates the workflow to proceed with deconfiguration
by watching over workload namespace addition/deletion. AKO identifies
the workload namespaces and differentiates between them and other System
namespace by way of a label "vSphereClusterID: <cluster-id>" which
is only present in user created Workload namespaces.