### PR TITLE
Remove overwriting controllerVersion on POST/PUT/DELETE api calls

### DIFF
--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -67,8 +67,14 @@ func SyncLSLRNetwork() {
 	if !matched {
 		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = constructLsLrInCloud(lslrmap)
 		path := "/api/cloud/" + *cloudModel.UUID
-		restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: utils.RestPut, Obj: &cloudModel,
-			Tenant: "admin", Model: "cloud", Version: utils.CtrlVersion}
+		restOp := utils.RestOp{
+			ObjName: utils.CloudName,
+			Path:    path,
+			Method:  utils.RestPut,
+			Obj:     &cloudModel,
+			Tenant:  "admin",
+			Model:   "cloud",
+		}
 		executeRestOp("fullsync", client, &restOp)
 	} else {
 		utils.AviLog.Infof("LS LR update not required in cloud: %s", utils.CloudName)
@@ -121,8 +127,14 @@ func AddSegment(obj interface{}) bool {
 	if updateRequired {
 		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = lslrList
 		path := "/api/cloud/" + *cloudModel.UUID
-		restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: utils.RestPut, Obj: &cloudModel,
-			Tenant: "admin", Model: "cloud", Version: utils.CtrlVersion}
+		restOp := utils.RestOp{
+			ObjName: utils.CloudName,
+			Path:    path,
+			Method:  utils.RestPut,
+			Obj:     &cloudModel,
+			Tenant:  "admin",
+			Model:   "cloud",
+		}
 		executeRestOp(objKey, client, &restOp)
 	} else {
 		utils.AviLog.Infof("key: %s, LSLR update not required in cloud: %s", objKey, utils.CloudName)
@@ -177,8 +189,14 @@ func DeleteSegment(obj interface{}) {
 	if updateRequired {
 		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = lslrList
 		path := "/api/cloud/" + *cloudModel.UUID
-		restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: utils.RestPut, Obj: &cloudModel,
-			Tenant: "admin", Model: "cloud", Version: utils.CtrlVersion}
+		restOp := utils.RestOp{
+			ObjName: utils.CloudName,
+			Path:    path,
+			Method:  utils.RestPut,
+			Obj:     &cloudModel,
+			Tenant:  "admin",
+			Model:   "cloud",
+		}
 		executeRestOp(objKey, client, &restOp)
 	} else {
 		utils.AviLog.Infof("key: %s, LSLR update not required in cloud: %s", objKey, utils.CloudName)
@@ -300,8 +318,14 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 		netModel.ConfiguredSubnets = append(netModel.ConfiguredSubnets, &subnet)
 
 	}
-	restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: method, Obj: &netModel,
-		Tenant: "admin", Model: "network", Version: utils.CtrlVersion}
+	restOp := utils.RestOp{
+		ObjName: utils.CloudName,
+		Path:    path,
+		Method:  method,
+		Obj:     &netModel,
+		Tenant:  "admin",
+		Model:   "network",
+	}
 
 	utils.AviLog.Debugf("key: %s, executing restop to add/update vcf network: %v", objKey, restOp)
 	executeRestOp(objKey, client, &restOp)
@@ -343,8 +367,14 @@ func delCIDRFromNetwork(objKey string, cidrs map[string]struct{}) {
 	path = "/api/network/" + *netModel.UUID
 
 	utils.AviLog.Infof("key: %s, list of CIDRs to be deleted: %v", objKey, cidrs)
-	restOp := utils.RestOp{ObjName: utils.CloudName, Path: path, Method: method, Obj: &netModel,
-		Tenant: "admin", Model: "network", Version: utils.CtrlVersion}
+	restOp := utils.RestOp{
+		ObjName: utils.CloudName,
+		Path:    path,
+		Method:  method,
+		Obj:     &netModel,
+		Tenant:  "admin",
+		Model:   "network",
+	}
 
 	utils.AviLog.Debugf("key: %s, executing restop to delete CIDR from vcf network: %v", objKey, restOp)
 	executeRestOp(objKey, client, &restOp)

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -63,8 +63,13 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/vsdatascriptset/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsdatascriptset,
-			Tenant: ds_meta.Tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPut,
+			Obj:    vsdatascriptset,
+			Tenant: ds_meta.Tenant,
+			Model:  "VSDataScriptSet",
+		}
 	} else {
 		// Patch an existing ds if it exists in the cache but not associated with this VS.
 		ds_key := avicache.NamespaceName{Namespace: ds_meta.Tenant, Name: ds_meta.Name}
@@ -72,12 +77,22 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 		if ok {
 			ds_cache_obj, _ := ds_cache.(*avicache.AviDSCache)
 			path = "/api/vsdatascriptset/" + ds_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: vsdatascriptset,
-				Tenant: ds_meta.Tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPut,
+				Obj:    vsdatascriptset,
+				Tenant: ds_meta.Tenant,
+				Model:  "VSDataScriptSet",
+			}
 		} else {
 			path = "/api/vsdatascriptset"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vsdatascriptset,
-				Tenant: ds_meta.Tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPost,
+				Obj:    vsdatascriptset,
+				Tenant: ds_meta.Tenant,
+				Model:  "VSDataScriptSet",
+			}
 		}
 	}
 
