### PR TITLE
AV-149930 Fix named ports with Ingress

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -30,7 +30,6 @@ import (
 	avimodels "github.com/vmware/alb-sdk/go/models"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -842,7 +841,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForEVH(vsNode []*AviEvhVsNode, childN
 			Tenant:     lib.GetTenant(),
 			VrfContext: lib.GetVrf(),
 			Port:       path.Port,
-			TargetPort: intstr.FromInt(int(path.TargetPort)),
+			TargetPort: path.TargetPort,
 			ServiceMetadata: lib.ServiceMetadataObj{
 				IngressName: ingName,
 				Namespace:   namespace,

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -26,7 +26,6 @@ import (
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -308,7 +307,7 @@ func buildPoolNode(key, poolName, ingName, namespace, priorityLabel, hostname st
 		Tenant:        lib.GetTenant(),
 		PriorityLabel: priorityLabel,
 		Port:          obj.Port,
-		TargetPort:    intstr.FromInt(int(obj.TargetPort)),
+		TargetPort:    obj.TargetPort,
 		ServiceMetadata: lib.ServiceMetadataObj{
 			IngressName:           ingName,
 			Namespace:             namespace,

--- a/internal/nodes/avi_model_l7_translator.go
+++ b/internal/nodes/avi_model_l7_translator.go
@@ -26,7 +26,6 @@ import (
 	avimodels "github.com/vmware/alb-sdk/go/models"
 	"google.golang.org/protobuf/proto"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -409,7 +408,7 @@ func (o *AviObjectGraph) BuildPolicyPGPoolsForSNI(vsNode []*AviVsNode, tlsNode *
 				Tenant:        lib.GetTenant(),
 				PriorityLabel: priorityLabel,
 				Port:          path.Port,
-				TargetPort:    intstr.FromInt(int(path.TargetPort)),
+				TargetPort:    path.TargetPort,
 				ServiceMetadata: lib.ServiceMetadataObj{
 					IngressName: ingName,
 					Namespace:   namespace,

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1516,7 +1516,7 @@ type IngressHostPathSvc struct {
 	Port           int32
 	weight         int32 //required for alternate backends in openshift route
 	PortName       string
-	TargetPort     int32
+	TargetPort     intstr.IntOrString
 	clusterContext string // required for Multi-cluster ingress
 	svcNamespace   string // required for Multi-cluster ingress
 }

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
@@ -145,7 +143,7 @@ func (o *AviObjectGraph) BuildGraphForPassthrough(svclist []IngressHostPathSvc, 
 		poolNode.IngressName = objName
 		poolNode.PortName = obj.PortName
 		poolNode.Port = obj.Port
-		poolNode.TargetPort = intstr.FromInt(int(obj.TargetPort))
+		poolNode.TargetPort = obj.TargetPort
 		poolNode.ServiceMetadata = lib.ServiceMetadataObj{
 			IngressName: objName, Namespace: namespace, PoolRatio: obj.weight,
 			HostNames: []string{hostname},

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -34,6 +34,7 @@ import (
 	advl4v1alpha1pre1 "github.com/vmware-tanzu/service-apis/apis/v1alpha1pre1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -237,7 +238,7 @@ func SetupAdvLBService(t *testing.T, svcname, namespace, gwname, gwnamespace str
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}
 
 	svcCreate := svc.Service()
@@ -547,7 +548,7 @@ func TestAdvL4ProtocolChangeInService(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -602,7 +603,7 @@ func TestAdvL4PortChangeInService(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -656,7 +657,7 @@ func TestAdvL4LabelUpdatesInService(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -799,7 +800,7 @@ func TestAdvL4GatewayListenerPortUpdate(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -889,7 +890,7 @@ func TestAdvL4GatewayListenerProtocolUpdate(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -952,7 +953,7 @@ func TestAdvL4MultiGatewayServiceUpdate(t *testing.T) {
 			lib.GatewayTypeLabelKey:      "direct",
 		},
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func VerifyEvhPoolDeletion(t *testing.T, g *gomega.WithT, aviModel interface{}, poolCount int) {
@@ -240,7 +241,7 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 
 	_, err := KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})

--- a/tests/evhtests/l7_evh_rest_test.go
+++ b/tests/evhtests/l7_evh_rest_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
@@ -311,7 +312,7 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "3"
 	_, err = KubeClient.CoreV1().Services("default").Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -328,7 +329,7 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "4"
 	_, err = KubeClient.CoreV1().Services("default").Update(context.TODO(), svcExample, metav1.UpdateOptions{})

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/vmware/alb-sdk/go/models"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -316,7 +317,7 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 
 	_, err := KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})

--- a/tests/ingresstests/l7_nodeport_test.go
+++ b/tests/ingresstests/l7_nodeport_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func SetUpTestForIngressInNodePortMode(t *testing.T, model_Name string) {
@@ -108,7 +109,7 @@ func TestMultiIngressToSameClusterIPSvcInNodePort(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 
 	_, err := KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})
@@ -285,7 +286,7 @@ func TestMultiIngressToSameNodePortSvcInNodePort(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeNodePort,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080, NodePort: nodePort}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080), NodePort: nodePort}},
 	}).Service()
 
 	_, err := KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})

--- a/tests/ingresstests/l7_rest_test.go
+++ b/tests/ingresstests/l7_rest_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func SetupDomain() {
@@ -287,7 +288,7 @@ func TestUpdatePoolCacheSync(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "3"
 	_, err = KubeClient.CoreV1().Services("default").Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -304,7 +305,7 @@ func TestUpdatePoolCacheSync(t *testing.T) {
 		Name:         "avisvc",
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "4"
 	_, err = KubeClient.CoreV1().Services("default").Update(context.TODO(), svcExample, metav1.UpdateOptions{})

--- a/tests/integrationtest/l4_nodeport_service_test.go
+++ b/tests/integrationtest/l4_nodeport_service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // TestNodeAddInNodePortMode tests if VRF creation is skipped in NodePort mode for node addition
@@ -79,7 +80,7 @@ func TestSinglePortL4SvcNodePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "2"
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -97,7 +98,7 @@ func TestSinglePortL4SvcNodePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080, NodePort: 31031}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080), NodePort: 31031}},
 	}).Service()
 	svcExample.ResourceVersion = "3"
 	_, err = KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -146,7 +147,7 @@ func TestSinglePortL4SvcSkipNodePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080, NodePort: 31031}},
+		ServicePorts: []Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080), NodePort: 31031}},
 		Annotations:  skipNodePort,
 	}).Service()
 	svcExample.ResourceVersion = "3"
