### PR TITLE
Skip label configuration during AviInfraSetting validation if disableStaticRouteSync set to true

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -1034,6 +1034,12 @@ func validateAviInfraSetting(key string, infraSetting *akov1alpha1.AviInfraSetti
 // addSeGroupLabel configures SEGroup with appropriate labels, during AviInfraSetting
 // creation/updates after ingestion
 func addSeGroupLabel(key, segName string) {
+	// No need to configure labels if static route sync is disabled globally.
+	if lib.GetDisableStaticRoute() {
+		utils.AviLog.Infof("Skipping the check for SE group labels for SEG %s", segName)
+		return
+	}
+
 	// assign the last avi client for ref checks
 	clients := avicache.SharedAVIClients()
 	aviClientLen := lib.GetshardSize()


### PR DESCRIPTION
This commit resolves an issue wherein every SEGroup used in the AviInfraSetting
was getting configured with the labels required for static route syncing.
This was being done even if the user specified `disableStaticRouteSync` to be true
or in cases where static route syncing is not required.
Fixes AV-139903