@@ -88,8 +103,12 @@ func (rest *RestOperations) AviDSBuild(ds_meta *nodes.AviHTTPDataScriptNode, cac
 
 func (rest *RestOperations) AviDSDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/vsdatascriptset/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "VSDataScriptSet", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "VSDataScriptSet",
+	}
 	utils.AviLog.Info(spew.Sprintf("key: %s, msg: DS DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -421,15 +421,25 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		// Do a POST call in that case
 		if rest_method == utils.RestPut && cache_obj.Uuid != "" {
 			path = "/api/virtualservice/" + cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: rest_method,
+				Obj:    vs,
+				Tenant: vs_meta.Tenant,
+				Model:  "VirtualService",
+			}
 			rest_ops = append(rest_ops, &rest_op)
 
 		} else {
 			rest_method = utils.RestPost
 			path = "/api/virtualservice/"
-			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: rest_method,
+				Obj:    vs,
+				Tenant: vs_meta.Tenant,
+				Model:  "VirtualService",
+			}
 			rest_ops = append(rest_ops, &rest_op)
 
 		}
@@ -532,14 +542,24 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 	if rest_method == utils.RestPut {
 
 		path = "/api/virtualservice/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: evhChild,
-			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: rest_method,
+			Obj:    evhChild,
+			Tenant: vs_meta.Tenant,
+			Model:  "VirtualService",
+		}
 		rest_ops = append(rest_ops, &rest_op)
 
 	} else {
 		path = "/api/virtualservice"
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: evhChild,
-			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: rest_method,
+			Obj:    evhChild,
+			Tenant: vs_meta.Tenant,
+			Model:  "VirtualService",
+		}
 		rest_ops = append(rest_ops, &rest_op)
 
 	}

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -246,8 +246,13 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/httppolicyset/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
-			Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPut,
+			Obj:    hps,
+			Tenant: hps_meta.Tenant,
+			Model:  "HTTPPolicySet",
+		}
 
 	} else {
 		// Patch an existing http policy set object if it exists in the cache but not associated with this VS.
@@ -256,12 +261,22 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 		if ok {
 			hps_cache_obj, _ := hps_cache.(*avicache.AviHTTPPolicyCache)
 			path = "/api/httppolicyset/" + hps_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
-				Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPut,
+				Obj:    hps,
+				Tenant: hps_meta.Tenant,
+				Model:  "HTTPPolicySet",
+			}
 		} else {
 			path = "/api/httppolicyset/"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: hps,
-				Tenant: hps_meta.Tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPost,
+				Obj:    hps,
+				Tenant: hps_meta.Tenant,
+				Model:  "HTTPPolicySet",
+			}
 		}
 	}
 
@@ -272,8 +287,12 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 
 func (rest *RestOperations) AviHttpPolicyDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/httppolicyset/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "HTTPPolicySet", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "HTTPPolicySet",
+	}
 	utils.AviLog.Debug(spew.Sprintf("HTTP Policy Set DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -105,8 +105,13 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/l4policyset/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
-			Tenant: hps_meta.Tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPut,
+			Obj:    hps,
+			Tenant: hps_meta.Tenant,
+			Model:  "L4PolicySet",
+		}
 
 	} else {
 		// Patch an existing l4 policy set object if it exists in the cache but not associated with this VS.
@@ -115,12 +120,22 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 		if ok {
 			hps_cache_obj, _ := hps_cache.(*avicache.AviL4PolicyCache)
 			path = "/api/l4policyset/" + hps_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: hps,
-				Tenant: hps_meta.Tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPut,
+				Obj:    hps,
+				Tenant: hps_meta.Tenant,
+				Model:  "L4PolicySet",
+			}
 		} else {
 			path = "/api/l4policyset/"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: hps,
-				Tenant: hps_meta.Tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPost,
+				Obj:    hps,
+				Tenant: hps_meta.Tenant,
+				Model:  "L4PolicySet",
+			}
 		}
 	}
 