@@ -166,7 +167,7 @@ func TestSinglePortL4SvcSkipNodePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080, NodePort: 31031}},
+		ServicePorts: []Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080), NodePort: 31031}},
 		Annotations:  skipNodePort,
 	}).Service()
 	svcExample.ResourceVersion = "4"

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -174,7 +175,7 @@ func TestAviSvcCreationSinglePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "2"
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -192,7 +193,7 @@ func TestAviSvcCreationSinglePort(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.ResourceVersion = "3"
 	_, err = KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcExample, metav1.UpdateOptions{})
@@ -671,7 +672,7 @@ func TestAviSvcCreationWithStaticIP(t *testing.T) {
 		Namespace:      NAMESPACE,
 		Type:           corev1.ServiceTypeLoadBalancer,
 		LoadBalancerIP: staticIP,
-		ServicePorts:   []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts:   []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcExample, metav1.CreateOptions{})
 	if err != nil {
@@ -708,7 +709,7 @@ func TestWithInfraSettingStatusUpdates(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.Annotations = map[string]string{lib.InfraSettingNameAnnotation: settingName}
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcExample, metav1.CreateOptions{})
@@ -850,7 +851,7 @@ func TestInfraSettingDelete(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.Annotations = map[string]string{lib.InfraSettingNameAnnotation: settingName}
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcExample, metav1.CreateOptions{})
@@ -908,7 +909,7 @@ func TestInfraSettingChangeMapping(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.Annotations = map[string]string{lib.InfraSettingNameAnnotation: settingName1}
 	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcExample, metav1.CreateOptions{})
@@ -938,7 +939,7 @@ func TestInfraSettingChangeMapping(t *testing.T) {
 		Name:         SINGLEPORTSVC,
 		Namespace:    NAMESPACE,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcUpdate.Annotations = map[string]string{lib.InfraSettingNameAnnotation: settingName2}
 	svcUpdate.ResourceVersion = "2"

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -615,7 +615,7 @@ type Serviceport struct {
 	PortNumber int32
 	NodePort   int32
 	Protocol   corev1.Protocol
-	TargetPort int
+	TargetPort intstr.IntOrString
 }
 
 func (svc FakeService) Service() *corev1.Service {
@@ -625,7 +625,7 @@ func (svc FakeService) Service() *corev1.Service {
 			Name:       svcport.PortName,
 			Port:       svcport.PortNumber,
 			Protocol:   svcport.Protocol,
-			TargetPort: intstr.FromInt(svcport.TargetPort),
+			TargetPort: svcport.TargetPort,
 			NodePort:   svcport.NodePort,
 		})
 	}
@@ -798,7 +798,7 @@ func ConstructService(ns string, Name string, Type corev1.ServiceType, multiPort
 			PortName:   fmt.Sprintf("foo%d", i),
 			PortNumber: int32(mPort),
 			Protocol:   "TCP",
-			TargetPort: mPort,
+			TargetPort: intstr.FromInt(mPort),
 		}
 		if Type != corev1.ServiceTypeClusterIP {
 			// set nodeport value in case of LoadBalancer and NodePort service type

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/vmware/alb-sdk/go/models"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -632,7 +633,7 @@ func TestNPLLBSvc(t *testing.T) {
 		Name:         integrationtest.SINGLEPORTSVC,
 		Namespace:    defaultNS,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.Annotations = make(map[string]string)
 	svcExample.Annotations[lib.NPLSvcAnnotation] = "true"
@@ -653,7 +654,7 @@ func TestNPLLBSvc(t *testing.T) {
 		Name:         integrationtest.SINGLEPORTSVC,
 		Namespace:    defaultNS,
 		Type:         corev1.ServiceTypeLoadBalancer,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: 8080}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
 	}).Service()
 	svcExample.Annotations = make(map[string]string)
 	svcExample.Annotations[lib.NPLSvcAnnotation] = "true"

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	servicesapi "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
@@ -262,7 +263,7 @@ func SetupSvcApiService(t *testing.T, svcname, namespace, gwname, gwnamespace st
 			lib.SvcApiGatewayNamespaceLabelKey: gwnamespace,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}
 
 	svcCreate := svc.Service()
