### PR TITLE
Support for kubernetes 1.24

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,4 +6,4 @@ role is described in [GOVERNANCE.md](GOVERNANCE.md).
 | Maintainer | GitHub ID | Affiliation |
 | ---------- | --------- | ----------- |
 | Akshay Havile | akshayhavile | VMware |
-| Shubham Chauhan | chauhanshubham | VMware |
+| Swathin Sankaran | swathinsankaran | VMware |

--- a/buildsettings.json
+++ b/buildsettings.json
@@ -5,7 +5,7 @@
         "minVersion": "20.1.5"
     },
     "kubernetes": {
-        "maxVersion": "1.23",
-        "minVersion": "1.19"
+        "maxVersion": "1.24",
+        "minVersion": "1.21"
     }
 }


### PR DESCRIPTION
AKO supports 4 major releases of Kubernetes. So changed min and max according to it. 

@apalsule @swathinsankaran @aaha97 @abhishekbsingh : We need to check from customer perspective impact of changing min K8 version. But I think we should keep only 4 major releases into picture to reduce wide variety of testing