### PR TITLE
[MCI] AviInfraSetting with default values

### DIFF
--- a/internal/nodes/route_ingress_model.go
+++ b/internal/nodes/route_ingress_model.go
@@ -371,5 +371,15 @@ func (mciModel *multiClusterIngressModel) GetDiffPathSvc(storedPathSvc map[strin
 }
 
 func (mciModel *multiClusterIngressModel) GetAviInfraSetting() *akov1alpha1.AviInfraSetting {
-	return nil
+	enablePublicIP := true
+	return &akov1alpha1.AviInfraSetting{
+		Spec: akov1alpha1.AviInfraSettingSpec{
+			Network: akov1alpha1.AviInfraSettingNetwork{
+				EnablePublicIP: &enablePublicIP,
+			},
+		},
+		Status: akov1alpha1.AviInfraSettingStatus{
+			Status: lib.StatusAccepted,
+		},
+	}
 }


### PR DESCRIPTION
This PR hardcodes the AviInfraSetting values such as `enablePublicIP` to true by default for MCI.