### PR TITLE
Cherry-pick from 1.7.1, 1.6.2, 1.6.1 to branch 1.5.3. 

### DIFF
--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -42,43 +42,33 @@ func SharedAVIClients() *utils.AviRestClientPool {
 	}
 
 	if AviClientInstance == nil || len(AviClientInstance.AviClient) == 0 {
-		if AviClientInstance == nil || len(AviClientInstance.AviClient) == 0 {
-			// Always create 9 clients irrespective of shard size
-			AviClientInstance, err = utils.NewAviRestClientPool(
-				9,
-				ctrlIpAddress,
-				ctrlUsername,
-				ctrlPassword,
-				ctrlAuthToken,
-			)
-			connectionStatus = utils.AVIAPI_CONNECTED
-			if err != nil {
-				connectionStatus = utils.AVIAPI_DISCONNECTED
-				utils.AviLog.Error("AVI controller initilization failed")
-				return nil
-			}
 
-			controllerVersion := utils.CtrlVersion
-			// Ensure that the controllerVersion is less than the supported Avi maxVersion and more than minVersion.
-			if lib.CompareVersions(controllerVersion, ">", lib.GetAviMaxSupportedVersion()) {
-				controllerVersion = lib.GetAviMaxSupportedVersion()
-			}
-			if lib.CompareVersions(controllerVersion, "<", lib.GetAviMinSupportedVersion()) {
-				utils.AviLog.Fatal("AKO is not supported for the following Avi version %s, Avi must be %s or more", controllerVersion, lib.GetAviMinSupportedVersion())
-			}
-			utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
-
-			// set the tenant and controller version in avisession obj
-			for _, client := range AviClientInstance.AviClient {
-				SetTenant := session.SetTenant(lib.GetTenant())
-				SetTenant(client.AviSession)
-
-				lib.SetEnableCtrl2014Features(controllerVersion)
-				SetVersion := session.SetVersion(controllerVersion)
-				SetVersion(client.AviSession)
-
-			}
+		// Always create 9 clients irrespective of shard size
+		AviClientInstance, err = utils.NewAviRestClientPool(
+			9,
+			ctrlIpAddress,
+			ctrlUsername,
+			ctrlPassword,
+			ctrlAuthToken,
+		)
+		connectionStatus = utils.AVIAPI_CONNECTED
+		if err != nil {
+			connectionStatus = utils.AVIAPI_DISCONNECTED
+			utils.AviLog.Error("AVI controller initilization failed")
+			return nil
 		}
+		controllerVersion := lib.SetControllerVersion()
+		// set the tenant and controller version in avisession obj
+		for _, client := range AviClientInstance.AviClient {
+			SetTenant := session.SetTenant(lib.GetTenant())
+			SetTenant(client.AviSession)
+
+			lib.SetEnableCtrl2014Features(controllerVersion)
+			SetVersion := session.SetVersion(controllerVersion)
+			SetVersion(client.AviSession)
+
+		}
+
 	}
 
 	models.RestStatus.UpdateAviApiRestStatus(connectionStatus, err)

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2416,7 +2416,6 @@ func (c *AviObjCache) AviCloudPropertiesPopulate(client *clients.AviClient, clou
 	subdomains := c.AviDNSPropertyPopulate(client, *cloud.UUID)
 	if len(subdomains) == 0 {
 		utils.AviLog.Warnf("Cloud: %v does not have a dns provider configured", cloudName)
-		return nil
 	}
 
 	if subdomains != nil {

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -149,7 +149,9 @@ func isRouteUpdated(oldRoute, newRoute *routev1.Route) bool {
 	if oldSpecHash != newSpecHash {
 		return true
 	}
-
+	if !reflect.DeepEqual(newRoute.Annotations, oldRoute.Annotations) {
+		return true
+	}
 	return false
 }
 

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -98,7 +98,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
 				if err := validateHostRuleObj(key, hostrule); err != nil {
-					utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
+					utils.AviLog.Warnf("key: %s, msg: Error retrieved during validation of HostRule: %v", key, err)
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
@@ -114,7 +114,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 					key := lib.HostRule + "/" + utils.ObjKey(hostrule)
 					if err := validateHostRuleObj(key, hostrule); err != nil {
-						utils.AviLog.Warnf("Error retrieved during validation of HostRule: %v", err)
+						utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
 					}
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
@@ -310,6 +310,16 @@ func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
 			Error:  err.Error(),
 		})
 		return err
+	}
+	if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" {
+		if fqdn == hostrule.Spec.VirtualHost.Gslb.Fqdn {
+			err = fmt.Errorf("GSLB FQDN and local FQDN are same")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{
+				Status: lib.StatusRejected,
+				Error:  err.Error(),
+			})
+			return err
+		}
 	}
 
 	refData := map[string]string{

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1360,5 +1360,6 @@ func SetControllerVersion() string {
 		utils.AviLog.Fatal("AKO is not supported for the following Avi version %s, Avi must be %s or more", controllerVersion, GetAviMinSupportedVersion())
 	}
 	utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
+	utils.CtrlVersion = controllerVersion
 	return controllerVersion
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1256,7 +1256,8 @@ func RefreshAuthToken(kc kubernetes.Interface) {
 	ctrlAuthToken := ctrlProp[utils.ENV_CTRL_AUTHTOKEN]
 	ctrlIpAddress := os.Getenv(utils.ENV_CTRL_IPADDRESS)
 
-	aviClient := utils.NewAviRestClientWithToken(ctrlIpAddress, ctrlUsername, ctrlAuthToken)
+	controllerVersion := SetControllerVersion()
+	aviClient := utils.NewAviRestClientWithToken(ctrlIpAddress, ctrlUsername, ctrlAuthToken, GetTenant(), controllerVersion)
 	if aviClient == nil {
 		utils.AviLog.Errorf("Failed to initialize AVI client")
 		return
@@ -1347,4 +1348,17 @@ func GetK8sMinSupportedVersion() string {
 
 func GetK8sMaxSupportedVersion() string {
 	return k8sMaxVersion
+}
+
+func SetControllerVersion() string {
+	controllerVersion := utils.CtrlVersion
+	// Ensure that the controllerVersion is less than the supported Avi maxVersion and more than minVersion.
+	if CompareVersions(controllerVersion, ">", GetAviMaxSupportedVersion()) {
+		controllerVersion = GetAviMaxSupportedVersion()
+	}
+	if CompareVersions(controllerVersion, "<", GetAviMinSupportedVersion()) {
+		utils.AviLog.Fatal("AKO is not supported for the following Avi version %s, Avi must be %s or more", controllerVersion, GetAviMinSupportedVersion())
+	}
+	utils.AviLog.Infof("Setting the client version to %s", controllerVersion)
+	return controllerVersion
 }

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -826,7 +826,9 @@ func (o *AviObjectGraph) BuildModelGraphForInsecureEVH(routeIgrObj RouteIngressM
 	// Remove the redirect for secure to insecure transition
 	hosts := []string{host}
 	if pathsvcmap.gslbHostHeader != "" {
-		hosts = append(hosts, pathsvcmap.gslbHostHeader)
+		if !utils.HasElem(hosts, pathsvcmap.gslbHostHeader) {
+			hosts = append(hosts, pathsvcmap.gslbHostHeader)
+		}
 	}
 	RemoveRedirectHTTPPolicyInModelForEvh(evhNode, hosts, key)
 	vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, host), key)
@@ -1099,7 +1101,9 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 	if certsBuilt {
 		hosts := []string{host}
 		if paths.gslbHostHeader != "" {
-			hosts = append(hosts, paths.gslbHostHeader)
+			if !utils.HasElem(hosts, paths.gslbHostHeader) {
+				hosts = append(hosts, paths.gslbHostHeader)
+			}
 		}
 		o.BuildPolicyPGPoolsForEVH(vsNode, evhNode, namespace, ingName, key, infraSettingName, hosts, paths.ingressHPSvc, &tlssetting)
 		foundEvhModel := FindAndReplaceEvhInModel(evhNode, vsNode, key)

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1136,12 +1136,28 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 			vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, host), key)
 			RemoveEvhInModel(evhNode.Name, vsNode, key)
 			RemoveRedirectHTTPPolicyInModelForEvh(evhNode, hostsToRemove, key)
+			vsNode[0].RemoveFQDNsFromModel(hostsToRemove, key)
 		}
 
 	}
 }
 
 // Util functions
