### PR TITLE
Add support for Shared VIP with Service of type LoadBalancer

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -783,12 +783,12 @@ func (c *AviController) FullSyncK8s() error {
 			isSvcLb := isServiceLBType(svcObj)
 			var key string
 			if isSvcLb && !lib.GetLayer7Only() {
-				/*
-					Key added to Ingestion queue if
-					1. Advance L4 enabled or
-					2. Namespace is valid
-				*/
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
+				if svcObj.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+					// mark the object type as ShareVipSvc
+					// to separate these out from regulare clusterip, svclb services
+					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svcObj)
+				}
 			} else {
 				if lib.GetAdvancedL4() {
 					continue

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -589,12 +589,17 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				if lib.GetAdvancedL4() {
 					checkSvcForGatewayPortConflict(svc, key)
 				}
-				if lib.UseServicesAPI() {
-					checkSvcForSvcApiGatewayPortConflict(svc, key)
+				if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+					// mark the object type as ShareVipSvc
+					// to separate these out from regulare clusterip, svclb services
+					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 				}
 			} else {
 				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
+				}
+				if lib.UseServicesAPI() {
+					checkSvcForSvcApiGatewayPortConflict(svc, key)
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
 			}
@@ -634,6 +639,14 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					return
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
+				if lib.GetAdvancedL4() {
+					checkSvcForGatewayPortConflict(svc, key)
+				}
+				if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+					// mark the object type as ShareVipSvc
+					// to separate these out from regulare clusterip, svclb services
+					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
+				}
 			} else {
 				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
@@ -665,19 +678,36 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					if lib.GetAdvancedL4() {
 						checkSvcForGatewayPortConflict(svc, key)
 					}
-					if lib.UseServicesAPI() {
-						checkSvcForSvcApiGatewayPortConflict(svc, key)
+					if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+						key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 					}
 				} else {
 					if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 						return
 					}
+					if lib.UseServicesAPI() {
+						checkSvcForSvcApiGatewayPortConflict(svc, key)
+					}
 					key = utils.Service + "/" + utils.ObjKey(svc)
 				}
 
 				bkt := utils.Bkt(namespace, numWorkers)