@@ -131,8 +146,12 @@ func (rest *RestOperations) AviL4PSBuild(hps_meta *nodes.AviL4PolicyNode, cache_
 
 func (rest *RestOperations) AviL4PolicyDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/l4policyset/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "L4PolicySet", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "L4PolicySet",
+	}
 	utils.AviLog.Infof(spew.Sprintf("L4 Policy Set DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -165,8 +165,14 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/pool/" + cache_obj.Uuid
-		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: pool,
-			Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			ObjName: name,
+			Path:    path,
+			Method:  utils.RestPut,
+			Obj:     pool,
+			Tenant:  pool_meta.Tenant,
+			Model:   "Pool",
+		}
 	} else {
 		// Patch an existing pool if it exists in the cache but not associated with this VS.
 		pool_key := avicache.NamespaceName{Namespace: pool_meta.Tenant, Name: name}
@@ -174,12 +180,24 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 		if ok {
 			pool_cache_obj, _ := pool_cache.(*avicache.AviPoolCache)
 			path = "/api/pool/" + pool_cache_obj.Uuid
-			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: pool,
-				Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPut,
+				Obj:     pool,
+				Tenant:  pool_meta.Tenant,
+				Model:   "Pool",
+			}
 		} else {
 			path = "/api/pool/"
-			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: pool,
-				Tenant: pool_meta.Tenant, Model: "Pool", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPost,
+				Obj:     pool,
+				Tenant:  pool_meta.Tenant,
+				Model:   "Pool",
+			}
 		}
 	}
 
@@ -190,8 +208,12 @@ func (rest *RestOperations) AviPoolBuild(pool_meta *nodes.AviPoolNode, cache_obj
 
 func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/pool/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "Pool", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "Pool",
+	}
 	utils.AviLog.Info(spew.Sprintf("key: %s, msg: pool DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -89,8 +89,14 @@ func (rest *RestOperations) AviVrfBuild(key string, vrfNode *nodes.AviVrfNode, u
 		patchPayload["static_routes"] = mergedStaticRoutes
 	}
 
-	restOp := utils.RestOp{Path: path, Method: utils.RestPatch, PatchOp: patchOp, Obj: patchPayload,
-		Tenant: lib.GetAdminTenant(), Model: "VrfContext", Version: utils.CtrlVersion}
+	restOp := utils.RestOp{
+		Path:    path,
+		Method:  utils.RestPatch,
+		PatchOp: patchOp,
+		Obj:     patchPayload,
+		Tenant:  lib.GetAdminTenant(),
+		Model:   "VrfContext",
+	}
 
 	return &restOp
 }

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -244,13 +244,25 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		// Do a POST call in that case
 		if rest_method == utils.RestPut && cache_obj.Uuid != "" {
 			path = "/api/virtualservice/" + cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: vs,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion, ObjName: *vs.Name}
+			rest_op = utils.RestOp{
+				Path:    path,
+				Method:  rest_method,
+				Obj:     vs,
+				Tenant:  vs_meta.Tenant,
+				Model:   "VirtualService",
+				ObjName: *vs.Name,
+			}
 			rest_ops = append(rest_ops, &rest_op)
 		} else {
 			path = "/api/virtualservice/"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vs,
-				Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion, ObjName: *vs.Name}
+			rest_op = utils.RestOp{
+				Path:    path,
+				Method:  utils.RestPost,
+				Obj:     vs,
+				Tenant:  vs_meta.Tenant,
+				Model:   "VirtualService",
+				ObjName: *vs.Name,
+			}
 			rest_ops = append(rest_ops, &rest_op)
 		}
 		return rest_ops
@@ -343,14 +355,24 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 	if rest_method == utils.RestPut {
 
 		path = "/api/virtualservice/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: sniChild,
-			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: rest_method,
+			Obj:    sniChild,
+			Tenant: vs_meta.Tenant,
+			Model:  "VirtualService",
+		}
 		rest_ops = append(rest_ops, &rest_op)
 
 	} else {
 		path = "/api/virtualservice"
-		rest_op = utils.RestOp{Path: path, Method: rest_method, Obj: sniChild,
-			Tenant: vs_meta.Tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: rest_method,
+			Obj:    sniChild,
+			Tenant: vs_meta.Tenant,
+			Model:  "VirtualService",
+		}
 		rest_ops = append(rest_ops, &rest_op)
 	}
 
