### PR TITLE
Chery-Pick: L4 Shared VIP Infrasetting: Error out if all L4 VS does not have same avi-infra annotation (#881)

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -1,7 +1,7 @@
 {
     "version": "1.8.1",
     "avi": {
-        "maxVersion": "21.1.3",
+        "maxVersion": "21.1.4",
         "minVersion": "20.1.5"
     },
     "kubernetes": {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -500,8 +500,8 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 			break
 		}
 
-		if infraSettingAnnotation, ok := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok &&
-			(infraSettingAnnotation == "" || infraSettingAnnotation != sharedVipInfraSetting) {
+		infraSettingAnnotation, _ := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]
+		if i != 0 && infraSettingAnnotation != sharedVipInfraSetting {
 			utils.AviLog.Errorf("Service AviInfraSetting annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, infraSettingAnnotation, serviceNSNames[0], sharedVipInfraSetting)
 			isShareVipKeyDelete = true
 			break


### PR DESCRIPTION
Cherry Pick: Fixes [AV-149725] 

* L4 Shared VIP Infrasetting: Error out if all L4 VS does not have same avi-infra annotation

* Change max version supported to 21.1.4 in 1.8.1