### PR TITLE
AV-147609: HTTP Ingress with a single path gives a 470 error

### DIFF
--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -305,7 +305,7 @@ func buildPoolNode(key, poolName, ingName, namespace, priorityLabel, hostname st
 		IngressName:   ingName,
 		PortName:      obj.PortName,
 		Tenant:        lib.GetTenant(),
-		PriorityLabel: priorityLabel,
+		PriorityLabel: strings.ToLower(priorityLabel),
 		Port:          obj.Port,
 		TargetPort:    obj.TargetPort,
 		ServiceMetadata: lib.ServiceMetadataObj{


### PR DESCRIPTION
**Issue** is present only in Insecure Ingress for SNI deployment. DataScript is being used to redirect traffic to respective poolgroup and pool-member. As DataScript is doing case insensitive search to select pool member using `priority label`,  pool with case sensitive name was not getting selected and that was causing 470 error.

**Fix** For insecure ingress pool, priority label has been updated to all lower case characters to match appropriate pool.
For existing deployment, it will cause `PUT` request on pool and pool groups who has case sensitive host name and path.
This will impact only insecure ingress deployment on SNI.

Other modes uses, http policyset to redirect traffic and no datascript comes into picture.

**Previous to fix**
![image](https://user-images.githubusercontent.com/6167479/187811401-af8cbb92-fee9-4b93-95e3-1c9a6f8e47f8.png)

![image](https://user-images.githubusercontent.com/6167479/187811477-44d4d48e-c994-485f-80fa-641c575aa846.png)


**After fix ***
![image](https://user-images.githubusercontent.com/6167479/187811552-abb794d2-9027-4ac4-9fc5-799dbc9f770b.png)

![image](https://user-images.githubusercontent.com/6167479/187811603-9c1f4633-4bf0-46f0-9b5b-65ace2a99365.png)
