### PR TITLE
[cherrypick]: Add support for Shared VIP with Service of type LoadBalancer (#828)

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -783,12 +783,12 @@ func (c *AviController) FullSyncK8s() error {
 			isSvcLb := isServiceLBType(svcObj)
 			var key string
 			if isSvcLb && !lib.GetLayer7Only() {
-				/*
-					Key added to Ingestion queue if
-					1. Advance L4 enabled or
-					2. Namespace is valid
-				*/
 				key = utils.L4LBService + "/" + utils.ObjKey(svcObj)
+				if svcObj.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
+					// mark the object type as ShareVipSvc
+					// to separate these out from regulare clusterip, svclb services
+					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svcObj)
+				}
 			} else {
 				if lib.GetAdvancedL4() {
 					continue

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -168,6 +168,7 @@ const (
 	SSLPort                                    = 443
 	IPAMProviderInfoblox                       = "IPAMDNS_TYPE_INFOBLOX"
 	IPAMProviderCustom                         = "IPAMDNS_TYPE_CUSTOM"
+	SharedVipServiceKey                        = "SharedVipService"
 
 	// AKO Event constants
 	AKOEventComponent      = "avi-kubernetes-operator"
@@ -213,6 +214,7 @@ const (
 	WCPCloud                       = "ako.vmware.com/wcp-cloud-name"
 	VSAnnotation                   = "ako.vmware.com/host-fqdn-vs-uuid-map"
 	ControllerAnnotation           = "ako.vmware.com/controller-cluster-uuid"
+	SharedVipSvcLBAnnotation       = "ako.vmware.com/enable-shared-vip"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -115,6 +115,7 @@ func (c ServiceMetadataObj) ServiceMetadataMapping(objType string) ServiceMetada
 		// Check for `NamespaceServiceName` in Pool serviceMetadata. Present in case of
 		// 1) Advl4 Pools: without hostname information
 		// 2) SvcApi Pools: with hostname information
+		// 3) SharedVip SvcLB Pools: with hostname information
 		return GatewayPool
 	} else if c.Namespace != "" && c.IngressName != "" {
 		// Check for `Namespace` and `IngressName` in Pool serviceMetadata. Present in case of
@@ -334,8 +335,8 @@ func GetL4VSVipName(svcName, namespace string) string {
 	return Encode(NamePrefix+namespace+"-"+svcName, L4VIP)
 }
 
-func GetL4PoolName(svcName, namespace string, port int32) string {
-	poolName := NamePrefix + namespace + "-" + svcName + "--" + strconv.Itoa(int(port))
+func GetL4PoolName(svcName, namespace, protocol string, port int32) string {
+	poolName := NamePrefix + namespace + "-" + svcName + "-" + protocol + "-" + strconv.Itoa(int(port))
 	return Encode(poolName, L4Pool)
 }
 

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -29,19 +29,24 @@ import (
 	svcapiv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
-func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace string, gatewayName string, key string) {
+func (o *AviObjectGraph) BuildAdvancedL4Graph(namespace, gatewayName, key string, sharedVipOnSvcLBUsecase bool) {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 	var vsNode *AviVsNode
-	if lib.UseServicesAPI() {
+
+	if sharedVipOnSvcLBUsecase {
+		vsNode = o.ConstructSharedVipSvcLBNode(gatewayName, namespace, key)
+	} else if lib.UseServicesAPI() {
 		vsNode = o.ConstructSvcApiL4VsNode(gatewayName, namespace, key)
 	} else {
 		vsNode = o.ConstructAdvL4VsNode(gatewayName, namespace, key)
 	}
 	if vsNode != nil {
-		o.ConstructAdvL4PolPoolNodes(vsNode, gatewayName, namespace, key)
+		if !sharedVipOnSvcLBUsecase {
+			o.ConstructAdvL4PolPoolNodes(vsNode, gatewayName, namespace, key)
+		}
 		o.AddModelNode(vsNode)
-		utils.AviLog.Infof("key: %s, msg: checksum  for AVI VS object %v", key, vsNode.GetCheckSum())
+		utils.AviLog.Infof("key: %s, msg: checksum for AVI VS object %v", key, vsNode.GetCheckSum())
 	}
 }
 
@@ -50,86 +55,87 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 	// A L4 policyset object is create where listener port --> pool. Pool gets it's server from the endpoints that has the same name as the 'service' pointed
 	// by the listener port.
 	found, listeners := objects.ServiceGWLister().GetGWListeners(namespace + "/" + gatewayName)
-	if found {
-		vsName := lib.GetL4VSName(gatewayName, namespace)
-		gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for advancedL4: %s", err)
-			return nil
-		}
-
-		var serviceNSNames []string
-		if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
-			for svcListener, service := range services {
-				// assume it to have only a single backend service, the check is in isGatewayDelete
-				if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
-					serviceNSNames = append(serviceNSNames, service[0])
-				}
-			}
-		}
-
-		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
-			ServiceMetadata: lib.ServiceMetadataObj{
-				NamespaceServiceName: serviceNSNames,
-				Gateway:              namespace + "/" + gatewayName,
-			},
-			ServiceEngineGroup: lib.GetSEGName(),
-			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
-		}
-
-		avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
-
-		isTCP, isUDP := false, false
-		var portProtocols []AviPortHostProtocol
-		for _, listener := range listeners {
-			portProto := strings.Split(listener, "/") // format: protocol/port
-			port, _ := utilsnet.ParsePort(portProto[1], true)
-			pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
-			portProtocols = append(portProtocols, pp)
-			if portProto[0] == "" || portProto[0] == utils.TCP {
-				isTCP = true
-			} else if portProto[0] == utils.UDP {
-				isUDP = true
-			}
-		}
-
-		avi_vs_meta.PortProto = portProtocols
-		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
-
-		// In case the VS has services that are a mix of TCP and UDP sockets,
-		// we create the VS with global network profile TCP Fast Path,
-		// and override required services with UDP Fast Path. Having a separate
-		// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-		// on existing VSes.
-		if isTCP && !isUDP {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		} else if isUDP && !isTCP {
-			avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-		} else {
-			avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-		}
-
-		vsVipNode := &AviVSVIPNode{
-			Name:        lib.GetL4VSVipName(gatewayName, namespace),
-			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
-			VipNetworks: lib.GetVipNetworkList(),
-		}
-
-		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
-			vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
-		}
-
-		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
-			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
-		}
-		avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
-		return avi_vs_meta
+	if !found {
+		return nil
 	}
-	return nil
+
+	vsName := lib.GetL4VSName(gatewayName, namespace)
+	gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for advancedL4: %s", err)
+		return nil
+	}
+
+	var serviceNSNames []string
+	if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
+		for svcListener, service := range services {
+			// assume it to have only a single backend service, the check is in isGatewayDelete
+			if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
+				serviceNSNames = append(serviceNSNames, service[0])
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			NamespaceServiceName: serviceNSNames,
+			Gateway:              namespace + "/" + gatewayName,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
+
+	isTCP, isUDP := false, false
+	var portProtocols []AviPortHostProtocol
+	for _, listener := range listeners {
+		portProto := strings.Split(listener, "/") // format: protocol/port
+		port, _ := utilsnet.ParsePort(portProto[1], true)
+		pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
+		portProtocols = append(portProtocols, pp)
+		if portProto[0] == "" || portProto[0] == utils.TCP {
+			isTCP = true
+		} else if portProto[0] == utils.UDP {
+			isUDP = true
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	// In case the VS has services that are a mix of TCP and UDP sockets,
+	// we create the VS with global network profile TCP Fast Path,
+	// and override required services with UDP Fast Path. Having a separate
+	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
+	// on existing VSes.
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(gatewayName, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == advl4v1alpha1pre1.IPAddressType {
+		vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	}
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
 }
 
 func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key string) *AviVsNode {
@@ -137,119 +143,119 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 	// A L4 policyset object is create where listener port --> pool. Pool gets it's server from the endpoints that has the same name as the 'service' pointed
 	// by the listener port.
 	found, listeners := objects.ServiceGWLister().GetGWListeners(namespace + "/" + gatewayName)
-	if found {
-		vsName := lib.GetL4VSName(gatewayName, namespace)
-		gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
-			return nil
-		}
-
-		var serviceNSNames []string
-		listenerSvcMapping := make(map[string][]string)
-		if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
-			for svcListener, service := range services {
-				// assume it to have only a single backend service, the check is in isGatewayDelete
-				if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
-					serviceNSNames = append(serviceNSNames, service[0])
-					if val, ok := listenerSvcMapping[svcListener]; ok {
-						listenerSvcMapping[svcListener] = append(val, service[0])
-					} else {
-						listenerSvcMapping[svcListener] = []string{service[0]}
-					}
-				}
-			}
-		}
-
-		var fqdns []string
-		for _, listener := range gw.Spec.Listeners {
-			autoFQDN := true
-			// Honour the hostname if specified corresponding to the listener.
-			if listener.Hostname != nil && string(*listener.Hostname) != "" {
-				fqdns = append(fqdns, string(*listener.Hostname))
-				autoFQDN = false
-			}
-
-			subDomains := GetDefaultSubDomain()
-			if subDomains != nil && autoFQDN {
-				services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
-				for _, service := range services {
-					svcNsName := strings.Split(service, "/")
-					if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
-						fqdns = append(fqdns, fqdn)
-					}
-				}
-			}
-		}
-
-		avi_vs_meta := &AviVsNode{
-			Name:       vsName,
-			Tenant:     lib.GetTenant(),
-			VrfContext: lib.GetVrf(),
-			ServiceMetadata: lib.ServiceMetadataObj{
-				Gateway:   namespace + "/" + gatewayName,
-				HostNames: fqdns,
-			},
-			ServiceEngineGroup: lib.GetSEGName(),
-			EnableRhi:          proto.Bool(lib.GetEnableRHI()),
-		}
-
-		isTCP, isUDP := false, false
-		avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
-		var portProtocols []AviPortHostProtocol
-		for _, listener := range listeners {
-			portProto := strings.Split(listener, "/") // format: protocol/port
-			port, _ := utilsnet.ParsePort(portProto[1], true)
-			pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
-			portProtocols = append(portProtocols, pp)
-			if portProto[0] == "" || portProto[0] == utils.TCP {
-				isTCP = true
-			} else if portProto[0] == utils.UDP {
-				isUDP = true
-			}
-		}
-
-		avi_vs_meta.PortProto = portProtocols
-		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
-
-		// In case the VS has services that are a mix of TCP and UDP sockets,
-		// we create the VS with global network profile TCP Fast Path,
-		// and override required services with UDP Fast Path. Having a separate
-		// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-		// on existing VSes.
-		if isTCP && !isUDP {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		} else if isUDP && !isTCP {
-			avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-		} else {
-			avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-		}
-
-		vsVipNode := &AviVSVIPNode{
-			Name:        lib.GetL4VSVipName(gatewayName, namespace),
-			Tenant:      lib.GetTenant(),
-			VrfContext:  lib.GetVrf(),
-			FQDNs:       fqdns,
-			VipNetworks: lib.GetVipNetworkList(),
-		}
-
-		if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
-			vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
-		}
-
-		// configures VS and VsVip nodes using infraSetting object (via CRD).
-		if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
-			buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
-		}
-
-		if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
-			vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
-		}
-
-		avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
-		return avi_vs_meta
+	if !found {
+		return nil
 	}