+func (o *AviEvhVsNode) RemoveFQDNsFromModel(hosts []string, key string) {
+	if len(o.VSVIPRefs) == 0 {
+		return
+	}
+	for i := 0; i < len(o.VSVIPRefs[0].FQDNs); i++ {
+		for _, host := range hosts {
+			if host == o.VSVIPRefs[0].FQDNs[i] {
+				o.VSVIPRefs[0].FQDNs = append(o.VSVIPRefs[0].FQDNs[:i], o.VSVIPRefs[0].FQDNs[i+1:]...)
+				i--
+				break
+			}
+		}
+	}
+	utils.AviLog.Debugf("key: %s, msg: Removed hosts %v from VS %s", key, hosts, o.Name)
+}
 
 func FindAndReplaceEvhInModel(currentEvhNode *AviEvhVsNode, modelEvhNodes []*AviEvhVsNode, key string) bool {
 	for i, modelEvhNode := range modelEvhNodes[0].EvhNodes {

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -197,7 +197,7 @@ func PopulateServersForNPL(poolNode *AviPoolNode, ns string, serviceName string,
 
 	targetPorts := make(map[int]bool)
 	for _, port := range svcObj.Spec.Ports {
-		if port.Name != poolNode.PortName && len(svcObj.Spec.Ports) != 1 {
+		if port.Name != poolNode.PortName && len(svcObj.Spec.Ports) > 1 {
 			// continue only if port name does not match and it is multiport svcobj
 			continue
 		}

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -427,6 +427,7 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 		if len(ingressHostMap.GetIngressesForHostName(sniHost)) == 0 {
 			RemoveSniInModel(sniNode.Name, vsNode, key)
 			RemoveRedirectHTTPPolicyInModel(vsNode[0], sniHostToRemove, key)
+			RemoveFQDNsFromModel(vsNode[0], sniHosts, key)
 		}
 	}
 }

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -79,23 +79,21 @@ func (rest *RestOperations) AviPoolGroupBuild(pg_meta *nodes.AviPoolGroupNode, c
 
 func (rest *RestOperations) SanitizePGMembers(Members []*avimodels.PoolGroupMember, key string) []*avimodels.PoolGroupMember {
 	// This method iterates over the pg members and removes any duplicate.
-	var newList []string
-	var pgmemberscopy []*avimodels.PoolGroupMember
-	pgmemberscopy = make([]*avimodels.PoolGroupMember, len(Members))
-	copy(pgmemberscopy, Members)
-	for i, member := range Members {
-		if utils.HasElem(newList, member.PoolRef) {
-			// Duplicate detected, remove it from the copy
-			pgmemberscopy = append(pgmemberscopy[:i], pgmemberscopy[i+1:]...)
-			utils.AviLog.Warnf("key: %s, msg: detected duplicate poolref :%s", key, member.PoolRef)
+	var pgmembers []*avimodels.PoolGroupMember
+	var refList []string
+	for _, member := range Members {
+		if utils.HasElem(refList, *member.PoolRef) {
+			// Duplicate detected.
+			utils.AviLog.Warnf("key: %s, msg: detected duplicate poolref :%s", key, *member.PoolRef)
 		} else if member.PriorityLabel != nil && lib.CheckObjectNameLength(*member.PriorityLabel, lib.PriorityLabel) {
 			utils.AviLog.Warnf("key: %s not adding priority label to pool ref to PG", key)
-			pgmemberscopy = append(pgmemberscopy[:i], pgmemberscopy[i+1:]...)
 		} else {
-			newList = append(newList, *member.PoolRef)
+			// No duplicates, append the member.
+			refList = append(refList, *member.PoolRef)
+			pgmembers = append(pgmembers, member)
 		}
 	}
-	return pgmemberscopy
+	return pgmembers
 }
 
 func (rest *RestOperations) AviPGDel(uuid string, tenant string, key string) *utils.RestOp {

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -49,7 +49,7 @@ func UpdateNPLAnnotation(key, namespace, name string) {
 		return
 	}
 	if service.Spec.Type == corev1.ServiceTypeNodePort {
-		utils.AviLog.Infof("key: %s, returning without updating NPL annotation for Service type NodePort")
+		utils.AviLog.Infof("key: %s, returning without updating NPL annotation for Service type NodePort", key)
 		return
 	}
 	ann := service.GetAnnotations()

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -34,7 +34,7 @@ type AviRestClientPool struct {
 
 var AviClientInstance *AviRestClientPool
 
-func NewAviRestClientWithToken(api_ep string, username string, authToken string) *clients.AviClient {
+func NewAviRestClientWithToken(api_ep string, username string, authToken string, tenant string, controllerVersion string) *clients.AviClient {
 	var aviClient *clients.AviClient
 	var transport *http.Transport
 	var err error
@@ -63,6 +63,10 @@ func NewAviRestClientWithToken(api_ep string, username string, authToken string)
 		AviLog.Warnf("NewAviClient returned err %v", err)
 		return nil
 	}
+	SetTenant := session.SetTenant(tenant)
+	SetTenant(aviClient.AviSession)
+	SetVersion := session.SetVersion(controllerVersion)
+	SetVersion(aviClient.AviSession)
 	return aviClient
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -179,7 +179,11 @@ func instantiateInformers(kubeClient KubeClientIntf, registeredInformers []strin
 		case EndpointInformer:
 			informers.EpInformer = kubeInformerFactory.Core().V1().Endpoints()
 		case SecretInformer:
-			informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
+			if akoNSBoundInformer {
+				informers.SecretInformer = akoNSInformerFactory.Core().V1().Secrets()
+			} else {
+				informers.SecretInformer = kubeInformerFactory.Core().V1().Secrets()
+			}
 		case NodeInformer:
 			informers.NodeInformer = kubeInformerFactory.Core().V1().Nodes()
 		case ConfigMapInformer:
@@ -239,6 +243,12 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 				AviLog.Warnf("Unknown Key %s in args", k)
 			}
 		}
+	}
+
+	// In Openshift cluster use NS bound informer for secret as certificates for routes are specified in the route itself. Also,
+	// there are many secrets installed by default in Openshift cluster which have to be handled if NS bound informer is not used.
+	if HasElem(registeredInformers, RouteInformer) {
+		akoNSBoundInformer = true
 	}
 
 	if !instantiateOnce {

--- a/tests/ingresstests/l7_nodeport_test.go
+++ b/tests/ingresstests/l7_nodeport_test.go
@@ -716,7 +716,7 @@ func TestMultiPortServiceIngressInNodePort(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
 		ServiceName: "avisvc",
-	}).Ingress(true)
+	}).IngressMultiPort()
 
 	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
 	if err != nil {

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -1201,9 +1201,12 @@ func TestNPLSvcNodePort(t *testing.T) {
 		return false
 	}, 20*time.Second).Should(gomega.Equal(false))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	if err == nil {
+		err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("Couldn't DELETE the Ingress %v", err)
+		}
 	}
 }
 
@@ -1256,10 +1259,12 @@ func TestIngressAddPodWithMultiportSvc(t *testing.T) {
 	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(40001)))
 	g.Expect(*nodes[0].PoolRefs[1].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
 	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(40002)))
-
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	_, err = KubeClient.NetworkingV1beta1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	if err == nil {
+		err = KubeClient.NetworkingV1beta1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("Couldn't DELETE the Ingress %v", err)
+		}
 	}
 	verifyIngressDeletion(t, g, aviModel, 0)
 }

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -67,6 +67,14 @@ func createPodWithNPLAnnotation(labels map[string]string) {
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
 
+func createPodWithMultipleNPLAnnotations(labels map[string]string) {
+	testPod := getTestPod(labels)
+	ann := make(map[string]string)
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}, {\"podPort\":8081,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40002}]"
+	testPod.Annotations = ann
+	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
+}
+
 func updatePodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
@@ -1139,6 +1147,10 @@ func TestNPLSvcNodePort(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	SetUpTestForIngress(t, defaultL7Model)
+	defer func() {
+		tearDownTestForSvcLB(t, g)
+		TearDownTestForIngress(t, defaultL7Model)
+	}()
 	selectors := make(map[string]string)
 	selectors["app"] = "npl"
 	integrationtest.CreateServiceWithSelectors(t, defaultNS, "avisvc", corev1.ServiceTypeClusterIP, false, selectors)
@@ -1188,4 +1200,66 @@ func TestNPLSvcNodePort(t *testing.T) {
 		}
 		return false
 	}, 20*time.Second).Should(gomega.Equal(false))