@@ -776,8 +798,12 @@ func (rest *RestOperations) AviVSDel(uuid string, tenant string, key string) (*u
 		return nil, false
 	}
 	path := "/api/virtualservice/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "VirtualService", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "VirtualService",
+	}
 	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VirtualService DELETE Restop %v ",
 		key, utils.Stringify(rest_op)))
 	return &rest_op, true

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -148,7 +148,6 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 			Obj:     vsvip,
 			Tenant:  vsvip_meta.Tenant,
 			Model:   "VsVip",
-			Version: utils.CtrlVersion,
 		}
 	} else {
 		var vips []*avimodels.Vip
@@ -256,8 +255,13 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 					// Clear the cache for this key
 					rest.cache.VSVIPCache.AviCacheDelete(vsvip_key)
 					utils.AviLog.Warnf("key: %s, Removed the vsvip object from the cache", key)
-					rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: vsvip,
-						Tenant: vsvip_meta.Tenant, Model: "VsVip", Version: utils.CtrlVersion}
+					rest_op = utils.RestOp{
+						Path:   path,
+						Method: utils.RestPost,
+						Obj:    vsvip,
+						Tenant: vsvip_meta.Tenant,
+						Model:  "VsVip",
+					}
 					return &rest_op, nil
 				}
 				// If it's not nil, return an error.
@@ -296,7 +300,6 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 				Obj:     vsvip_avi,
 				Tenant:  vsvip_meta.Tenant,
 				Model:   "VsVip",
-				Version: utils.CtrlVersion,
 			}
 		} else {
 			rest_op = utils.RestOp{
@@ -306,7 +309,6 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 				Obj:     vsvip,
 				Tenant:  vsvip_meta.Tenant,
 				Model:   "VsVip",
-				Version: utils.CtrlVersion,
 			}
 		}
 	}
@@ -342,8 +344,12 @@ func (rest *RestOperations) AviVsVipGet(key, uuid, name string) (*avimodels.VsVi
 
 func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/vsvip/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "VsVip", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "VsVip",
+	}
 	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VSVIP DELETE Restop %v ", key,
 		utils.Stringify(rest_op)))
 	return &rest_op
@@ -352,12 +358,11 @@ func (rest *RestOperations) AviVsVipDel(uuid string, tenant string, key string) 
 func (rest *RestOperations) AviVsVipPut(uuid string, vsvipObj *avimodels.VsVip, tenant string, key string) *utils.RestOp {
 	path := "/api/vsvip/" + uuid
 	rest_op := utils.RestOp{
-		Path:    path,
-		Method:  utils.RestPut,
-		Obj:     vsvipObj,
-		Tenant:  tenant,
-		Model:   "VsVip",
-		Version: utils.CtrlVersion,
+		Path:   path,
+		Method: utils.RestPut,
+		Obj:    vsvipObj,
+		Tenant: tenant,
+		Model:  "VsVip",
 	}
 	utils.AviLog.Info(spew.Sprintf("key: %s, msg: VSVIP PUT Restop %v ", key,
 		utils.Stringify(rest_op)))

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -56,8 +56,13 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/poolgroup/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pg,
-			Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPut,
+			Obj:    pg,
+			Tenant: pg_meta.Tenant,
+			Model:  "PoolGroup",
+		}
 	} else {
 		// Patch an existing pg if it exists in the cache but not associated with this VS.
 		pg_key := avicache.NamespaceName{Namespace: pg_meta.Tenant, Name: name}
@@ -65,12 +70,22 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 		if ok {
 			pg_cache_obj, _ := pg_cache.(*avicache.AviPGCache)
 			path = "/api/poolgroup/" + pg_cache_obj.Uuid
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pg,
-				Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPut,
+				Obj:    pg,
+				Tenant: pg_meta.Tenant,
+				Model:  "PoolGroup",
+			}
 		} else {
 			path = "/api/poolgroup/"
-			rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: pg,
-				Tenant: pg_meta.Tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				Path:   path,
+				Method: utils.RestPost,
+				Obj:    pg,
+				Tenant: pg_meta.Tenant,
+				Model:  "PoolGroup",
+			}
 		}
 	}
 