-	return nil
+	vsName := lib.GetL4VSName(gatewayName, namespace)
+	gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gatewayName)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
+		return nil
+	}
+
+	var serviceNSNames []string
+	listenerSvcMapping := make(map[string][]string)
+	if found, services := objects.ServiceGWLister().GetGwToSvcs(namespace + "/" + gatewayName); found {
+		for svcListener, service := range services {
+			// assume it to have only a single backend service, the check is in isGatewayDelete
+			if utils.HasElem(listeners, svcListener) && len(service) == 1 && !utils.HasElem(serviceNSNames, service[0]) {
+				serviceNSNames = append(serviceNSNames, service[0])
+				if val, ok := listenerSvcMapping[svcListener]; ok {
+					listenerSvcMapping[svcListener] = append(val, service[0])
+				} else {
+					listenerSvcMapping[svcListener] = []string{service[0]}
+				}
+			}
+		}
+	}
+
+	var fqdns []string
+	for _, listener := range gw.Spec.Listeners {
+		autoFQDN := true
+		// Honour the hostname if specified corresponding to the listener.
+		if listener.Hostname != nil && string(*listener.Hostname) != "" {
+			fqdns = append(fqdns, string(*listener.Hostname))
+			autoFQDN = false
+		}
+
+		subDomains := GetDefaultSubDomain()
+		if subDomains != nil && autoFQDN {
+			services := listenerSvcMapping[fmt.Sprintf("%s/%d", listener.Protocol, listener.Port)]
+			for _, service := range services {
+				svcNsName := strings.Split(service, "/")
+				if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
+					fqdns = append(fqdns, fqdn)
+				}
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			Gateway:   namespace + "/" + gatewayName,
+			HostNames: fqdns,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	isTCP, isUDP := false, false
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, gatewayName)
+	var portProtocols []AviPortHostProtocol
+	for _, listener := range listeners {
+		portProto := strings.Split(listener, "/") // format: protocol/port
+		port, _ := utilsnet.ParsePort(portProto[1], true)
+		pp := AviPortHostProtocol{Port: int32(port), Protocol: portProto[0]}
+		portProtocols = append(portProtocols, pp)
+		if portProto[0] == "" || portProto[0] == utils.TCP {
+			isTCP = true
+		} else if portProto[0] == utils.UDP {
+			isUDP = true
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	// In case the VS has services that are a mix of TCP and UDP sockets,
+	// we create the VS with global network profile TCP Fast Path,
+	// and override required services with UDP Fast Path. Having a separate
+	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
+	// on existing VSes.
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(gatewayName, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		FQDNs:       fqdns,
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
+		buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
+	}
+
+	if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
+		vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	}
+
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+	return avi_vs_meta
 }
 
 func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, namespace, key string) {
@@ -363,10 +369,10 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			poolNode.AviMarkers = lib.PopulateAdvL4PoolNodeMarkers(namespace, svcNSName[1], gwName, port)
 		}
 