-				c.workqueue[bkt].AddRateLimited(key)
-				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
+				if isSvcLb &&
+					!lib.GetLayer7Only() &&
+					oldobj.Annotations[lib.SharedVipSvcLBAnnotation] != svc.Annotations[lib.SharedVipSvcLBAnnotation] {
+					// Handles annotation -> no-annotation transition, old pool needs to be deleted.
+					// Handles no-annotation -> annotation transition too, old L4 VS is deleted.
+					if oldobj.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+						key = lib.SharedVipServiceKey + "/" + utils.ObjKey(oldobj)
+					} else {
+						key = utils.L4LBService + "/" + utils.ObjKey(oldobj)
+					}
+					c.workqueue[bkt].AddRateLimited(key)
+					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
+				} else {
+					c.workqueue[bkt].AddRateLimited(key)
+					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
+				}
 			}
 		},
 	}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -168,6 +168,7 @@ const (
 	SSLPort                                    = 443
 	IPAMProviderInfoblox                       = "IPAMDNS_TYPE_INFOBLOX"
 	IPAMProviderCustom                         = "IPAMDNS_TYPE_CUSTOM"
+	SharedVipServiceKey                        = "SharedVipService"
 
 	// AKO Event constants
 	AKOEventComponent      = "avi-kubernetes-operator"
@@ -213,6 +214,7 @@ const (
 	WCPCloud                       = "ako.vmware.com/wcp-cloud-name"
 	VSAnnotation                   = "ako.vmware.com/host-fqdn-vs-uuid-map"
 	ControllerAnnotation           = "ako.vmware.com/controller-cluster-uuid"
+	SharedVipSvcLBAnnotation       = "ako.vmware.com/enable-shared-vip"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -335,8 +335,8 @@ func GetL4VSVipName(svcName, namespace string) string {
 	return Encode(NamePrefix+namespace+"-"+svcName, L4VIP)
 }
 
-func GetL4PoolName(svcName, namespace string, port int32) string {
-	poolName := NamePrefix + namespace + "-" + svcName + "--" + strconv.Itoa(int(port))
+func GetL4PoolName(svcName, namespace, protocol string, port int32) string {
+	poolName := NamePrefix + namespace + "-" + svcName + "-" + protocol + "-" + strconv.Itoa(int(port))
 	return Encode(poolName, L4Pool)
 }
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -115,6 +115,7 @@ func (c ServiceMetadataObj) ServiceMetadataMapping(objType string) ServiceMetada
 		// Check for `NamespaceServiceName` in Pool serviceMetadata. Present in case of
 		// 1) Advl4 Pools: without hostname information
 		// 2) SvcApi Pools: with hostname information
+		// 3) SharedVip SvcLB Pools: with hostname information
 		return GatewayPool
 	} else if c.Namespace != "" && c.IngressName != "" {
 		// Check for `Namespace` and `IngressName` in Pool serviceMetadata. Present in case of

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -33,13 +33,21 @@ func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace string, gatewayName stri
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 	var vsNode *AviVsNode
-	if lib.UseServicesAPI() {
+
+	sharedVipOnSvcLBUsecase := strings.Contains(key, lib.SharedVipServiceKey)
+	if sharedVipOnSvcLBUsecase {
+		vsNode = o.ConstructSharedVipSvcLBNode(gatewayName, namespace, key)
+	} else if lib.UseServicesAPI() {
 		vsNode = o.ConstructSvcApiL4VsNode(gatewayName, namespace, key)
 	} else {
 		vsNode = o.ConstructAdvL4VsNode(gatewayName, namespace, key)
 	}
 	if vsNode != nil {
-		o.ConstructAdvL4PolPoolNodes(vsNode, gatewayName, namespace, key)
+		if sharedVipOnSvcLBUsecase {
+			o.ConstructSharedVipPolPoolNodes(vsNode, gatewayName, namespace, key)
+		} else {
+			o.ConstructAdvL4PolPoolNodes(vsNode, gatewayName, namespace, key)
+		}
 		o.AddModelNode(vsNode)
 		utils.AviLog.Infof("key: %s, msg: checksum  for AVI VS object %v", key, vsNode.GetCheckSum())
 	}
@@ -50,86 +58,87 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 	// A L4 policyset object is create where listener port --> pool. Pool gets it's server from the endpoints that has the same name as the 'service' pointed
 	// by the listener port.
 	found, listeners := objects.ServiceGWLister().GetGWListeners(namespace + "/" + gatewayName)
-	if found {
-		vsName := lib.GetL4VSName(gatewayName, namespace)
-		gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for advancedL4: %s", err)
-			return nil
-		}
-
-		var serviceNSNames []string
-		if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
-			for svcListener, service := range services {
-				// assume it to have only a single backend service, the check is in isGatewayDelete
-				if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
-					serviceNSNames = append(serviceNSNames, service[0])
-				}
-			}
-		}
-
-		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
-			ServiceMetadata: lib.ServiceMetadataObj{
-				NamespaceServiceName: serviceNSNames,
-				Gateway:              namespace + "/" + gatewayName,
-			},
-			ServiceEngineGroup: lib.GetSEGName(),
-			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
-		}
-
-		avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
-
-		isTCP, isUDP := false, false
-		var portProtocols []AviPortHostProtocol
-		for _, listener := range listeners {
-			portProto := strings.Split(listener, "/") // format: protocol/port
-			port, _ := utilsnet.ParsePort(portProto[1], true)
-			pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
-			portProtocols = append(portProtocols, pp)
-			if portProto[0] == "" || portProto[0] == utils.TCP {
-				isTCP = true
-			} else if portProto[0] == utils.UDP {
-				isUDP = true
-			}
-		}
-
-		avi_vs_meta.PortProto = portProtocols
-		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
-
-		// In case the VS has services that are a mix of TCP and UDP sockets,
-		// we create the VS with global network profile TCP Fast Path,
-		// and override required services with UDP Fast Path. Having a separate
-		// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-		// on existing VSes.
-		if isTCP && !isUDP {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		} else if isUDP && !isTCP {
-			avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-		} else {
-			avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-		}
-
-		vsVipNode := &AviVSVIPNode{
-			Name:        lib.GetL4VSVipName(gatewayName, namespace),
-			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
-			VipNetworks: lib.GetVipNetworkList(),
-		}
-
-		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
-			vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
-		}
-
-		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
-			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
-		}
-		avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
-		return avi_vs_meta
+	if !found {
+		return nil
 	}
