### PR TITLE
[fix] AKO not honoring httprule updates in Openshift

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -919,7 +919,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 	childNode.Paths = pathSet.List()
 	childNode.IngressNames = ingressNameSet.List()
 	for _, path := range paths {
-		BuildPoolHTTPRule(hosts[0], path.Path, ingName, namespace, infraSettingName, key, childNode, true, vsNode[0].Dedicated)
+		BuildPoolHTTPRule(hosts[0], path.Path, ingName, namespace, infraSettingName, key, childNode, true, vsNode[0].Dedicated, modelType == utils.Ingress)
 	}
 
 	utils.AviLog.Infof("key: %s, msg: added pools and poolgroups. childNodeChecksum for childNode :%s is :%v", key, childNode.Name, childNode.GetCheckSum())

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -209,7 +209,7 @@ func (o *AviObjectGraph) BuildPoolPGPolicyForDedicatedVS(vsNode []*AviVsNode, na
 				vsNode[0].ReplaceSniHTTPRefInSNINode(httpPGPath, httpPolName, key)
 			}
 		}
-		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, infraSettingName, key, vsNode[0], true, vsNode[0].Dedicated)
+		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, infraSettingName, key, vsNode[0], true, vsNode[0].Dedicated, isIngr)
 	}
 	vsNode[0].Paths = pathSet.List()
 	vsNode[0].IngressNames = ingressNameSet.List()
@@ -287,7 +287,7 @@ func (o *AviObjectGraph) BuildL7VSGraphHostNameShard(vsName, hostname string, ro
 
 	}
 	for _, obj := range pathsvc {
-		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, infraSettingName, key, vsNode[0], false, vsNode[0].Dedicated)
+		BuildPoolHTTPRule(hostname, obj.Path, ingName, namespace, infraSettingName, key, vsNode[0], false, vsNode[0].Dedicated, routeIgrObj.GetType() == utils.Ingress)
 	}
 
 	// Reset the PG Node members and rebuild them

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -476,7 +476,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 					tlsNode.ReplaceSniHTTPRefInSNINode(httpPGPath, httpPolName, key)
 				}
 			}
-			BuildPoolHTTPRule(host, path.Path, ingName, namespace, infraSettingName, key, tlsNode, true, vsNode[0].Dedicated)
+			BuildPoolHTTPRule(host, path.Path, ingName, namespace, infraSettingName, key, tlsNode, true, vsNode[0].Dedicated, isIngr)
 		}
 		sniFQDNs = append(sniFQDNs, pathFQDNs...)
 	}


### PR DESCRIPTION
In the case of routes, the pool name ends with the service name but AKO was considering only till the ingress name due to which the AKO was not selecting the pool and hence not honoring the updates to httprule.
This commit includes the changes to consider the service name also in the pool name for route objects while honoring the httprule updates.

Scenarios tested:
1. EVH/SNI in k8s 
2. EVH/SNI in OCE
In both cases, the pools are getting updated with the values given in httprule.