-		pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
+		poolRef := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
 		portPool := AviHostPathPortPoolPG{
 			Port:     uint32(port),
-			Pool:     pool_ref,
+			Pool:     poolRef,
 			Protocol: portProto[0],
 		}
 		portPoolSet = append(portPoolSet, portPool)
@@ -382,6 +388,198 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 		Tenant:     lib.GetTenant(),
 		PortPool:   portPoolSet,
 		AviMarkers: lib.PopulateAdvL4VSNodeMarkers(namespace, gwName),
+	}
+
+	l4Policies = append(l4Policies, l4policyNode)
+	vsNode.L4PolicyRefs = l4Policies
+	utils.AviLog.Infof("key: %s, msg: evaluated L4 pool policies :%v", key, utils.Stringify(vsNode.L4PolicyRefs))
+}
+
+func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, key string) *AviVsNode {
+	namespacedShareVipKey := namespace + "/" + sharedVipKey
+	found, serviceNSNames := objects.SharedlbLister().GetSharedVipKeyToServices(namespacedShareVipKey)
+	if !found {
+		return nil
+	}
+
+	vsName := lib.GetL4VSName(sharedVipKey, namespace)
+
+	var fqdns []string
+	autoFQDN := true
+	subDomains := GetDefaultSubDomain()
+	if subDomains != nil && autoFQDN {
+		for _, service := range serviceNSNames {
+			svcNsName := strings.Split(service, "/")
+			if fqdn := getAutoFQDNForService(svcNsName[0], svcNsName[1]); fqdn != "" {
+				fqdns = append(fqdns, fqdn)
+			}
+		}
+	}
+
+	avi_vs_meta := &AviVsNode{
+		Name:       vsName,
+		Tenant:     lib.GetTenant(),
+		VrfContext: lib.GetVrf(),
+		ServiceMetadata: lib.ServiceMetadataObj{
+			HostNames: fqdns,
+		},
+		ServiceEngineGroup: lib.GetSEGName(),
+		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+	}
+
+	isTCP, isUDP := false, false
+	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, sharedVipKey)
+	var portProtocols []AviPortHostProtocol
+	var sharedPreferredVIP string
+	for i, serviceNSName := range serviceNSNames {
+		svcNSName := strings.Split(serviceNSName, "/")
+		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
+		if err != nil {
+			utils.AviLog.Debugf("key: %s, msg: there was an error in retrieving the service", key)
+			return nil
+		}
+
+		if i == 0 {
+			sharedPreferredVIP = svcObj.Spec.LoadBalancerIP
+		}
+
+		for _, listener := range svcObj.Spec.Ports {
+			protocol := string(listener.Protocol)
+			pp := AviPortHostProtocol{Port: listener.Port, Protocol: protocol}
+			portProtocols = append(portProtocols, pp)
+			if protocol == "" || protocol == utils.TCP {
+				isTCP = true
+			} else if protocol == utils.UDP {
+				isUDP = true
+			}
+		}
+	}
+
+	avi_vs_meta.PortProto = portProtocols
+	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	if isTCP && !isUDP {
+		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+	} else if isUDP && !isTCP {
+		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
+	} else {
+		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
+	}
+
+	vsVipNode := &AviVSVIPNode{
+		Name:        lib.GetL4VSVipName(sharedVipKey, namespace),
+		Tenant:      lib.GetTenant(),
+		VrfContext:  lib.GetVrf(),
+		FQDNs:       fqdns,
+		VipNetworks: lib.GetVipNetworkList(),
+	}
+
+	if sharedPreferredVIP != "" {
+		vsVipNode.IPAddress = sharedPreferredVIP
+	}
+
+	if avi_vs_meta.EnableRhi != nil && *avi_vs_meta.EnableRhi {
+		vsVipNode.BGPPeerLabels = lib.GetGlobalBgpPeerLabels()
+	}
+
+	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	// if infraSetting, err := getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName); err == nil {
+	// 	buildWithInfraSetting(key, avi_vs_meta, vsVipNode, infraSetting)
+	// }
+
+	// if len(gw.Spec.Addresses) > 0 && gw.Spec.Addresses[0].Type == svcapiv1alpha1.IPAddressType {
+	// 	vsVipNode.IPAddress = gw.Spec.Addresses[0].Value
+	// }
+
+	avi_vs_meta.VSVIPRefs = append(avi_vs_meta.VSVIPRefs, vsVipNode)
+
+	o.ConstructSharedVipPolPoolNodes(avi_vs_meta, sharedVipKey, namespace, key)
+	return avi_vs_meta
+}
+
+func (o *AviObjectGraph) ConstructSharedVipPolPoolNodes(vsNode *AviVsNode, sharedVipKey, namespace, key string) {
+	namespacedShareVipKey := namespace + "/" + sharedVipKey
+	found, serviceNSNames := objects.SharedlbLister().GetSharedVipKeyToServices(namespacedShareVipKey)
+	if !found {
+		return
+	}
+
+	var l4Policies []*AviL4PolicyNode
+	// var infraSetting *v1alpha1.AviInfraSetting
+	// if lib.UseServicesAPI() {
+	// 	gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
+	// 	if err != nil {
+	// 		utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for services APIs : %s", err)
+	// 		return
+	// 	}
+	// 	// configures VS and VsVip nodes using infraSetting object (via CRD).
+	// 	infraSetting, err = getL4InfraSetting(key, nil, &gw.Spec.GatewayClassName)
+	// 	if err != nil {
+	// 		utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Gateway %s", key, err.Error())
+	// 		return
+	// 	}
+	// }
+
+	var portPoolSet []AviHostPathPortPoolPG
+	for _, serviceNSName := range serviceNSNames {
+		svcNSName := strings.Split(serviceNSName, "/")
+		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
+		if err != nil {
+			utils.AviLog.Debugf("key: %s, msg: there was an error in retrieving the service", key)
+			return
+		}
+
+		for _, listener := range svcObj.Spec.Ports {
+			protocol := string(listener.Protocol)
+			port := listener.Port
+
+			var svcFQDN string
+			if lib.GetL4FqdnFormat() != lib.AutoFQDNDisabled && svcFQDN == "" {
+				svcFQDN = getAutoFQDNForService(svcNSName[0], svcNSName[1])
+			}
+
+			poolName := lib.GetSvcApiL4PoolName(svcNSName[1], namespace, sharedVipKey, protocol, port)
+			poolNode := &AviPoolNode{
+				Name:     poolName,
+				Tenant:   lib.GetTenant(),
+				Protocol: protocol,
+				PortName: listener.Name,
+				ServiceMetadata: lib.ServiceMetadataObj{
+					NamespaceServiceName: []string{serviceNSName},
+				},
+				VrfContext: lib.GetVrf(),
+			}
+			poolNode.NetworkPlacementSettings, _ = lib.GetNodeNetworkMap()
+
+			if svcFQDN != "" {
+				poolNode.ServiceMetadata.HostNames = []string{svcFQDN}
+			}
+
+			if servers := PopulateServers(poolNode, svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, false, key); servers != nil {
+				poolNode.Servers = servers
+			}
+
+			poolNode.AviMarkers = lib.PopulateSvcApiL4PoolNodeMarkers(namespace, svcNSName[1], sharedVipKey, protocol, int(port))
+			poolRef := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
+			portPool := AviHostPathPortPoolPG{
+				Port:     uint32(port),
+				Pool:     poolRef,
+				Protocol: protocol,
+			}
+			portPoolSet = append(portPoolSet, portPool)
+
+			// buildPoolWithInfraSetting(key, poolNode, infraSetting)
+
+			vsNode.PoolRefs = append(vsNode.PoolRefs, poolNode)
+			utils.AviLog.Infof("key: %s, msg: evaluated L4 pool values :%v", key, utils.Stringify(poolNode))
+		}
+	}
+
+	l4policyNode := &AviL4PolicyNode{
+		Name:       vsNode.Name,
+		Tenant:     lib.GetTenant(),
+		PortPool:   portPoolSet,
+		AviMarkers: lib.PopulateAdvL4VSNodeMarkers(namespace, sharedVipKey),
 	}
 
 	l4Policies = append(l4Policies, l4policyNode)

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -139,7 +139,7 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 	for _, portProto := range vsNode.PortProto {
 		filterPort := portProto.Port
 		poolNode := &AviPoolNode{
-			Name:       lib.GetL4PoolName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace, filterPort),
+			Name:       lib.GetL4PoolName(svcObj.ObjectMeta.Name, svcObj.ObjectMeta.Namespace, portProto.Protocol, filterPort),
 			Tenant:     lib.GetTenant(),
 			Protocol:   portProto.Protocol,
 			PortName:   portProto.Name,

--- a/internal/objects/lbservices.go
+++ b/internal/objects/lbservices.go
@@ -25,15 +25,23 @@ var lbonce sync.Once
 
 func SharedlbLister() *lbLister {
 	lbonce.Do(func() {
-		lbStore := NewObjectMapStore()
-		lbinstance = &lbLister{}
-		lbinstance.lbStore = lbStore
+		lbinstance = &lbLister{
+			lbStore:                     NewObjectMapStore(),
+			sharedVipKeyToServicesStore: NewObjectMapStore(),
+			serviceToSharedVipKeyStore:  NewObjectMapStore(),
+		}
 	})
 	return lbinstance
 }
 
 type lbLister struct {
 	lbStore *ObjectMapStore
+
+	// annotationKey -> [svc1, svc2, svc3]
+	sharedVipKeyToServicesStore *ObjectMapStore
+
+	// svc1 -> annotationKey
+	serviceToSharedVipKeyStore *ObjectMapStore
 }
 
 func (a *lbLister) Save(svcName string, lb interface{}) {
@@ -53,5 +61,49 @@ func (a *lbLister) GetAll() interface{} {
 
 func (a *lbLister) Delete(svcName string) {
 	a.lbStore.Delete(svcName)
+}
 
+func (a *lbLister) UpdateSharedVipKeyServiceMappings(key, svc string) {
+	a.serviceToSharedVipKeyStore.AddOrUpdate(svc, key)
+	found, services := a.GetSharedVipKeyToServices(key)
+	if found {
+		if utils.HasElem(services, svc) {
+			return
+		}
+		services = append(services, svc)
+		a.sharedVipKeyToServicesStore.AddOrUpdate(key, services)
+		return
+	}
+	a.sharedVipKeyToServicesStore.AddOrUpdate(key, []string{svc})
+}
+
+func (a *lbLister) RemoveSharedVipKeyServiceMappings(svc string) bool {
+	if found, key := a.GetServiceToSharedVipKey(svc); found {
+		if foundServices, services := a.GetSharedVipKeyToServices(key); foundServices {
+			services = utils.Remove(services, svc)
+			if len(services) == 0 {
+				a.sharedVipKeyToServicesStore.Delete(key)
+			} else {
+				a.sharedVipKeyToServicesStore.AddOrUpdate(key, services)
+			}
+		}
+	}
+	a.serviceToSharedVipKeyStore.Delete(svc)
+	return true
+}
+
+func (a *lbLister) GetSharedVipKeyToServices(key string) (bool, []string) {
+	found, serviceList := a.sharedVipKeyToServicesStore.Get(key)
+	if !found {
+		return false, make([]string, 0)
+	}
+	return true, serviceList.([]string)
+}
+
+func (a *lbLister) GetServiceToSharedVipKey(svc string) (bool, string) {
+	found, key := a.serviceToSharedVipKeyStore.Get(svc)
+	if !found {
+		return false, ""
+	}
+	return true, key.(string)
 }

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -217,8 +217,7 @@ func (rest *RestOperations) AviPoolDel(uuid string, tenant string, key string) *
 		Tenant: tenant,
 		Model:  "Pool",
 	}
-	utils.AviLog.Info(spew.Sprintf("key: %s, msg: pool DELETE Restop %v ", key,
-		utils.Stringify(rest_op)))
+	utils.AviLog.Infof("key: %s, msg: pool DELETE Restop %v ", key, utils.Stringify(rest_op))
 	return &rest_op
 }
 
@@ -354,14 +353,12 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 					}
 				}
 			}