@@ -568,7 +569,7 @@ func TestServicesAPIProtocolChangeInService(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -622,7 +623,7 @@ func TestServicesAPIPortChangeInService(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -675,7 +676,7 @@ func TestServicesAPILabelUpdatesInService(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -815,7 +816,7 @@ func TestServicesAPIGatewayListenerPortUpdate(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8080, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -903,7 +904,7 @@ func TestServicesAPIGatewayListenerProtocolUpdate(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolUDP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -965,7 +966,7 @@ func TestServicesAPIMultiGatewayServiceUpdate(t *testing.T) {
 			lib.SvcApiGatewayNamespaceLabelKey: ns,
 		},
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: 8081}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo1", Protocol: corev1.ProtocolTCP, PortNumber: 8081, TargetPort: intstr.FromInt(8081)}},
 	}.Service()
 	svcUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.CoreV1().Services(ns).Update(context.TODO(), svcUpdate, metav1.UpdateOptions{}); err != nil {
@@ -1083,7 +1084,7 @@ func TestServicesAPIMultiServiceMultiProtocol(t *testing.T) {
 		Namespace:    ns,
 		Labels:       labels,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8081, TargetPort: 80}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8081, TargetPort: intstr.FromInt(80)}},
 	}
 	if _, err := KubeClient.CoreV1().Services(ns).Create(context.TODO(), svc1.Service(), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Service: %v", err)
@@ -1095,7 +1096,7 @@ func TestServicesAPIMultiServiceMultiProtocol(t *testing.T) {
 		Namespace:    ns,
 		Labels:       labels,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "fooudp", Protocol: "UDP", PortNumber: 8082, TargetPort: 80}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "fooudp", Protocol: "UDP", PortNumber: 8082, TargetPort: intstr.FromInt(80)}},
 	}
 
 	if _, err := KubeClient.CoreV1().Services(ns).Create(context.TODO(), svc2.Service(), metav1.CreateOptions{}); err != nil {
@@ -1180,7 +1181,7 @@ func TestServicesAPISvcHostnameStatusUpdate(t *testing.T) {
 		Namespace:    ns,
 		Labels:       labels,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8081, TargetPort: 80}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8081, TargetPort: intstr.FromInt(80)}},
 	}
 	if _, err := KubeClient.CoreV1().Services(ns).Create(context.TODO(), svc1.Service(), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Service: %v", err)
@@ -1191,7 +1192,7 @@ func TestServicesAPISvcHostnameStatusUpdate(t *testing.T) {
 		Namespace:    ns,
 		Labels:       labels,
 		Type:         corev1.ServiceTypeClusterIP,
-		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8082, TargetPort: 80}},
+		ServicePorts: []integrationtest.Serviceport{{PortName: "footcp", Protocol: "TCP", PortNumber: 8082, TargetPort: intstr.FromInt(80)}},
 	}
 	if _, err := KubeClient.CoreV1().Services(ns).Create(context.TODO(), svc2.Service(), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Service: %v", err)


### PR DESCRIPTION
Fixes the servers not being added to pool for ingress with named ports

testing done:
on AKO with serviceType as NodePortLocal, created an ingress with named ports. 

result:
servers got added to pool