### PR TITLE
AV-148367: NPL optimisations

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -812,6 +812,10 @@ func (c *AviController) FullSyncK8s() error {
 		}
 		for _, podObj := range podObjs {
 			key := utils.Pod + "/" + utils.ObjKey(podObj)
+			if _, ok := podObj.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
+				utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
+				continue
+			}
 			meta, err := meta.Accessor(podObj)
 			if err == nil {
 				resVer := meta.GetResourceVersion()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -467,6 +467,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
+			if _, ok := pod.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
+				utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -490,6 +494,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
+			if _, ok := pod.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
+				utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
@@ -504,6 +512,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			if !reflect.DeepEqual(newPod, oldPod) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newPod))
 				key := utils.Pod + "/" + utils.ObjKey(oldPod)
+				if _, ok := newPod.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
+					utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
+					return
+				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1166,7 +1166,6 @@ func InformersToRegister(kclient *kubernetes.Clientset, oclient *oshiftclient.Cl
 		utils.EndpointInformer,
 		utils.SecretInformer,
 		utils.ConfigMapInformer,
-		utils.PodInformer,
 	}
 
 	if GetServiceType() == NodePortLocal {


### PR DESCRIPTION
This PR adds the code to ignore the processing of the pods which don't have the annotation "nodeportlocal.antrea.io"
in it. This was done previously at the Graph layer and with this commit, the
check will done at the Ingestion layer.
fixes AV-148367.