-
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToPoolKeyCollection(k)
-			utils.AviLog.Debug(spew.Sprintf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey,
-				vs_cache_obj))
+			utils.AviLog.Debugf("key: %s, msg: added VS cache key during pool update %v val %v", key, vsKey, utils.Stringify(vs_cache_obj))
 		}
-		utils.AviLog.Info("key: %s, msg: Added Pool cache k %v val %v", key, k, utils.Stringify(pool_cache_obj))
+		utils.AviLog.Infof("key: %s, msg: Added Pool cache k %v val %v", key, k, utils.Stringify(pool_cache_obj))
 	}
 
 	return nil

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -589,8 +589,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		} else {
 			vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 			vs_cache_obj.AddToVSVipKeyCollection(k)
-			utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey,
-				vs_cache_obj))
+			utils.AviLog.Infof("key: %s, msg: added VS cache key during vsvip update %v val %v", key, vsKey, utils.Stringify(vs_cache_obj))
 			if rest_op.Method == utils.RestPut {
 				if len(vs_cache_obj.SNIChildCollection) > 0 {
 					for _, childUuid := range vs_cache_obj.SNIChildCollection {

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -545,7 +545,7 @@ func deleteRouteObject(option UpdateOptions, key string, isVSDelete bool, retryN
 
 	oldRouteStatus := mRoute.Status.DeepCopy()
 	if len(option.ServiceMetadata.HostNames) > 0 {
-		// If the route status for the host is already fasle, then don't delete the status
+		// If the route status for the host is already false, then don't delete the status
 		if !routeStatusCheck(key, oldRouteStatus.Ingress, option.ServiceMetadata.HostNames[0]) {
 			return nil
 		}

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -304,7 +304,7 @@ func TestL4NamingConvention(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.ContainSubstring("cluster--red-ns-testsvcmulti--808"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.ContainSubstring("cluster--red-ns-testsvcmulti-TCP-808"))
 	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
 	g.Expect(nodes[0].L4PolicyRefs[0].Name).To(gomega.Equal("cluster--red-ns-testsvcmulti"))
 
@@ -417,7 +417,7 @@ func TestCreateServiceLBCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", NAMESPACE, SINGLEPORTSVC)))
 		g.Expect(vsCacheObj.Tenant).To(gomega.Equal(AVINAMESPACE))
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc-TCP-8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
@@ -491,7 +491,7 @@ func TestCreateServiceLBWithFaultCacheSync(t *testing.T) {
 		g.Expect(vsCacheObj.Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", NAMESPACE, SINGLEPORTSVC)))
 		g.Expect(vsCacheObj.Tenant).To(gomega.Equal(AVINAMESPACE))
 		g.Expect(vsCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
-		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc--8080"))
+		g.Expect(vsCacheObj.PoolKeyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc-TCP-8080"))
 		g.Expect(vsCacheObj.L4PolicyCollection).To(gomega.HaveLen(1))
 		g.Expect(vsCacheObj.L4PolicyCollection[0].Name).To(gomega.MatchRegexp("cluster--red-ns-testsvc"))
 	}
@@ -532,7 +532,7 @@ func TestUpdateAndDeleteServiceLBCacheSync(t *testing.T) {
 	SetUpTestForSvcLB(t)
 
 	// Get hold of the pool checksum on CREATE
-	poolName := "cluster--red-ns-testsvc--8080"
+	poolName := "cluster--red-ns-testsvc-TCP-8080"
 	mcache := cache.SharedAviObjCache()
 	poolKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: poolName}
 	poolCacheBefore, _ := mcache.PoolCache.AviCacheGet(poolKey)


### PR DESCRIPTION
* Add support for Shared VIP with Service of type LoadBalancer

cache fixes, transition between lb svc <-> sharevip lb service fixed

* Support for preferred VIP in SharedVIP Service of type LB

This commit is also taking care o Endpoint updates for respective
service of type LB in a shared VIP scenario.

* Fix for annotation add/remove/update transitions for SvcLB SharedVIP

This adds fix for transition cases wherein the annotation for
SharedVIP among Service of Type LBs ios added or removed.
This also updates the naming convention for L4 Pools to
incorporate Protocol used as well. This will be helpful when
Service of Type LBs can provide different protocol on the same
Port (think DNS - TCP/UDP 53). Services can declare different
protocols with same port when MixedProtocolLBService is enabled
in the kubernetes cluster.