### PR TITLE
Sets the client-go logger as AviLogger

### DIFF
--- a/ako-infra/ingestion/vcf_k8s_controller.go
+++ b/ako-infra/ingestion/vcf_k8s_controller.go
@@ -233,7 +233,7 @@ func (c *VCFK8sController) handleNamespaceDelete() {
 func (c *VCFK8sController) getWorkloadNamespaceCount() (int, error) {
 	nsList, err := c.informers.NSInformer.Lister().List(labels.Set(nil).AsSelector())
 	if err != nil {
-		utils.AviLog.Error(err)
+		utils.AviLog.Error(nil, err.Error())
 		return 0, err
 	}
 
@@ -336,7 +336,7 @@ func (c *VCFK8sController) HandleVCF(informers K8sinformers, stopCh <-chan struc
 			}
 			utils.AviLog.Warnf("Failed to fetch transportzone from bootstrap CR status")
 		} else {
-			utils.AviLog.Error("AVI controller initialization failed with err: %v", err)
+			utils.AviLog.Errorf("AVI controller initialization failed with err: %v", err)
 		}
 	} else {
 		utils.AviLog.Infof("Got error while fetching avi-secret: %v", err)

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 	svcapi "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 )
 
@@ -65,6 +66,10 @@ func InitializeAKC() {
 	var err error
 	kubeCluster := false
 	utils.AviLog.Info("AKO is running with version: ", version)
+
+	// set the logger for k8s as AviLogger.
+	klog.SetLogger(utils.AviLog)
+
 	// Check if we are running inside kubernetes. Hence try authenticating with service token
 	cfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
+	k8s.io/klog/v2 v2.8.0
 	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/controller-runtime v0.9.6
 	sigs.k8s.io/service-apis v0.1.0

--- a/internal/cache/avi_ctrl_clients.go
+++ b/internal/cache/avi_ctrl_clients.go
@@ -63,7 +63,7 @@ func SharedAVIClients() *utils.AviRestClientPool {
 		connectionStatus = utils.AVIAPI_CONNECTED
 		if err != nil {
 			connectionStatus = utils.AVIAPI_DISCONNECTED
-			utils.AviLog.Error("AVI controller initilization failed")
+			utils.AviLog.Errorf("AVI controller initialization failed")
 			return nil
 		}
 

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2755,7 +2755,7 @@ func DeConfigureSeGroupLabels() {
 	SetTenant := session.SetTenant(lib.GetTenant())
 	seGroup, err := GetAviSeGroup(client, segName)
 	if err != nil {
-		utils.AviLog.Error(err)
+		utils.AviLog.Errorf("Failed to get SE group. Error: %v", err)
 		return
 	}
 	clusterLabel := lib.GetLabels()[0]

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -455,7 +455,7 @@ func (c *AviController) ValidAviSecret() bool {
 			utils.AviLog.Infof("Successfully connected to AVI controller using existing AKO secret")
 			return true
 		} else {
-			utils.AviLog.Error("AVI controller initialization failed with err: %v", err)
+			utils.AviLog.Errorf("AVI controller initialization failed with err: %v", err)
 		}
 	} else {
 		utils.AviLog.Infof("Got error while fetching avi-secret: %v", err)

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -1083,7 +1083,7 @@ func addSeGroupLabel(key, segName string) {
 	// configure labels on SeGroup if not present already.
 	seGroup, err := avicache.GetAviSeGroup(clients.AviClient[aviClientLen], segName)
 	if err != nil {
-		utils.AviLog.Error(err)
+		utils.AviLog.Errorf("Failed to get SE group")
 		return
 	}
 

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -131,7 +131,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 
 			if vsCache != nil && !vsCache.EnableRhi && len(vsvip_meta.BGPPeerLabels) > 0 {
 				err = fmt.Errorf("to use selective vip advertisement, %s VS must advertise vips via BGP. Please recreate the VS", vsCache.Name)
-				utils.AviLog.Error(err)
+				utils.AviLog.Errorf("To use selective vip advertisement, %s VS must advertise vips via BGP. Please recreate the VS", vsCache.Name)
 				return nil, err
 			}
 

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -60,7 +60,7 @@ func UpdateIngressStatus(options []UpdateOptions, bulk bool) {
 	for _, option := range updateIngressOptions {
 		if ingress := ingressMap[option.IngSvc]; ingress != nil {
 			if err = updateObject(ingress, option); err != nil {
-				utils.AviLog.Error("key: %s, msg: updating Ingress object failed: %v", option.Key, err)
+				utils.AviLog.Errorf("key: %s, msg: updating Ingress object failed: %v", option.Key, err)
 			}
 			skipDelete[option.IngSvc] = true
 		}

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -50,8 +51,8 @@ func (aviLogger *AviLogger) Infof(template string, args ...interface{}) {
 	aviLogger.sugar.Infof(template, args...)
 }
 
-func (aviLogger *AviLogger) Info(args ...interface{}) {
-	aviLogger.sugar.Info(args...)
+func (aviLogger AviLogger) Info(msg string, args ...interface{}) {
+	aviLogger.sugar.Info(msg, args)
 }
 
 func (aviLogger *AviLogger) Warnf(template string, args ...interface{}) {
@@ -66,8 +67,8 @@ func (aviLogger *AviLogger) Errorf(template string, args ...interface{}) {
 	aviLogger.sugar.Errorf(template, args...)
 }
 
-func (aviLogger *AviLogger) Error(args ...interface{}) {
-	aviLogger.sugar.Error(args...)
+func (aviLogger AviLogger) Error(err error, msg string, args ...interface{}) {
+	aviLogger.sugar.Error(msg)
 }
 
 func (aviLogger *AviLogger) Debugf(template string, args ...interface{}) {
@@ -89,6 +90,25 @@ func (aviLogger *AviLogger) Fatalf(template string, args ...interface{}) {
 // SetLevel changes loglevel during runtime
 func (aviLogger *AviLogger) SetLevel(l string) {
 	aviLogger.atom.SetLevel(LogLevelMap[l])
+}
+
+func (aviLogger AviLogger) Enabled() bool {
+	return aviLogger.sugar != nil
+}
+
+func (aviLogger AviLogger) V(level int) logr.Logger {
+	return aviLogger
+}
+
+func (aviLogger AviLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	// Not used
+	return &aviLogger
+}
+
+func (aviLogger AviLogger) WithName(name string) logr.Logger {
+	_ = aviLogger.sugar.Named(name)
+	return &aviLogger
+
 }
 
 // log file sample name /log/ako-12345.avi.log
@@ -168,6 +188,4 @@ func init() {
 	sugar := logger.Sugar()
 	defer sugar.Sync()
 	AviLog = AviLogger{sugar, logger, atom}
-
-	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -665,6 +665,7 @@ k8s.io/client-go/util/workqueue
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1
 # k8s.io/klog/v2 v2.8.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
This PR sets the client-go logger as AviLogger, thereby converting all the client-go logs into AviLogger format.
It fixes the bug AV-91662.

Reference: https://github.com/kubernetes/client-go/issues/18#issuecomment-624162529

Tested the changes by removing the hostrule CRD when AKO was running and found the following client-go logs are coming in AviLogger format.

Logs:
```
2022-07-25T18:24:50.870+0530	DEBUG	nodes/avi_model_evh_nodes.go:521	key: Endpoints/default/ew-app, msg: Added hosts [ingress-host-insecure-kubernetes.avi.internal] to HTTP policy for VS kubernetes--c992fe61f72008238aa3fbe1c599bf85696bb212
2022-07-25T18:24:53.871+0530	ERROR	v2/klog.go:914	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s/controller.go:1206: Failed to watch *v1alpha1.HostRule: the server could not find the requested resource (get hostrules.ako.vmware.com)
```
