### PR TITLE
Shchauhan nsx alb integration

### DIFF
--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -291,8 +291,8 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 			continue
 		}
 		startIP, endIP := gocidr.AddressRange(ipnet)
-		startIPStr := startIP.String()
-		endIPStr := endIP.String()
+		startIPStr := gocidr.Inc(startIP).String()
+		endIPStr := gocidr.Dec(endIP).String()
 		ipStr := ipnet.IP.String()
 		addrType := "V4"
 		if !utils.IsV4(ipStr) {

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -359,7 +359,7 @@ func addNetworkInIPAM(key string) {
 		len(ipam.InternalProfile.UsableNetworks) > 0 {
 		exists := false
 		for _, ntw := range ipam.InternalProfile.UsableNetworks {
-			if strings.Contains(*ntw.NwRef, networkRef) {
+			if strings.Contains(*ntw.NwRef, netName) {
 				exists = true
 			}
 		}
@@ -444,9 +444,9 @@ func delSegmentInCloud(lslrList []*models.Tier1LogicalRouterInfo, lr, ls string)
 }
 
 func matchSegmentInCloud(lslrList []*models.Tier1LogicalRouterInfo, lslrMap map[string]string) bool {
-	if len(lslrMap) != len(lslrList) {
-		return false
-	}
+	// if len(lslrMap) != len(lslrList) {
+	// 	return false
+	// }
 	for i := range lslrList {
 		if lslrMap[*lslrList[i].SegmentID] != *lslrList[i].Tier1LrID {
 			return false

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -42,7 +42,7 @@ var IPAMCache *models.IPAMDNSProviderProfile
 // and updates the cloud if any LS-LR data is missing. It also creates or updates the VCF network with the CIDRs
 // Provided in the Networkinfo objects.
 func SyncLSLRNetwork() {
-	lslrmap, cidrs := lib.GetNetworkInfoCRData()
+	lslrmap, cidrs := lib.GetNetworkInfoCRData(lib.GetDynamicClientSet())
 	utils.AviLog.Infof("Got data LS LR Map: %v, from NetworkInfo CR", lslrmap)
 
 	client := InfraAviClientInstance()
@@ -112,7 +112,7 @@ func AddSegment(obj interface{}) bool {
 		utils.AviLog.Infof("cidr not found in networkinfo object")
 		// If not found, try fetching from cluster network info CRD
 		var clusterNetworkCIDRFound bool
-		if cidrIntf, clusterNetworkCIDRFound = lib.GetClusterNetworkInfoCRData(); !clusterNetworkCIDRFound {
+		if cidrIntf, clusterNetworkCIDRFound = lib.GetClusterNetworkInfoCRData(lib.GetDynamicClientSet()); !clusterNetworkCIDRFound {
 			return false
 		}
 		utils.AviLog.Infof("Ingress CIDR found from Cluster Network Info %v", cidrIntf)

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -86,8 +86,8 @@ func SyncLSLRNetwork() {
 		}
 	}
 
-	addNetworkInCloud("fullsync", cidrs, true)
-	addNetworkInIPAM("fullsync")
+	addNetworkInCloud("fullsync", cidrs, client)
+	addNetworkInIPAM("fullsync", client)
 }
 
 func AddSegment(obj interface{}) bool {
@@ -151,8 +151,8 @@ func AddSegment(obj interface{}) bool {
 		utils.AviLog.Infof("key: %s, LSLR update not required in cloud: %s", objKey, utils.CloudName)
 	}
 
-	addNetworkInCloud(objKey, cidrs, false)
-	addNetworkInIPAM(objKey)
+	addNetworkInCloud(objKey, cidrs, client)
+	addNetworkInIPAM(objKey, client)
 	return true
 }
 
@@ -254,8 +254,12 @@ func findAndRemoveCidrInNetwork(subnets []*models.Subnet, cidrs map[string]struc
 	return subnetsCopy, false
 }
 
-func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool) {
-	client := InfraAviClientInstance()
+func addNetworkInCloud(objKey string, cidrs map[string]struct{}, client *clients.AviClient) {
+	replaceAll := false
+	if objKey == "fullsync" {
+		replaceAll = true
+	}
+
 	netName := lib.GetVCFNetworkName()
 	method := utils.RestPost
 	path := "/api/network/"
@@ -343,8 +347,7 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 	executeRestOp(objKey, client, &restOp)
 }
 
-func addNetworkInIPAM(key string) {
-	client := InfraAviClientInstance()
+func addNetworkInIPAM(key string, client *clients.AviClient) {
 	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
 	if !found {
 		utils.AviLog.Warnf("Failed to get Cloud data from cache")

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -20,7 +20,9 @@ import (
 	"net"
 	"strings"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
+	avimodels "github.com/vmware/alb-sdk/go/models"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/rest"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -43,7 +45,7 @@ func SyncLSLRNetwork() {
 	lslrmap, cidrs := lib.GetNetinfoCRData()
 	utils.AviLog.Infof("Got data LS LR Map: %v, from NetworkInfo CR", lslrmap)
 
-	client := avicache.SharedAVIClients().AviClient[0]
+	client := InfraAviClientInstance()
 	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
 	if !found {
 		utils.AviLog.Warnf("Failed to get Cloud data from cache")
@@ -59,28 +61,33 @@ func SyncLSLRNetwork() {
 		utils.AviLog.Infof("NSX-T cloud is using Vlan Segments, LS-LR mapping won't be updated")
 		return
 	}
+
 	if cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual == nil {
 		utils.AviLog.Warnf("Tier1SegmentConfig is nil in NSX-T cloud, LS-LR mapping won't be updated")
 		return
 	}
-	matched := matchSegmentInCloud(cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs, lslrmap)
-	if !matched {
-		cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = constructLsLrInCloud(lslrmap)
-		path := "/api/cloud/" + *cloudModel.UUID
-		restOp := utils.RestOp{
-			ObjName: utils.CloudName,
-			Path:    path,
-			Method:  utils.RestPut,
-			Obj:     &cloudModel,
-			Tenant:  "admin",
-			Model:   "cloud",
+
+	if len(lslrmap) > 0 {
+		matched := matchSegmentInCloud(cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs, lslrmap)
+		if !matched {
+			cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = constructLsLrInCloud(lslrmap)
+			path := "/api/cloud/" + *cloudModel.UUID
+			restOp := utils.RestOp{
+				ObjName: utils.CloudName,
+				Path:    path,
+				Method:  utils.RestPut,
+				Obj:     &cloudModel,
+				Tenant:  "admin",
+				Model:   "cloud",
+			}
+			executeRestOp("fullsync", client, &restOp)
+		} else {
+			utils.AviLog.Infof("LS LR update not required in cloud: %s", utils.CloudName)
 		}
-		executeRestOp("fullsync", client, &restOp)
-	} else {
-		utils.AviLog.Infof("LS LR update not required in cloud: %s", utils.CloudName)
 	}
+
 	addNetworkInCloud("fullsync", cidrs, true)
-	addNetworkInIPAM()
+	addNetworkInIPAM("fullsync")
 }
 
 func AddSegment(obj interface{}) bool {
@@ -111,7 +118,7 @@ func AddSegment(obj interface{}) bool {
 	}
 
 	utils.AviLog.Infof("key: %s, Adding LR %s, LS %s from networkinfo CR", objKey, lr, ls)
-	client := avicache.SharedAVIClients().AviClient[0]
+	client := InfraAviClientInstance()
 	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
 	if !found {
 		utils.AviLog.Fatalf("key: %s, Failed to get Cloud data from cache", objKey)
@@ -141,6 +148,7 @@ func AddSegment(obj interface{}) bool {
 	}
 
 	addNetworkInCloud(objKey, cidrs, false)
+	addNetworkInIPAM(objKey)
 	return true
 }
 
@@ -173,7 +181,7 @@ func DeleteSegment(obj interface{}) {
 
 	utils.AviLog.Infof("key: %s, Network Info CR deleted, removing LR %s, LS %s and CIDR %v from cloud", objKey, lr, ls, cidrs)
 
-	client := avicache.SharedAVIClients().AviClient[0]
+	client := InfraAviClientInstance()
 	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
 	if !found {
 		utils.AviLog.Warnf("key: %s, Failed to get Cloud data from cache", objKey)
@@ -243,7 +251,7 @@ func findAndRemoveCidrInNetwork(subnets []*models.Subnet, cidrs map[string]struc
 }
 
 func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool) {
-	client := avicache.SharedAVIClients().AviClient[0]
+	client := InfraAviClientInstance()
 	netName := lib.GetVCFNetworkName()
 	method := utils.RestPost
 	path := "/api/network/"
@@ -316,8 +324,8 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 		}
 		subnet.StaticIPRanges = append(subnet.StaticIPRanges, &staticRange)
 		netModel.ConfiguredSubnets = append(netModel.ConfiguredSubnets, &subnet)
-
 	}
+
 	restOp := utils.RestOp{
 		ObjName: utils.CloudName,
 		Path:    path,
@@ -327,12 +335,12 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 		Model:   "network",
 	}
 
-	utils.AviLog.Debugf("key: %s, executing restop to add/update vcf network: %v", objKey, restOp)
+	utils.AviLog.Infof("key: %s, Adding/Updating VCF network: %v", objKey, restOp)
 	executeRestOp(objKey, client, &restOp)
 }
 
-func addNetworkInIPAM() {
-	client := avicache.SharedAVIClients().AviClient[0]
+func addNetworkInIPAM(key string) {
+	client := InfraAviClientInstance()
 	found, cloudModel := getAviCloudFromCache(client, utils.CloudName)
 	if !found {
 		utils.AviLog.Warnf("Failed to get Cloud data from cache")
@@ -346,13 +354,38 @@ func addNetworkInIPAM() {
 	netName := lib.GetVCFNetworkName()
 	networkRef := "/api/network/?name=" + netName
 
-	if !utils.HasElem(ipam.InternalProfile.UsableNetworkRefs, networkRef) {
-		ipam.InternalProfile.UsableNetworkRefs = append(ipam.InternalProfile.UsableNetworkRefs, networkRef)
+	if ipam.InternalProfile != nil &&
+		ipam.InternalProfile.UsableNetworks != nil &&
+		len(ipam.InternalProfile.UsableNetworks) > 0 {
+		exists := false
+		for _, ntw := range ipam.InternalProfile.UsableNetworks {
+			if strings.Contains(*ntw.NwRef, networkRef) {
+				exists = true
+			}
+		}
+		if !exists {
+			ipam.InternalProfile.UsableNetworks = append(ipam.InternalProfile.UsableNetworks, &models.IPAMUsableNetwork{
+				NwRef: proto.String(networkRef),
+			})
+		}
+	} else {
+		ipam.InternalProfile = &avimodels.IPAMDNSInternalProfile{
+			UsableNetworks: []*models.IPAMUsableNetwork{{NwRef: proto.String(networkRef)}},
+		}
 	}
+	path := strings.Split(*cloudModel.IPAMProviderRef, "/ipamdnsproviderprofile/")[1]
+	restOp := utils.RestOp{
+		Path:   "/api/ipamdnsproviderprofile/" + path,
+		Method: utils.RestPut,
+		Obj:    &ipam,
+		Tenant: "admin",
+		Model:  "ipamdnsproviderprofile",
+	}
+	executeRestOp(key, client, &restOp)
 }
 
 func delCIDRFromNetwork(objKey string, cidrs map[string]struct{}) {
-	client := avicache.SharedAVIClients().AviClient[0]
+	client := InfraAviClientInstance()
 	netName := lib.GetVCFNetworkName()
 	method := utils.RestPut
 	path := "/api/network/"
@@ -557,9 +590,18 @@ func executeRestOp(key string, client *clients.AviClient, restOp *utils.RestOp, 
 	}
 	err := rest.AviRestOperateWrapper(client, []*utils.RestOp{restOp})
 	if err != nil {
-		utils.AviLog.Infof("key %s, Got error in executing rest request: %v", key, err)
 		if checkAndRetry(key, err) {
 			executeRestOp(key, client, restOp, retry+1)
+		} else if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			utils.AviLog.Debugf("Switching to admin context from  %s", lib.GetTenant())
+			SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
+			SetTenant := session.SetTenant(lib.GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			executeRestOp(key, client, restOp)
+		} else {
+			utils.AviLog.Warnf("key %s, Got error in executing rest request: %v", key, err)
+			return
 		}
 	}
 	switch restOp.Model {

--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -42,7 +42,7 @@ var IPAMCache *models.IPAMDNSProviderProfile
 // and updates the cloud if any LS-LR data is missing. It also creates or updates the VCF network with the CIDRs
 // Provided in the Networkinfo objects.
 func SyncLSLRNetwork() {
-	lslrmap, cidrs := lib.GetNetinfoCRData()
+	lslrmap, cidrs := lib.GetNetworkInfoCRData()
 	utils.AviLog.Infof("Got data LS LR Map: %v, from NetworkInfo CR", lslrmap)
 
 	client := InfraAviClientInstance()
@@ -68,9 +68,9 @@ func SyncLSLRNetwork() {
 	}
 
 	if len(lslrmap) > 0 {
-		matched := matchSegmentInCloud(cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs, lslrmap)
-		if !matched {
-			cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = constructLsLrInCloud(lslrmap)
+		dataNetworkTier1Lrs := cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs
+		if !matchSegmentInCloud(dataNetworkTier1Lrs, lslrmap) {
+			cloudModel.NsxtConfiguration.DataNetworkConfig.Tier1SegmentConfig.Manual.Tier1Lrs = constructLsLrInCloud(dataNetworkTier1Lrs, lslrmap)
 			path := "/api/cloud/" + *cloudModel.UUID
 			restOp := utils.RestOp{
 				ObjName: utils.CloudName,
@@ -109,12 +109,16 @@ func AddSegment(obj interface{}) bool {
 	cidrs := make(map[string]struct{})
 	cidrIntf, ok := spec["ingressCIDRs"].([]interface{})
 	if !ok {
-		utils.AviLog.Infof("key: %s, cidr not found from NetInfo CR", objKey)
-		return false
-	} else {
-		for _, cidr := range cidrIntf {
-			cidrs[cidr.(string)] = struct{}{}
+		utils.AviLog.Infof("cidr not found in networkinfo object")
+		// If not found, try fetching from cluster network info CRD
+		var clusterNetworkCIDRFound bool
+		if cidrIntf, clusterNetworkCIDRFound = lib.GetClusterNetworkInfoCRData(); !clusterNetworkCIDRFound {
+			return false
 		}
+		utils.AviLog.Infof("Ingress CIDR found from Cluster Network Info %v", cidrIntf)
+	}
+	for _, cidr := range cidrIntf {
+		cidrs[cidr.(string)] = struct{}{}
 	}
 
 	utils.AviLog.Infof("key: %s, Adding LR %s, LS %s from networkinfo CR", objKey, lr, ls)
@@ -335,7 +339,7 @@ func addNetworkInCloud(objKey string, cidrs map[string]struct{}, replaceAll bool
 		Model:   "network",
 	}
 
-	utils.AviLog.Infof("key: %s, Adding/Updating VCF network: %v", objKey, restOp)
+	utils.AviLog.Infof("key: %s, Adding/Updating VCF network: %v", objKey, utils.Stringify(restOp))
 	executeRestOp(objKey, client, &restOp)
 }
 
@@ -346,7 +350,8 @@ func addNetworkInIPAM(key string) {
 		utils.AviLog.Warnf("Failed to get Cloud data from cache")
 		return
 	}
-	found, ipam := getAviIPAMFromCache(client, *cloudModel.IPAMProviderRef)
+
+	found, ipam := getAviIPAMFromCache(client, strings.Split(*cloudModel.IPAMProviderRef, "#")[1])
 	if !found {
 		utils.AviLog.Warnf("Failed to get IPAM data from cache")
 		return
@@ -409,7 +414,7 @@ func delCIDRFromNetwork(objKey string, cidrs map[string]struct{}) {
 		Model:   "network",
 	}
 
-	utils.AviLog.Debugf("key: %s, executing restop to delete CIDR from vcf network: %v", objKey, restOp)
+	utils.AviLog.Debugf("key: %s, executing restop to delete CIDR from vcf network: %v", objKey, utils.Stringify(restOp))
 	executeRestOp(objKey, client, &restOp)
 }
 
@@ -444,27 +449,37 @@ func delSegmentInCloud(lslrList []*models.Tier1LogicalRouterInfo, lr, ls string)
 }
 
 func matchSegmentInCloud(lslrList []*models.Tier1LogicalRouterInfo, lslrMap map[string]string) bool {
-	// if len(lslrMap) != len(lslrList) {
-	// 	return false
-	// }
+	cloudLSLRMap := make(map[string]string)
 	for i := range lslrList {
-		if lslrMap[*lslrList[i].SegmentID] != *lslrList[i].Tier1LrID {
+		cloudLSLRMap[*lslrList[i].SegmentID] = *lslrList[i].Tier1LrID
+	}
+
+	for ls, lr := range lslrMap {
+		if val, ok := cloudLSLRMap[ls]; !ok || (ok && val != lr) {
 			return false
 		}
 	}
 	return true
 }
 
-func constructLsLrInCloud(lslrMap map[string]string) []*models.Tier1LogicalRouterInfo {
-	var lslrList []*models.Tier1LogicalRouterInfo
+func constructLsLrInCloud(lslrList []*models.Tier1LogicalRouterInfo, lslrMap map[string]string) []*models.Tier1LogicalRouterInfo {
+	var cloudLSLRList []*models.Tier1LogicalRouterInfo
+	cloudLSLRMap := make(map[string]string)
+	for i := range lslrList {
+		cloudLSLRMap[*lslrList[i].SegmentID] = *lslrList[i].Tier1LrID
+	}
 	for ls, lr := range lslrMap {
-		lslr := models.Tier1LogicalRouterInfo{
+		if val, ok := cloudLSLRMap[ls]; !ok || (ok && val != lr) {
+			cloudLSLRMap[ls] = lr
+		}
+	}
+	for ls, lr := range cloudLSLRMap {
+		cloudLSLRList = append(lslrList, &models.Tier1LogicalRouterInfo{
 			SegmentID: &ls,
 			Tier1LrID: &lr,
-		}
-		lslrList = append(lslrList, &lslr)
+		})
 	}
-	return lslrList
+	return cloudLSLRList
 }
 
 func getAviCloudFromCache(client *clients.AviClient, cloudName string) (bool, models.Cloud) {
@@ -485,11 +500,9 @@ func getAviNetFromCache(client *clients.AviClient, netName string) (bool, models
 	return true, *NetCache
 }
 
-func getAviIPAMFromCache(client *clients.AviClient, ipamRef string) (bool, models.IPAMDNSProviderProfile) {
+func getAviIPAMFromCache(client *clients.AviClient, ipamName string) (bool, models.IPAMDNSProviderProfile) {
 	if IPAMCache == nil {
-		ipamRefStr := strings.Split(ipamRef, "/")
-		ipamUuid := ipamRefStr[len(ipamRefStr)-1]
-		if AviIPAMCachePopulate(client, ipamUuid) != nil {
+		if AviIPAMCachePopulate(client, ipamName) != nil {
 			return false, models.IPAMDNSProviderProfile{}
 		}
 	}
@@ -498,7 +511,7 @@ func getAviIPAMFromCache(client *clients.AviClient, ipamRef string) (bool, model
 
 // AviCloudCachePopulate queries avi rest api to get cloud data and stores in CloudCache
 func AviCloudCachePopulate(client *clients.AviClient, cloudName string) error {
-	uri := "/api/cloud/?name=" + cloudName
+	uri := "/api/cloud/?include_name&name=" + cloudName
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("Cloud Get uri %v returned err %v", uri, err)
@@ -522,12 +535,14 @@ func AviCloudCachePopulate(client *clients.AviClient, cloudName string) error {
 		utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
 		return err
 	}
+
+	AviIPAMCachePopulate(client, strings.Split(*CloudCache.IPAMProviderRef, "#")[1])
 	return nil
 }
 
 // AviNetCachePopulate queries avi rest api to get network data for vcf and stores in NetCache
 func AviNetCachePopulate(client *clients.AviClient, netName, cloudName string) error {
-	uri := "/api/network/?name=" + netName + "&cloud_ref.name=" + cloudName
+	uri := "/api/network/?include_name&name=" + netName + "&cloud_ref.name=" + cloudName
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("Cloud Get uri %v returned err %v", uri, err)
@@ -555,30 +570,36 @@ func AviNetCachePopulate(client *clients.AviClient, netName, cloudName string) e
 }
 
 // AviIPAMCachePopulate queries avi rest api to get IPAM data and stores in IPAMCache
-func AviIPAMCachePopulate(client *clients.AviClient, ipamUuid string) error {
-	uri := "/api/ipamdnsproviderprofile/" + ipamUuid
-	result, err := lib.AviGetRaw(client, uri)
+func AviIPAMCachePopulate(client *clients.AviClient, ipamName string) error {
+	uri := "/api/ipamdnsproviderprofile/?include_name&name=" + ipamName
+	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("Cloud Get uri %v returned err %v", uri, err)
 		return err
 	}
 
-	var data json.RawMessage
-	err = json.Unmarshal(result, &data)
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
 	if err != nil {
 		utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
 		return err
 	}
 
-	if err = json.Unmarshal(data, &IPAMCache); err != nil {
-		utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
+	if result.Count != 1 {
+		utils.AviLog.Infof("Expected one IPAM with name: %s, found: %d", ipamName, result.Count)
+		return fmt.Errorf("Expected one IPAM with name: %s, found: %d", ipamName, result.Count)
+	}
+
+	IPAMCache = &models.IPAMDNSProviderProfile{}
+	if err = json.Unmarshal(elems[0], &IPAMCache); err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal IPAM data, err: %v", err)
 		return err
 	}
 	return nil
 }
 
 func executeRestOp(key string, client *clients.AviClient, restOp *utils.RestOp, retryNum ...int) {
-	utils.AviLog.Debugf("key: %s, Executing rest operation to sync object in cloud: %v", key, *restOp)
+	utils.AviLog.Debugf("key: %s, Executing rest operation to sync object in cloud: %v", key, utils.Stringify(restOp))
 	retry := 0
 	if len(retryNum) > 0 {
 		utils.AviLog.Infof("key: %s, Retrying to execute rest request", key)
@@ -606,11 +627,12 @@ func executeRestOp(key string, client *clients.AviClient, restOp *utils.RestOp, 
 	}
 	switch restOp.Model {
 	case "cloud":
+	case "ipamdnsproviderprofile":
 		AviCloudCachePopulate(client, utils.CloudName)
 	case "network":
 		AviNetCachePopulate(client, lib.GetVCFNetworkName(), utils.CloudName)
 	}
-	utils.AviLog.Infof("key: %s, Successfully executed rest operation to sync object: %v", key, *restOp)
+	utils.AviLog.Infof("key: %s, Successfully executed rest operation to sync object: %v", key, utils.Stringify(restOp))
 }
 
 func checkAndRetry(key string, err error) bool {

--- a/ako-infra/avirest/rest.go
+++ b/ako-infra/avirest/rest.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package avirest
+
+import (
+	"sync"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
+)
+
+var infraAviClientInstance *clients.AviClient
+var ctrlClientOnce sync.Once
+
+func InfraAviClientInstance(c ...*clients.AviClient) *clients.AviClient {
+	ctrlClientOnce.Do(func() {
+		if len(c) > 0 {
+			infraAviClientInstance = c[0]
+		}
+	})
+	return infraAviClientInstance
+}

--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -196,7 +196,7 @@ func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
 func fetchSEGroup(client *clients.AviClient, overrideUri ...lib.NextPage) (error, *models.ServiceEngineGroup) {
 	var uri string
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName
 	}
@@ -248,7 +248,7 @@ func fetchSEGroup(client *clients.AviClient, overrideUri ...lib.NextPage) (error
 		next_uri := strings.Split(result.Next, "/api/serviceenginegroup")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/serviceenginegroup" + next_uri[1]
-			nextPage := lib.NextPage{Next_uri: overrideUri}
+			nextPage := lib.NextPage{NextURI: overrideUri}
 			return fetchSEGroup(client, nextPage)
 		}
 	}

--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -24,9 +24,12 @@ import (
 	"strings"
 
 	"github.com/vmware/alb-sdk/go/models"
+	avimodels "github.com/vmware/alb-sdk/go/models"
+	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-infra/avirest"
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -35,22 +38,22 @@ import (
 )
 
 type AviControllerInfra struct {
-	AviRestClients *utils.AviRestClientPool
-	cs             kubernetes.Interface
+	AviRestClient *clients.AviClient
+	cs            kubernetes.Interface
 }
 
 func NewAviControllerInfra(cs kubernetes.Interface) *AviControllerInfra {
 	PopulateControllerProperties(cs)
-	AviRestClientsPool := avicache.SharedAVIClients()
-	return &AviControllerInfra{AviRestClients: AviRestClientsPool, cs: cs}
+	aviClient := avirest.InfraAviClientInstance()
+	return &AviControllerInfra{AviRestClient: aviClient, cs: cs}
 }
 
 func (a *AviControllerInfra) InitInfraController() {
-	if a.AviRestClients == nil {
+	if a.AviRestClient == nil {
 		utils.AviLog.Fatalf("Avi client not initialized during Infra bootup")
 	}
 
-	if a.AviRestClients != nil && !avicache.IsAviClusterActive(a.AviRestClients.AviClient[0]) {
+	if a.AviRestClient != nil && !avicache.IsAviClusterActive(a.AviRestClient) {
 		utils.AviLog.Fatalf("Avi Controller Cluster state is not Active, shutting down AKO infa container")
 	}
 
@@ -64,7 +67,7 @@ func (a *AviControllerInfra) InitInfraController() {
 func (a *AviControllerInfra) VerifyAviControllerLicense() error {
 	uri := "/api/systemconfiguration"
 	response := models.SystemConfiguration{}
-	err := lib.AviGet(a.AviRestClients.AviClient[0], uri, &response)
+	err := lib.AviGet(a.AviRestClient, uri, &response)
 	if err != nil {
 		utils.AviLog.Warnf("System config Get uri %v returned err %v", uri, err)
 		return err
@@ -82,7 +85,7 @@ func (a *AviControllerInfra) VerifyAviControllerLicense() error {
 func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, string, string) {
 	// This method queries the Avi controller for all available cloud and then returns the cloud that matches the supplied transport zone
 	uri := "/api/cloud/"
-	result, err := lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
+	result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
 	if err != nil {
 		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
 		return err, "", ""
@@ -103,132 +106,102 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 		}
 		vtype := *cloud.Vtype
 		if vtype == lib.CLOUD_NSXT && cloud.NsxtConfiguration != nil {
-			if cloud.NsxtConfiguration.TransportZone != nil && *cloud.NsxtConfiguration.TransportZone == tz {
-				utils.AviLog.Infof("Found NSX-T cloud :%s match Transport Zone : %s", *cloud.Name, tz)
-				if *cloud.SeGroupTemplateRef != "" {
+			if cloud.NsxtConfiguration.ManagementNetworkConfig != nil &&
+				cloud.NsxtConfiguration.ManagementNetworkConfig.TransportZone != nil &&
+				*cloud.NsxtConfiguration.ManagementNetworkConfig.TransportZone == tz {
+				utils.AviLog.Infof("Found NSX-T cloud: %s match Transport Zone: %s", *cloud.Name, tz)
+				if cloud.SeGroupTemplateRef != nil &&
+					*cloud.SeGroupTemplateRef != "" {
 					tokenized := strings.Split(*cloud.SeGroupTemplateRef, "/api/serviceenginegroup/")
 					if len(tokenized) == 2 {
 						return nil, *cloud.Name, tokenized[1]
 					}
 				}
 			}
-			return nil, *cloud.Name, ""
+
+			// fetch Default-SEGroup uuid
+			uri = "/api/serviceenginegroup/?include_name&cloud_ref.name=" + *cloud.Name + "&name=Default-Group"
+			result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
+			if err != nil {
+				utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+				return err, *cloud.Name, ""
+			}
+
+			elems := make([]json.RawMessage, result.Count)
+			err = json.Unmarshal(result.Results, &elems)
+			if err != nil {
+				utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
+				return err, *cloud.Name, ""
+			}
+
+			if len(elems) == 0 {
+				utils.AviLog.Errorf("No ServiceEngine Group with name Default-Group found.")
+				return errors.New("No ServiceEngine Group with name Default-Group found."), *cloud.Name, ""
+			}
+
+			defaultSEG := models.ServiceEngineGroup{}
+			err = json.Unmarshal(elems[0], &defaultSEG)
+			if err != nil {
+				utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
+				return err, *cloud.Name, ""
+			}
+			return nil, *cloud.Name, *defaultSEG.UUID
 		}
 	}
 	return errors.New("Cloud not found"), "", ""
 }
 
 func (a *AviControllerInfra) SetupSEGroup(tz string) bool {
-
-	err, seGroup := lib.FetchSEGroupWithMarkerSet(a.AviRestClients.AviClient[0])
-	if err == nil && seGroup != "" {
-		utils.AviLog.Infof("SE Group: %s already configured with the marker labels: %s", seGroup, lib.GetClusterID())
-	}
-	// This method checks if the cloud in Avi has a SE Group template configured or not. If has the SEG template then it returns true, else false
-	err, cloudName, segUuid := a.DeriveCloudNameAndSEGroupTmpl(tz)
+	err, cloudName, segTemplateUuid := a.DeriveCloudNameAndSEGroupTmpl(tz)
 	if err != nil {
 		return false
 	}
 	utils.AviLog.Infof("Obtained matching cloud to be used: %s", cloudName)
 	utils.SetCloudName(cloudName)
 
-	if checkSeGroup(a.AviRestClients.AviClient[0], cloudName) {
-		return true
+	clusterName := lib.GetClusterID()
+	err, configuredSEGroup := fetchSEGroup(a.AviRestClient)
+	seGroupExists := false
+	if err == nil && configuredSEGroup != nil {
+		seGroupExists = true
+		if len(configuredSEGroup.Markers) == 1 &&
+			*configuredSEGroup.Markers[0].Key == lib.ClusterNameLabelKey &&
+			len(configuredSEGroup.Markers[0].Values) == 1 &&
+			configuredSEGroup.Markers[0].Values[0] == clusterName {
+			utils.AviLog.Infof("SE Group: %s already configured with the markers: %s", *configuredSEGroup.Name, utils.Stringify(configuredSEGroup.Markers))
+			cloudName := strings.Split(*configuredSEGroup.CloudRef, "#")[1]
+			utils.AviLog.Infof("Obtained matching cloud to be used: %s", cloudName)
+			utils.SetCloudName(cloudName)
+			return true
+		}
 	}
 
-	var uri string
-	if segUuid == "" {
-		// The cloud does not have a SEG template set, use `Default-Group`
-		uri = "/api/serviceenginegroup/?include_name&cloud_ref.name=" + cloudName + "&name=Default-Group"
-	} else {
-		// se group template exists, use the same to fetch the SE group details and use it to create the new SE group
-		// The cloud does not have a SEG template set, use `Default-Group`
-		uri = "/api/serviceenginegroup/" + segUuid
-	}
-	var result session.AviCollectionResult
-	result, err = lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
-	if err != nil {
-		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
-			//SE in provider context no read access
-			utils.AviLog.Debugf("Switching to admin context from  %s", lib.GetTenant())
-			SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
-			SetTenant := session.SetTenant(lib.GetTenant())
-			SetAdminTenant(a.AviRestClients.AviClient[0].AviSession)
-			defer SetTenant(a.AviRestClients.AviClient[0].AviSession)
-			result, err = lib.AviGetCollectionRaw(a.AviRestClients.AviClient[0], uri)
-			if err != nil {
-				utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
-				return false
-			}
-
-		} else {
+	// This method checks if the cloud in Avi has a SE Group template configured or not. If has the SEG template then it returns true, else false
+	if configuredSEGroup == nil {
+		uri := "/api/serviceenginegroup/" + segTemplateUuid
+		err = lib.AviGet(a.AviRestClient, uri, &configuredSEGroup)
+		if err != nil {
 			utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
 			return false
 		}
 	}
-	// Construct an SE group based on parameters in the `Default-Group`
-	elems := make([]json.RawMessage, result.Count)
-	err = json.Unmarshal(result.Results, &elems)
-	if err != nil {
-		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
+
+	if !ConfigureSeGroup(a.AviRestClient, configuredSEGroup, seGroupExists) {
 		return false
 	}
 
-	for _, elem := range elems {
-		seg := models.ServiceEngineGroup{}
-		if err := json.Unmarshal(elem, &seg); err != nil {
-			utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
-			continue
-		}
-
-		if !ConfigureSeGroup(a.AviRestClients.AviClient[0], &seg) {
-			return false
-		}
-	}
 	return true
 }
 
-// ConfigureSeGroup creates the SE group with the supplied properties, alters just the SE group name and the labels.
-func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGroup) bool {
-	// Change the name of the SE group
-	*seGroup.Name = lib.GetClusterID()
-
-	uri := "/api/serviceenginegroup/"
-	// Add the labels.
-	seGroup.Labels = lib.GetLabels()
-	response := models.ServiceEngineGroupAPIResponse{}
-	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
-	SetTenant := session.SetTenant(lib.GetTenant())
-
-	err := lib.AviPost(client, uri, seGroup, response)
-	if err != nil {
-		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
-			//SE in provider context
-			utils.AviLog.Debugf("Switching to admin context from  %s", lib.GetTenant())
-			SetAdminTenant(client.AviSession)
-			defer SetTenant(client.AviSession)
-			err := lib.AviPost(client, uri, seGroup, response)
-			if err != nil {
-				utils.AviLog.Warnf("Error during POST call to create the SE group :%v", err.Error())
-				return false
-
-			}
-		} else {
-			utils.AviLog.Warnf("Error during POST call to create the SE group :%v", err.Error())
-			return false
-		}
+func fetchSEGroup(client *clients.AviClient, overrideUri ...lib.NextPage) (error, *models.ServiceEngineGroup) {
+	var uri string
+	if len(overrideUri) == 1 {
+		uri = overrideUri[0].Next_uri
+	} else {
+		uri = "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName
 	}
-	utils.AviLog.Infof("labels: %v set on Service Engine Group :%v", utils.Stringify(lib.GetLabels()), *seGroup.Name)
-	return true
-
-}
-
-func checkSeGroup(client *clients.AviClient, cloudName string) bool {
-	segroupName := lib.GetClusterID()
-
-	uri := "/api/serviceenginegroup/?name=" + segroupName + "&cloud_ref.name=" + cloudName
-	response := models.ServiceEngineGroupAPIResponse{}
-	err := lib.AviGet(client, uri, &response)
+	var result session.AviCollectionResult
+	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
 			//SE in provider context no read access
@@ -237,18 +210,80 @@ func checkSeGroup(client *clients.AviClient, cloudName string) bool {
 			SetTenant := session.SetTenant(lib.GetTenant())
 			SetAdminTenant(client.AviSession)
 			defer SetTenant(client.AviSession)
-			err := lib.AviGet(client, uri, &response)
+			result, err = lib.AviGetCollectionRaw(client, uri)
 			if err != nil {
-				utils.AviLog.Warnf("Error during Get call for the SE group :%v", err.Error())
-				return false
-
+				utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+				return err, nil
 			}
 		} else {
-			utils.AviLog.Warnf("Error during Get call for the SE group :%v", err.Error())
-			return false
+			utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+			return err, nil
 		}
 	}
-	utils.AviLog.Infof("Found Service Engine Group :%v", segroupName)
+
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
+		return err, nil
+	}
+
+	// Using clusterID for advl4.
+	clusterName := lib.GetClusterID()
+	for _, elem := range elems {
+		seg := models.ServiceEngineGroup{}
+		err = json.Unmarshal(elem, &seg)
+		if err != nil {
+			utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
+			continue
+		}
+
+		if *seg.Name == clusterName {
+			return nil, &seg
+		}
+	}
+
+	if result.Next != "" {
+		// It has a next page, let's recursively call the same method.
+		next_uri := strings.Split(result.Next, "/api/serviceenginegroup")
+		if len(next_uri) > 1 {
+			overrideUri := "/api/serviceenginegroup" + next_uri[1]
+			nextPage := lib.NextPage{Next_uri: overrideUri}
+			return fetchSEGroup(client, nextPage)
+		}
+	}
+
+	utils.AviLog.Infof("No Service Engine Group found for Cluster.")
+	return nil, nil
+}
+
+// ConfigureSeGroup creates the SE group with the supplied properties, alters just the SE group name and the markers.
+func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGroup, segExists bool) bool {
+	// Change the name of the SE group, and add markers
+	*seGroup.Name = lib.GetClusterID()
+	markers := []*avimodels.RoleFilterMatchLabel{{
+		Key:    proto.String(lib.ClusterNameLabelKey),
+		Values: []string{lib.GetClusterID()},
+	}}
+	seGroup.Markers = markers
+
+	response := models.ServiceEngineGroupAPIResponse{}
+	var err error
+	var uri string
+	if segExists {
+		uri = "/api/serviceenginegroup/" + *seGroup.UUID
+		err = lib.AviPut(client, uri, seGroup, response)
+	} else {
+		uri = "/api/serviceenginegroup/"
+		err = lib.AviPost(client, uri, seGroup, response)
+	}
+
+	if err != nil {
+		utils.AviLog.Warnf("Error during API call to CreateOrUpdate the SE group :%v", err.Error())
+		return false
+	}
+
+	utils.AviLog.Infof("Markers: %v set on Service Engine Group: %v", utils.Stringify(markers), *seGroup.Name)
 	return true
 }
 

--- a/ako-infra/ingestion/vcf_k8s_controller.go
+++ b/ako-infra/ingestion/vcf_k8s_controller.go
@@ -315,33 +315,6 @@ func (c *VCFK8sController) AddNetworkInfoEventHandler(k8sinfo K8sinformers, stop
 // If Bootstrap CR is not found, AKO would wait for it to be created. If the authtoken from Bootstrap CR
 // can be used to connect to the AVI Controller, then avi-secret would be created with that token.
 func (c *VCFK8sController) HandleVCF(informers K8sinformers, stopCh <-chan struct{}, ctrlCh chan struct{}, skipAviClient ...bool) string {
-	cs := c.informers.ClientSet
-	aviSecret, err := cs.CoreV1().Secrets(utils.GetAKONamespace()).Get(context.TODO(), lib.AviSecret, metav1.GetOptions{})
-	ctrlIP := lib.GetControllerURLFromBootstrapCR()
-	if err == nil && ctrlIP != "" {
-		lib.SetControllerIP(ctrlIP)
-		authToken := aviSecret.Data["authtoken"]
-		username := aviSecret.Data["username"]
-		var transport *http.Transport
-		_, err = clients.NewAviClient(
-			ctrlIP, string(username), session.SetAuthToken(string(authToken)),
-			session.SetNoControllerStatusCheck, session.SetTransport(transport),
-			session.SetInsecure,
-		)
-		if err == nil || len(skipAviClient) == 1 {
-			utils.AviLog.Infof("Successfully connected to AVI controller using existing AKO secret")
-			boostrapdata, ok := lib.GetBootstrapCRData()
-			if ok {
-				return boostrapdata.TZPath
-			}
-			utils.AviLog.Warnf("Failed to fetch transportzone from bootstrap CR status")
-		} else {
-			utils.AviLog.Error("AVI controller initialization failed with err: %v", err)
-		}
-	} else {
-		utils.AviLog.Infof("Got error while fetching avi-secret: %v", err)
-	}
-
 	if !c.ValidBootStrapData() {
 		utils.AviLog.Infof("Running in a VCF Cluster, but valid Bootstrap CR not found, waiting .. ")
 		startSyncCh := make(chan struct{})
@@ -382,7 +355,7 @@ func (c *VCFK8sController) CreateOrUpdateAviSecret() error {
 	var aviSecret corev1.Secret
 	aviSecret.ObjectMeta.Name = lib.AviSecret
 	aviSecret.Data = make(map[string][]byte)
-	aviSecret.Data["authtoken"] = []byte(ncpSecret.Data["authToken"])
+	aviSecret.Data["authtoken"] = ncpSecret.Data["authToken"]
 	aviSecret.Data["username"] = []byte(boostrapdata.UserName)
 
 	_, err = cs.CoreV1().Secrets(utils.GetAKONamespace()).Get(context.TODO(), lib.AviSecret, metav1.GetOptions{})
@@ -414,27 +387,41 @@ func (c *VCFK8sController) ValidBootStrapData() bool {
 	}
 	utils.AviLog.Infof("Got data from Bootstrap CR, secretName: %s, namespace: %s, username: %s, tansportzone: %s", boostrapdata.SecretName, boostrapdata.SecretNamespace, boostrapdata.UserName, boostrapdata.TZPath)
 	setTranzportZone(boostrapdata.TZPath)
-	var ncpSecret *corev1.Secret
-	var err error
-	ncpSecret, err = cs.CoreV1().Secrets(boostrapdata.SecretNamespace).Get(context.TODO(), boostrapdata.SecretName, metav1.GetOptions{})
+
+	ncpSecret, err := cs.CoreV1().Secrets(boostrapdata.SecretNamespace).Get(context.TODO(), boostrapdata.SecretName, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Failed to get secret, got err: %v", err)
 		return false
 	}
-	authToken := ncpSecret.Data["authToken"]
+
+	authToken := string(ncpSecret.Data["authToken"])
 	ctrlIP := boostrapdata.AviURL
 	lib.SetControllerIP(ctrlIP)
+
 	var transport *http.Transport
-	_, err = clients.NewAviClient(
+	aviClient, err := clients.NewAviClient(
 		ctrlIP, boostrapdata.UserName, session.SetAuthToken(string(authToken)),
 		session.SetNoControllerStatusCheck, session.SetTransport(transport),
 		session.SetInsecure,
 	)
 	if err != nil {
-		utils.AviLog.Infof("Failed to connect to AVI controller using secret provided by NCP, the secret would be deleted, err: %v", err)
+		utils.AviLog.Errorf("Failed to connect to AVI controller using secret provided by NCP, the secret would be deleted, err: %v", err)
 		c.deleteNCPSecret(boostrapdata.SecretName, boostrapdata.SecretNamespace)
 		return false
 	}
+
+	ctrlVersion := lib.GetControllerVersion()
+	if ctrlVersion == "" {
+		version, err := aviClient.AviSession.GetControllerVersion()
+		if err == nil {
+			utils.AviLog.Infof("Setting the client version to the current controller version %v", version)
+			ctrlVersion = version
+		}
+	}
+	SetVersion := session.SetVersion(ctrlVersion)
+	SetVersion(aviClient.AviSession)
+
+	avirest.InfraAviClientInstance(aviClient)
 	utils.AviLog.Infof("Successfully connected to AVI controller using secret provided by NCP")
 	return true
 }

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -171,7 +171,7 @@ func InitializeAKC() {
 	}
 	informersArg[utils.INFORMERS_ADVANCED_L4] = lib.GetAdvancedL4()
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
-	lib.NewDynamicInformers(dynamicClient)
+	lib.NewDynamicInformers(dynamicClient, false)
 	if lib.GetAdvancedL4() {
 		k8s.NewAdvL4Informers(advl4Client)
 	} else {
@@ -191,15 +191,7 @@ func InitializeAKC() {
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
 
-	// if utils.IsVCFCluster() {
-	vcfDynamicClient, err := lib.NewVCFDynamicClientSet(cfg)
-	if err != nil {
-		utils.AviLog.Fatalf("Error creating VCF dynamic clientset: %s", err.Error())
-	}
-
-	lib.NewVCFDynamicInformers(vcfDynamicClient)
-	c.InitVCFHandlers(informers, kubeClient, ctrlCh, stopCh)
-	// }
+	c.InitVCFHandlers(kubeClient, ctrlCh, stopCh)
 
 	aviRestClientPool := avicache.SharedAVIClients()
 	if aviRestClientPool == nil {

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -191,68 +191,15 @@ func InitializeAKC() {
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
 
-	lib.NewVCFDynamicClientSet(cfg)
-	// In VCF environment, avi controller details have to be fetched from the Bootstrap CR
-	if lib.GetControllerIP() == "" {
-		utils.AviLog.Infof("Unable to find Avi Controller endpoint, trying to fetch from bootstrap Resource.")
-		ctrlIP := lib.GetControllerURLFromBootstrapCR()
-		if ctrlIP != "" {
-			lib.SetControllerIP(ctrlIP)
-		} else {
-			utils.AviLog.Infof("Valid Avi Controller details not found, waiting .. ")
-			startSyncCh := make(chan struct{})
-			c.AddNCPBootstrapEventHandler(informers, stopCh, startSyncCh)
-		L1:
-			for {
-				select {
-				case <-startSyncCh:
-					break L1
-				case <-ctrlCh:
-					return
-				}
-			}
-		}
-	}
-
-	if !c.ValidAviSecret() {
-		utils.AviLog.Infof("Valid Avi Secret not found, waiting .. ")
-		startSyncCh := make(chan struct{})
-		c.AddBootupSecretEventHandler(informers, stopCh, startSyncCh)
-	L2:
-		for {
-			select {
-			case <-startSyncCh:
-				lib.AviSecretInitialized = true
-				break L2
-			case <-ctrlCh:
-				return
-			}
-		}
-	}
-	utils.AviLog.Infof("Valid Avi Secret found, continuing .. ")
-
-	err = k8s.PopulateControllerProperties(kubeClient)
-	if !c.SetSEGroupCloudName() {
-		utils.AviLog.Infof("SEgroup name not found, waiting ..")
-		startSyncCh := make(chan struct{})
-		c.AddBootupNSEventHandler(informers, stopCh, startSyncCh)
-	L3:
-		for {
-			select {
-			case <-startSyncCh:
-				lib.AviSEInitialized = true
-				break L3
-			case <-ctrlCh:
-				return
-			}
-		}
-	}
-	utils.AviLog.Infof("SEgroup name found, continuing ..")
-
+	// if utils.IsVCFCluster() {
+	vcfDynamicClient, err := lib.NewVCFDynamicClientSet(cfg)
 	if err != nil {
-		utils.AviLog.Warnf("Error while fetching secret for AKO bootstrap %s", err)
-		lib.ShutdownApi()
+		utils.AviLog.Fatalf("Error creating VCF dynamic clientset: %s", err.Error())
 	}
+
+	lib.NewVCFDynamicInformers(vcfDynamicClient)
+	c.InitVCFHandlers(informers, kubeClient, ctrlCh, stopCh)
+	// }
 
 	aviRestClientPool := avicache.SharedAVIClients()
 	if aviRestClientPool == nil {
@@ -272,17 +219,8 @@ func InitializeAKC() {
 		return
 	}
 
-	if !utils.IsVCFCluster() {
-		if _, err := lib.GetVipNetworkListEnv(); err != nil {
-			utils.AviLog.Fatalf("Error in getting VIP network %s, shutting down AKO", err)
-		}
-	} else {
-		lib.NewVCFDynamicClientSet(cfg)
-		lslrMap, _ := lib.GetNetworkInfoCRData()
-		for _, lr := range lslrMap {
-			lib.SetT1LRPath(lr)
-			break
-		}
+	if _, err := lib.GetVipNetworkListEnv(); !utils.IsVCFCluster() && err != nil {
+		utils.AviLog.Fatalf("Error in getting VIP network %s, shutting down AKO", err)
 	}
 
 	c.InitializeNamespaceSync()

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -91,7 +91,7 @@ func InitializeAKC() {
 	var advl4Client *advl4.Clientset
 	var svcAPIClient *svcapi.Clientset
 	var istioClient *istiocrd.Clientset
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		advl4Client, err = advl4.NewForConfig(cfg)
 		if err != nil {
 			utils.AviLog.Fatalf("Error building service-api v1alpha1pre1 clientset: %s", err.Error())
@@ -169,10 +169,16 @@ func InitializeAKC() {
 	if lib.GetNamespaceToSync() != "" {
 		informersArg[utils.INFORMERS_NAMESPACE] = lib.GetNamespaceToSync()
 	}
-	informersArg[utils.INFORMERS_ADVANCED_L4] = lib.GetAdvancedL4()
+
+	// Namespace bound Secret informers should be initialized for AKO in VDS,
+	// For AKO in VCF, we will need to watch on Secrets across all namespaces.
+	if !utils.IsVCFCluster() && lib.GetAdvancedL4() {
+		informersArg[utils.INFORMERS_ADVANCED_L4] = true
+	}
+
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
 	lib.NewDynamicInformers(dynamicClient, false)
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		k8s.NewAdvL4Informers(advl4Client)
 	} else {
 		k8s.NewCRDInformers(crdClient)
@@ -180,7 +186,8 @@ func InitializeAKC() {
 			k8s.NewSvcApiInformers(svcAPIClient)
 		}
 	}
-	// Set Istio Informers
+
+	// Set Istio Informers.
 	if lib.IsIstioEnabled() {
 		k8s.NewIstioCRDInformers(istioClient)
 	}

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -278,7 +278,7 @@ func InitializeAKC() {
 		}
 	} else {
 		lib.NewVCFDynamicClientSet(cfg)
-		lslrMap, _ := lib.GetNetinfoCRData()
+		lslrMap, _ := lib.GetNetworkInfoCRData()
 		for _, lr := range lslrMap {
 			lib.SetT1LRPath(lr)
 			break

--- a/cmd/infra-main/main.go
+++ b/cmd/infra-main/main.go
@@ -85,12 +85,11 @@ func InitializeAKOInfra() {
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
 	lib.NewDynamicInformers(dynamicClient, true)
 
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 
-	transportZone := c.HandleVCF(informers, stopCh, ctrlCh)
+	transportZone := c.HandleVCF(stopCh, ctrlCh)
 	lib.VCFInitialized = true
 
 	// Checking/Setting up Avi pre-reqs
@@ -112,8 +111,8 @@ func InitializeAKOInfra() {
 	a.SetupSEGroup(transportZone)
 	avirest.SyncLSLRNetwork()
 	a.AnnotateSystemNamespace(lib.GetClusterID(), utils.CloudName)
-	c.AddNetworkInfoEventHandler(informers, stopCh)
-	c.AddNamespaceEventHandler(informers, stopCh)
+	c.AddNetworkInfoEventHandler(stopCh)
+	c.AddNamespaceEventHandler(stopCh)
 
 	<-stopCh
 	close(ctrlCh)

--- a/cmd/infra-main/main.go
+++ b/cmd/infra-main/main.go
@@ -63,7 +63,7 @@ func InitializeAKOInfra() {
 		}
 	}
 
-	dynamicClient, err := lib.NewVCFDynamicClientSet(cfg)
+	dynamicClient, err := lib.NewDynamicClientSet(cfg)
 	if err != nil {
 		utils.AviLog.Warnf("Error while creating dynamic client %v", err)
 	}
@@ -83,7 +83,7 @@ func InitializeAKOInfra() {
 	informersArg := make(map[string]interface{})
 
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
-	lib.NewVCFDynamicInformers(dynamicClient)
+	lib.NewDynamicInformers(dynamicClient, true)
 
 	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -291,7 +291,7 @@ type AviPkiProfileCache struct {
 }
 
 type NextPage struct {
-	Next_uri   string
+	NextURI    string
 	Collection interface{}
 }
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -402,7 +402,7 @@ func (c *AviObjCache) AviPopulateAllPGs(client *clients.AviClient, cloud string,
 	akoUser := lib.AKOUser
 
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/poolgroup/?" + "include_name=true&cloud_ref.name=" + cloud + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -456,7 +456,7 @@ func (c *AviObjCache) AviPopulateAllPGs(client *clients.AviClient, cloud string,
 		next_uri := strings.Split(result.Next, "/api/poolgroup")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/poolgroup" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllPGs(client, cloud, pgData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -504,7 +504,7 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 	akoUser := lib.AKOUser
 
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/pkiprofile/?" + "&include_name=true&" + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -546,7 +546,7 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiDa
 		next_uri := strings.Split(result.Next, "/api/pkiprofile")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/pkiprofile" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllPkiPRofiles(client, pkiData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -562,7 +562,7 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 	akoUser := lib.AKOUser
 
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/pool/?" + "&include_name=true&cloud_ref.name=" + cloud + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -620,7 +620,7 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 		next_uri := strings.Split(result.Next, "/api/pool")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/pool" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllPools(client, cloud, poolData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -695,7 +695,7 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 	var uri string
 
 	if len(nextPage) == 1 {
-		uri = nextPage[0].Next_uri
+		uri = nextPage[0].NextURI
 	} else {
 		uri = "/api/vsvip/?" + "name.contains=" + lib.GetNamePrefix() + "&include_name=true" + "&cloud_ref.name=" + cloud + "&page_size=100"
 	}
@@ -771,7 +771,7 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 		next_uri := strings.Split(result.Next, "/api/vsvip")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/vsvip" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, err := c.AviPopulateAllVSVips(client, cloud, vsVipData, nextPage)
 			if err != nil {
 				return nil, err
@@ -816,7 +816,7 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 	akoUser := lib.AKOUser
 
 	if len(nextPage) == 1 {
-		uri = nextPage[0].Next_uri
+		uri = nextPage[0].NextURI
 	} else {
 		uri = "/api/vsdatascriptset/?" + "&include_name=true&created_by=" + akoUser
 	}
@@ -872,7 +872,7 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 		next_uri := strings.Split(result.Next, "/api/vsdatascriptset")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/vsdatascriptset" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllDSs(client, cloud, DsData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -916,7 +916,7 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 	akoUser := lib.AKOUser
 
 	if len(nextPage) == 1 {
-		uri = nextPage[0].Next_uri
+		uri = nextPage[0].NextURI
 	} else {
 		uri = "/api/sslkeyandcertificate/?" + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -974,7 +974,7 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 		next_uri := strings.Split(result.Next, "/api/sslkeyandcertificate")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/sslkeyandcertificate" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllSSLKeys(client, cloud, SslData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -1529,7 +1529,7 @@ func (c *AviObjCache) AviPopulateAllHttpPolicySets(client *clients.AviClient, cl
 	akoUser := lib.AKOUser
 
 	if len(nextPage) == 1 {
-		uri = nextPage[0].Next_uri
+		uri = nextPage[0].NextURI
 	} else {
 		uri = "/api/httppolicyset/?" + "&include_name=true" + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -1596,7 +1596,7 @@ func (c *AviObjCache) AviPopulateAllHttpPolicySets(client *clients.AviClient, cl
 		next_uri := strings.Split(result.Next, "/api/httppolicyset")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/httppolicyset" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllHttpPolicySets(client, cloud, httpPolicyData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -1643,7 +1643,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 	akoUser := lib.AKOUser
 
 	if len(nextPage) == 1 {
-		uri = nextPage[0].Next_uri
+		uri = nextPage[0].NextURI
 	} else {
 		uri = "/api/l4policyset/?" + "&include_name=true" + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -1716,7 +1716,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 		next_uri := strings.Split(result.Next, "/api/l4policyset")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/l4policyset" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			_, _, err := c.AviPopulateAllL4PolicySets(client, cloud, l4PolicyData, nextPage)
 			if err != nil {
 				return nil, 0, err
@@ -1802,7 +1802,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 	var uri string
 	httpCacheRefreshCount := 1 // Refresh count for http cache is attempted once per page
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/virtualservice/?" + "include_name=true" + "&cloud_ref.name=" + cloud + "&created_by=" + akoUser + "&page_size=100"
 	}
@@ -2038,7 +2038,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 			if len(next_uri) > 1 {
 				overrideUri := "/api/virtualservice" + next_uri[1]
 				utils.AviLog.Debugf("Next page uri for vs: %s", overrideUri)
-				nextPage := NextPage{Next_uri: overrideUri}
+				nextPage := NextPage{NextURI: overrideUri}
 				c.AviObjVSCachePopulate(client, cloud, vsCacheCopy, nextPage)
 			}
 		}
@@ -2543,7 +2543,7 @@ func ValidateUserInput(client *clients.AviClient) (bool, error) {
 	isCloudValid := checkAndSetCloudType(client, &err)
 	isRequiredValuesValid := checkRequiredValuesYaml(&err)
 	isSegroupValid := validateAndConfigureSeGroup(client, &err)
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		if isTenantValid &&
 			isCloudValid &&
 			isRequiredValuesValid &&
@@ -2936,6 +2936,7 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 		return true, nil
 	}
 
+	// 2. AKO created VIP network for AKO in VCF
 	if utils.IsVCFCluster() {
 		vipNetList := akov1alpha1.AviInfraSettingVipNetwork{
 			NetworkName: lib.GetVCFNetworkName(),
@@ -2944,7 +2945,7 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 		return true, nil
 	}
 
-	// 2. Marker based (only advancedL4)
+	// 3. Marker based (only advancedL4 - AKO in VDS)
 	var err error
 	markerNetworkFound := ""
 	if lib.GetAdvancedL4() && ipamRefUri != nil {
@@ -2981,8 +2982,8 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 
 	}
 
-	// 3. Empty VipNetworkList
-	if lib.GetAdvancedL4() && markerNetworkFound == "" {
+	// 4. Empty VipNetworkList
+	if lib.IsWCP() && markerNetworkFound == "" {
 		lib.SetVipNetworkList([]akov1alpha1.AviInfraSettingVipNetwork{})
 		return true, nil
 	}
@@ -2994,7 +2995,7 @@ func fetchNetworkWithMarkerSet(client *clients.AviClient, usableNetworkNames []s
 	clusterName := lib.GetClusterID()
 	var uri string
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/network/?include_name&page_size=100&name.in=" + strings.Join(usableNetworkNames, ",")
 	}
@@ -3034,7 +3035,7 @@ func fetchNetworkWithMarkerSet(client *clients.AviClient, usableNetworkNames []s
 		next_uri := strings.Split(result.Next, "/api/network")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/network" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			return fetchNetworkWithMarkerSet(client, usableNetworkNames, nextPage)
 		}
 	}
@@ -3186,7 +3187,7 @@ func checkAndSetVRFFromNetwork(client *clients.AviClient, returnErr *error) bool
 func fetchAndSetVrf(client *clients.AviClient, overrideUri ...NextPage) (error, bool) {
 	var uri string
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/vrfcontext?" + "&include_name=true&cloud_ref.name=" + utils.CloudName + "&page_size=100"
 	}
@@ -3228,7 +3229,7 @@ func fetchAndSetVrf(client *clients.AviClient, overrideUri ...NextPage) (error, 
 		next_uri := strings.Split(result.Next, "/api/vrfcontext")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/vrfcontext" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			return fetchAndSetVrf(client, nextPage)
 		}
 	}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2936,6 +2936,14 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 		return true, nil
 	}
 
+	if utils.IsVCFCluster() {
+		vipNetList := akov1alpha1.AviInfraSettingVipNetwork{
+			NetworkName: lib.GetVCFNetworkName(),
+		}
+		lib.SetVipNetworkList([]akov1alpha1.AviInfraSettingVipNetwork{vipNetList})
+		return true, nil
+	}
+
 	// 2. Marker based (only advancedL4)
 	var err error
 	markerNetworkFound := ""
@@ -2976,14 +2984,6 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 	// 3. Empty VipNetworkList
 	if lib.GetAdvancedL4() && markerNetworkFound == "" {
 		lib.SetVipNetworkList([]akov1alpha1.AviInfraSettingVipNetwork{})
-		return true, nil
-	}
-
-	if utils.IsVCFCluster() {
-		vipNetList := akov1alpha1.AviInfraSettingVipNetwork{
-			NetworkName: lib.GetVCFNetworkName(),
-		}
-		lib.SetVipNetworkList([]akov1alpha1.AviInfraSettingVipNetwork{vipNetList})
 		return true, nil
 	}
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2944,7 +2944,8 @@ func checkIPAMForUsableNetworkLabels(client *clients.AviClient, ipamRefUri *stri
 		ipam := models.IPAMDNSProviderProfile{}
 		ipamRef := strings.SplitAfter(*ipamRefUri, "/api/")
 		ipamRefWithoutName := strings.Split(ipamRef[1], "#")[0]
-		if err := lib.AviGet(client, "/api/"+ipamRefWithoutName+"/?include_name", &ipam); err != nil {
+		ipamURI := "/api/" + ipamRefWithoutName + "/?include_name"
+		if err := lib.AviGet(client, ipamURI, &ipam); err != nil {
 			return false, fmt.Errorf("Get uri %v returned err %v", ipamRef, err)
 		}
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -51,27 +51,27 @@ import (
 func PopulateCache() error {
 	var parentKeys []avicache.NamespaceName
 	var err error
-	avi_rest_client_pool := avicache.SharedAVIClients()
-	avi_obj_cache := avicache.SharedAviObjCache()
+	aviRestClientPool := avicache.SharedAVIClients()
+	aviObjCache := avicache.SharedAviObjCache()
 	// Randomly pickup a client.
-	if avi_rest_client_pool != nil && len(avi_rest_client_pool.AviClient) > 0 {
-		_, parentKeys, err = avi_obj_cache.AviObjCachePopulate(avi_rest_client_pool.AviClient, utils.CtrlVersion, utils.CloudName)
+	if aviRestClientPool != nil && len(aviRestClientPool.AviClient) > 0 {
+		_, parentKeys, err = aviObjCache.AviObjCachePopulate(aviRestClientPool.AviClient, utils.CtrlVersion, utils.CloudName)
 		if err != nil {
 			utils.AviLog.Warnf("failed to populate avi cache with error: %v", err.Error())
 			return err
 		}
 		if lib.GetDeleteConfigMap() {
 			go SetDeleteSyncChannel()
-			deleteAviObjects(parentKeys, avi_obj_cache, avi_rest_client_pool)
+			deleteAviObjects(parentKeys, aviObjCache, aviRestClientPool)
 		}
-		if err = avicache.SetControllerClusterUUID(avi_rest_client_pool); err != nil {
+		if err = avicache.SetControllerClusterUUID(aviRestClientPool); err != nil {
 			utils.AviLog.Warnf("Failed to set the controller cluster uuid with error: %v", err)
 		}
 	}
 
 	// Delete Stale objects by deleting model for dummy VS
 	aviclient := avicache.SharedAVIClients()
-	restlayer := rest.NewRestOperations(avi_obj_cache, aviclient)
+	restlayer := rest.NewRestOperations(aviObjCache, aviclient)
 	staleVSKey := lib.GetTenant() + "/" + lib.DummyVSForStaleData
 	if _, err := lib.IsClusterNameValid(); err != nil {
 		utils.AviLog.Errorf("AKO cluster name is invalid.")
@@ -84,10 +84,10 @@ func PopulateCache() error {
 			Name:      lib.DummyVSForStaleData,
 			Namespace: lib.GetTenant(),
 		}
-		avi_obj_cache.VsCacheMeta.AviCacheDelete(staleCacheKey)
+		aviObjCache.VsCacheMeta.AviCacheDelete(staleCacheKey)
 	}
 
-	vsKeysPending := avi_obj_cache.VsCacheMeta.AviGetAllKeys()
+	vsKeysPending := aviObjCache.VsCacheMeta.AviGetAllKeys()
 	if lib.GetDeleteConfigMap() {
 		//Delete NPL annotations
 		DeleteNPLAnnotations()
@@ -166,7 +166,7 @@ func (c *AviController) SetSEGroupCloudName() bool {
 	client := avicache.SharedAVIClients().AviClient[0]
 	var err error
 	// 2. Marker based (only advancedL4)
-	if seGroupToUse == "" && lib.GetAdvancedL4() {
+	if seGroupToUse == "" && lib.GetAdvancedL4() && !utils.IsVCFCluster() {
 		err, seGroupToUse = lib.FetchSEGroupWithMarkerSet(client)
 		if err != nil {
 			utils.AviLog.Infof("Setting SEGroup with markerset and no SEGroup found from env")
@@ -186,7 +186,7 @@ func (c *AviController) SetSEGroupCloudName() bool {
 	}
 
 	nsName := utils.GetAKONamespace()
-	nsObj, err := c.informers.NSInformer.Lister().Get(nsName)
+	nsObj, err := c.informers.ClientSet.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Failed to GET the namespace %s details due to the following error: %v", nsName, err.Error())
 		return false
@@ -675,16 +675,16 @@ func (c *AviController) addIndexers() {
 
 func (c *AviController) FullSync() {
 
-	avi_rest_client_pool := avicache.SharedAVIClients()
-	avi_obj_cache := avicache.SharedAviObjCache()
+	aviRestClientPool := avicache.SharedAVIClients()
+	aviObjCache := avicache.SharedAviObjCache()
 	// Randomly pickup a client.
-	if len(avi_rest_client_pool.AviClient) > 0 {
-		avi_obj_cache.AviClusterStatusPopulate(avi_rest_client_pool.AviClient[0])
+	if len(aviRestClientPool.AviClient) > 0 {
+		aviObjCache.AviClusterStatusPopulate(aviRestClientPool.AviClient[0])
 		if !lib.GetAdvancedL4() {
-			avi_obj_cache.AviCacheRefresh(avi_rest_client_pool.AviClient[0], utils.CloudName)
+			aviObjCache.AviCacheRefresh(aviRestClientPool.AviClient[0], utils.CloudName)
 		} else {
 			// In this case we just sync the Gateway status to the LB status
-			restlayer := rest.NewRestOperations(avi_obj_cache, avi_rest_client_pool)
+			restlayer := rest.NewRestOperations(aviObjCache, aviRestClientPool)
 			restlayer.SyncObjectStatuses()
 		}
 		allModelsMap := objects.SharedAviGraphLister().GetAll()

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -43,6 +43,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -244,10 +245,10 @@ func (c *AviController) AddBootupNSEventHandler(k8sinfo K8sinformers, stopCh <-c
 	}
 }
 
-func (c *AviController) AddNCPBootstrapEventHandler(k8sinfo K8sinformers, stopCh <-chan struct{}, startSyncCh chan struct{}) {
+func (c *AviController) AddNCPBootstrapEventHandler(stopCh <-chan struct{}, startSyncCh chan struct{}) {
 	NCPBootstrapHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			utils.AviLog.Infof("NCP Bootstrap ADD Event")
+			utils.AviLog.Infof("NCP Bootstrap Add Event")
 			ctrlIP := lib.GetControllerURLFromBootstrapCR()
 			if ctrlIP != "" && startSyncCh != nil {
 				lib.SetControllerIP(ctrlIP)
@@ -265,10 +266,10 @@ func (c *AviController) AddNCPBootstrapEventHandler(k8sinfo K8sinformers, stopCh
 			}
 		},
 	}
-	c.dynamicInformers.NCPBootstrapInformer.Informer().AddEventHandler(NCPBootstrapHandler)
+	c.dynamicInformers.VCFNCPBootstrapInformer.Informer().AddEventHandler(NCPBootstrapHandler)
 
-	go c.dynamicInformers.NCPBootstrapInformer.Informer().Run(stopCh)
-	if !cache.WaitForCacheSync(stopCh, c.dynamicInformers.NCPBootstrapInformer.Informer().HasSynced) {
+	go c.dynamicInformers.VCFNCPBootstrapInformer.Informer().Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, c.dynamicInformers.VCFNCPBootstrapInformer.Informer().HasSynced) {
 		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
 	} else {
 		utils.AviLog.Info("Caches synced for NCP Bootstrap informer")
@@ -463,6 +464,117 @@ func (c *AviController) ValidAviSecret() bool {
 		utils.AviLog.Infof("Got error while fetching avi-secret: %v", err)
 	}
 	return false
+}
+
+func (c *AviController) InitVCFHandlers(informers K8sinformers, kubeClient kubernetes.Interface, ctrlCh <-chan struct{}, stopCh <-chan struct{}) {
+	// In VCF environment, avi controller details have to be fetched from the Bootstrap CR
+	if lib.GetControllerIP() == "" {
+		utils.AviLog.Infof("Unable to find Avi Controller endpoint, trying to fetch from bootstrap Resource.")
+		ctrlIP := lib.GetControllerURLFromBootstrapCR()
+		if ctrlIP != "" {
+			lib.SetControllerIP(ctrlIP)
+		} else {
+			utils.AviLog.Infof("Valid Avi Controller details not found, waiting .. ")
+			startSyncCh := make(chan struct{})
+			c.AddNCPBootstrapEventHandler(stopCh, startSyncCh)
+		L1:
+			for {
+				select {
+				case <-startSyncCh:
+					break L1
+				case <-ctrlCh:
+					return
+				}
+			}
+		}
+	}
+
+	if !c.ValidAviSecret() {
+		utils.AviLog.Infof("Valid Avi Secret not found, waiting .. ")
+		startSyncCh := make(chan struct{})
+		c.AddBootupSecretEventHandler(informers, stopCh, startSyncCh)
+	L2:
+		for {
+			select {
+			case <-startSyncCh:
+				lib.AviSecretInitialized = true
+				break L2
+			case <-ctrlCh:
+				return
+			}
+		}
+	}
+	utils.AviLog.Infof("Valid Avi Secret found, continuing .. ")
+
+	err := PopulateControllerProperties(kubeClient)
+	if err != nil {
+		utils.AviLog.Warnf("Error while fetching secret for AKO bootstrap %s", err)
+		lib.ShutdownApi()
+	}
+
+	if !c.SetSEGroupCloudName() {
+		utils.AviLog.Infof("SEgroup name not found, waiting ..")
+		startSyncCh := make(chan struct{})
+		c.AddBootupNSEventHandler(informers, stopCh, startSyncCh)
+	L3:
+		for {
+			select {
+			case <-startSyncCh:
+				lib.AviSEInitialized = true
+				break L3
+			case <-ctrlCh:
+				return
+			}
+		}
+	}
+	utils.AviLog.Infof("SEgroup name found, continuing ..")
+
+	c.AddNetworkInfoEventHandlers(ctrlCh, stopCh)
+}
+
+func (c *AviController) AddNetworkInfoEventHandlers(ctrlCh <-chan struct{}, stopCh <-chan struct{}) {
+	fetchNST1LR := func(obj interface{}) (string, string, bool) {
+		var ns, t1lr string
+		resourceObj := obj.(*unstructured.Unstructured)
+		ns = resourceObj.Object["metadata"].(map[string]string)["namespace"]
+		topology, ok := resourceObj.Object["topology"]
+		if !ok {
+			utils.AviLog.Errorf("topology key not found in namespace network info object.")
+			return "", "", false
+		}
+		t1lr, ok = topology.(map[string]string)["gatewayPath"]
+		if !ok || t1lr == "" {
+			utils.AviLog.Errorf("invalid gatewayPath found in namespace network info object.")
+			return "", "", false
+		}
+		return ns, t1lr, true
+	}
+
+	namespaceNetworkInfoHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if ns, t1lr, found := fetchNST1LR(obj); found {
+				objects.SharedWCPLister().UpdateNamespaceTier1LrCache(ns, t1lr)
+			}
+		},
+		UpdateFunc: func(old, obj interface{}) {
+			if ns, t1lr, found := fetchNST1LR(obj); found {
+				objects.SharedWCPLister().UpdateNamespaceTier1LrCache(ns, t1lr)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			namespace := obj.(*unstructured.Unstructured).Object["metadata"].(map[string]string)["namespace"]
+			objects.SharedWCPLister().RemoveNamespaceTier1LrCache(namespace)
+		},
+	}
+	c.dynamicInformers.VCFNetworkInfoInformer.Informer().AddEventHandler(namespaceNetworkInfoHandler)
+
+	go c.dynamicInformers.VCFNetworkInfoInformer.Informer().Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh,
+		c.dynamicInformers.VCFNetworkInfoInformer.Informer().HasSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+	} else {
+		utils.AviLog.Info("Caches synced for Cluster/Namepsace network info CRs.")
+	}
 }
 
 func (c *AviController) InitController(informers K8sinformers, registeredInformers []string, ctrlCh <-chan struct{}, stopCh <-chan struct{}, quickSyncCh chan struct{}, waitGroupMap ...map[string]*sync.WaitGroup) {

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -436,8 +436,7 @@ func (c *AviController) InitVCFHandlers(kubeClient kubernetes.Interface, ctrlCh 
 	}
 
 	if !c.ValidAviSecret() {
-		c.informers.ClientSet.CoreV1().Secrets("vmware-system-ako").Delete(context.TODO(), "avi-init-secret", metav1.DeleteOptions{})
-		utils.AviLog.Fatalf("Valid Avi Secret not found, removing init-secret and stopping AKO.")
+		lib.WaitForInitSecretRecreateAndReboot()
 	}
 	utils.AviLog.Infof("Valid Avi Secret found, continuing ..")
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -164,30 +164,8 @@ func deleteConfigFromConfigmap(cs kubernetes.Interface) bool {
 	return true
 }
 
-func (c *AviController) SetSEGroupCloudName() bool {
-	seGroupToUse := lib.GetSEGNameEnv()
-	client := avicache.SharedAVIClients().AviClient[0]
-	var err error
-	// 2. Marker based (only advancedL4)
-	if seGroupToUse == "" && lib.GetAdvancedL4() && !utils.IsVCFCluster() {
-		err, seGroupToUse = lib.FetchSEGroupWithMarkerSet(client)
-		if err != nil {
-			utils.AviLog.Infof("Setting SEGroup with markerset and no SEGroup found from env")
-			return false
-		}
-	}
-
-	// 3. Default-SEGroup
-	if seGroupToUse == "" {
-		utils.AviLog.Infof("Setting SEGroup %s for VS placement.", lib.DEFAULT_SE_GROUP)
-		seGroupToUse = lib.DEFAULT_SE_GROUP
-	}
-
-	if !utils.IsVCFCluster() {
-		lib.SetSEGName(seGroupToUse)
-		return true
-	}
-
+func (c *AviController) SetSEGroupCloudNameFromNSAnnotations() bool {
+	var seGroup, cloudName string
 	nsName := utils.GetAKONamespace()
 	nsObj, err := c.informers.ClientSet.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
 	if err != nil {
@@ -195,22 +173,23 @@ func (c *AviController) SetSEGroupCloudName() bool {
 		return false
 	}
 
+	var ok bool
 	annotations := nsObj.GetAnnotations()
-	segroup, ok := annotations[lib.WCPSEGroup]
+	seGroup, ok = annotations[lib.WCPSEGroup]
 	if !ok {
 		utils.AviLog.Warnf("Failed to get SEGroup from annotation in namespace")
 		return false
 	}
 
-	cloud, ok := annotations[lib.WCPCloud]
+	cloudName, ok = annotations[lib.WCPCloud]
 	if !ok {
 		utils.AviLog.Warnf("Failed to get cloud name from annotation in namespace")
 		return false
 	}
-	utils.AviLog.Infof("Setting SEGroup %s, cloud %s for VS placement.", segroup, cloud)
-	lib.SetSEGName(segroup)
-	utils.SetCloudName(cloud)
 
+	lib.SetSEGName(seGroup)
+	utils.SetCloudName(cloudName)
+	utils.AviLog.Infof("Setting SEGroup %s, cloud %s for VS placement.", seGroup, cloudName)
 	return true
 }
 
@@ -220,7 +199,7 @@ func (c *AviController) AddBootupNSEventHandler(stopCh <-chan struct{}, startSyn
 			if lib.AviSEInitialized {
 				return
 			}
-			if c.SetSEGroupCloudName() {
+			if c.SetSEGroupCloudNameFromNSAnnotations() {
 				startSyncCh <- struct{}{}
 				startSyncCh = nil
 			}
@@ -229,7 +208,7 @@ func (c *AviController) AddBootupNSEventHandler(stopCh <-chan struct{}, startSyn
 			if lib.AviSEInitialized {
 				return
 			}
-			if c.SetSEGroupCloudName() {
+			if c.SetSEGroupCloudNameFromNSAnnotations() {
 				startSyncCh <- struct{}{}
 				startSyncCh = nil
 			}
@@ -239,40 +218,40 @@ func (c *AviController) AddBootupNSEventHandler(stopCh <-chan struct{}, startSyn
 
 	go c.informers.NSInformer.Informer().Run(stopCh)
 	if !cache.WaitForCacheSync(stopCh, c.informers.NSInformer.Informer().HasSynced) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 	} else {
 		utils.AviLog.Info("Caches synced for NS informer")
 	}
 }
 
-func (c *AviController) AddNCPBootstrapEventHandler(stopCh <-chan struct{}, startSyncCh chan struct{}) {
-	NCPBootstrapHandler := cache.ResourceEventHandlerFuncs{
+func (c *AviController) AddConfigMapEventHandler(stopCh <-chan struct{}, startSyncCh chan struct{}) {
+	configmapHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			utils.AviLog.Infof("NCP Bootstrap Add Event")
-			ctrlIP := lib.GetControllerURLFromBootstrapCR(lib.GetDynamicClientSet())
-			if ctrlIP != "" && startSyncCh != nil {
-				lib.SetControllerIP(ctrlIP)
+			utils.AviLog.Infof("ConfigMap Add")
+			cm := obj.(*corev1.ConfigMap)
+			if controllerIP := cm.Data["controllerIP"]; controllerIP != "" && startSyncCh != nil {
+				lib.SetControllerIP(controllerIP)
 				startSyncCh <- struct{}{}
 				startSyncCh = nil
 			}
 		},
 		UpdateFunc: func(old, obj interface{}) {
-			utils.AviLog.Infof("NCP Bootstrap Update Event")
-			ctrlIP := lib.GetControllerURLFromBootstrapCR(lib.GetDynamicClientSet())
-			if ctrlIP != "" && startSyncCh != nil {
-				lib.SetControllerIP(ctrlIP)
+			utils.AviLog.Infof("ConfigMap Update")
+			cm := obj.(*corev1.ConfigMap)
+			if controllerIP := cm.Data["controllerIP"]; controllerIP != "" && startSyncCh != nil {
+				lib.SetControllerIP(controllerIP)
 				startSyncCh <- struct{}{}
 				startSyncCh = nil
 			}
 		},
 	}
-	c.dynamicInformers.VCFNCPBootstrapInformer.Informer().AddEventHandler(NCPBootstrapHandler)
 
-	go c.dynamicInformers.VCFNCPBootstrapInformer.Informer().Run(stopCh)
-	if !cache.WaitForCacheSync(stopCh, c.dynamicInformers.VCFNCPBootstrapInformer.Informer().HasSynced) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+	c.informers.ConfigMapInformer.Informer().AddEventHandler(configmapHandler)
+	go c.informers.ConfigMapInformer.Informer().Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, c.informers.ConfigMapInformer.Informer().HasSynced) {
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 	} else {
-		utils.AviLog.Info("Caches synced for NCP Bootstrap informer")
+		utils.AviLog.Info("Caches synced for ConfigMap informer")
 	}
 }
 
@@ -383,55 +362,15 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 	}
 
 	c.informers.ConfigMapInformer.Informer().AddEventHandler(configMapEventHandler)
-
 	go c.informers.ConfigMapInformer.Informer().Run(stopCh)
 	if !cache.WaitForCacheSync(stopCh,
 		c.informers.ConfigMapInformer.Informer().HasSynced,
 	) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 	} else {
 		utils.AviLog.Info("Caches synced")
 	}
 	return nil
-}
-
-func (c *AviController) AddBootupSecretEventHandler(stopCh <-chan struct{}, startSyncCh chan struct{}) {
-	NCPSecretHandler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			if lib.AviSecretInitialized {
-				return
-			}
-			data, ok := obj.(*corev1.Secret)
-			if !ok || data.Namespace != utils.GetAKONamespace() {
-				return
-			}
-			if c.ValidAviSecret() {
-				startSyncCh <- struct{}{}
-				startSyncCh = nil
-			}
-		},
-		UpdateFunc: func(old, obj interface{}) {
-			if lib.AviSecretInitialized {
-				return
-			}
-			data, ok := obj.(*corev1.Secret)
-			if !ok || data.Namespace != utils.GetAKONamespace() {
-				return
-			}
-			if c.ValidAviSecret() {
-				startSyncCh <- struct{}{}
-				startSyncCh = nil
-			}
-		},
-	}
-	c.informers.SecretInformer.Informer().AddEventHandler(NCPSecretHandler)
-
-	go c.informers.SecretInformer.Informer().Run(stopCh)
-	if !cache.WaitForCacheSync(stopCh, c.informers.SecretInformer.Informer().HasSynced) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
-	} else {
-		utils.AviLog.Info("Caches synced for Avi Secret informer")
-	}
 }
 
 func (c *AviController) ValidAviSecret() bool {
@@ -467,67 +406,46 @@ func (c *AviController) ValidAviSecret() bool {
 }
 
 func (c *AviController) InitVCFHandlers(kubeClient kubernetes.Interface, ctrlCh <-chan struct{}, stopCh <-chan struct{}) {
-	// In VCF environment, avi controller details have to be fetched from the Bootstrap CR
-	if lib.GetControllerIP() == "" {
-		utils.AviLog.Infof("Unable to find Avi Controller endpoint, trying to fetch from bootstrap Resource.")
-		ctrlIP := lib.GetControllerURLFromBootstrapCR(lib.GetDynamicClientSet())
-		if ctrlIP != "" {
-			lib.SetControllerIP(ctrlIP)
-		} else {
-			utils.AviLog.Infof("Valid Avi Controller details not found, waiting .. ")
-			startSyncCh := make(chan struct{})
-			c.AddNCPBootstrapEventHandler(stopCh, startSyncCh)
-		L1:
-			for {
-				select {
-				case <-startSyncCh:
-					break L1
-				case <-ctrlCh:
-					return
-				}
-			}
-		}
-	}
-
-	if !c.ValidAviSecret() {
-		utils.AviLog.Infof("Valid Avi Secret not found, waiting .. ")
-		startSyncCh := make(chan struct{})
-		c.AddBootupSecretEventHandler(stopCh, startSyncCh)
-	L2:
-		for {
-			select {
-			case <-startSyncCh:
-				lib.AviSecretInitialized = true
-				break L2
-			case <-ctrlCh:
-				return
-			}
-		}
-	}
-	utils.AviLog.Infof("Valid Avi Secret found, continuing .. ")
-
-	err := PopulateControllerProperties(kubeClient)
-	if err != nil {
-		utils.AviLog.Warnf("Error while fetching secret for AKO bootstrap %s", err)
-		lib.ShutdownApi()
-	}
-
-	if !c.SetSEGroupCloudName() {
-		utils.AviLog.Infof("SEgroup name not found, waiting ..")
+	if !c.SetSEGroupCloudNameFromNSAnnotations() {
+		utils.AviLog.Infof("SEgroup/CloudName name not found, waiting ..")
 		startSyncCh := make(chan struct{})
 		c.AddBootupNSEventHandler(stopCh, startSyncCh)
-	L3:
+	L1:
 		for {
 			select {
 			case <-startSyncCh:
 				lib.AviSEInitialized = true
-				break L3
+				break L1
 			case <-ctrlCh:
 				return
 			}
 		}
 	}
 	utils.AviLog.Infof("SEgroup name found, continuing ..")
+
+	configmap, err := c.informers.ClientSet.CoreV1().ConfigMaps("vmware-system-ako").Get(context.TODO(), "avi-k8s-config", metav1.GetOptions{})
+	if err != nil {
+		utils.AviLog.Warnf("Failed to get ConfigMap, got err: %v", err)
+	}
+
+	controllerIP := configmap.Data["controllerIP"]
+	if controllerIP != "" {
+		lib.SetControllerIP(controllerIP)
+	} else {
+		utils.AviLog.Fatalf("Avi controllerIP not found.")
+	}
+
+	if !c.ValidAviSecret() {
+		c.informers.ClientSet.CoreV1().Secrets("vmware-system-ako").Delete(context.TODO(), "avi-init-secret", metav1.DeleteOptions{})
+		utils.AviLog.Fatalf("Valid Avi Secret not found, removing init-secret and stopping AKO.")
+	}
+	utils.AviLog.Infof("Valid Avi Secret found, continuing ..")
+
+	err = PopulateControllerProperties(kubeClient)
+	if err != nil {
+		utils.AviLog.Warnf("Error while fetching secret for AKO bootstrap %s", err)
+		lib.ShutdownApi()
+	}
 
 	c.AddNetworkInfoEventHandlers(stopCh)
 }
@@ -573,7 +491,7 @@ func (c *AviController) AddNetworkInfoEventHandlers(stopCh <-chan struct{}) {
 
 	go c.dynamicInformers.VCFNetworkInfoInformer.Informer().Run(stopCh)
 	if !cache.WaitForCacheSync(stopCh, c.dynamicInformers.VCFNetworkInfoInformer.Informer().HasSynced) {
-		runtime.HandleError(fmt.Errorf("Timed out waiting for caches to sync"))
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 	} else {
 		utils.AviLog.Info("Caches synced for Namepsace NetworkInfo CRs.")
 	}

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/rest"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/retry"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/session"
@@ -46,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	servicesapi "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
 func PopulateCache() error {
@@ -522,10 +524,6 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 
 	// Setup and start event handlers for objects.
 	c.addIndexers()
-	c.AddCrdIndexer()
-	if lib.UseServicesAPI() {
-		c.AddSvcApiIndexers()
-	}
 	c.Start(stopCh)
 
 	// once the l3 cache is populated, we can call the updatestatus functions from here
@@ -638,6 +636,7 @@ func (c *AviController) addIndexers() {
 			},
 		)
 	}
+
 	c.informers.ServiceInformer.Informer().AddIndexers(
 		cache.Indexers{
 			lib.AviSettingServicesIndex: func(obj interface{}) ([]string, error) {
@@ -654,6 +653,7 @@ func (c *AviController) addIndexers() {
 			},
 		},
 	)
+
 	if c.informers.RouteInformer != nil {
 		c.informers.RouteInformer.Informer().AddIndexers(
 			cache.Indexers{
@@ -671,6 +671,52 @@ func (c *AviController) addIndexers() {
 		)
 	}
 
+	informer := lib.AKOControlConfig().CRDInformers()
+	if lib.AKOControlConfig().AviInfraSettingEnabled() {
+		informer.AviInfraSettingInformer.Informer().AddIndexers(
+			cache.Indexers{
+				lib.SeGroupAviSettingIndex: func(obj interface{}) ([]string, error) {
+					infraSetting, ok := obj.(*akov1alpha1.AviInfraSetting)
+					if !ok {
+						return []string{}, nil
+					}
+					return []string{infraSetting.Spec.SeGroup.Name}, nil
+				},
+			},
+		)
+	}
+
+	if lib.UseServicesAPI() {
+		informer := lib.AKOControlConfig().SvcAPIInformers()
+		informer.GatewayInformer.Informer().AddIndexers(
+			cache.Indexers{
+				lib.GatewayClassGatewayIndex: func(obj interface{}) ([]string, error) {
+					gw, ok := obj.(*servicesapi.Gateway)
+					if !ok {
+						return []string{}, nil
+					}
+					return []string{gw.Spec.GatewayClassName}, nil
+				},
+			},
+		)
+
+		informer.GatewayClassInformer.Informer().AddIndexers(
+			cache.Indexers{
+				lib.AviSettingGWClassIndex: func(obj interface{}) ([]string, error) {
+					gwclass, ok := obj.(*servicesapi.GatewayClass)
+					if !ok {
+						return []string{}, nil
+					}
+					if gwclass.Spec.ParametersRef != nil {
+						// sample settingKey: ako.vmware.com/AviInfraSetting/avi-1
+						settingKey := gwclass.Spec.ParametersRef.Group + "/" + gwclass.Spec.ParametersRef.Kind + "/" + gwclass.Spec.ParametersRef.Name
+						return []string{settingKey}, nil
+					}
+					return []string{}, nil
+				},
+			},
+		)
+	}
 }
 
 func (c *AviController) FullSync() {

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -506,7 +506,9 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	if lib.GetNamespaceToSync() != "" {
 		informersArg[utils.INFORMERS_NAMESPACE] = lib.GetNamespaceToSync()
 	}
-	informersArg[utils.INFORMERS_ADVANCED_L4] = lib.GetAdvancedL4()
+	if lib.IsWCP() {
+		informersArg[utils.INFORMERS_ADVANCED_L4] = true
+	}
 	c.informers = utils.NewInformers(utils.KubeClientIntf{ClientSet: informers.Cs}, registeredInformers, informersArg)
 	c.dynamicInformers = lib.NewDynamicInformers(informers.DynamicClient, false)
 	var ingestionwg *sync.WaitGroup
@@ -567,7 +569,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	fullSyncInterval := os.Getenv(utils.FULL_SYNC_INTERVAL)
 	interval, err := strconv.ParseInt(fullSyncInterval, 10, 64)
 
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		// Set the error to nil
 		err = nil
 		interval = 300 // seconds, hardcoded for now.
@@ -752,13 +754,13 @@ func (c *AviController) addIndexers() {
 }
 
 func (c *AviController) FullSync() {
-
 	aviRestClientPool := avicache.SharedAVIClients()
 	aviObjCache := avicache.SharedAviObjCache()
+
 	// Randomly pickup a client.
 	if len(aviRestClientPool.AviClient) > 0 {
 		aviObjCache.AviClusterStatusPopulate(aviRestClientPool.AviClient[0])
-		if !lib.GetAdvancedL4() {
+		if !lib.IsWCP() {
 			aviObjCache.AviCacheRefresh(aviRestClientPool.AviClient[0], utils.CloudName)
 		} else {
 			// In this case we just sync the Gateway status to the LB status
@@ -868,7 +870,7 @@ func (c *AviController) FullSyncK8s() error {
 				*/
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
 			} else {
-				if lib.GetAdvancedL4() {
+				if lib.IsWCP() {
 					continue
 				}
 				key = utils.Service + "/" + utils.ObjKey(svcObj)
@@ -946,7 +948,28 @@ func (c *AviController) FullSyncK8s() error {
 		}
 
 	}
-	if !lib.GetAdvancedL4() {
+
+	if utils.GetInformers().IngressInformer != nil {
+		for namespace := range acceptedNamespaces {
+			ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses(namespace).List(labels.Set(nil).AsSelector())
+			if err != nil {
+				utils.AviLog.Errorf("Unable to retrieve the ingresses during full sync: %s", err)
+			} else {
+				for _, ingObj := range ingObjs {
+					key := utils.Ingress + "/" + utils.ObjKey(ingObj)
+					meta, err := meta.Accessor(ingObj)
+					if err == nil {
+						resVer := meta.GetResourceVersion()
+						objects.SharedResourceVerInstanceLister().Save(key, resVer)
+					}
+					utils.AviLog.Debugf("Dequeue for ingress key: %v", key)
+					nodes.DequeueIngestion(key, true)
+				}
+			}
+		}
+	}
+
+	if !lib.IsWCP() {
 		hostRuleObjs, err := lib.AKOControlConfig().CRDInformers().HostRuleInformer.Lister().HostRules(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Errorf("Unable to retrieve the hostrules during full sync: %s", err)
@@ -1020,26 +1043,6 @@ func (c *AviController) FullSyncK8s() error {
 			}
 		}
 
-		// Ingress Section
-		if utils.GetInformers().IngressInformer != nil {
-			for namespace := range acceptedNamespaces {
-				ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses(namespace).List(labels.Set(nil).AsSelector())
-				if err != nil {
-					utils.AviLog.Errorf("Unable to retrieve the ingresses during full sync: %s", err)
-				} else {
-					for _, ingObj := range ingObjs {
-						key := utils.Ingress + "/" + utils.ObjKey(ingObj)
-						meta, err := meta.Accessor(ingObj)
-						if err == nil {
-							resVer := meta.GetResourceVersion()
-							objects.SharedResourceVerInstanceLister().Save(key, resVer)
-						}
-						utils.AviLog.Debugf("Dequeue for ingress key: %v", key)
-						nodes.DequeueIngestion(key, true)
-					}
-				}
-			}
-		}
 		//Route Section
 		if utils.GetInformers().RouteInformer != nil {
 			routeObjs, err := utils.GetInformers().RouteInformer.Lister().List(labels.Set(nil).AsSelector())

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -58,7 +58,7 @@ func PopulateCache() error {
 	aviObjCache := avicache.SharedAviObjCache()
 	// Randomly pickup a client.
 	if aviRestClientPool != nil && len(aviRestClientPool.AviClient) > 0 {
-		_, parentKeys, err = aviObjCache.AviObjCachePopulate(aviRestClientPool.AviClient, utils.CtrlVersion, utils.CloudName)
+		_, parentKeys, err = aviObjCache.AviObjCachePopulate(aviRestClientPool.AviClient, lib.AKOControlConfig().ControllerVersion(), utils.CloudName)
 		if err != nil {
 			utils.AviLog.Warnf("failed to populate avi cache with error: %v", err.Error())
 			return err

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -42,11 +42,12 @@ var ctrlonce sync.Once
 
 // These tags below are only applicable in case of advanced L4 features at the moment.
 
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=ncp.vmware.com,resources=akobootstrapconditions;akobootstrapconditions/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=nsx.vmware.com,resources=namespacenetworkinfos;namespacenetworkinfos/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gateways;gateways/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses;gatewayclasses/status,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete;update;patch
 // +kubebuilder:rbac:groups=core,resources=services;services/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -583,7 +583,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isSvcLb && !lib.GetLayer7Only() {
 				//L4 Namespace sync not applicable for advance L4 and service API
 				if !utils.IsServiceNSValid(namespace) {
-					utils.AviLog.Debugf("L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", namespace)
+					utils.AviLog.Infof("L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", namespace)
 					return
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -45,6 +45,7 @@ var ctrlonce sync.Once
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=ncp.vmware.com,resources=akobootstrapconditions;akobootstrapconditions/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=nsx.vmware.com,resources=namespacenetworkinfos;namespacenetworkinfos/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=extensions;networking.k8s.io,resources=ingresses;ingresses/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gateways;gateways/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses;gatewayclasses/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;delete;update;patch
@@ -169,6 +170,7 @@ func isNamespaceUpdated(oldNS, newNS *corev1.Namespace) bool {
 	}
 	return false
 }
+
 func AddIngressFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
 	ingObjs, err := utils.GetInformers().IngressInformer.Lister().Ingresses(namespace).List(labels.Set(nil).AsSelector())
 	if err != nil {
@@ -181,8 +183,8 @@ func AddIngressFromNSToIngestionQueue(numWorkers uint32, c *AviController, names
 		c.workqueue[bkt].AddRateLimited(key)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
-
 }
+
 func AddRoutesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
 	routeObjs, err := utils.GetInformers().RouteInformer.Lister().Routes(namespace).List(labels.Set(nil).AsSelector())
 	if err != nil {
@@ -195,14 +197,9 @@ func AddRoutesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namesp
 		c.workqueue[bkt].AddRateLimited(key)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
-
 }
+
 func AddServicesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
-	// For Advanced L4 and service api , do not handle. services already been taken care
-	// in service handler
-	if lib.GetAdvancedL4() {
-		return
-	}
 	var key string
 	svcObjs, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).List(labels.Set(nil).AsSelector())
 	if err != nil {
@@ -224,8 +221,8 @@ func AddServicesFromNSToIngestionQueue(numWorkers uint32, c *AviController, name
 		c.workqueue[bkt].AddRateLimited(key)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
-
 }
+
 func AddGatewaysFromNSToIngestionQueue(numWorkers uint32, c *AviController, namespace string, msg string) {
 	//TODO: Add code for gateway
 	gatewayObjs, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).List(labels.Set(nil).AsSelector())
@@ -282,7 +279,6 @@ func AddServiceImportsFromNSToIngestionQueue(numWorkers uint32, c *AviController
 /* Namespace update event:  2 cases to handle : NS label changed from 1) valid to invalid --> Call ingress and service delete
  * 2) invalid to valid --> Call ingress and service add
  */
-
 func AddNamespaceEventHandler(numWorkers uint32, c *AviController) cache.ResourceEventHandler {
 	namespaceEventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -587,14 +583,14 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					return
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
-				if lib.GetAdvancedL4() {
+				if lib.IsWCP() {
 					checkSvcForGatewayPortConflict(svc, key)
 				}
 				if lib.UseServicesAPI() {
 					checkSvcForSvcApiGatewayPortConflict(svc, key)
 				}
 			} else {
-				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsWCP() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
@@ -636,7 +632,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
 			} else {
-				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsWCP() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
@@ -663,14 +659,14 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 						return
 					}
 					key = utils.L4LBService + "/" + utils.ObjKey(svc)
-					if lib.GetAdvancedL4() {
+					if lib.IsWCP() {
 						checkSvcForGatewayPortConflict(svc, key)
 					}
 					if lib.UseServicesAPI() {
 						checkSvcForSvcApiGatewayPortConflict(svc, key)
 					}
 				} else {
-					if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+					if lib.IsWCP() || !utils.CheckIfNamespaceAccepted(namespace) {
 						return
 					}
 					key = utils.Service + "/" + utils.ObjKey(svc)
@@ -822,7 +818,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 		c.informers.SecretInformer.Informer().AddEventHandler(secretEventHandler)
 	}
 
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		// servicesAPI handlers GW/GWClass
 		c.SetupAdvL4EventHandlers(numWorkers)
 		return
@@ -1133,8 +1129,20 @@ func (c *AviController) Start(stopCh <-chan struct{}) {
 		informersList = append(informersList, c.dynamicInformers.HostSubnetInformer.Informer().HasSynced)
 	}
 
+	if utils.IsVCFCluster() {
+		if c.informers.IngressClassInformer != nil {
+			go c.informers.IngressClassInformer.Informer().Run(stopCh)
+			informersList = append(informersList, c.informers.IngressClassInformer.Informer().HasSynced)
+		}
+
+		if c.informers.IngressInformer != nil {
+			go c.informers.IngressInformer.Informer().Run(stopCh)
+			informersList = append(informersList, c.informers.IngressInformer.Informer().HasSynced)
+		}
+	}
+
 	// Disable all informers if we are in advancedL4 mode. We expect to only provide L4 load balancing capability for this feature.
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		go lib.AKOControlConfig().AdvL4Informers().GatewayClassInformer.Informer().Run(stopCh)
 		informersList = append(informersList, lib.AKOControlConfig().AdvL4Informers().GatewayClassInformer.Informer().HasSynced)
 		go lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Informer().Run(stopCh)
@@ -1146,6 +1154,12 @@ func (c *AviController) Start(stopCh <-chan struct{}) {
 			go lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Informer().Run(stopCh)
 			informersList = append(informersList, lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Informer().HasSynced)
 		}
+
+		if c.informers.IngressClassInformer != nil {
+			go c.informers.IngressClassInformer.Informer().Run(stopCh)
+			informersList = append(informersList, c.informers.IngressClassInformer.Informer().HasSynced)
+		}
+
 		if c.informers.IngressInformer != nil {
 			go c.informers.IngressInformer.Informer().Run(stopCh)
 			informersList = append(informersList, c.informers.IngressInformer.Informer().HasSynced)
@@ -1154,11 +1168,6 @@ func (c *AviController) Start(stopCh <-chan struct{}) {
 		if c.informers.RouteInformer != nil {
 			go c.informers.RouteInformer.Informer().Run(stopCh)
 			informersList = append(informersList, c.informers.RouteInformer.Informer().HasSynced)
-		}
-
-		if c.informers.IngressClassInformer != nil {
-			go c.informers.IngressClassInformer.Informer().Run(stopCh)
-			informersList = append(informersList, c.informers.IngressClassInformer.Informer().HasSynced)
 		}
 
 		go c.informers.NSInformer.Informer().Run(stopCh)

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -300,23 +300,6 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 	return
 }
 
-func (c *AviController) AddCrdIndexer() {
-	informer := lib.AKOControlConfig().CRDInformers()
-	if lib.AKOControlConfig().AviInfraSettingEnabled() {
-		informer.AviInfraSettingInformer.Informer().AddIndexers(
-			cache.Indexers{
-				lib.SeGroupAviSettingIndex: func(obj interface{}) ([]string, error) {
-					infraSetting, ok := obj.(*akov1alpha1.AviInfraSetting)
-					if !ok {
-						return []string{}, nil
-					}
-					return []string{infraSetting.Spec.SeGroup.Name}, nil
-				},
-			},
-		)
-	}
-}
-
 // SetupIstioCRDEventHandlers handles setting up of Istio CRD event handlers
 func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 	utils.AviLog.Infof("Setting up AKO Istio CRD Event handlers")

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -312,34 +312,3 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 	informer.GatewayClassInformer.Informer().AddEventHandler(gatewayClassEventHandler)
 	return
 }
-
-func (c *AviController) AddSvcApiIndexers() {
-	informer := lib.AKOControlConfig().SvcAPIInformers()
-	informer.GatewayInformer.Informer().AddIndexers(
-		cache.Indexers{
-			lib.GatewayClassGatewayIndex: func(obj interface{}) ([]string, error) {
-				gw, ok := obj.(*servicesapi.Gateway)
-				if !ok {
-					return []string{}, nil
-				}
-				return []string{gw.Spec.GatewayClassName}, nil
-			},
-		},
-	)
-	informer.GatewayClassInformer.Informer().AddIndexers(
-		cache.Indexers{
-			lib.AviSettingGWClassIndex: func(obj interface{}) ([]string, error) {
-				gwclass, ok := obj.(*servicesapi.GatewayClass)
-				if !ok {
-					return []string{}, nil
-				}
-				if gwclass.Spec.ParametersRef != nil {
-					// sample settingKey: ako.vmware.com/AviInfraSetting/avi-1
-					settingKey := gwclass.Spec.ParametersRef.Group + "/" + gwclass.Spec.ParametersRef.Kind + "/" + gwclass.Spec.ParametersRef.Name
-					return []string{settingKey}, nil
-				}
-				return []string{}, nil
-			},
-		},
-	)
-}

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -277,7 +277,8 @@ func NewAviRestClientWithToken(api_ep string, username string, authToken string)
 		utils.AviLog.Warnf("NewAviClient returned err %v", err)
 		return nil
 	}
-	controllerVersion := GetControllerVersion()
+
+	controllerVersion := AKOControlConfig().ControllerVersion()
 	SetTenant := session.SetTenant(GetTenant())
 	SetTenant(aviClient.AviSession)
 	SetVersion := session.SetVersion(controllerVersion)

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -67,6 +67,17 @@ func AviGet(client *clients.AviClient, uri string, response interface{}, retryNu
 	err := client.AviSession.Get(uri, &response)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			utils.AviLog.Debugf("Switching to admin context from %s", GetTenant())
+			SetAdminTenant := session.SetTenant(GetAdminTenant())
+			SetTenant := session.SetTenant(GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			if err := AviGet(client, uri, response); err != nil {
+				utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v after context switch", uri, err)
+				return err
+			}
+		}
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
@@ -117,6 +128,17 @@ func AviPut(client *clients.AviClient, uri string, payload interface{}, response
 	err := client.AviSession.Put(uri, payload, &response)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to execute Put on uri %s %v", uri, err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			utils.AviLog.Debugf("Switching to admin context from %s", GetTenant())
+			SetAdminTenant := session.SetTenant(GetAdminTenant())
+			SetTenant := session.SetTenant(GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			if err := AviPut(client, uri, payload, response); err != nil {
+				utils.AviLog.Warnf("msg: Unable to execute Put on uri %s %v after context switch", uri, err)
+				return err
+			}
+		}
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 400 {
@@ -142,6 +164,17 @@ func AviPost(client *clients.AviClient, uri string, payload interface{}, respons
 	err := client.AviSession.Post(uri, payload, &response)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to execute Post on uri %s %v", uri, err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			utils.AviLog.Debugf("Switching to admin context from %s", GetTenant())
+			SetAdminTenant := session.SetTenant(GetAdminTenant())
+			SetTenant := session.SetTenant(GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			if err := AviPost(client, uri, payload, response); err != nil {
+				utils.AviLog.Warnf("msg: Unable to execute Post on uri %s %v after context switch", uri, err)
+				return err
+			}
+		}
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
@@ -167,6 +200,17 @@ func AviDelete(client *clients.AviClient, uri string, retryNum ...int) error {
 	err := client.AviSession.Delete(uri)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to execute Delete on uri %s %v", uri, err)
+		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
+			utils.AviLog.Debugf("Switching to admin context from %s", GetTenant())
+			SetAdminTenant := session.SetTenant(GetAdminTenant())
+			SetTenant := session.SetTenant(GetTenant())
+			SetAdminTenant(client.AviSession)
+			defer SetTenant(client.AviSession)
+			if err := AviDelete(client, uri); err != nil {
+				utils.AviLog.Warnf("msg: Unable to execute Post on uri %s %v after context switch", uri, err)
+				return err
+			}
+		}
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
@@ -193,7 +237,6 @@ func checkForInvalidCredentials(uri string, err error) {
 			}
 		}
 	}
-	return
 }
 
 func NewAviRestClientWithToken(api_ep string, username string, authToken string) *clients.AviClient {

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -228,6 +228,11 @@ func checkForInvalidCredentials(uri string, err error) {
 		return
 	}
 
+	if utils.IsVCFCluster() {
+		WaitForInitSecretRecreateAndReboot()
+		return
+	}
+
 	if webSyncErr, ok := err.(*utils.WebSyncError); ok {
 		aviError, ok := webSyncErr.GetWebAPIError().(session.AviError)
 		if ok && aviError.HttpStatusCode == 401 {

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -16,6 +16,7 @@ package lib
 
 import (
 	"context"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,10 @@ import (
 	advl4crd "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/clientset/versioned"
 	advl4informer "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/service-apis/client/informers/externalversions/apis/v1alpha1pre1"
 )
+
+func init() {
+
+}
 
 type AdvL4Informers struct {
 	GatewayInformer      advl4informer.GatewayInformer
@@ -102,15 +107,21 @@ type akoControlConfig struct {
 	licenseType string
 
 	// primaryaAKO is set to true/false if as per primaryaAKO value
-	//in values.yaml
+	// in values.yaml
 	primaryaAKO bool
+
+	// controllerVersion stores the version of the controller to
+	// which AKO is communicating with
+	controllerVersion string
 }
 
 var akoControlConfigInstance *akoControlConfig
 
 func AKOControlConfig() *akoControlConfig {
 	if akoControlConfigInstance == nil {
-		akoControlConfigInstance = &akoControlConfig{}
+		akoControlConfigInstance = &akoControlConfig{
+			controllerVersion: os.Getenv("CTRL_VERSION"),
+		}
 	}
 	return akoControlConfigInstance
 }
@@ -118,6 +129,7 @@ func AKOControlConfig() *akoControlConfig {
 func (c *akoControlConfig) SetAKOInstanceFlag(flag bool) {
 	c.primaryaAKO = flag
 }
+
 func (c *akoControlConfig) GetAKOInstanceFlag() bool {
 	return c.primaryaAKO
 }
@@ -203,6 +215,10 @@ func (c *akoControlConfig) HostRuleEnabled() bool {
 
 func (c *akoControlConfig) HttpRuleEnabled() bool {
 	return c.httpRuleEnabled
+}
+
+func (c *akoControlConfig) ControllerVersion() string {
+	return c.controllerVersion
 }
 
 func (c *akoControlConfig) SetIstioClientset(cs istiocrd.Interface) {

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -79,7 +79,7 @@ type BootstrapCRData struct {
 // NewDynamicClientSet initializes dynamic client set instance
 func NewDynamicClientSet(config *rest.Config) (dynamic.Interface, error) {
 	// do not instantiate the dynamic client set if the CNI being used is NOT calico
-	if GetCNIPlugin() != CALICO_CNI && GetCNIPlugin() != OPENSHIFT_CNI && !utils.IsVCFCluster() {
+	if GetCNIPlugin() != CALICO_CNI && GetCNIPlugin() != OPENSHIFT_CNI {
 		return nil, nil
 	}
 
@@ -107,7 +107,9 @@ func GetDynamicClientSet() dynamic.Interface {
 type DynamicInformers struct {
 	CalicoBlockAffinityInformer informers.GenericInformer
 	HostSubnetInformer          informers.GenericInformer
-	NCPBootstrapInformer        informers.GenericInformer
+	VCFNCPBootstrapInformer     informers.GenericInformer
+	VCFNetworkInfoInformer      informers.GenericInformer
+	VCFClusterNetworkInformer   informers.GenericInformer
 }
 
 // NewDynamicInformers initializes the DynamicInformers struct
@@ -125,7 +127,9 @@ func NewDynamicInformers(client dynamic.Interface) *DynamicInformers {
 	}
 
 	if utils.IsVCFCluster() {
-		informers.NCPBootstrapInformer = f.ForResource(BootstrapGVR)
+		informers.VCFNCPBootstrapInformer = f.ForResource(BootstrapGVR)
+		informers.VCFNetworkInfoInformer = f.ForResource(NetworkInfoGVR)
+		informers.VCFClusterNetworkInformer = f.ForResource(ClusterNetworkGVR)
 	}
 
 	dynamicInformerInstance = informers

--- a/internal/lib/dynamic_client.go
+++ b/internal/lib/dynamic_client.go
@@ -236,12 +236,7 @@ func GetBootstrapCRData() (BootstrapCRData, bool) {
 		utils.AviLog.Errorf("Status not found in bootstrap CR")
 		return boostrapdata, false
 	}
-	tzone, ok := status["transportZone"].(map[string]interface{})
-	if !ok {
-		utils.AviLog.Errorf("transportZone not found in status of bootstrap CR")
-		return boostrapdata, false
-	}
-	tzPath, ok := tzone["path"].(string)
+	tzPath, ok := status["transportZone"].(string)
 	if !ok {
 		utils.AviLog.Errorf("transportZone path not found in status of bootstrap CR")
 		return boostrapdata, false
@@ -310,6 +305,11 @@ func GetNetinfoCRData() (map[string]string, map[string]struct{}) {
 	crList, err := crdClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		utils.AviLog.Errorf("Error getting Networkinfo CR %v", err)
+		return lslrMap, cidrs
+	}
+
+	if len(crList.Items) == 0 {
+		utils.AviLog.Infof("No Networkinfo CRs found.")
 		return lslrMap, cidrs
 	}
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -754,7 +754,6 @@ func GetDomain() string {
 func GetAdvancedL4() bool {
 	advanceL4 := os.Getenv(ADVANCED_L4)
 	if advanceL4 == "true" {
-
 		return true
 	}
 	return false
@@ -1162,6 +1161,7 @@ func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Cl
 		utils.SecretInformer,
 		utils.ConfigMapInformer,
 		utils.PodInformer,
+		utils.NSInformer,
 	}
 
 	if GetServiceType() == NodePortLocal {
@@ -1169,7 +1169,6 @@ func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Cl
 	}
 
 	if !GetAdvancedL4() {
-		allInformers = append(allInformers, utils.NSInformer)
 		allInformers = append(allInformers, utils.NodeInformer)
 
 		informerTimeout := int64(120)
@@ -1195,10 +1194,6 @@ func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Cl
 			allInformers = append(allInformers, utils.MultiClusterIngressInformer)
 			allInformers = append(allInformers, utils.ServiceImportInformer)
 		}
-	}
-
-	if akoInfra {
-		allInformers = append(allInformers, utils.NSInformer)
 	}
 
 	return allInformers, nil
@@ -1665,7 +1660,7 @@ func GetK8sMaxSupportedVersion() string {
 }
 
 func GetControllerVersion() string {
-	controllerVersion := utils.CtrlVersion
+	controllerVersion := AKOControlConfig().ControllerVersion()
 	// Ensure that the controllerVersion is less than the supported Avi maxVersion and more than minVersion.
 	if CompareVersions(controllerVersion, ">", GetAviMaxSupportedVersion()) {
 		utils.AviLog.Infof("Setting the client version to AVI Max supported version %s", GetAviMaxSupportedVersion())

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -681,17 +681,8 @@ func GetGlobalBgpPeerLabels() []string {
 	return bgpPeerLabels
 }
 
-var t1LrPath string
-
-func SetT1LRPath(lr string) {
-	t1LrPath = lr
-}
-
 func GetT1LRPath() string {
-	if t1LrPath == "" {
-		t1LrPath = os.Getenv("NSXT_T1_LR")
-	}
-	return t1LrPath
+	return os.Getenv("NSXT_T1_LR")
 }
 
 var SEGroupName string

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -876,7 +876,7 @@ func GetDisableStaticRoute() bool {
 }
 
 func GetClusterName() string {
-	if GetAdvancedL4() {
+	if utils.IsVCFCluster() || GetAdvancedL4() {
 		return GetClusterIDSplit()
 	}
 	clusterName := os.Getenv(CLUSTER_NAME)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -149,7 +149,7 @@ func GetNamePrefix() string {
 }
 
 func Encode(s, objType string) string {
-	if !IsEvhEnabled() || GetAdvancedL4() {
+	if !IsEvhEnabled() || IsWCP() {
 		CheckObjectNameLength(s, objType)
 		return s
 	}
@@ -291,7 +291,7 @@ func GetAKOUser() string {
 }
 
 func GetshardSize() uint32 {
-	if GetAdvancedL4() {
+	if IsWCP() {
 		// shard to 8 go routines in the REST layer
 		return ShardSizeMap["LARGE"]
 	}
@@ -305,7 +305,7 @@ func GetshardSize() uint32 {
 }
 
 func GetL4FqdnFormat() string {
-	if GetAdvancedL4() {
+	if IsWCP() {
 		// disable for advancedL4
 		return AutoFQDNDisabled
 	}
@@ -649,8 +649,8 @@ func GetVipNetworkList() []akov1alpha1.AviInfraSettingVipNetwork {
 
 func GetVipNetworkListEnv() ([]akov1alpha1.AviInfraSettingVipNetwork, error) {
 	var vipNetworkList []akov1alpha1.AviInfraSettingVipNetwork
-	if GetAdvancedL4() || utils.IsVCFCluster() {
-		// do not return error in case of advancedL4 (wcp)
+	if IsWCP() {
+		// do not return error in case of WCP deployments.
 		return vipNetworkList, nil
 	}
 	vipNetworkListStr := os.Getenv(VIP_NETWORK_LIST)
@@ -744,21 +744,27 @@ func GetDomain() string {
 // the user requires advanced L4 functionality
 func GetAdvancedL4() bool {
 	advanceL4 := os.Getenv(ADVANCED_L4)
-	if advanceL4 == "true" {
+	return advanceL4 == "true"
+}
+
+// Wrapper function for AKO running in either VDS
+// or VCF (WCP with NSX).
+func IsWCP() bool {
+	if GetAdvancedL4() || utils.IsVCFCluster() {
 		return true
 	}
 	return false
 }
 
 type NextPage struct {
-	Next_uri   string
+	NextURI    string
 	Collection interface{}
 }
 
 func FetchSEGroupWithMarkerSet(client *clients.AviClient, overrideUri ...NextPage) (error, string) {
 	var uri string
 	if len(overrideUri) == 1 {
-		uri = overrideUri[0].Next_uri
+		uri = overrideUri[0].NextURI
 	} else {
 		uri = "/api/serviceenginegroup/?include_name&page_size=100&cloud_ref.name=" + utils.CloudName
 	}
@@ -815,7 +821,7 @@ func FetchSEGroupWithMarkerSet(client *clients.AviClient, overrideUri ...NextPag
 		next_uri := strings.Split(result.Next, "/api/serviceenginegroup")
 		if len(next_uri) > 1 {
 			overrideUri := "/api/serviceenginegroup" + next_uri[1]
-			nextPage := NextPage{Next_uri: overrideUri}
+			nextPage := NextPage{NextURI: overrideUri}
 			return FetchSEGroupWithMarkerSet(client, nextPage)
 		}
 	}
@@ -863,7 +869,7 @@ func IsValidCni(returnErr *error) bool {
 
 func GetDisableStaticRoute() bool {
 	// We don't need the static routes for NSX-T cloud
-	if GetAdvancedL4() || (GetCloudType() == CLOUD_NSXT && GetCNIPlugin() == NCP_CNI) {
+	if IsWCP() || (GetCloudType() == CLOUD_NSXT && GetCNIPlugin() == NCP_CNI) {
 		return true
 	}
 	if ok, _ := strconv.ParseBool(os.Getenv(DISABLE_STATIC_ROUTE_SYNC)); ok {
@@ -876,7 +882,7 @@ func GetDisableStaticRoute() bool {
 }
 
 func GetClusterName() string {
-	if utils.IsVCFCluster() || GetAdvancedL4() {
+	if IsWCP() {
 		return GetClusterIDSplit()
 	}
 	clusterName := os.Getenv(CLUSTER_NAME)
@@ -1146,19 +1152,31 @@ func PopulatePassthroughPoolMarkers(host, svcName string) utils.AviObjectMarkers
 
 func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Clientset, akoInfra bool) ([]string, error) {
 	var isOshift bool
+	// Initialize the following informers in all AKO deployments. Provide AKO the ability to watch over
+	// Services, Endpoints, Secrets, ConfigMaps and Namespaces.
 	allInformers := []string{
 		utils.ServiceInformer,
 		utils.EndpointInformer,
 		utils.SecretInformer,
 		utils.ConfigMapInformer,
-		utils.PodInformer,
 		utils.NSInformer,
 	}
 
+	// AKO must watch over Pods in case of NodePortLocal, to get Antrea annotation values.
 	if GetServiceType() == NodePortLocal {
 		allInformers = append(allInformers, utils.PodInformer)
 	}
 
+	// Watch over Ingresses for AKO deployment in WCP with NSX.
+	if utils.IsVCFCluster() {
+		allInformers = append(allInformers, utils.IngressInformer)
+		allInformers = append(allInformers, utils.IngressClassInformer)
+	}
+
+	// For all deployments excluding AKO in VDS, watch over
+	// Nodes, Ingresses, IngressClasses, Routes, MultiClusterIngress and ServiceImports.
+	// Routes should be watched over in Openshift environments only.
+	// MultiClusterIngress and ServiceImport should be watched over only when MCI is enabled.
 	if !GetAdvancedL4() {
 		allInformers = append(allInformers, utils.NodeInformer)
 

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -80,7 +80,8 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		}
 
 		var vrfcontext string
-		if lib.GetT1LRPath() == "" {
+		t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+		if t1lr == "" {
 			vrfcontext = lib.GetVrf()
 			avi_vs_meta.VrfContext = vrfcontext
 		}
@@ -124,8 +125,8 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 			VipNetworks: lib.GetVipNetworkList(),
 		}
 
-		if lib.GetT1LRPath() != "" {
-			vsVipNode.T1Lr = lib.GetT1LRPath()
+		if t1lr != "" {
+			vsVipNode.T1Lr = t1lr
 		}
 
 		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -203,7 +204,8 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		}
 
 		var vrfcontext string
-		if lib.GetT1LRPath() == "" {
+		t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+		if t1lr == "" {
 			vrfcontext = lib.GetVrf()
 			avi_vs_meta.VrfContext = vrfcontext
 		}
@@ -247,8 +249,8 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 			VipNetworks: lib.GetVipNetworkList(),
 		}
 
-		if lib.GetT1LRPath() != "" {
-			vsVipNode.T1Lr = lib.GetT1LRPath()
+		if t1lr != "" {
+			vsVipNode.T1Lr = t1lr
 		}
 
 		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -309,6 +311,8 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		}
 	}
 
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+
 	var portPoolSet []AviHostPathPortPoolPG
 	for listener, svc := range svcListeners {
 		if !utils.HasElem(gwListeners, listener) || len(svc) != 1 {
@@ -342,9 +346,9 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			VrfContext: lib.GetVrf(),
 		}
 
-		if lib.GetT1LRPath() != "" {
-			poolNode.T1Lr = lib.GetT1LRPath()
-			// Unset the poolnode's vrfcontext.
+		// Unset the poolnode's vrfcontext.
+		if t1lr != "" {
+			poolNode.T1Lr = t1lr
 			poolNode.VrfContext = ""
 		}
 

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -69,15 +69,20 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		}
 
 		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
+			Name:   vsName,
+			Tenant: lib.GetTenant(),
 			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceServiceName: serviceNSNames,
 				Gateway:              namespace + "/" + gatewayName,
 			},
 			ServiceEngineGroup: lib.GetSEGName(),
 			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+		}
+
+		var vrfcontext string
+		if lib.GetT1LRPath() == "" {
+			vrfcontext = lib.GetVrf()
+			avi_vs_meta.VrfContext = vrfcontext
 		}
 
 		avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
@@ -115,8 +120,12 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 		vsVipNode := &AviVSVIPNode{
 			Name:        lib.GetL4VSVipName(gatewayName, namespace),
 			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
+			VrfContext:  vrfcontext,
 			VipNetworks: lib.GetVipNetworkList(),
+		}
+
+		if lib.GetT1LRPath() != "" {
+			vsVipNode.T1Lr = lib.GetT1LRPath()
 		}
 
 		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -183,15 +192,20 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		}
 
 		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
+			Name:   vsName,
+			Tenant: lib.GetTenant(),
 			ServiceMetadata: lib.ServiceMetadataObj{
 				Gateway:   namespace + "/" + gatewayName,
 				HostNames: fqdns,
 			},
 			ServiceEngineGroup: lib.GetSEGName(),
 			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+		}
+
+		var vrfcontext string
+		if lib.GetT1LRPath() == "" {
+			vrfcontext = lib.GetVrf()
+			avi_vs_meta.VrfContext = vrfcontext
 		}
 
 		isTCP, isUDP := false, false
@@ -228,9 +242,13 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 		vsVipNode := &AviVSVIPNode{
 			Name:        lib.GetL4VSVipName(gatewayName, namespace),
 			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
+			VrfContext:  vrfcontext,
 			FQDNs:       fqdns,
 			VipNetworks: lib.GetVipNetworkList(),
+		}
+
+		if lib.GetT1LRPath() != "" {
+			vsVipNode.T1Lr = lib.GetT1LRPath()
 		}
 
 		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -323,6 +341,13 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			},
 			VrfContext: lib.GetVrf(),
 		}
+
+		if lib.GetT1LRPath() != "" {
+			poolNode.T1Lr = lib.GetT1LRPath()
+			// Unset the poolnode's vrfcontext.
+			poolNode.VrfContext = ""
+		}
+
 		poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
 
 		if svcFQDN != "" {

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -738,7 +738,9 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName, key string, ro
 			avi_vs_meta.ApplicationProfile = utils.DEFAULT_L7_SECURE_APP_PROFILE
 		}
 	}
-	if lib.GetT1LRPath() == "" {
+
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(routeIgrObj.GetNamespace())
+	if t1lr == "" {
 		vrfcontext = lib.GetVrf()
 		avi_vs_meta.VrfContext = vrfcontext
 	}
@@ -756,8 +758,8 @@ func (o *AviObjectGraph) ConstructAviL7SharedVsNodeForEvh(vsName, key string, ro
 		VipNetworks: lib.GetVipNetworkList(),
 	}
 
-	if lib.GetT1LRPath() != "" {
-		vsVipNode.T1Lr = lib.GetT1LRPath()
+	if t1lr != "" {
+		vsVipNode.T1Lr = t1lr
 	}
 
 	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -852,9 +854,9 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 		}
 
 		poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
-
-		if lib.GetT1LRPath() != "" {
-			poolNode.T1Lr = lib.GetT1LRPath()
+		t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+		if t1lr != "" {
+			poolNode.T1Lr = t1lr
 			// Unset the poolnode's vrfcontext.
 			poolNode.VrfContext = ""
 		}

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -67,7 +67,8 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	}
 
 	vrfcontext := lib.GetVrf()
-	if lib.GetT1LRPath() != "" {
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(svcObj.Namespace)
+	if t1lr != "" {
 		vrfcontext = ""
 	} else {
 		avi_vs_meta.VrfContext = vrfcontext
@@ -105,8 +106,8 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		VrfContext:  vrfcontext,
 		VipNetworks: lib.GetVipNetworkList(),
 	}
-	if lib.GetT1LRPath() != "" {
-		vsVipNode.T1Lr = lib.GetT1LRPath()
+	if t1lr != "" {
+		vsVipNode.T1Lr = t1lr
 	}
 
 	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -149,9 +150,9 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 		}
 
 		poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
-
-		if lib.GetT1LRPath() != "" {
-			poolNode.T1Lr = lib.GetT1LRPath()
+		t1lr := objects.SharedWCPLister().GetT1LrForNamespace(svcObj.Namespace)
+		if t1lr != "" {
+			poolNode.T1Lr = t1lr
 			// Unset the poolnode's vrfcontext.
 			poolNode.VrfContext = ""
 		}

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -321,8 +321,9 @@ func buildPoolNode(key, poolName, ingName, namespace, priorityLabel, hostname st
 
 	poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
 
-	if lib.GetT1LRPath() != "" {
-		poolNode.T1Lr = lib.GetT1LRPath()
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+	if t1lr != "" {
+		poolNode.T1Lr = t1lr
 		// Unset the poolnode's vrfcontext.
 		poolNode.VrfContext = ""
 	}

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -92,7 +92,8 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 	}
 
 	// If NSX-T LR path is empty, set vrfContext
-	if lib.GetT1LRPath() == "" {
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(routeIgrObj.GetNamespace())
+	if t1lr == "" {
 		vrfcontext = lib.GetVrf()
 		avi_vs_meta.VrfContext = vrfcontext
 	}
@@ -114,8 +115,8 @@ func (o *AviObjectGraph) ConstructAviL7VsNode(vsName string, key string, routeIg
 		VipNetworks: lib.GetVipNetworkList(),
 	}
 
-	if lib.GetT1LRPath() != "" {
-		vsVipNode.T1Lr = lib.GetT1LRPath()
+	if t1lr != "" {
+		vsVipNode.T1Lr = t1lr
 	}
 
 	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -421,8 +422,9 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 
 			poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
 
-			if lib.GetT1LRPath() != "" {
-				poolNode.T1Lr = lib.GetT1LRPath()
+			t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+			if t1lr != "" {
+				poolNode.T1Lr = t1lr
 				// Unset the poolnode's vrfcontext.
 				poolNode.VrfContext = ""
 			}

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
@@ -51,7 +52,8 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 	avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
 
 	vrfcontext := ""
-	if lib.GetT1LRPath() == "" {
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+	if t1lr == "" {
 		vrfcontext = lib.GetVrf()
 		avi_vs_meta.VrfContext = vrfcontext
 	}
@@ -70,8 +72,8 @@ func (o *AviObjectGraph) BuildVSForPassthrough(vsName, namespace, hostname, key 
 		VipNetworks: lib.GetVipNetworkList(),
 	}
 
-	if lib.GetT1LRPath() != "" {
-		vsVipNode.T1Lr = lib.GetT1LRPath()
+	if t1lr != "" {
+		vsVipNode.T1Lr = t1lr
 	}
 
 	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
@@ -124,7 +126,8 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 	// store the Pools in the a temoprary list to be used for populating PG members
 	tmpPoolList := []*AviPoolNode{}
 	vrfContext := ""
-	if lib.GetT1LRPath() == "" {
+	t1lr := objects.SharedWCPLister().GetT1LrForNamespace(namespace)
+	if t1lr == "" {
 		vrfContext = lib.GetVrf()
 	}
 	for _, obj := range svclist {
@@ -137,8 +140,8 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 				VrfContext: vrfContext,
 			}
 			poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
-			if lib.GetT1LRPath() != "" {
-				poolNode.T1Lr = lib.GetT1LRPath()
+			if t1lr != "" {
+				poolNode.T1Lr = t1lr
 			}
 			poolNode.AviMarkers = lib.PopulatePassthroughPoolMarkers(hostname, obj.ServiceName)
 		}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -585,7 +585,6 @@ func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.Work
 	bkt := utils.Bkt(modelName, sharedQueue.NumWorkers)
 	sharedQueue.Workqueue[bkt].AddRateLimited(modelName)
 	utils.AviLog.Infof("key: %s, msg: Published key with modelName: %s", key, modelName)
-
 }
 
 func isServiceDelete(svcName string, namespace string, key string) bool {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -131,7 +131,7 @@ func DequeueIngestion(key string, fullsync bool) {
 		}
 	}
 
-	if !ingressFound && !lib.GetAdvancedL4() && !mciFound {
+	if !ingressFound && !lib.IsWCP() && !mciFound {
 		// If ingress is not found, let's do the other checks.
 		if objType == utils.L4LBService {
 			// L4 type of services need special handling. We create a dedicated VS in Avi for these.
@@ -164,9 +164,9 @@ func DequeueIngestion(key string, fullsync bool) {
 	}
 
 	// handle the services APIs
-	if (lib.GetAdvancedL4() && objType == utils.L4LBService) ||
+	if (lib.IsWCP() && objType == utils.L4LBService) ||
 		(lib.UseServicesAPI() && (objType == utils.Service || objType == utils.L4LBService)) ||
-		((lib.GetAdvancedL4() || lib.UseServicesAPI()) && (objType == lib.Gateway || objType == lib.GatewayClass || objType == utils.Endpoints || objType == lib.AviInfraSetting)) {
+		((lib.IsWCP() || lib.UseServicesAPI()) && (objType == lib.Gateway || objType == lib.GatewayClass || objType == utils.Endpoints || objType == lib.AviInfraSetting)) {
 		if !valid && objType == utils.L4LBService {
 			// Required for advl4 schemas.
 			schema, _ = ConfigDescriptor().GetByType(utils.Service)
@@ -362,7 +362,7 @@ func handlePod(key, namespace, podName string, fullsync bool) {
 func isGatewayDelete(gatewayKey, key string) bool {
 	// parse the gateway name and namespace
 	namespace, _, gwName := lib.ExtractTypeNameNamespace(gatewayKey)
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		gateway, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
 		if err != nil && errors.IsNotFound(err) {
 			return true
@@ -405,11 +405,7 @@ func isGatewayDelete(gatewayKey, key string) bool {
 		}
 	}
 	found, _ := objects.ServiceGWLister().GetGWListeners(namespace + "/" + gwName)
-	if !found {
-		return true
-	}
-
-	return false
+	return !found
 }
 
 func handleRoute(key string, fullsync bool, routeNames []string) {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -370,13 +370,14 @@ func isGatewayDelete(gatewayKey, key string) bool {
 
 		// check if deletiontimesttamp is present to see intended delete
 		if gateway.GetDeletionTimestamp() != nil {
-			utils.AviLog.Infof("key: %s, deletionTimestamp set on gateway, will be deleting VS", key)
+			utils.AviLog.Infof("key: %s, msg: deletionTimestamp set on gateway, will be deleting VS", key)
 			return true
 		}
 
 		// Check if the gateway has a valid gateway class
 		err = validateGatewayForClass(key, gateway)
 		if err != nil {
+			utils.AviLog.Infof("key: %s, msg: Valid GatewayClass for gateway %s not found", key, gateway)
 			return true
 		}
 	} else if lib.UseServicesAPI() {
@@ -399,6 +400,7 @@ func isGatewayDelete(gatewayKey, key string) bool {
 		// Check if the gateway has a valid gateway class
 		err = validateSvcApiGatewayForClass(key, gateway)
 		if err != nil {
+			utils.AviLog.Infof("key: %s, msg: Valid GatewayClass for gateway %s not found", key, gateway)
 			return true
 		}
 	}

--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -255,7 +255,7 @@ func EPToGateway(epName string, namespace string, key string) ([]string, bool) {
 func GatewayChanges(gwName string, namespace string, key string) ([]string, bool) {
 	var allGateways []string
 	allGateways = append(allGateways, namespace+"/"+gwName)
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		gateway, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
 		if err != nil && k8serrors.IsNotFound(err) {
 			// Remove all the Gateway to Services mapping.
@@ -849,7 +849,7 @@ func ParseL4ServiceForGateway(svc *corev1.Service, key string) (string, []string
 	}
 
 	var gwNameLabel, gwNamespaceLabel string
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		gwNameLabel = lib.GatewayNameLabelKey
 		gwNamespaceLabel = lib.GatewayNamespaceLabelKey
 	} else if lib.UseServicesAPI() {

--- a/internal/nodes/validator.go
+++ b/internal/nodes/validator.go
@@ -36,7 +36,7 @@ type Validator struct {
 
 func NewNodesValidator() *Validator {
 	validator := &Validator{}
-	if !lib.GetAdvancedL4() {
+	if !lib.IsWCP() {
 		validator.subDomains = GetDefaultSubDomain()
 	}
 	return validator
@@ -70,7 +70,7 @@ func validateSpecFromHostnameCache(key string, ingress *networkingv1.Ingress) bo
 					utils.AviLog.Warnf("key: %s, msg: Duplicate entries found for hostpath %s: %s%s in ingresses: %+v", key, nsIngress, rule.Host, svcPath.Path, utils.Stringify(val))
 				}
 			}
-			// In VCF, we use VIP per Namespace, hence same hostname can should not be present across multiple namespaces
+			// In VCF, we use VIP per Namespace, hence same hostname should not be present across multiple namespaces
 			if lib.VIPPerNamespace() {
 				if ok, oldNS := SharedHostNameLister().GetNamespace(rule.Host); ok {
 					if oldNS != ingress.Namespace {

--- a/internal/objects/wcp.go
+++ b/internal/objects/wcp.go
@@ -39,14 +39,14 @@ type WCPLister struct {
 }
 
 func (w *WCPLister) UpdateNamespaceTier1LrCache(namespace, t1lr string) {
-	w.NamespaceTier1LrCache.ObjLock.Lock()
-	defer w.NamespaceTier1LrCache.ObjLock.Unlock()
+	// w.NamespaceTier1LrCache.ObjLock.Lock()
+	// defer w.NamespaceTier1LrCache.ObjLock.Unlock()
 	w.NamespaceTier1LrCache.AddOrUpdate(namespace, t1lr)
 }
 
 func (w *WCPLister) RemoveNamespaceTier1LrCache(namespace string) {
-	w.NamespaceTier1LrCache.ObjLock.Lock()
-	defer w.NamespaceTier1LrCache.ObjLock.Unlock()
+	// w.NamespaceTier1LrCache.ObjLock.Lock()
+	// defer w.NamespaceTier1LrCache.ObjLock.Unlock()
 	w.NamespaceTier1LrCache.Delete(namespace)
 }
 

--- a/internal/objects/wcp.go
+++ b/internal/objects/wcp.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package objects
+
+import (
+	"os"
+	"sync"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+var WCPInstance *WCPLister
+var wcponce sync.Once
+
+func SharedWCPLister() *WCPLister {
+	wcponce.Do(func() {
+		WCPInstance = &WCPLister{
+			NamespaceTier1LrCache: NewObjectMapStore(),
+		}
+	})
+	return WCPInstance
+}
+
+type WCPLister struct {
+	// namespace -> tier1lr
+	NamespaceTier1LrCache *ObjectMapStore
+}
+
+func (w *WCPLister) UpdateNamespaceTier1LrCache(namespace, t1lr string) {
+	w.NamespaceTier1LrCache.ObjLock.Lock()
+	defer w.NamespaceTier1LrCache.ObjLock.Unlock()
+	w.NamespaceTier1LrCache.AddOrUpdate(namespace, t1lr)
+}
+
+func (w *WCPLister) RemoveNamespaceTier1LrCache(namespace string) {
+	w.NamespaceTier1LrCache.ObjLock.Lock()
+	defer w.NamespaceTier1LrCache.ObjLock.Unlock()
+	w.NamespaceTier1LrCache.Delete(namespace)
+}
+
+func (w *WCPLister) GetT1LrForNamespace(namespace ...string) string {
+	if utils.IsVCFCluster() {
+		found, t1lr := w.NamespaceTier1LrCache.Get(namespace[0])
+		if found {
+			return t1lr.(string)
+		}
+	}
+	return os.Getenv("NSXT_T1_LR")
+}

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -293,8 +293,6 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 		svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 		svc_mdata := string(svc_mdata_json)
 
-		vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
-
 		seGroupRef := "/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup
 		vs := avimodels.VirtualService{
 			Name:                  &name,
@@ -306,9 +304,11 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 			ServiceMetadata:       &svc_mdata,
 			SeGroupRef:            &seGroupRef,
 		}
-		if lib.GetT1LRPath() == "" {
-			vs.VrfContextRef = &vrfContextRef
+
+		if vs_meta.VrfContext != "" {
+			vs.VrfContextRef = proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext)
 		}
+
 		var enableRhi bool
 		if vs_meta.EnableRhi != nil {
 			enableRhi = *vs_meta.EnableRhi
@@ -471,7 +471,6 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 
 	cloudRef := "/api/cloud?name=" + utils.CloudName
 	network_prof := "/api/networkprofile/?name=" + "System-TCP-Proxy"
-	vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
 	seGroupRef := "/api/serviceenginegroup?name=" + lib.GetSEGName()
 	svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 	svc_mdata := string(svc_mdata_json)
@@ -492,8 +491,9 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 		Enabled:               vs_meta.Enabled,
 		VhType:                proto.String(utils.VS_TYPE_VH_ENHANCED),
 	}
-	if lib.GetT1LRPath() == "" {
-		evhChild.VrfContextRef = &vrfContextRef
+
+	if vs_meta.VrfContext != "" {
+		evhChild.VrfContextRef = proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext)
 	}
 	//This VS has a TLSKeyCert associated, we need to mark 'type': 'VS_TYPE_VH_PARENT'
 	vh_type := utils.VS_TYPE_VH_CHILD

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -115,7 +115,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			vs.EnableRhi = &enableRhi
 		}
 
-		if lib.GetAdvancedL4() {
+		if lib.IsWCP() {
 			vs.IgnPoolNetReach = proto.Bool(true)
 		}
 

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -89,7 +89,6 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			TenantRef:             proto.String(fmt.Sprintf("/api/tenant/?name=%s", vs_meta.Tenant)),
 			ApplicationProfileRef: proto.String("/api/applicationprofile/?name=" + vs_meta.ApplicationProfile),
 			SeGroupRef:            proto.String("/api/serviceenginegroup?name=" + vs_meta.ServiceEngineGroup),
-			VrfContextRef:         proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext),
 			WafPolicyRef:          &vs_meta.WafPolicyRef,
 			AnalyticsProfileRef:   &vs_meta.AnalyticsProfileRef,
 			ErrorPageProfileRef:   &vs_meta.ErrorPageProfileRef,
@@ -102,10 +101,10 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			vs.ApplicationProfileRef = proto.String(vs_meta.AppProfileRef)
 		}
 
-		if lib.GetT1LRPath() != "" {
-			// Clear the vrfContextRef
-			vs.VrfContextRef = nil
+		if vs_meta.VrfContext != "" {
+			vs.VrfContextRef = proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext)
 		}
+
 		var enableRhi bool
 		if vs_meta.EnableRhi != nil {
 			enableRhi = *vs_meta.EnableRhi
@@ -286,7 +285,6 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 
 	cloudRef := "/api/cloud?name=" + utils.CloudName
 	network_prof := "/api/networkprofile/?name=" + "System-TCP-Proxy"
-	vrfContextRef := "/api/vrfcontext?name=" + vs_meta.VrfContext
 	seGroupRef := "/api/serviceenginegroup?name=" + lib.GetSEGName()
 	svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 	svc_mdata := string(svc_mdata_json)
@@ -298,7 +296,6 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 		ApplicationProfileRef: &app_prof,
 		EastWestPlacement:     proto.Bool(false),
 		CloudRef:              &cloudRef,
-		VrfContextRef:         &vrfContextRef,
 		SeGroupRef:            &seGroupRef,
 		ServiceMetadata:       &svc_mdata,
 		WafPolicyRef:          &vs_meta.WafPolicyRef,
@@ -308,9 +305,8 @@ func (rest *RestOperations) AviVsSniBuild(vs_meta *nodes.AviVsNode, rest_method 
 		Enabled:               vs_meta.Enabled,
 	}
 	sniChild.AnalyticsPolicy = vs_meta.GetAnalyticsPolicy()
-	if lib.GetT1LRPath() != "" {
-		// Clear the vrfContextRef
-		sniChild.VrfContextRef = nil
+	if vs_meta.VrfContext != "" {
+		sniChild.VrfContextRef = proto.String("/api/vrfcontext?name=" + vs_meta.VrfContext)
 	}
 	//This VS has a TLSKeyCert associated, we need to mark 'type': 'VS_TYPE_VH_PARENT'
 	vh_type := utils.VS_TYPE_VH_CHILD

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -192,7 +192,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 								Mask:   proto.Int32(int32(mask)),
 							},
 						}
-					} else if !lib.GetAdvancedL4() {
+					} else if !lib.IsWCP() {
 						vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{
 							Subnet: &avimodels.IPAddrPrefix{
 								IPAddr: &avimodels.IPAddr{Type: &ipType, Addr: &ipPrefixSlice[0]},
@@ -385,7 +385,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 			vs_cache_obj, found := vs_cache.(*avicache.AviVsCache)
 			if found && vs_cache_obj.ServiceMetadataObj.Gateway != "" {
 				gwNSName := strings.Split(vs_cache_obj.ServiceMetadataObj.Gateway, "/")
-				if lib.GetAdvancedL4() {
+				if lib.IsWCP() {
 					gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(gwNSName[0]).Get(gwNSName[1])
 					if err != nil {
 						utils.AviLog.Warnf("key: %s, msg: Gateway object not found, skippig status update %v", key, err)

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -177,7 +177,7 @@ func (rest *RestOperations) vrfCU(key, vrfName string, avimodel *nodes.AviObject
 }
 
 // CheckAndPublishForRetry : Check if the error is of type 401, has string "Rest request error" or was timed out,
-// then publish the key to retry layer. These error do not depend on the objet state, hence cache refresh is not required.
+// then publish the key to retry layer. These error do not depend on the object state, hence cache refresh is not required.
 func (rest *RestOperations) CheckAndPublishForRetry(err error, publishKey, key string, avimodel *nodes.AviObjectGraph) bool {
 	if err == nil {
 		return false
@@ -187,6 +187,10 @@ func (rest *RestOperations) CheckAndPublishForRetry(err error, publishKey, key s
 			switch aviError.HttpStatusCode {
 			case 401:
 				if strings.Contains(*aviError.Message, "Invalid credentials") {
+					if utils.IsVCFCluster() {
+						lib.WaitForInitSecretRecreateAndReboot()
+						return true
+					}
 					utils.AviLog.Errorf("key: %s, msg: Invalid credentials error, Shutting down API Server", key)
 					lib.ShutdownApi()
 				} else if avimodel != nil && avimodel.GetRetryCounter() != 0 {

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -703,18 +703,14 @@ func (rest *RestOperations) DataScriptDelete(dsToDelete []avicache.NamespaceName
 }
 
 func (rest *RestOperations) PublishKeyToRetryLayer(parentVsKey string, key string) {
-	var bkt uint32
-	bkt = 0
 	fastRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.FAST_RETRY_LAYER)
-	fastRetryQueue.Workqueue[bkt].AddRateLimited(parentVsKey)
+	fastRetryQueue.Workqueue[0].AddRateLimited(parentVsKey)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to fast path retry queue: %s", key, parentVsKey)
 }
 
 func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, key string) {
-	var bkt uint32
-	bkt = 0
 	slowRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.SLOW_RETRY_LAYER)
-	slowRetryQueue.Workqueue[bkt].AddRateLimited(parentVsKey)
+	slowRetryQueue.Workqueue[0].AddRateLimited(parentVsKey)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to slow path retry queue: %s", key, parentVsKey)
 }
 

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -134,9 +134,10 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		}
 	}
 
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		status.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
 		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
 	} else {
 		if lib.UseServicesAPI() {
 			status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
@@ -150,5 +151,4 @@ func (rest *RestOperations) SyncObjectStatuses() {
 
 	utils.AviLog.Infof("Status syncing completed")
 	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, lib.StatusSync, "Status syncing completed")
-
 }

--- a/internal/status/advl4_status.go
+++ b/internal/status/advl4_status.go
@@ -101,7 +101,7 @@ func parseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, []U
 
 func DeleteGatewayStatusAddress(svcMetadataObj lib.ServiceMetadataObj, key string) error {
 	gwNSName := strings.Split(svcMetadataObj.Gateway, "/")
-	if lib.GetAdvancedL4() {
+	if lib.IsWCP() {
 		gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(gwNSName[0]).Get(gwNSName[1])
 		if err != nil {
 			utils.AviLog.Warnf("key: %s, msg: there was a problem in resetting the gateway address status: %s", key, err)

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -35,7 +35,7 @@ func UpdateL4LBStatus(options []UpdateOptions, bulk bool) {
 	var updateServiceOptions []UpdateOptions
 
 	for _, option := range options {
-		if len(option.ServiceMetadata.HostNames) != 1 && !lib.GetAdvancedL4() {
+		if len(option.ServiceMetadata.HostNames) != 1 && !lib.IsWCP() {
 			utils.AviLog.Warnf("key: %s, msg: Service hostname not found for service %v status update", option.Key, option.ServiceMetadata.NamespaceServiceName)
 		}
 

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -34,8 +34,8 @@ type AviRestClientPool struct {
 
 var AviClientInstance *AviRestClientPool
 
-func NewAviRestClientPool(num uint32, api_ep string, username string,
-	password string, authToken string) (*AviRestClientPool, error) {
+func NewAviRestClientPool(num uint32, api_ep, username,
+	password, authToken, controllerVersion string) (*AviRestClientPool, string, error) {
 	var clientPool AviRestClientPool
 	var wg sync.WaitGroup
 	var globalErr error
@@ -95,19 +95,19 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 	wg.Wait()
 
 	// Get the controller version if it is not present in env variable.
-	if CtrlVersion == "" {
+	if controllerVersion == "" {
 		version, err := clientPool.AviClient[0].AviSession.GetControllerVersion()
 		if err == nil {
 			AviLog.Infof("Setting the client version to the current controller version %v", version)
-			CtrlVersion = version
+			controllerVersion = version
 		}
 	}
 
 	if globalErr != nil {
-		return &clientPool, globalErr
+		return &clientPool, controllerVersion, globalErr
 	}
 
-	return &clientPool, nil
+	return &clientPool, controllerVersion, nil
 }
 
 func (p *AviRestClientPool) AviRestOperate(c *clients.AviClient, rest_ops []*RestOp) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -418,7 +418,7 @@ func CheckIfNamespaceAccepted(namespace string, opts ...interface{}) bool {
 	return false
 }
 func IsServiceNSValid(namespace string) bool {
-	//L4 Namespace sync not applicable for advance L4
+	// L4 Namespace sync not applicable for advance L4
 	if !GetAdvancedL4() {
 		if !CheckIfNamespaceAccepted(namespace) {
 			return false

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,7 +40,6 @@ import (
 	akoinformers "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/informers/externalversions"
 )
 
-var CtrlVersion string
 var runtimeScheme = k8sruntime.NewScheme()
 
 func init() {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -44,8 +44,7 @@ var CtrlVersion string
 var runtimeScheme = k8sruntime.NewScheme()
 
 func init() {
-	//Setting the package-wide version
-	CtrlVersion = os.Getenv("CTRL_VERSION")
+	// Setting the package-wide version
 	networkingv1.AddToScheme(runtimeScheme)
 }
 

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -102,7 +102,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	integrationtest.PollForSyncStart(ctrl, 10)
 

--- a/tests/bootuptests/stale_obj_delete_test.go
+++ b/tests/bootuptests/stale_obj_delete_test.go
@@ -38,7 +38,6 @@ func TestMain(m *testing.M) {
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 
-	utils.CtrlVersion = "20.1.1"
 	restChan = make(chan bool)
 	uuidMap = make(map[string]bool)
 
@@ -48,6 +47,7 @@ func TestMain(m *testing.M) {
 	akoControlConfig.SetCRDClientset(CRDClient)
 	akoControlConfig.SetAKOInstanceFlag(true)
 	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	lib.AKOControlConfig().SetControllerVersion("20.1.1")
 	data := map[string][]byte{
 		"username": []byte("admin"),
 		"password": []byte("admin"),

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -112,7 +112,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -140,7 +140,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())
 }

--- a/tests/infratests/akoinfra_test.go
+++ b/tests/infratests/akoinfra_test.go
@@ -70,7 +70,7 @@ func initInfraTest(testData []*unstructured.Unstructured) {
 	dynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToKind, testData[0], testData[1])
 	dynamicClient.Resource(lib.BootstrapGVR).Namespace("default").Create(context.TODO(), testData[0], v1.CreateOptions{})
 	dynamicClient.Resource(lib.NetworkInfoGVR).Namespace("default").Create(context.TODO(), testData[1], v1.CreateOptions{})
-	lib.SetVCFVCFDynamicClientSet(dynamicClient)
+	lib.SetDynamicClientSet(dynamicClient)
 
 	registeredInformers := []string{
 		utils.SecretInformer,
@@ -78,8 +78,7 @@ func initInfraTest(testData []*unstructured.Unstructured) {
 	informersArg := make(map[string]interface{})
 
 	utils.NewInformers(utils.KubeClientIntf{ClientSet: kubeClient}, registeredInformers, informersArg)
-	lib.NewVCFDynamicInformers(dynamicClient)
-
+	lib.NewDynamicInformers(dynamicClient, true)
 }
 
 // TestBoostrapNoALBEndpoint adds an akobootstrapconditions object with no albEndpoint.

--- a/tests/infratests/akoinfra_test.go
+++ b/tests/infratests/akoinfra_test.go
@@ -65,10 +65,8 @@ func waitAndverify(t *testing.T, expectTimeout bool) {
 func initInfraTest(testData []*unstructured.Unstructured) {
 	gvrToKind := make(map[schema.GroupVersionResource]string)
 	gvrToKind[lib.NetworkInfoGVR] = "namespacenetworkinfosList"
-	gvrToKind[lib.BootstrapGVR] = "akobootstrapconditionsList"
 
 	dynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToKind, testData[0], testData[1])
-	dynamicClient.Resource(lib.BootstrapGVR).Namespace("default").Create(context.TODO(), testData[0], v1.CreateOptions{})
 	dynamicClient.Resource(lib.NetworkInfoGVR).Namespace("default").Create(context.TODO(), testData[1], v1.CreateOptions{})
 	lib.SetDynamicClientSet(dynamicClient)
 

--- a/tests/infratests/akoinfra_test.go
+++ b/tests/infratests/akoinfra_test.go
@@ -128,7 +128,6 @@ func TestBoostrapNoALBEndpoint(t *testing.T) {
 	})
 
 	initInfraTest(testData)
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := make(chan struct{})
 	ctrlCh := make(chan struct{})
@@ -137,7 +136,7 @@ func TestBoostrapNoALBEndpoint(t *testing.T) {
 	defer integrationtest.AviFakeClientInstance.Close()
 
 	go func() {
-		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+		_ = c.HandleVCF(stopCh, ctrlCh, true)
 
 		lib.VCFInitialized = true
 		keyChan <- true
@@ -194,7 +193,6 @@ func TestBoostrapNoTransportZone(t *testing.T) {
 	})
 
 	initInfraTest(testData)
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := make(chan struct{})
 
@@ -204,7 +202,7 @@ func TestBoostrapNoTransportZone(t *testing.T) {
 	defer integrationtest.AviFakeClientInstance.Close()
 
 	go func() {
-		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+		_ = c.HandleVCF(stopCh, ctrlCh, true)
 
 		lib.VCFInitialized = true
 		keyChan <- true
@@ -261,7 +259,6 @@ func TestBoostrapNoSecretRef(t *testing.T) {
 	})
 
 	initInfraTest(testData)
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := make(chan struct{})
 
@@ -271,7 +268,7 @@ func TestBoostrapNoSecretRef(t *testing.T) {
 	defer integrationtest.AviFakeClientInstance.Close()
 
 	go func() {
-		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+		_ = c.HandleVCF(stopCh, ctrlCh, true)
 
 		lib.VCFInitialized = true
 		keyChan <- true
@@ -328,7 +325,6 @@ func TestBoostrapNoUserName(t *testing.T) {
 	})
 
 	initInfraTest(testData)
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := make(chan struct{})
 
@@ -338,7 +334,7 @@ func TestBoostrapNoUserName(t *testing.T) {
 	defer integrationtest.AviFakeClientInstance.Close()
 
 	go func() {
-		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+		_ = c.HandleVCF(stopCh, ctrlCh, true)
 
 		lib.VCFInitialized = true
 		keyChan <- true
@@ -393,7 +389,6 @@ func TestValidBootstrapData(t *testing.T) {
 	})
 
 	initInfraTest(testData)
-	informers := ingestion.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}
 	c := ingestion.SharedVCFK8sController()
 	stopCh := make(chan struct{})
 
@@ -403,7 +398,7 @@ func TestValidBootstrapData(t *testing.T) {
 	defer integrationtest.AviFakeClientInstance.Close()
 
 	go func() {
-		_ = c.HandleVCF(informers, stopCh, ctrlCh, true)
+		_ = c.HandleVCF(stopCh, ctrlCh, true)
 
 		lib.VCFInitialized = true
 		keyChan <- true

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -119,7 +119,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -139,7 +139,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	AddConfigMap(KubeClient)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 	PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -267,7 +267,7 @@ func TestMain(m *testing.M) {
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
 	AddCMap()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	ctrl.HandleConfigMap(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}, ctrlCh, stopCh, quickSyncCh)
 	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient})

--- a/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
+++ b/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
@@ -124,7 +124,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 	os.Exit(m.Run())

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	integrationtest.PollForSyncStart(ctrl, 10)
 

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -225,7 +225,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	integrationtest.PollForSyncStart(ctrl, 10)
 

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -186,7 +186,7 @@ func TestMain(m *testing.M) {
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	defaultKey = "app"
 	defaultValue = "migrate"

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -117,7 +117,7 @@ func TestMain(m *testing.M) {
 	waitGroupMap["status"] = wgStatus
 
 	integrationtest.AddConfigMap(KubeClient)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	integrationtest.PollForSyncStart(ctrl, 10)
 

--- a/tests/temp/temp_sni_to_pool_test.go
+++ b/tests/temp/temp_sni_to_pool_test.go
@@ -106,7 +106,7 @@ func TestMain(m *testing.M) {
 	integrationtest.PollForSyncStart(ctrl, 10)
 
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
-	ctrl.SetSEGroupCloudName()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
 
 	integrationtest.KubeClient = KubeClient
 	integrationtest.AddDefaultIngressClass()


### PR DESCRIPTION
- Set controller version in ako-infra from fetching it from the controller.
- Fix avi client usage in ako-infra, before this the container was using clients from the AKO initialized avi shared clients.
- Do not try configuring ls-lr mappings in the cloud (PUT calls) when no mappings are found in the CRs.
- Correct the usable network configuration in IPAM profile for nsxt cloud, use UsableNetworks instead of UsableNetworkRefs (deprecated)
- Allow for both create and update of serviceenginegroup while ako-infra boots up. Earlier the infra container was programmed to just create SEG - leading to errors related to repetetive Post API calls on every bootup.
- While creating SEGroups, configure markers and NOT labels, in order for AKO to find the relevant SE group for syncing VSes.
- In nsx-t cloud's NsxtConfiguration, configure the transport zone properly in ManagementNetworkConfig.
- Earlier the infra-container used a deprecated transport zone field in the cloud configuration.
- Fix incorrect copying of secret from NCP secret to AKO secret.
- Add clusterroles for namespace (to allow updating AKO namespace with annotations) and secrets (for creating and updating AKO secret) for AKO in WCP.
- Sync updated status schema of akobootstrapconditions CRD, to fetch transportZone path details properly.
- Misc cleanup for admin switch context API retries.
- Fix Secret handling when the token is no more valid. Wait for the new Secret to be created before shutting down AKO container.
- Add support for Ingress/IngressClass handling in VCF Clusters. Sanitize code around AdvancedL4 (wcp with VDS) and VCF (wcp with NSXT) usecases. 