### PR TITLE
Fix for the issue `Predefined health monitors are not assigned to a pool` 

### DIFF
--- a/pkg/apis/ako/v1alpha1/aviinfrasetting.go
+++ b/pkg/apis/ako/v1alpha1/aviinfrasetting.go
@@ -68,7 +68,7 @@ type AviInfraL7Settings struct {
 // AviInfraSettingStatus holds the status of the AviInfraSetting
 type AviInfraSettingStatus struct {
 	Status string `json:"status,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Error  string `json:"error"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/ako/v1alpha1/httprule.go
+++ b/pkg/apis/ako/v1alpha1/httprule.go
@@ -64,7 +64,7 @@ type HTTPRuleTLS struct {
 // HTTPRuleStatus holds the status of the HTTPRule
 type HTTPRuleStatus struct {
 	Status string `json:"status,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Error  string `json:"error"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/tests/dedicatedvstests/l7_dedicated_crd_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_crd_test.go
@@ -78,6 +78,7 @@ func TestHostruleFQDNAliasesForDedicatedVS(t *testing.T) {
 	aliases := []string{"alias1.com", "alias2.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -102,6 +103,7 @@ func TestHostruleFQDNAliasesForDedicatedVS(t *testing.T) {
 	// Append one more alias and check whether it is getting added to parent and child VS.
 	aliases = append(aliases, "alias3.com")
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -126,6 +128,7 @@ func TestHostruleFQDNAliasesForDedicatedVS(t *testing.T) {
 	// Remove one alias from hostrule and check whether its reference is removed properly.
 	aliases = aliases[1:]
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "4"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -595,6 +595,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 		LogAllHeaders: &enabled,
 	}
 	hrUpdate.Spec.VirtualHost.AnalyticsPolicy = analyticsPolicy
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -622,6 +623,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 
 	// Remove the analytics Policy and check whether it is removed from VS.
 	hrUpdate.Spec.VirtualHost.AnalyticsPolicy = nil
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -698,6 +700,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 	aliases := []string{"alias1.com", "alias2.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -722,6 +725,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 	// Append one more alias and check whether it is getting added to parent and child VS.
 	aliases = append(aliases, "alias3.com")
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -746,6 +750,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 	// Remove one alias from hostrule and check whether its reference is removed properly.
 	aliases = aliases[1:]
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "4"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -810,6 +815,7 @@ func TestHostruleFQDNAliasesForMultiPathIngressEvh(t *testing.T) {
 	aliases := []string{"alias1.foo.com", "alias2.foo.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Create(context.TODO(), hrUpdate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)

--- a/tests/ingresstests/crd_test.go
+++ b/tests/ingresstests/crd_test.go
@@ -639,6 +639,7 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 		LogAllHeaders: &enabled,
 	}
 	hrUpdate.Spec.VirtualHost.AnalyticsPolicy = analyticsPolicy
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -666,6 +667,7 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 
 	// Remove the analyticPolicy and check whether values are removed from VS
 	hrUpdate.Spec.VirtualHost.AnalyticsPolicy = nil
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -737,6 +739,7 @@ func TestHostruleFQDNAliases(t *testing.T) {
 	aliases := []string{"alias1.com", "alias2.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -761,6 +764,7 @@ func TestHostruleFQDNAliases(t *testing.T) {
 	// Append one more alias and check whether it is getting added to parent and child VS.
 	aliases = append(aliases, "alias3.com")
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -785,6 +789,7 @@ func TestHostruleFQDNAliases(t *testing.T) {
 	// Remove one alias from hostrule and check whether its reference is removed properly.
 	aliases = aliases[1:]
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "4"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -851,6 +856,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 	aliases := []string{"alias1.com", "alias1.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -863,6 +869,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 	// Update host rule with aliases that contains FQDN
 	aliases = []string{"foo.com", "alias1.com"}
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "3"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -875,6 +882,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 	// Update host rule with aliases that contains GSLB FQDN
 	aliases = []string{"bar.com", "alias1.com"}
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "4"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -888,6 +896,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 	aliases = []string{"bar.com", "alias1.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Contains
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "5"
 	_, err = CRDClient.AkoV1alpha1().HostRules("default").Update(context.TODO(), hrUpdate, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)
@@ -961,6 +970,7 @@ func TestHostruleFQDNAliasesForMultiPathIngress(t *testing.T) {
 	aliases := []string{"alias1.foo.com", "alias2.foo.com"}
 	hrUpdate.Spec.VirtualHost.FqdnType = v1alpha1.Exact
 	hrUpdate.Spec.VirtualHost.Aliases = aliases
+	hrUpdate.ResourceVersion = "2"
 	_, err := CRDClient.AkoV1alpha1().HostRules("default").Create(context.TODO(), hrUpdate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in updating HostRule: %v", err)


### PR DESCRIPTION
AV-143438: Cherrypicks the fix added in the master branch to the release-1.7.2 branch.