### PR TITLE
AV-139061 Added cloud_uuid to network api call

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2888,6 +2888,9 @@ func checkAndSetCloudType(client *clients.AviClient, returnErr *error) bool {
 	utils.AviLog.Infof("Setting cloud vType: %v", vType)
 	lib.SetCloudType(vType)
 
+	utils.AviLog.Infof("Setting cloud uuid: %s", *cloud.UUID)
+	lib.SetCloudUUID(*cloud.UUID)
+
 	// IPAM is mandatory for vcenter and noaccess cloud
 	if !lib.IsPublicCloud() && cloud.IPAMProviderRef == nil {
 		*returnErr = fmt.Errorf("Cloud does not have a ipam_provider_ref configured")

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -889,7 +889,7 @@ func checkRefOnController(key, refKey, refValue string) error {
 		if lib.UsesNetworkRef() {
 			var rest_response interface{}
 			utils.AviLog.Infof("Cloud is  %s, checking network ref using uuid", lib.GetCloudType())
-			uri := fmt.Sprintf("/api/%s/%s", refModelMap[refKey], refValue)
+			uri := fmt.Sprintf("/api/%s/%s?cloud_uuid=%s", refModelMap[refKey], refValue, lib.GetCloudUUID())
 			err := lib.AviGet(clients.AviClient[aviClientLen], uri, &rest_response)
 			if err != nil {
 				utils.AviLog.Warnf("key: %s, msg: Get uri %v returned err %v", key, uri, err)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1301,9 +1301,14 @@ func IsValidLabelOnNode(labels map[string]string, key string) bool {
 }
 
 var CloudType string
+var CloudUUID string
 
 func SetCloudType(cloudType string) {
 	CloudType = cloudType
+}
+
+func SetCloudUUID(cloudUUID string) {
+	CloudUUID = cloudUUID
 }
 
 func GetCloudType() string {
@@ -1311,6 +1316,10 @@ func GetCloudType() string {
 		return CLOUD_VCENTER
 	}
 	return CloudType
+}
+
+func GetCloudUUID() string {
+	return CloudUUID
 }
 
 var IsCloudInAdminTenant = true


### PR DESCRIPTION
This PR adds a cloud_uuid query parameter in the /api/network call which will work in case of both Default-Cloud and NonDefault-Cloud.