### PR TITLE
L4 Shared VIP Infrasetting: Error out if all L4 VS does not have same avi-infra annotation

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.7.1",
+    "version": "1.7.2",
     "avi": {
         "maxVersion": "21.1.4",
         "minVersion": "20.1.5"

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -499,8 +499,8 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 			break
 		}
 
-		if infraSettingAnnotation, ok := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok &&
-			(infraSettingAnnotation == "" || infraSettingAnnotation != sharedVipInfraSetting) {
+		infraSettingAnnotation, _ := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]
+		if i != 0 && infraSettingAnnotation != sharedVipInfraSetting {
 			utils.AviLog.Errorf("Service AviInfraSetting annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, infraSettingAnnotation, serviceNSNames[0], sharedVipInfraSetting)
 			isShareVipKeyDelete = true
 			break

--- a/version.yaml
+++ b/version.yaml
@@ -1,4 +1,4 @@
 major: 1
 minor: 7
-maintenance: 1
+maintenance: 2
 patch: null


### PR DESCRIPTION
[AV-149725]:  L4 Shared VIP Infrasetting: Error out if all L4 VS does not have same avi-infra annotation