-	return nil
+
+	vsName := lib.GetL4VSName(gatewayName, namespace)
+	gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for advancedL4: %s", err)
+		return nil
+	}
+
+	var serviceNSNames []string
+	if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
+		for svcListener, service := range services {
+			// assume it to have only a single backend service, the check is in isGatewayDelete
+			if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
+				serviceNSNames = append(serviceNSNames, service[0])
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			NamespaceServiceName: serviceNSNames,
+			Gateway:              namespace + "/" + gatewayName,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
+
+	isTCP, isUDP := false, false
+	var portProtocols []AviPortHostProtocol
+	for _, listener := range listeners {
+		portProto := strings.Split(listener, "/") // format: protocol/port
+		port, _ := utilsnet.ParsePort(portProto[1], true)
+		pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
+		portProtocols = append(portProtocols, pp)
+		if portProto[0] == "" || portProto[0] == utils.TCP {
+			isTCP = true
+		} else if portProto[0] == utils.UDP {
+			isUDP = true
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	// In case the VS has services that are a mix of TCP and UDP sockets,
+	// we create the VS with global network profile TCP Fast Path,
+	// and override required services with UDP Fast Path. Having a separate
+	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
+	// on existing VSes.
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(gatewayName, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
+		vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	}
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
 }
 
 func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key string) *AviVsNode {
@@ -137,119 +146,119 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 	// A L4 policyset object is create where listener port --> pool. Pool gets it's server from the endpoints that has the same name as the 'service' pointed
 	// by the listener port.
 	found, listeners := objects.ServiceGWLister().GetGWListeners(namespace + "/" + gatewayName)
-	if found {
-		vsName := lib.GetL4VSName(gatewayName, namespace)
-		gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
-			return nil
-		}
-
-		var serviceNSNames []string
-		listenerSvcMapping := make(map[string][]string)
-		if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
-			for svcListener, service := range services {
-				// assume it to have only a single backend service, the check is in isGatewayDelete
-				if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
-					serviceNSNames = append(serviceNSNames, service[0])
-					if val, ok := listenerSvcMapping[svcListener]; ok {
-						listenerSvcMapping[svcListener] = append(val, service[0])
-					} else {
-						listenerSvcMapping[svcListener] = []string{service[0]}
-					}
-				}
-			}
-		}
-
-		var fqdns []string
-		for _, listener := range gw.Spec.Listeners {
-			autoFQDN := true
-			// Honour the hostname if specified corresponding to the listener.
-			if listener.Hostname != nil && string(*listener.Hostname) != "" {
-				fqdns = append(fqdns, string(*listener.Hostname))
-				autoFQDN = false
-			}
-
-			subDomains := GetDefaultSubDomain()
-			if subDomains != nil && autoFQDN {
-				services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
-				for _, service := range services {
-					svcNsName := strings.Split(service, "/")
-					if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
-						fqdns = append(fqdns, fqdn)
-					}
-				}
-			}
-		}
-
-		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
-			ServiceMetadata: lib.ServiceMetadataObj{
-				Gateway:   namespace + "/" + gatewayName,
-				HostNames: fqdns,
-			},
-			ServiceEngineGroup: lib.GetSEGName(),
-			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
-		}
-
-		isTCP, isUDP := false, false
-		avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
-		var portProtocols []AviPortHostProtocol
-		for _, listener := range listeners {
-			portProto := strings.Split(listener, "/") // format: protocol/port
-			port, _ := utilsnet.ParsePort(portProto[1], true)
-			pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
-			portProtocols = append(portProtocols, pp)
-			if portProto[0] == "" || portProto[0] == utils.TCP {
-				isTCP = true
-			} else if portProto[0] == utils.UDP {
-				isUDP = true
-			}
-		}
-
-		avi_vs_meta.PortProto = portProtocols
-		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
-
-		// In case the VS has services that are a mix of TCP and UDP sockets,
-		// we create the VS with global network profile TCP Fast Path,
-		// and override required services with UDP Fast Path. Having a separate
-		// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-		// on existing VSes.
-		if isTCP && !isUDP {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		} else if isUDP && !isTCP {
-			avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-		} else {
-			avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-		}
-
-		vsVipNode := &AviVSVIPNode{
-			Name:        lib.GetL4VSVipName(gatewayName, namespace),
-			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
-			FQDNs:       fqdns,
-			VipNetworks: lib.GetVipNetworkList(),
-		}
-
-		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
-			vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
-		}
-
-		// configures VS and VsVip nodes using infraSetting object (via CRD).
-		if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
-			buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
-		}
-
-		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
-			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
-		}
-
-		avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
-		return avi_vs_meta
+	if !found {
+		return nil
 	}
