### PR TITLE
Remove vipPerNamespace from user configurable parameters

### DIFF
--- a/docs/akoconfig.md
+++ b/docs/akoconfig.md
@@ -27,7 +27,6 @@ spec:
       labelKey: ""
       labelValue: ""
     servicesAPI: false
-    vipPerNamespace: false
 
   networkSettings:
     nodeNetworkList: []
@@ -94,7 +93,6 @@ spec:
     * `namespaceSelector.labelKey`: Set the key of a namespace's label, if the requirement is to sync k8s objects from that namespace.
     * `namespaceSelector.labelValue`: Set the value of a namespace's label, if the requirement is to sync k8s objects from that namespace.
     * `servicesAPI`: Flag that enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently implemented only for L4. This flag uses the upstream GA APIs which are not backward compatible with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1
-    * `vipPerNamespace`: # Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
   - `networkSettings`: Data network setting
     * `nodeNetworkList`: This list of network and cidrs are used in pool placement network for vcenter cloud. Node Network details are not needed when in nodeport mode / static routes are disabled / non vcenter clouds.
     * `enableRHI`: This is a cluster wide setting for BGP peering.

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -16,7 +16,6 @@ data:
   servicesAPI: {{ .Values.AKOSettings.servicesAPI | quote }}
   enableEVH: {{ .Values.AKOSettings.enableEVH | quote }}
   layer7Only: {{ .Values.AKOSettings.layer7Only | quote }}
-  vipPerNamespace: {{ .Values.AKOSettings.vipPerNamespace | quote }}
   tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
   defaultDomain: {{ .Values.L4Settings.defaultDomain | quote }}
   disableStaticRouteSync: {{ .Values.AKOSettings.disableStaticRouteSync | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -63,11 +63,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: cniPlugin
-          - name: VIP_PER_NAMESPACE
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: vipPerNamespace
           - name: SHARD_VS_SIZE
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -26,9 +26,7 @@ AKOSettings:
   namespaceSelector:
     labelKey: ""
     labelValue: ""
-  servicesAPI: false # Flag that enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently implemented only for L4. This flag uses the upstream GA APIs which are not backward compatible 
-                     # with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 
-  vipPerNamespace: "false" # Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
+  servicesAPI: false # Flag that enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently implemented only for L4.
 
 ### This section outlines the network settings for virtualservices. 
 NetworkSettings:

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1687,8 +1687,7 @@ func GetControllerVersion() string {
 }
 
 func VIPPerNamespace() bool {
-	vipPerNS := os.Getenv(VIP_PER_NAMESPACE)
-	return vipPerNS == "true"
+	return utils.IsVCFCluster()
 }
 
 var controllerIP string


### PR DESCRIPTION
vipPerNamespace is only used in a VCF cluster with WCP enabled
over a NSX topology. Therefore vipPerNamespace can be automatically
set to active in a VCF Cluster. This does not require an explicit
user configuration.