+
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+}
+
+// TestIngressAddPodWithMultiportSvc creates a Pod with multiple nodeportlocal.antrea.io annotations, Service with multiport and
+// an Ingress which uses that Service. Port number is mentioned instead of port name as backend servicePort.
+func TestIngressAddPodWithMultiportSvc(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	SetUpTestForIngress(t, defaultL7Model)
+	defer func() {
+		tearDownTestForSvcLB(t, g)
+		TearDownTestForIngress(t, defaultL7Model)
+	}()
+	selectors := make(map[string]string)
+	selectors["app"] = "npl"
+	integrationtest.CreateServiceWithSelectors(t, defaultNS, "avisvc", corev1.ServiceTypeClusterIP, true, selectors)
+	createPodWithMultipleNPLAnnotations(selectors)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(defaultL7Model)
+		return found
+	}, 20*time.Second, 1*time.Second).Should(gomega.Equal(false))
+
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).IngressMultiPort()
+
+	_, err := KubeClient.NetworkingV1beta1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(defaultL7Model)
+		return found
+	}, 20*time.Second, 1*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(defaultL7Model)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(2))
+	g.Expect(nodes[0].PoolRefs[0].Servers).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].PoolRefs[1].Servers).To(gomega.HaveLen(1))
+	g.Expect(*nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(40001)))
+	g.Expect(*nodes[0].PoolRefs[1].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
+	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(40002)))
+
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	verifyIngressDeletion(t, g, aviModel, 0)
 }

