### PR TITLE
Running multiple AKO instances in cluster

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -83,8 +84,9 @@ func InitializeAKC() {
 
 	// Initialize akoControlConfig
 	akoControlConfig := lib.AKOControlConfig()
-	//Use this AKO_ID to set vrf context, static routes
-	lib.SetAKOID()
+	//Used to set vrf context, static routes
+	isPrimaryAKO, _ := strconv.ParseBool(os.Getenv("PRIMARY_AKO_FLAG"))
+	akoControlConfig.SetAKOInstanceFlag(isPrimaryAKO)
 	var crdClient *crd.Clientset
 	var advl4Client *advl4.Clientset
 	var svcAPIClient *svcapi.Clientset

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -83,7 +83,8 @@ func InitializeAKC() {
 
 	// Initialize akoControlConfig
 	akoControlConfig := lib.AKOControlConfig()
-
+	//Use this AKO_ID to set vrf context, static routes
+	lib.SetAKOID()
 	var crdClient *crd.Clientset
 	var advl4Client *advl4.Clientset
 	var svcAPIClient *svcapi.Clientset

--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.AKOSettings.akoID 1 }}
+{{- if .Values.AKOSettings.primaryInstance }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.AKOSettings.akoID 1 }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -7,10 +8,7 @@ rules:
     resources: ["*"]
     verbs: ['get','watch','list']
   - apiGroups: ["apps"]
-    resources: ["statefulsets"]
-    verbs: ["get","watch","list","patch","update"]
-  - apiGroups: ["apps"]
-    resources: ["statefulsets/status"]
+    resources: ["statefulsets","statefulsets/status"]
     verbs: ["get","watch","list","patch","update"]
   - apiGroups: ["extensions","networking.k8s.io"]
     resources: ["ingresses","ingresses/status"]
@@ -60,4 +58,5 @@ rules:
     - use
     resourceNames:
     - {{ template "ako.name" . }}
+{{- end }}
 {{- end }}

--- a/helm/ako/templates/clusterrolebinding.yaml
+++ b/helm/ako/templates/clusterrolebinding.yaml
@@ -1,7 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if eq .Values.AKOSettings.akoID 1 }}
   name: ako-crb
+  {{- else }}
+  name: ako-crb-{{ .Values.AKOSettings.akoID }}
+  {{- end }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 roleRef:

--- a/helm/ako/templates/clusterrolebinding.yaml
+++ b/helm/ako/templates/clusterrolebinding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  {{- if eq .Values.AKOSettings.akoID 1 }}
+  {{- if .Values.AKOSettings.primaryInstance }}
   name: ako-crb
   {{- else }}
-  name: ako-crb-{{ .Values.AKOSettings.akoID }}
+  name: ako-crb-{{ .Release.Namespace }}
   {{- end }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: avi-k8s-config
   namespace: {{ .Release.Namespace }}
 data:
+  akoID: {{ .Values.AKOSettings.akoID | quote }}
   controllerIP: {{ .Values.ControllerSettings.controllerHost | quote }}
   controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
   cniPlugin: {{ .Values.AKOSettings.cniPlugin | quote }}

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: avi-k8s-config
   namespace: {{ .Release.Namespace }}
 data:
-  akoID: {{ .Values.AKOSettings.akoID | quote }}
+  primaryInstance: {{ .Values.AKOSettings.primaryInstance | quote }}
   controllerIP: {{ .Values.ControllerSettings.controllerHost | quote }}
   controllerVersion: {{ .Values.ControllerSettings.controllerVersion | quote }}
   cniPlugin: {{ .Values.AKOSettings.cniPlugin | quote }}

--- a/helm/ako/templates/ingressclass.yaml
+++ b/helm/ako/templates/ingressclass.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.AKOSettings.akoID 1 }}
+{{- if .Values.AKOSettings.primaryInstance }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass

--- a/helm/ako/templates/ingressclass.yaml
+++ b/helm/ako/templates/ingressclass.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.AKOSettings.akoID 1 }}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
@@ -10,3 +11,4 @@ metadata:
 spec:
   controller: ako.vmware.com/avi-lb
 {{ end }}
