### PR TITLE
Removes the shortname of clustersets

### DIFF
--- a/helm/ako/crds/ako.vmware.com_clustersets.yaml
+++ b/helm/ako/crds/ako.vmware.com_clustersets.yaml
@@ -10,8 +10,6 @@ spec:
     kind: ClusterSet
     listKind: ClusterSetList
     plural: clustersets
-    shortNames:
-    - cs
     singular: clusterset
   scope: Namespaced
 


### PR DESCRIPTION
This PR removes the shortname of clustersets as it was conflicting with shortname of ComponentStatus API.