### PR TITLE
AviInfrasetting Support to Passthrough Routes

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -369,6 +369,26 @@ func GetL7SharedPGName(vsName string) string {
 	return l7PGName
 }
 
+func GetPassthroughPGName(hostname, infrasettingName string) string {
+	var pgName string
+	if infrasettingName != "" {
+		pgName = GetClusterName() + "--" + infrasettingName + "-" + hostname
+	} else {
+		pgName = GetClusterName() + "--" + hostname
+	}
+	return pgName
+}
+
+func GetPassthroughPoolName(hostname, serviceName, infrasettingName string) string {
+	var poolName string
+	if infrasettingName != "" {
+		poolName = GetClusterName() + "--" + infrasettingName + "-" + hostname + "-" + serviceName
+	} else {
+		poolName = GetClusterName() + "--" + hostname + "-" + serviceName
+	}
+	return poolName
+}
+
 func GetL7PoolName(priorityLabel, namespace, ingName, infrasetting string, args ...string) string {
 	priorityLabel = strings.ReplaceAll(priorityLabel, "/", "_")
 	var poolName string
@@ -1146,16 +1166,18 @@ func PopulateL4PoolNodeMarkers(namespace, svcName, port string) utils.AviObjectM
 	return markers
 }
 
-func PopulatePassthroughPGMarkers(host string) utils.AviObjectMarkers {
+func PopulatePassthroughPGMarkers(host, infrasettingName string) utils.AviObjectMarkers {
 	var markers utils.AviObjectMarkers
 	markers.Host = []string{host}
+	markers.InfrasettingName = infrasettingName
 	return markers
 }
 
-func PopulatePassthroughPoolMarkers(host, svcName string) utils.AviObjectMarkers {
+func PopulatePassthroughPoolMarkers(host, svcName, infrasettingName string) utils.AviObjectMarkers {
 	var markers utils.AviObjectMarkers
 	markers.Host = []string{host}
 	markers.ServiceName = svcName
+	markers.InfrasettingName = infrasettingName
 	return markers
 }
 
@@ -1375,12 +1397,13 @@ func GetAKOIDPrefix() string {
 	}
 	return akoID
 }
-func GetPassthroughShardVSName(s string, key string) string {
+func GetPassthroughShardVSName(s, aviInfraSettingName, key string, shardSize uint32) string {
 	var vsNum uint32
-	shardSize := PassthroughShardSize()
-
 	shardVsPrefix := GetClusterName() + "--" + GetAKOIDPrefix() + PassthroughPrefix
 	vsNum = utils.Bkt(s, shardSize)
+	if aviInfraSettingName != "" {
+		shardVsPrefix += aviInfraSettingName + "-"
+	}
 	vsName := shardVsPrefix + strconv.Itoa(int(vsNum))
 	utils.AviLog.Infof("key: %s, msg: Passthrough ShardVSName: %s", key, vsName)
 	return vsName


### PR DESCRIPTION
When Aviinfrasetting  CRD applied to passthrough Route using annotation, Naming conventions for Avi object will be as follows:
1. VS: `<cluster-name>--Shared-Passthrough-<aviinfraCrdName>-<number>`
2. PoolGroup: `<cluster-name>--<AviInfraCrdName>-hostname`
3. Pool: `<cluster-name>--<AviInfraCrdName>-hostname-svcname`
4. DataScript: `<cluster-name>--Shared-Passthrough-<aviinfraCrdName>-<number>`


Testing Done:

1.  SNI: Create passthrough route with aviinfra annotation without redirect: 
2. SNI: Create passthrough route with aviinfra annotation with redirect
3. SNI: Transition passthrough route: With annotation to without annotation.
4. SNI:  Transition passthrough route: Without annotation to with annotation
5.  SNI: Apply aviinfra crd with l7Setting: ShardSize (This will change passthrough shard size)
6.   EVH:   Create passthrough route with aviinfra annotation without redirect: 
7 .  EVH: Create passthrough route with aviinfra annotation with redirect
8. EVH:  Transition passthrough route: With annotation to without annotation.
9. EVH: Transition passthrough route: Without annotation to with annotation
10. EVH: Apply aviinfra crd with l7Setting: ShardSize (This will change passthrough shard size)

TODO: Passthrough Ingress Testing