+{{- end }}

--- a/helm/ako/templates/psppolicy.yaml
+++ b/helm/ako/templates/psppolicy.yaml
@@ -6,7 +6,11 @@ apiVersion: extensions/v1beta1
 {{ end -}}
 kind: PodSecurityPolicy
 metadata:
+  {{- if eq .Values.AKOSettings.akoID 1 }}
   name: {{ template "ako.name" . }}
+  {{- else }}
+  name: {{ template "ako.name" . }}-{{ .Values.AKOSettings.akoID }}
+  {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/helm/ako/templates/psppolicy.yaml
+++ b/helm/ako/templates/psppolicy.yaml
@@ -6,10 +6,10 @@ apiVersion: extensions/v1beta1
 {{ end -}}
 kind: PodSecurityPolicy
 metadata:
-  {{- if eq .Values.AKOSettings.akoID 1 }}
+  {{- if .Values.AKOSettings.primaryInstance }}
   name: {{ template "ako.name" . }}
   {{- else }}
-  name: {{ template "ako.name" . }}-{{ .Values.AKOSettings.akoID }}
+  name: {{ template "ako.name" . }}-{{ .Release.Namespace }}
   {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -83,6 +83,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: fullSyncFrequency
+          - name: AKO_ID
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: akoID
           - name: CLOUD_NAME
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -83,11 +83,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: fullSyncFrequency
-          - name: AKO_ID
+          - name: PRIMARY_AKO_FLAG
             valueFrom:
               configMapKeyRef:
                 name: avi-k8s-config
-                key: akoID
+                key: primaryInstance
           - name: CLOUD_NAME
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -10,6 +10,7 @@ image:
 
 ### This section outlines the generic AKO settings
 AKOSettings:
+  akoID: "1" # Defines unique ID of AKO instance. If multiple AKOs are running in a cluster, this ID should be different for each AKO instance. Default value: 1.
   enableEvents: "true" # Enables/disables Event broadcasting via AKO 
   logLevel: "WARN" # enum: INFO|DEBUG|WARN|ERROR
   fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -10,7 +10,7 @@ image:
 
 ### This section outlines the generic AKO settings
 AKOSettings:
-  akoID: "1" # Defines unique ID of AKO instance. If multiple AKOs are running in a cluster, this ID should be different for each AKO instance. Default value: 1.
+  primaryInstance: true # Defines AKO instance is primary or not. Value `true` indicates that AKO instance is primary. In a multiple AKO deployment in a cluster, only one AKO instance should be primary. Default value: true.
   enableEvents: "true" # Enables/disables Event broadcasting via AKO 
   logLevel: "WARN" # enum: INFO|DEBUG|WARN|ERROR
   fullSyncFrequency: "1800" # This frequency controls how often AKO polls the Avi controller to update itself with cloud configurations.

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1752,9 +1752,9 @@ func (c *AviObjCache) AviObjVrfCachePopulate(client *clients.AviClient, cloud st
 		utils.AviLog.Infof("Static route sync disabled in NodePort Mode")
 		return nil
 	}
-	ako_id := lib.GetAKOID()
-	if ako_id != "1" {
-		utils.AviLog.Warnf("AKO id is: [%v], not populating vrf cache.", ako_id)
+	isPrimaryAKO := lib.AKOControlConfig().GetAKOInstanceFlag()
+	if !isPrimaryAKO {
+		utils.AviLog.Warnf("AKO is not primary instance, not populating vrf cache.")
 		return nil
 	}
 	uri := "/api/vrfcontext?name=" + lib.GetVrf() + "&include_name=true&cloud_ref.name=" + cloud

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1752,6 +1752,11 @@ func (c *AviObjCache) AviObjVrfCachePopulate(client *clients.AviClient, cloud st
 		utils.AviLog.Infof("Static route sync disabled in NodePort Mode")
 		return nil
 	}
+	ako_id := lib.GetAKOID()
+	if ako_id != "1" {
+		utils.AviLog.Warnf("AKO id is: [%v], not populating vrf cache.", ako_id)
+		return nil
+	}
 	uri := "/api/vrfcontext?name=" + lib.GetVrf() + "&include_name=true&cloud_ref.name=" + cloud
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
@@ -3096,6 +3101,10 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient, returnErr *error) bool
 		// Need not set VRFContext for public clouds.
 		return true
 	}
+	if lib.IsNodePortMode() {
+		utils.AviLog.Infof("Using global VRF for NodePort mode")
+		return true
+	}
 
 	networkList := lib.GetVipNetworkList()
 	if len(networkList) == 0 {
@@ -3135,10 +3144,6 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient, returnErr *error) bool
 		return false
 	}
 
