### PR TITLE
Regression fix: Change L4 checksum as naming convention for L4 pool is changed in 1.7.1

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1091,6 +1091,14 @@ func PopulateL4VSNodeMarkers(namespace, serviceName string) utils.AviObjectMarke
 	return markers
 }
 
+func PopulateL4PolicysetMarkers(namespace, serviceName string, protocols string) utils.AviObjectMarkers {
+	var markers utils.AviObjectMarkers
+	markers.Namespace = namespace
+	markers.ServiceName = serviceName
+	markers.Protocol = protocols
+	return markers
+}
+
 func PopulateAdvL4VSNodeMarkers(namespace, gatewayName string) utils.AviObjectMarkers {
 	var markers utils.AviObjectMarkers
 	markers.Namespace = namespace

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -389,6 +389,7 @@ type AviVsNode struct {
 	IngressNames          []string
 	AnalyticsPolicy       *avimodels.AnalyticsPolicy
 	Dedicated             bool
+	IsL4VS                bool
 }
 
 // Implementing AviVsEvhSniModel
@@ -869,6 +870,12 @@ func (v *AviVsNode) CalculateCheckSum() {
 
 	for _, vhdomain := range v.VHDomainNames {
 		checksumStringSlice = append(checksumStringSlice, "VHDomain"+vhdomain)
+	}
+	if v.IsL4VS {
+		// As pool naming convention changed in 1.7.1, added pool name to checksum calculation
+		for _, poolref := range v.PoolRefs {
+			checksumStringSlice = append(checksumStringSlice, "Pool"+poolref.Name)
+		}
 	}
 
 	// Note: Changing the order of strings being appended, while computing vsRefs and checksum,


### PR DESCRIPTION
AV-149730: This PR addresses following issue:

Naming convention of L4 pool is changed in 1.7.1.  `protocol` field has been added as part of pool name. But as checksum was not getting changed for `VirtualService` and `L4PolicySet`, new pools were not getting referenced in L4policyset and Virtual Service. Also as old pools were attached to VS and L4 Policyset, old pools also were not getting deleted.

