### PR TITLE
Fix HttpRule: Remove mandatory check for DestCA and PkiProfile

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_httprules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_httprules.yaml
@@ -69,11 +69,6 @@ spec:
                           enum:
                           - reencrypt
                           type: string
-                      oneOf:
-                        - required:
-                          - destinationCA
-                        - required:
-                          - pkiProfile
                       required:
                       - type
                       type: object

--- a/helm/ako/crds/ako.vmware.com_httprules.yaml
+++ b/helm/ako/crds/ako.vmware.com_httprules.yaml
@@ -69,11 +69,6 @@ spec:
                           enum:
                           - reencrypt
                           type: string
-                      oneOf:
-                        - required:
-                          - destinationCA
-                        - required:
-                          - pkiProfile
                       required:
                       - type
                       type: object

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -965,6 +965,14 @@ func checkRefOnController(key, refKey, refValue string) error {
 func validateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
 	refData := make(map[string]string)
 	for _, path := range httprule.Spec.Paths {
+		if path.TLS.PKIProfile != "" && path.TLS.DestinationCA != "" {
+			//if both pkiProfile and destCA set, reject httprule
+			status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
+				Status: lib.StatusRejected,
+				Error:  lib.HttpRulePkiAndDestCASetErr,
+			})
+			return fmt.Errorf("key: %s, msg: %s", key, lib.HttpRulePkiAndDestCASetErr)
+		}
 		refData[path.TLS.SSLProfile] = "SslProfile"
 		refData[path.ApplicationPersistence] = "ApplicationPersistence"
 		if path.TLS.PKIProfile != "" {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -172,6 +172,7 @@ const (
 	IPAMProviderInfoblox                       = "IPAMDNS_TYPE_INFOBLOX"
 	IPAMProviderCustom                         = "IPAMDNS_TYPE_CUSTOM"
 	SharedVipServiceKey                        = "SharedVipService"
+	HttpRulePkiAndDestCASetErr                 = "PKIProfile and DestinationCA fields are set in the HTTPRule. Only one of the field should be set."
 
 	// AKO Event constants
 	AKOEventComponent      = "avi-kubernetes-operator"


### PR DESCRIPTION
This PR fixes mandatory check "to have destinationCA or pkiProfile in tls setting section for httprule". It also adds validation to have only pkiprofile or destinationCA in rule.

Testing Done:
1. Httprule without pkiprofile or  destinationCA -->Accepted
2. Httprule with pkiprofile --> Accepted
3. httprule with destinationCA --> Accepted
4. httprule with destinationCA and pkiProfile --> rule Rejected