--- a/tests/oshiftroutetests/oshift_crd_test.go
+++ b/tests/oshiftroutetests/oshift_crd_test.go
@@ -353,7 +353,7 @@ func TestOshiftGoodToBadHostRule(t *testing.T) {
 	hrUpdate := integrationtest.FakeHostRule{
 		Name:               hrname,
 		Namespace:          "default",
-		Fqdn:               "voo.com",
+		Fqdn:               "foo.com",
 		WafPolicy:          "thisisBADaviref",
 		ApplicationProfile: "thisisaviref-appprof",
 	}.HostRule()


### PR DESCRIPTION
Changes that are cherry-picked

1. Fix: AKO not updating the pool members correctly #644
2. Use NS bound informer for Secrets in Openshift #651
3. Support for multi-port Services with port number for ServiceType NodePort and NodePortLocal #655
4. Host rule rejection if GSLB FQDN and local FQDN in hostrule is same
5. Avoid duplicate fqdn addition for EVH.
6. Fix for child FQDNs not getting removed from parent VS #701
7. AV-131413: VS not getting converted to Dedicated VS Type using AVIInfraSetting CRD #705
8. Save cloud properties in cache if dns provider not set
9. Add tenant and api version for fetching authtoken #778
10. Remove overwriting controllerVersion on POST/PUT/DELETE api calls #788