-	return nil
+	vsName := lib.GetL4VSName(gatewayName, namespace)
+	gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
+		return nil
+	}
+
+	var serviceNSNames []string
+	listenerSvcMapping := make(map[string][]string)
+	if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
+		for svcListener, service := range services {
+			// assume it to have only a single backend service, the check is in isGatewayDelete
+			if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
+				serviceNSNames = append(serviceNSNames, service[0])
+				if val, ok := listenerSvcMapping[svcListener]; ok {
+					listenerSvcMapping[svcListener] = append(val, service[0])
+				} else {
+					listenerSvcMapping[svcListener] = []string{service[0]}
+				}
+			}
+		}
+	}
+
+	var fqdns []string
+	for _, listener := range gw.Spec.Listeners {
+		autoFQDN := true
+		// Honour the hostname if specified corresponding to the listener.
+		if listener.Hostname != nil && string(*listener.Hostname) != "" {
+			fqdns = append(fqdns, string(*listener.Hostname))
+			autoFQDN = false
+		}
+
+		subDomains := GetDefaultSubDomain()
+		if subDomains != nil && autoFQDN {
+			services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
+			for _, service := range services {
+				svcNsName := strings.Split(service, "/")
+				if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
+					fqdns = append(fqdns, fqdn)
+				}
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			Gateway:   namespace + "/" + gatewayName,
+			HostNames: fqdns,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	isTCP, isUDP := false, false
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
+	var portProtocols []AviPortHostProtocol
+	for _, listener := range listeners {
+		portProto := strings.Split(listener, "/") // format: protocol/port
+		port, _ := utilsnet.ParsePort(portProto[1], true)
+		pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
+		portProtocols = append(portProtocols, pp)
+		if portProto[0] == "" || portProto[0] == utils.TCP {
+			isTCP = true
+		} else if portProto[0] == utils.UDP {
+			isUDP = true
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	// In case the VS has services that are a mix of TCP and UDP sockets,
+	// we create the VS with global network profile TCP Fast Path,
+	// and override required services with UDP Fast Path. Having a separate
+	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
+	// on existing VSes.
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(gatewayName, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		FQDNs:       fqdns,
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
+		buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
+	}
+
+	if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
+		vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	}
+
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
 }
 
 func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, namespace, key string) {
@@ -363,10 +372,10 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			poolNode.AviMarkers = lib.PopulateAdvL4PoolNodeMarkers(namespace, svcNSName[1], gwName, port)
 		}
 
-		pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
+		poolRef := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
 		portPool := AviHostPathPortPoolPG{
 			Port:     uint32(port),
-			Pool:     pool_ref,
+			Pool:     poolRef,
 			Protocol: portProto[0],
 		}
 		portPoolSet = append(portPoolSet, portPool)
@@ -382,6 +391,187 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		Tenant:     lib.GetTenant(),
 		PortPool:   portPoolSet,
 		AviMarkers: lib.PopulateAdvL4VSNodeMarkers(namespace, gwName),
+	}
+
+	l4Policies = append(l4Policies, l4policyNode)
+	vsNode.L4PolicyRefs = l4Policies
+	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
+}
+
+func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, key string) *AviVsNode {
+	namespacedShareVipKey := namespace + "/" + sharedVipKey
+	found, serviceNSNames := objects.SharedlbLister().GetSharedVipKeyToServices(namespacedShareVipKey)
+	if !found {
+		return nil
+	}
+
+	vsName := lib.GetL4VSName(sharedVipKey, namespace)
+
+	var fqdns []string
+	autoFQDN := true
+	subDomains := GetDefaultSubDomain()
+	if subDomains != nil && autoFQDN {
+		for _, service := range serviceNSNames {
+			svcNsName := strings.Split(service, "/")
+			if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
+				fqdns = append(fqdns, fqdn)
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			HostNames: fqdns,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	isTCP, isUDP := false, false
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, sharedVipKey)
+	var portProtocols []AviPortHostProtocol
+	for _, serviceNSName := range serviceNSNames {
+		svcNSName := strings.Split(serviceNSName, "/")
+		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
+		if err != nil {
+			utils.AviLog.Debugf("key: %s, msg: there was an error in retrieving the service", key)
+			return nil
+		}
+
+		for _, listener := range svcObj.Spec.Ports {
+			protocol := string(listener.Protocol)
+			pp := AviPortHostProtocol{Port: listener.Port, Protocol: protocol}
+			portProtocols = append(portProtocols, pp)
+			if protocol == "" || protocol == utils.TCP {
+				isTCP = true
+			} else if protocol == utils.UDP {
+				isUDP = true
+			}
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(sharedVipKey, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		FQDNs:       fqdns,
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	// if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
+	// 	buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
+	// }
+
+	// if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
+	// 	vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	// }
+
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
+}
+
+func (o *AviObjectGraph) ConstructSharedVipPolPoolNodes(vsNode *AviVsNode, sharedVipKey, namespace, key string) {
+	namespacedShareVipKey := namespace + "/" + sharedVipKey
+	found, serviceNSNames := objects.SharedlbLister().GetSharedVipKeyToServices(namespacedShareVipKey)
+	if !found {
+		return
+	}
+
+	var l4Policies []*AviL4PolicyNode
+	// var infraSetting *v1alpha1.AviInfraSetting
+	// if lib.UseServicesAPI() {
+	// 	gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
+	// 	if err != nil {
+	// 		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
+	// 		return
+	// 	}
+	// 	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	// 	infraSetting, err = getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName)
+	// 	if err != nil {
+	// 		utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Gateway %s", key, err.Error())
+	// 		return
+	// 	}
+	// }
+
+	var portPoolSet []AviHostPathPortPoolPG
+	for _, serviceNSName := range serviceNSNames {
+		svcNSName := strings.Split(serviceNSName, "/")
+		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
+		if err != nil {
+			utils.AviLog.Debugf("key: %s, msg: there was an error in retrieving the service", key)
+			return
+		}
+
+		for _, listener := range svcObj.Spec.Ports {
+			protocol := string(listener.Protocol)
+			port := listener.Port
+
+			var svcFQDN string
+			if lib.GetL4FqdnFormat() != lib.AutoFQDNDisabled && svcFQDN == "" {
+				svcFQDN = getAutoFQDNForService(svcNSName[0], svcNSName[1])
+			}
+
+			poolName := lib.GetSvcApiL4PoolName(svcNSName[1], namespace, sharedVipKey, protocol, port)
+			poolNode := &AviPoolNode{
+				Name:     poolName,
+				Tenant:   lib.GetTenant(),
+				Protocol: protocol,
+				PortName: listener.Name,
+				ServiceMetadata: lib.ServiceMetadataObj{
+					NamespaceServiceName: []string{serviceNSName},
+				},
+				VrfContext: lib.GetVrf(),
+			}
+			poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
+
+			if svcFQDN != "" {
+				poolNode.ServiceMetadata.HostNames = []string{svcFQDN}
+			}
+
+			if servers := PopulateServers(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+				poolNode.Servers = servers
+			}
+
+			poolNode.AviMarkers = lib.PopulateSvcApiL4PoolNodeMarkers(namespace, svcNSName[1], sharedVipKey, protocol, int(port))
+			poolRef := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
+			portPool := AviHostPathPortPoolPG{
+				Port:     uint32(port),
+				Pool:     poolRef,
+				Protocol: protocol,
+			}
+			portPoolSet = append(portPoolSet, portPool)
+
+			// buildPoolWithInfraSetting(key, poolNode, infraSetting)
+
+			vsNode.PoolRefs = append(vsNode.PoolRefs, poolNode)
+			utils.AviLog.Infof("key: %s, msg: evaluated L4 pool values :%v", key, utils.Stringify(poolNode))
+		}
+	}
+
+	l4policyNode := &AviL4PolicyNode{
+		Name:       vsNode.Name,
+		Tenant:     lib.GetTenant(),
+		PortPool:   portPoolSet,
+		AviMarkers: lib.PopulateAdvL4VSNodeMarkers(namespace, sharedVipKey),
 	}
 
 	l4Policies = append(l4Policies, l4policyNode)

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -139,7 +139,7 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 	for _, portProto := range vsNode.PortProto {
 		filterPort := portProto.Port
 		poolNode := &AviPoolNode{
-			Name:       lib.GetL4PoolName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace, filterPort),
+			Name:       lib.GetL4PoolName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace, portProto.Protocol, filterPort),
 			Tenant:     lib.GetTenant(),
 			Protocol:   portProto.Protocol,
 			PortName:   portProto.Name,

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -694,7 +694,7 @@ func isServiceDelete(svcName string, namespace string, key string) bool {
 	// The annotation for sharedVip might have been added, in which case we should delete the L4
 	// dedicated virtual service.
 	if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
-		return false
+		return true
 	}
 
 	return false

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -25,6 +25,7 @@ import (
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -133,13 +134,23 @@ func DequeueIngestion(key string, fullsync bool) {
 
 	if !ingressFound && !lib.GetAdvancedL4() && !mciFound {
 		// If ingress is not found, let's do the other checks.
-		if objType == utils.L4LBService {
+		if objType == lib.SharedVipServiceKey {
+			sharedVipKeys, keysFound := schema.GetParentServices(name, namespace, key)
+			if keysFound && utils.CheckIfNamespaceAccepted(namespace) {
+				for _, sharedVipKey := range sharedVipKeys {
+					handleL4SharedVipService(sharedVipKey, key, fullsync)
+				}
+			}
+		} else if objType == utils.L4LBService {
 			// L4 type of services need special handling. We create a dedicated VS in Avi for these.
 			handleL4Service(key, fullsync)
 		} else if objType == utils.Endpoints {
 			svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 			if err != nil {
 				utils.AviLog.Debugf("key: %s, msg: there was an error in retrieving the service for endpoint", key)
+				return
+			}
+			if val, ok := svcObj.Annotations[lib.SharedVipSvcLBAnnotation]; ok && val != "" {
 				return
 			}
 			//Do not handle service update if it belongs to unaccepted namespace
@@ -421,6 +432,62 @@ func handleRoute(key string, fullsync bool, routeNames []string) {
 	}
 }
 
+/*
+to test
+1. 	key1 svc1 svc2 ; key2 svc3
+	change key from key1 to key2 in svc2
+	key 1 svc1 ; key2 svc3 svc2
+
+2.	key1 svc1
+	change service type to clusterip
+	deletes key1 VS
+	change servie type to lb
+	recreates key1 VS
+
+3. 	key1 svc1	ingress /bar svc1
+	change service type to clusterip
+	deletes key1 VS, adds to pool in ingress /bar
+	change service type to lb
+	creates key1 VS, deletes pool of ingress /bar
+*/
+/*
+validations
+1.	annotations must not be on service of type non LB
+2. 	port/protocol must be unique among all services with annotation key
+3. 	preferred IP must be same in all services with annotation key
+*/
+func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
+	if lib.GetLayer7Only() {
+		// If the layer 7 only flag is set, then we shouldn't handling layer 4 VSes.
+		utils.AviLog.Debugf("key: %s, msg: not handling service of type loadbalancer since AKO is configured to run in layer 7 mode only", key)
+		return
+	}
+
+	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
+	_, namespace, _ := lib.ExtractTypeNameNamespace(key)
+	modelName := lib.GetModelName(lib.GetTenant(), lib.Encode(lib.GetNamePrefix()+strings.ReplaceAll(namespacedVipKey, "/", "-"), lib.ADVANCED_L4))
+
+	found, services := objects.SharedlbLister().GetSharedVipKeyToServices(namespacedVipKey)
+	isShareVipKeyDelete := !found || len(services) == 0
+	if isShareVipKeyDelete {
+		// Check if a model corresponding to the gateway exists or not in memory.
+		if found, _ := objects.SharedAviGraphLister().Get(modelName); found {
+			objects.SharedAviGraphLister().Save(modelName, nil)
+			if !fullsync {
+				PublishKeyToRestLayer(modelName, key, sharedQueue)
+			}
+		}
+	} else {
+		aviModelGraph := NewAviObjectGraph()
+		vipKey := strings.Split(namespacedVipKey, "/")[1]
+		aviModelGraph.BuildAdvancedL4Graph(namespace, vipKey, key)
+		ok := saveAviModel(modelName, aviModelGraph, key)
+		if ok && len(aviModelGraph.GetOrderedNodes()) != 0 && !fullsync {
+			PublishKeyToRestLayer(modelName, key, sharedQueue)
+		}
+	}
+}
+
 func handleL4Service(key string, fullsync bool) {
 	if lib.GetLayer7Only() {
 		// If the layer 7 only flag is set, then we shouldn't handling layer 4 VSes.
@@ -429,8 +496,7 @@ func handleL4Service(key string, fullsync bool) {
 	}
 	_, namespace, name := lib.ExtractTypeNameNamespace(key)
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
-	// L4 type of services need special handling. We create a dedicated VS in Avi for these.
-	if !isServiceDelete(name, namespace, key) && utils.CheckIfNamespaceAccepted(namespace) {
+	if deleteCase, _ := isServiceDelete(name, namespace, key); !deleteCase && utils.CheckIfNamespaceAccepted(namespace) {
 		// If Service is Not Annotated with NPL annotation, annotate the service and return.
 		if lib.AutoAnnotateNPLSvc() {
 			if !status.CheckNPLSvcAnnotation(key, namespace, name) {
@@ -518,28 +584,28 @@ func getIngressNSNameForIngestion(objType, namespace, nsname string) (string, st
 	return namespace, nsname
 }
 
-func saveAviModel(model_name string, aviGraph *AviObjectGraph, key string) bool {
-	utils.AviLog.Debugf("key: %s, msg: Evaluating model :%s", key, model_name)
+func saveAviModel(modelName string, aviGraph *AviObjectGraph, key string) bool {
+	utils.AviLog.Debugf("key: %s, msg: Evaluating model :%s", key, modelName)
 	if lib.DisableSync {
 		// Note: This is not thread safe, however locking is expensive and the condition for locking should happen rarely
-		utils.AviLog.Infof("key: %s, msg: Disable Sync is True, model %s can not be saved", key, model_name)
+		utils.AviLog.Infof("key: %s, msg: Disable Sync is True, model %s can not be saved", key, modelName)
 		return false
 	}
-	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	if found && aviModel != nil {
 		prevChecksum := aviModel.(*AviObjectGraph).GraphChecksum
-		utils.AviLog.Debugf("key: %s, msg: the model: %s has a previous checksum: %v", key, model_name, prevChecksum)
+		utils.AviLog.Debugf("key: %s, msg: the model: %s has a previous checksum: %v", key, modelName, prevChecksum)
 		presentChecksum := aviGraph.GetCheckSum()
-		utils.AviLog.Debugf("key: %s, msg: the model: %s has a present checksum: %v", key, model_name, presentChecksum)
+		utils.AviLog.Debugf("key: %s, msg: the model: %s has a present checksum: %v", key, modelName, presentChecksum)
 		if prevChecksum == presentChecksum {
-			utils.AviLog.Debugf("key: %s, msg: The model: %s has identical checksums, hence not processing. Checksum value: %v", key, model_name, presentChecksum)
+			utils.AviLog.Debugf("key: %s, msg: The model: %s has identical checksums, hence not processing. Checksum value: %v", key, modelName, presentChecksum)
 			return false
 		}
 	}
 	// Right before saving the model, let's reset the retry counter for the graph.
 	aviGraph.SetRetryCounter()
 	aviGraph.CalculateCheckSum()
-	objects.SharedAviGraphLister().Save(model_name, aviGraph)
+	objects.SharedAviGraphLister().Save(modelName, aviGraph)
 	return true
 }
 
@@ -588,17 +654,23 @@ func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.Work
 
 }
 
-func isServiceDelete(svcName string, namespace string, key string) bool {
+func isServiceDelete(svcName string, namespace string, key string) (bool, *v1.Service) {
 	// If the service is not found we return true.
-	_, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
+	svc, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
 	if err != nil {
 		utils.AviLog.Warnf("key: %s, msg: could not retrieve the object for service: %s", key, err)
 		if errors.IsNotFound(err) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	// The annotation for sharedVip might have been added, in which case we should delete the L4
+	// dedicated virtual service.
+	if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+		return false, nil
+	}
+
+	return false, svc
 }
 
 func ConfigDescriptor() GraphDescriptor {

--- a/internal/objects/lbservices.go
+++ b/internal/objects/lbservices.go
@@ -25,15 +25,23 @@ var lbonce sync.Once
 
 func SharedlbLister() *lbLister {
 	lbonce.Do(func() {
-		lbStore := NewObjectMapStore()
-		lbinstance = &lbLister{}
-		lbinstance.lbStore = lbStore
+		lbinstance = &lbLister{
+			lbStore:                     NewObjectMapStore(),
+			sharedVipKeyToServicesStore: NewObjectMapStore(),
+			serviceToSharedVipKeyStore:  NewObjectMapStore(),
+		}
 	})
 	return lbinstance
 }
 
 type lbLister struct {
 	lbStore *ObjectMapStore
+
+	// annotationKey -> [svc1, svc2, svc3]
+	sharedVipKeyToServicesStore *ObjectMapStore
+
+	// svc1 -> annotationKey
+	serviceToSharedVipKeyStore *ObjectMapStore
 }
 
 func (a *lbLister) Save(svcName string, lb interface{}) {
@@ -53,5 +61,49 @@ func (a *lbLister) GetAll() interface{} {
 
 func (a *lbLister) Delete(svcName string) {
 	a.lbStore.Delete(svcName)
+}
 
+func (a *lbLister) UpdateSharedVipKeyServiceMappings(key, svc string) {
+	a.serviceToSharedVipKeyStore.AddOrUpdate(svc, key)
+	found, services := a.GetSharedVipKeyToServices(key)
+	if found {
+		if utils.HasElem(services, svc) {
+			return
+		}
+		services = append(services, svc)
+		a.sharedVipKeyToServicesStore.AddOrUpdate(key, services)
+		return
+	}
+	a.sharedVipKeyToServicesStore.AddOrUpdate(key, []string{svc})
+}
+
+func (a *lbLister) RemoveSharedVipKeyServiceMappings(svc string) bool {
+	if found, key := a.GetServiceToSharedVipKey(svc); found {
+		if foundServices, services := a.GetSharedVipKeyToServices(key); foundServices {
+			services = utils.Remove(services, svc)
+			if len(services) == 0 {
+				a.sharedVipKeyToServicesStore.Delete(key)
+			} else {
+				a.sharedVipKeyToServicesStore.AddOrUpdate(key, services)
+			}
+		}
+	}
+	a.serviceToSharedVipKeyStore.Delete(svc)
+	return true
+}
+
+func (a *lbLister) GetSharedVipKeyToServices(key string) (bool, []string) {
+	found, serviceList := a.sharedVipKeyToServicesStore.Get(key)
+	if !found {
+		return false, make([]string, 0)
+	}
+	return true, serviceList.([]string)
+}
+
+func (a *lbLister) GetServiceToSharedVipKey(svc string) (bool, string) {
+	found, key := a.serviceToSharedVipKeyStore.Get(svc)
+	if !found {
+		return false, ""
+	}
+	return true, key.(string)
 }

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -217,8 +217,7 @@ func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *
 		Tenant: tenant,
 		Model:  "Pool",
 	}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: pool DELETE Restop %v ", key,
-		utils.Stringify(rest_op)))
+	utils.AviLog.Infof("key: %s, msg: pool DELETE Restop %v ", key, utils.Stringify(rest_op))
 	return &rest_op
 }
 
@@ -354,14 +353,12 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 					}
 				}
 			}
-
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToPoolKeyCollection(k)
-			utils.AviLog.Debug(spew.Sprintf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey,
-				vs_cache_obj))
+			utils.AviLog.Debugf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey, utils.Stringify(vs_cache_obj))
 		}
-		utils.AviLog.Info("key: %s, msg: Added Pool cache k %v val %v", key, k, utils.Stringify(pool_cache_obj))
+		utils.AviLog.Infof("key: %s, msg: Added Pool cache k %v val %v", key, k, utils.Stringify(pool_cache_obj))
 	}
 
 	return nil

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -589,8 +589,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToVSVipKeyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey,
-				vs_cache_obj))
+			utils.AviLog.Infof("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey, utils.Stringify(vs_cache_obj))
 			if rest_op.Method == utils.RestPut {
 				if len(vs_cache_obj.SNIChildCollection) > 0 {
 					for _, childUuid := range vs_cache_obj.SNIChildCollection {

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -545,7 +545,7 @@ func deleteRouteObject(option UpdateOptions, key string, isVSDelete bool, retryN
 
 	oldRouteStatus := mRoute.Status.DeepCopy()
 	if len(option.ServiceMetadata.HostNames) > 0 {
-		// If the route status for the host is already fasle, then don't delete the status
+		// If the route status for the host is already false, then don't delete the status
 		if !routeStatusCheck(key, oldRouteStatus.Ingress, option.ServiceMetadata.HostNames[0]) {
 			return nil
 		}

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -304,7 +304,7 @@ func TestL4NamingConvention(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.ContainSubstring("cluster--red-ns-testsvcmulti--808"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.ContainSubstring("cluster--red-ns-testsvcmulti-TCP-808"))
 	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
 	g.Expect(nodes[0].L4PolicyRefs[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
 
@@ -417,7 +417,7 @@ func TestCreateServiceLBCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", NAMESPACE, SINGLEPORTSVC)))
 		g.Expect(vsCacheObj.Tenant).To(gomega.Equal(AVINAMESPACE))
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc-TCP-8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
@@ -491,7 +491,7 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", NAMESPACE, SINGLEPORTSVC)))
 		g.Expect(vsCacheObj.Tenant).To(gomega.Equal(AVINAMESPACE))
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc-TCP-8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
@@ -532,7 +532,7 @@ func TestUpdateAndDeleteServiceLBCacheSync(t *testing.T) {
 	SetUpTestForSvcLB(t)
 
 	// Get hold of the pool checksum on CREATE
-	poolName := "cluster--red-ns-testsvc--8080"
+	poolName := "cluster--red-ns-testsvc-TCP-8080"
 	mcache := cache.SharedAviObjCache()
 	poolKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: poolName}
 	poolCacheBefore, _ := mcache.PoolCache.AviCacheGet(poolKey)


### PR DESCRIPTION
This PR adds support for sharing VIPs among Service of Type LBs in kubernetes. The proposed functionality works by means of a annotation that can be added to these Services, which help the Services to be grouped under 1 VIP.
The annotation to be used is `ako.vmware.com/enable-shared-vip` that takes in a string value.

All services that share this unique annotation value, will be grouped into a single virtual service in Avi, and therefore get a single shared VIP. In other words, AKO would maintain 1 VIP per unique annotation value.

In case of users wanting to set a preferred static VIP through the `.spec.loadBalancerIP` field in the Service, it is required that all Services sharing a unique annotation value must have the same preferred VIP provided in the spec. If two Services in under the same annotation key have different static VIP setting, no virtual service will be configured. This will be treated as a misconfiguration and will be logged accordingly.

Sample Services with preferred static VIP configured.
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    ako.vmware.com/enable-shared-vip: "shared-vip-key-1"
  name: sharedvip-avisvc-lb1
  namespace: default
spec:
  type: LoadBalancer
  loadBalancerIP: 10.64.196.75
  ports:
  - port: 80
    targetPort: 8080
  selector:
    app: avi-server
---
apiVersion: v1
kind: Service
metadata:
  annotations:
    ako.vmware.com/enable-shared-vip: "shared-vip-key-1"
  name: sharedvip-avisvc-lb2
  namespace: default
spec:
  type: LoadBalancer
  loadBalancerIP: 10.64.196.75
  ports:
  - port: 81
    protocol: UDP
    targetPort: 8080
  selector:
    app: avi-server
```