### PR TITLE
[cherry-pick]: Fix Service LB handling with Gateways

### DIFF
--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -175,8 +175,9 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 				services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
 				for _, service := range services {
 					svcNsName := strings.Split(service, "/")
-					fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1])
-					fqdns = append(fqdns, fqdn)
+					if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
+						fqdns = append(fqdns, fqdn)
+					}
 				}
 			}
 		}

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -48,7 +48,9 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 
 	subDomains := GetDefaultSubDomain()
 	if subDomains != nil && autoFQDN {
-		fqdns = append(fqdns, getAutoFQDNForService(svcObj.Namespace, svcObj.Name))
+		if fqdn := getAutoFQDNForService(svcObj.Namespace, svcObj.Name); fqdn != "" {
+			fqdns = append(fqdns, fqdn)
+		}
 	}
 
 	vsName := lib.GetL4VSName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace)

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -558,27 +558,12 @@ func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.Work
 
 func isServiceDelete(svcName string, namespace string, key string) bool {
 	// If the service is not found we return true.
-	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
+	_, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
 	if err != nil {
 		utils.AviLog.Warnf("key: %s, msg: could not retrieve the object for service: %s", key, err)
 		if errors.IsNotFound(err) {
 			return true
 		}
-	}
-
-	var gwNameLabel, gwNamespaceLabel string
-	if lib.GetAdvancedL4() {
-		gwNameLabel = lib.GatewayNameLabelKey
-		gwNamespaceLabel = lib.GatewayNamespaceLabelKey
-	} else if lib.UseServicesAPI() {
-		gwNameLabel = lib.SvcApiGatewayNameLabelKey
-		gwNamespaceLabel = lib.SvcApiGatewayNamespaceLabelKey
-	}
-
-	_, nok := service.Labels[gwNameLabel]
-	_, nsok := service.Labels[gwNamespaceLabel]
-	if nsok || nok {
-		return true
 	}
 
 	return false

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -830,6 +830,11 @@ func ParseL4ServiceForGateway(svc *corev1.Service, key string) (string, []string
 	var gateway string
 	var portProtocols []string
 
+	if lib.UseServicesAPI() && svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		utils.AviLog.Infof("key: %s, msg: Service of Type LoadBalancer is not supported with Gateway APIs, will create dedicated VSes", key)
+		return gateway, portProtocols
+	}
+
 	var gwNameLabel, gwNamespaceLabel string
 	if lib.GetAdvancedL4() {
 		gwNameLabel = lib.GatewayNameLabelKey

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -178,7 +178,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 
 				// setting IPAMNetworkSubnet.Subnet value in case subnetCIDR is provided
 				if vipNetwork.Cidr == "" {
-					utils.AviLog.Warnf("Incomplete values provided for CIDR, will not use IPAMNetworkSubnet in vsvip")
+					utils.AviLog.Warnf("key: %s, msg: Incomplete values provided for CIDR, will not use IPAMNetworkSubnet in vsvip", key)
 				} else {
 					ipPrefixSlice := strings.Split(vipNetwork.Cidr, "/")
 					mask, _ := strconv.Atoi(ipPrefixSlice[1])


### PR DESCRIPTION
This commit fixes issues with using Gateways and ServiceLB at the same time.
The bug lead to improper dedicated VS creation of Service of type LB.
This also fixes an issue with L4 VSVIP when autoFqdn is disabled and no
subDomains are configured in the dnsProfile, which was leading to an empty
string fqdn programming.