-	if lib.IsNodePortMode() {
-		utils.AviLog.Infof("Using global VRF for NodePort mode")
-		return true
-	}
 	if lib.GetCloudType() == lib.CLOUD_NSXT &&
 		lib.GetServiceType() == "ClusterIP" &&
 		lib.GetCNIPlugin() != lib.NCP_CNI &&

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -670,8 +670,8 @@ func (c *AviController) FullSyncK8s() error {
 	if lib.GetDisableStaticRoute() && !lib.IsNodePortMode() {
 		utils.AviLog.Infof("Static route sync disabled, skipping node informers")
 	} else {
-		ako_id := lib.GetAKOID()
-		if ako_id == "1" {
+		isPrimaryAKO := lib.AKOControlConfig().GetAKOInstanceFlag()
+		if isPrimaryAKO {
 			lib.SetStaticRouteSyncHandler()
 			nodeObjects, _ := utils.GetInformers().NodeInformer.Lister().List(labels.Set(nil).AsSelector())
 			for _, node := range nodeObjects {
@@ -699,7 +699,7 @@ func (c *AviController) FullSyncK8s() error {
 				utils.AviLog.Warnf("Timed out while waiting for rest layer to respond, moving on with bootup")
 			}
 		} else {
-			utils.AviLog.Warnf("AKO id is: [%v], skipping vrf context publish in full sync.", ako_id)
+			utils.AviLog.Warnf("AKO is not primary instance, skipping vrf context publish in full sync.")
 		}
 	}
 

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1023,6 +1023,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 	if lib.GetDisableStaticRoute() && !lib.IsNodePortMode() {
 		utils.AviLog.Infof("Static route sync disabled, skipping node informers")
 	} else {
+		//For all AKO, node event handler can be enabled.
 		c.informers.NodeInformer.Informer().AddEventHandler(nodeEventHandler)
 	}
 

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -72,6 +72,7 @@ const (
 	ShardVSSubstring                           = "Shared-"
 	ShardVSPrefix                              = "Shared-L7"
 	ShardEVHVSPrefix                           = "Shared-L7-EVH-"
+	AKOSuffix                                  = "ako-"
 	DedicatedSuffix                            = "-L7-dedicated"
 	EVHSuffix                                  = "-EVH"
 	PassthroughPrefix                          = "Shared-Passthrough-"
@@ -164,6 +165,7 @@ const (
 	AutoFQDNDisabled                           = "Disabled"
 	VCF_NETWORK                                = "vcf-ako-net"
 	VIP_PER_NAMESPACE                          = "VIP_PER_NAMESPACE"
+	AKO_ID                                     = "AKO_ID"
 	CRDActive                                  = "ACTIVE"
 	CRDInactive                                = "INACTIVE"
 	SSLPort                                    = 443

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -165,7 +165,7 @@ const (
 	AutoFQDNDisabled                           = "Disabled"
 	VCF_NETWORK                                = "vcf-ako-net"
 	VIP_PER_NAMESPACE                          = "VIP_PER_NAMESPACE"
-	AKO_ID                                     = "AKO_ID"
+	PRIMARY_AKO_FLAG                           = "PRIMARY_AKO_FLAG"
 	CRDActive                                  = "ACTIVE"
 	CRDInactive                                = "INACTIVE"
 	SSLPort                                    = 443

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -93,6 +93,9 @@ type akoControlConfig struct {
 	// httpRuleEnabled is set to true if the cluster has
 	// HTTPRule CRD installed.
 	httpRuleEnabled bool
+	// primaryaAKO is set to true/false if as per primaryaAKO value
+	//in values.yaml
+	primaryaAKO bool
 }
 
 var akoControlConfigInstance *akoControlConfig
@@ -102,6 +105,13 @@ func AKOControlConfig() *akoControlConfig {
 		akoControlConfigInstance = &akoControlConfig{}
 	}
 	return akoControlConfigInstance
+}
+
+func (c *akoControlConfig) SetAKOInstanceFlag(flag bool) {
+	c.primaryaAKO = flag
+}
+func (c *akoControlConfig) GetAKOInstanceFlag() bool {
+	return c.primaryaAKO
 }
 
 func (c *akoControlConfig) SetAdvL4Clientset(cs advl4crd.Interface) {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -286,30 +286,18 @@ func GetLayer7Only() bool {
 }
 
 var AKOUser string
-var AKOID string
 
 func SetAKOUser() {
 	AKOUser = "ako-" + GetClusterName()
-	if GetAKOID() != "1" {
-		AKOUser = AKOUser + "-" + AKOID
+	isPrimaryAKO := akoControlConfigInstance.GetAKOInstanceFlag()
+	if !isPrimaryAKO {
+		AKOUser = AKOUser + "-" + os.Getenv("POD_NAMESPACE")
 	}
 	utils.AviLog.Infof("Setting AKOUser: %s for Avi Objects", AKOUser)
 }
 
 func GetAKOUser() string {
 	return AKOUser
-}
-
-func SetAKOID() {
-	AKOID = os.Getenv("AKO_ID")
-	if AKOID == "" {
-		utils.AviLog.Warn("Setting AKO ID to 1")
-		AKOID = "1"
-	}
-}
-
-func GetAKOID() string {
-	return AKOID
 }
 
 var enableCtrl2014Features bool

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -286,14 +286,30 @@ func GetLayer7Only() bool {
 }
 
 var AKOUser string
+var AKOID string
 
 func SetAKOUser() {
 	AKOUser = "ako-" + GetClusterName()
+	if GetAKOID() != "1" {
+		AKOUser = AKOUser + "-" + AKOID
+	}
 	utils.AviLog.Infof("Setting AKOUser: %s for Avi Objects", AKOUser)
 }
 
 func GetAKOUser() string {
 	return AKOUser
+}
+
+func SetAKOID() {
+	AKOID = os.Getenv("AKO_ID")
+	if AKOID == "" {
+		utils.AviLog.Warn("Setting AKO ID to 1")
+		AKOID = "1"
+	}
+}
+
+func GetAKOID() string {
+	return AKOID
 }
 
 var enableCtrl2014Features bool

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -1654,11 +1655,12 @@ func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (l
 		newInfraPrefix = newSetting.Name
 	}
 	var akoID string
-	if lib.GetAKOID() != "1" {
-		akoID = lib.AKOSuffix + lib.GetAKOID() + "-"
+	isPrimaryAKO := lib.AKOControlConfig().GetAKOInstanceFlag()
+	if !isPrimaryAKO {
+		akoID = os.Getenv("POD_NAMESPACE") + "-"
 	}
 
-	shardVsPrefix := lib.GetNamePrefix() + lib.ShardEVHVSPrefix + akoID
+	shardVsPrefix := lib.GetNamePrefix() + akoID + lib.ShardEVHVSPrefix
 	oldVsName, newVsName := shardVsPrefix, shardVsPrefix
 	if oldInfraPrefix != "" {
 		oldVsName += oldInfraPrefix + "-"

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1653,8 +1653,12 @@ func DeriveShardVSForEvh(hostname, key string, routeIgrObj RouteIngressModel) (l
 		}
 		newInfraPrefix = newSetting.Name
 	}
+	var akoID string
+	if lib.GetAKOID() != "1" {
+		akoID = lib.AKOSuffix + lib.GetAKOID() + "-"
+	}
 
-	shardVsPrefix := lib.GetNamePrefix() + lib.ShardEVHVSPrefix
+	shardVsPrefix := lib.GetNamePrefix() + lib.ShardEVHVSPrefix + akoID
 	oldVsName, newVsName := shardVsPrefix, shardVsPrefix
 	if oldInfraPrefix != "" {
 		oldVsName += oldInfraPrefix + "-"

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -67,7 +67,12 @@ func DequeueIngestion(key string, fullsync bool) {
 	// if in NodePort Mode we update pool servers
 	if objType == utils.NodeObj {
 		utils.AviLog.Debugf("key: %s, msg: processing node obj", key)
-		processNodeObj(key, name, sharedQueue, fullsync)
+		akoID := lib.GetAKOID()
+		if akoID == "1" {
+			processNodeObj(key, name, sharedQueue, fullsync)
+		} else {
+			utils.AviLog.Infof("key: %s, msg: ako id is: %s. Not procesing node objects.", key, akoID)
+		}
 		if lib.IsNodePortMode() && !fullsync {
 			svcl4Keys, svcl7Keys := lib.GetSvcKeysForNodeCRUD()
 			for _, svcl4Key := range svcl4Keys {
@@ -624,7 +629,11 @@ func (descriptor GraphDescriptor) GetByType(name string) (GraphSchema, bool) {
 
 func GetShardVSPrefix(key string) string {
 	// sample prefix: clusterName--Shared-L7-
-	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + "-"
+	var akoID string
+	if lib.GetAKOID() != "1" {
+		akoID = "-" + lib.AKOSuffix + lib.GetAKOID()
+	}
+	shardVsPrefix := lib.GetNamePrefix() + lib.ShardVSPrefix + akoID + "-"
 	utils.AviLog.Debugf("key: %s, msg: ShardVSPrefix: %s", key, shardVsPrefix)
 	return shardVsPrefix
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -75,6 +75,7 @@ const (
 	GlobalVRF                     = "global"
 	VRF_CONTEXT                   = "VRF_CONTEXT"
 	FULL_SYNC_INTERVAL            = "FULL_SYNC_INTERVAL"
+	AKO_ID                        = "AKO_ID"
 	DEFAULT_FILE_SUFFIX           = "avi.log"
 	K8S_ETIMEDOUT                 = "timed out"
 	ADVANCED_L4                   = "ADVANCED_L4"

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -75,7 +75,6 @@ const (
 	GlobalVRF                     = "global"
 	VRF_CONTEXT                   = "VRF_CONTEXT"
 	FULL_SYNC_INTERVAL            = "FULL_SYNC_INTERVAL"
-	AKO_ID                        = "AKO_ID"
 	DEFAULT_FILE_SUFFIX           = "avi.log"
 	K8S_ETIMEDOUT                 = "timed out"
 	ADVANCED_L4                   = "ADVANCED_L4"

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -47,6 +47,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("ADVANCED_L4", "true")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -47,12 +47,11 @@ func TestMain(m *testing.M) {
 	os.Setenv("ADVANCED_L4", "true")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	AdvL4Client = advl4fake.NewSimpleClientset()
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetAdvL4Clientset(AdvL4Client)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 	data := map[string][]byte{

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -37,6 +37,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	utils.CtrlVersion = "20.1.1"
 	restChan = make(chan bool)

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -37,8 +37,6 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	utils.CtrlVersion = "20.1.1"
 	restChan = make(chan bool)
@@ -48,6 +46,7 @@ func TestMain(m *testing.M) {
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 	data := map[string][]byte{
 		"username": []byte("admin"),

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -51,9 +51,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("SHARD_VS_SIZE", "DEDICATED")
 	os.Setenv("AUTO_L4_FQDN", "default")
 
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 	akoControlConfig := lib.AKOControlConfig()
+	akoControlConfig.SetAKOInstanceFlag(true)
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -51,6 +51,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("SHARD_VS_SIZE", "DEDICATED")
 	os.Setenv("AUTO_L4_FQDN", "default")
 
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -80,6 +80,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -80,13 +80,12 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 	data := map[string][]byte{
 		"username": []byte("admin"),

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -57,13 +57,12 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 	data := map[string][]byte{
 		"username": []byte("admin"),

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -57,6 +57,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -88,7 +88,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("AUTO_L4_FQDN", "disable")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -88,12 +88,12 @@ func TestMain(m *testing.M) {
 	os.Setenv("AUTO_L4_FQDN", "disable")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
+
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 	data := map[string][]byte{
 		"username": []byte("admin"),

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -95,6 +95,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("MCI_ENABLED", "true")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	data := map[string][]byte{
 		"username": []byte("admin"),

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -95,8 +95,6 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("MCI_ENABLED", "true")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	data := map[string][]byte{
 		"username": []byte("admin"),
@@ -109,6 +107,7 @@ func TestMain(m *testing.M) {
 	akoControlConfig := lib.AKOControlConfig()
 	crdClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(crdClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, kubeClient, true)
 
 	registeredInformers := []string{

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -238,8 +238,6 @@ func TestMain(m *testing.M) {
 	os.Setenv("SERVICE_TYPE", "NodePort")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	kubeClient = k8sfake.NewSimpleClientset()
@@ -253,6 +251,7 @@ func TestMain(m *testing.M) {
 	secret := &corev1.Secret{Data: data, ObjectMeta: object}
 	kubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Create(context.TODO(), secret, metav1.CreateOptions{})
 	akoControlConfig.SetCRDClientset(crdClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, kubeClient, true)
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, RegisteredInformers)
 	k8s.NewCRDInformers(crdClient)

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -238,6 +238,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("SERVICE_TYPE", "NodePort")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	kubeClient = k8sfake.NewSimpleClientset()

--- a/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
+++ b/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
@@ -64,6 +64,7 @@ func TestMain(m *testing.M) {
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	data := map[string][]byte{
 		"username": []byte("admin"),
 		"password": []byte("admin"),

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -52,6 +52,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("SERVICE_TYPE", "ClusterIP")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -52,14 +52,13 @@ func TestMain(m *testing.M) {
 	os.Setenv("SERVICE_TYPE", "ClusterIP")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	data := map[string][]byte{
 		"username": []byte("admin"),
 		"password": []byte("admin"),

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -168,6 +168,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("CNI_PLUGIN", "antrea")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -168,14 +168,13 @@ func TestMain(m *testing.M) {
 	os.Setenv("CNI_PLUGIN", "antrea")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	data := map[string][]byte{
 		"username": []byte("admin"),
 		"password": []byte("admin"),

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -123,14 +123,13 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	data := map[string][]byte{
 		"username": []byte("admin"),
 		"password": []byte("admin"),

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -123,6 +123,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -56,6 +56,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -56,14 +56,13 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("AUTO_L4_FQDN", "default")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	k8s.NewCRDInformers(CRDClient)
 
 	data := map[string][]byte{

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -55,13 +55,12 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
-	os.Setenv("AKO_ID", "1")
-	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()
 	CRDClient = crdfake.NewSimpleClientset()
 	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
 
 	registeredInformers := []string{

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -55,6 +55,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"net123","cidrs":["10.79.168.0/22"]}]`)
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AKO_ID", "1")
+	lib.SetAKOID()
 
 	akoControlConfig := lib.AKOControlConfig()
 	KubeClient = k8sfake.NewSimpleClientset()


### PR DESCRIPTION
This PR introduces changes for running multiple AKO instances per cluster. (Not contain changes for stretched cluster).
Use case is to improve performance of AKO for handling scale setup.
Customer can run multiple AKO with helm command as: 
`helm install ./ako --generate-name -n avi-system --set AKOSettings.namespaceSelector.labelKey="app" --set AKOSettings.namespaceSelector.labelValue="migrate" --set AKOSettings.primaryInstance=true`

value for `AKOSettings.primaryInstance` is `true/false`
Points to consider:
1. Each AKO instance needs to be installed in different namespace.
2. For non-primary AKO, shared Vs naming convention will be `Shared-VS-Name`= `<cluster-name>--<AKO-namespace>-Shared-L7-<Shard number>`
For Primary AKO, no naming convention changes.
3. User name (with which object created at AVI side) for non-primary will be `Username` = `ako-<cluster-name>-<AKO-namespace>`

