### PR TITLE
AV-149966 set vrf to global in nodeport

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -3109,11 +3109,20 @@ func checkNodeNetwork(client *clients.AviClient, returnErr *error) bool {
 
 func checkAndSetVRFFromNetwork(client *clients.AviClient, returnErr *error) bool {
 	if lib.IsPublicCloud() {
-		// Need not set VRFContext for public clouds.
+		if lib.GetCloudType() == lib.CLOUD_OPENSTACK {
+			if lib.GetTenant() == lib.GetAdminTenant() {
+				lib.SetVrf(utils.GlobalVRF)
+			} else {
+				lib.SetVrf(lib.GetTenant() + "-default")
+			}
+		} else {
+			lib.SetVrf(utils.GlobalVRF)
+		}
 		return true
 	}
 	if lib.IsNodePortMode() {
 		utils.AviLog.Infof("Using global VRF for NodePort mode")
+		lib.SetVrf(utils.GlobalVRF)
 		return true
 	}
 

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -563,11 +563,7 @@ func GetVrfUuid() string {
 
 func GetVrf() string {
 	if VRFContext == "" {
-		if GetTenant() == GetAdminTenant() {
-			return utils.GlobalVRF
-		} else {
-			return GetTenant() + "-default"
-		}
+		return utils.GlobalVRF
 	}
 	return VRFContext
 }


### PR DESCRIPTION
For all public clouds except openstack, use global vrf
for openstack, use tenant vrf for non admin tenant, and use global vrf otherwise

for nodeport mode, use global vrf always

in AV-149966, AKO used tenant vrf through getVrf because setting global vrf was skipped in checkAndSetVRFFromNetwork in nodeport mode