@@ -98,10 +113,13 @@ func (rest *RestOperations) SanitizePGMembers(Members []*avimodels.PoolGroupMemb
 
 func (rest *RestOperations) AviPGDel(uuid string, tenant string, key string) *utils.RestOp {
 	path := "/api/poolgroup/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "PoolGroup", Version: utils.CtrlVersion}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: PG DELETE Restop %v ", key,
-		utils.Stringify(rest_op)))
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "PoolGroup",
+	}
+	utils.AviLog.Info(spew.Sprintf("key: %s, msg: PG DELETE Restop %v ", key, utils.Stringify(rest_op)))
 	return &rest_op
 }
 

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -249,8 +249,10 @@ func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
-		SetVersion := session.SetVersion(op.Version)
-		SetVersion(c.AviSession)
+		if op.Version != "" {
+			SetVersion := session.SetVersion(op.Version)
+			SetVersion(c.AviSession)
+		}
 		switch op.Method {
 		case utils.RestPost:
 			op.Err = c.AviSession.Post(op.Path, op.Obj, &op.Response)

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -66,8 +66,14 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/sslkeyandcertificate/" + cache_obj.Uuid
-		rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: sslkeycert,
-			Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			ObjName: name,
+			Path:    path,
+			Method:  utils.RestPut,
+			Obj:     sslkeycert,
+			Tenant:  ssl_node.Tenant,
+			Model:   "SSLKeyAndCertificate",
+		}
 		rest_op.ObjName = name
 	} else {
 		ssl_key := avicache.NamespaceName{Namespace: ssl_node.Tenant, Name: name}
@@ -75,12 +81,24 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 		if ok {
 			ssl_cache_obj, _ := ssl_cache.(*avicache.AviSSLCache)
 			path = "/api/sslkeyandcertificate/" + ssl_cache_obj.Uuid
-			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPut, Obj: sslkeycert,
-				Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPut,
+				Obj:     sslkeycert,
+				Tenant:  ssl_node.Tenant,
+				Model:   "SSLKeyAndCertificate",
+			}
 		} else {
 			path = "/api/sslkeyandcertificate"
-			rest_op = utils.RestOp{ObjName: name, Path: path, Method: utils.RestPost, Obj: sslkeycert,
-				Tenant: ssl_node.Tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPost,
+				Obj:     sslkeycert,
+				Tenant:  ssl_node.Tenant,
+				Model:   "SSLKeyAndCertificate",
+			}
 		}
 	}
 	return &rest_op
@@ -88,8 +106,12 @@ func (rest *RestOperations) AviSSLBuild(ssl_node *nodes.AviTLSKeyCertNode, cache
 
 func (rest *RestOperations) AviSSLKeyCertDel(uuid string, tenant string) *utils.RestOp {
 	path := "/api/sslkeyandcertificate/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "SSLKeyAndCertificate", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "SSLKeyAndCertificate",
+	}
 	utils.AviLog.Info(spew.Sprintf("SSLCertKey DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op
@@ -220,20 +242,34 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 	var rest_op utils.RestOp
 	if cache_obj != nil {
 		path = "/api/pkiprofile/" + cache_obj.Uuid
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPut, Obj: pkiobject,
-			Tenant: pki_node.Tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPut,
+			Obj:    pkiobject,
+			Tenant: pki_node.Tenant,
+			Model:  "PKIprofile",
+		}
 	} else {
 		path = "/api/pkiprofile/"
-		rest_op = utils.RestOp{Path: path, Method: utils.RestPost, Obj: pkiobject,
-			Tenant: pki_node.Tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
+		rest_op = utils.RestOp{
+			Path:   path,
+			Method: utils.RestPost,
+			Obj:    pkiobject,
+			Tenant: pki_node.Tenant,
+			Model:  "PKIprofile",
+		}
 	}
 	return &rest_op
 }
 
 func (rest *RestOperations) AviPkiProfileDel(uuid string, tenant string) *utils.RestOp {
 	path := "/api/pkiprofile/" + uuid
-	rest_op := utils.RestOp{Path: path, Method: "DELETE",
-		Tenant: tenant, Model: "PKIprofile", Version: utils.CtrlVersion}
+	rest_op := utils.RestOp{
+		Path:   path,
+		Method: "DELETE",
+		Tenant: tenant,
+		Model:  "PKIprofile",
+	}
 	utils.AviLog.Info(spew.Sprintf("PKIprofile DELETE Restop %v ",
 		utils.Stringify(rest_op)))
 	return &rest_op


### PR DESCRIPTION
This commit removes the controller version that is being overwritten
on individual API calls to the controller instead of using the api
version which was used to initialise the session to the controller.
With these changes, all REST layer API calls end up using the version
which was used while initializing the session.