### PR TITLE
[Cherry-pick] Sets the non significant log duration as infinite by default (#773)

### DIFF
--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -144,8 +144,10 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 		}
 
 		if hostrule.Spec.VirtualHost.AnalyticsPolicy != nil {
+			var infinite int32 = 0 // Special value to set log duration as infinite
 			analyticsPolicy = &models.AnalyticsPolicy{
 				FullClientLogs: &models.FullClientLogs{
+					Duration: &infinite,
 					Enabled:  hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Enabled,
 					Throttle: lib.GetThrottle(hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Throttle),
 				},


### PR DESCRIPTION
This PR is the cherry-pick of fix done in release 1.6.2 for ako not setting the value of non-significant log duration to infinity by default.