### PR TITLE
IngressClass optimisations

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -961,6 +961,10 @@ func (c *AviController) FullSyncK8s() error {
 				} else {
 					for _, ingObj := range ingObjs {
 						key := utils.Ingress + "/" + utils.ObjKey(ingObj)
+						// optimization to check if ingress belongs to ingressClass handled by AKO.
+						if !lib.ValidateIngressForClass(key, ingObj) {
+							continue
+						}
 						meta, err := meta.Accessor(ingObj)
 						if err == nil {
 							resVer := meta.GetResourceVersion()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -929,6 +929,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
 				return
 			}
+			// optimization to check if ingress belongs to ingressClass handled by AKO.
+			if !lib.ValidateIngressForClass(key, ingress) {
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -958,6 +962,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				return
 			}
 
+			// optimization to check if ingress belongs to ingressClass handled by AKO.
+			if !lib.ValidateIngressForClass(key, ingress) {
+				return
+			}
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -115,6 +115,21 @@ func RemoveDefaultIngressClass() {
 	KubeClient.NetworkingV1().IngressClasses().Delete(context.TODO(), DefaultIngressClass, metav1.DeleteOptions{})
 }
 
+func AddIngressClassWithName(name string) {
+	ingClass := &networking.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: networking.IngressClassSpec{},
+	}
+
+	KubeClient.NetworkingV1().IngressClasses().Create(context.TODO(), ingClass, metav1.CreateOptions{})
+}
+
+func RemoveIngressClassWithName(ingClassName string) {
+	KubeClient.NetworkingV1().IngressClasses().Delete(context.TODO(), ingClassName, metav1.DeleteOptions{})
+}
+
 //Fake Namespace
 type FakeNamespace struct {
 	Name   string

--- a/tests/k8stest/controller_test.go
+++ b/tests/k8stest/controller_test.go
@@ -180,6 +180,31 @@ func TestEndpoint(t *testing.T) {
 	waitAndverify(t, "Endpoints/red-ns/testep")
 }
 
+func TestIngressClass(t *testing.T) {
+	apiGroup := "ako.vmware.com"
+	ingrClassExample := &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "avi-lb",
+			Annotations: map[string]string{
+				"ingressclass.kubernetes.io/is-default-class": "true",
+			},
+		},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: "ako.vmware.com/avi-lb",
+			Parameters: &networkingv1.IngressClassParametersReference{
+				APIGroup: &apiGroup,
+				Kind:     "IngressParameters",
+				Name:     "external-lb",
+			},
+		},
+	}
+	_, err := kubeClient.NetworkingV1().IngressClasses().Create(context.TODO(), ingrClassExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding IngressClass: %v", err)
+	}
+	waitAndverify(t, "IngressClass/avi-lb")
+}
+
 func TestIngress(t *testing.T) {
 	ingrExample := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/multicloudtests/multi_cloud_test.go
+++ b/tests/multicloudtests/multi_cloud_test.go
@@ -268,7 +268,9 @@ func TestMain(m *testing.M) {
 	quickSyncCh := make(chan struct{})
 	AddCMap()
 	ctrl.SetSEGroupCloudName()
-
+	integrationtest.KubeClient = kubeClient
+	integrationtest.AddDefaultIngressClass()
+	defer integrationtest.RemoveDefaultIngressClass()
 	ctrl.HandleConfigMap(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient}, ctrlCh, stopCh, quickSyncCh)
 	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: kubeClient, DynamicClient: dynamicClient})
 	setupQueue(stopCh)
@@ -371,6 +373,7 @@ func TestGCPCloudInClusterIPMode(t *testing.T) {
 // TestAzureCloudInNodePortMode tests case where Azure cloud is configured in NodePort mode. Sync should be enabled.
 func TestAzureCloudInNodePortMode(t *testing.T) {
 	waitAndverify(t, fmt.Sprintf("Secret/%s/avi-secret", utils.GetAKONamespace()))
+	waitAndverify(t, "IngressClass/avi-lb")
 	os.Setenv("CLOUD_NAME", "CLOUD_AZURE")
 	utils.SetCloudName("CLOUD_AZURE")
 	os.Setenv("SERVICE_TYPE", "NodePort")


### PR DESCRIPTION
This PR adds the optimization to process ingresses that belong to the ingressClasses owned by AKO.
It fixes AV-148368.

Optimizations added:
1. During AKO reboot, validates every ingress object and ignore it if it belongs to a non-ako ingressClass.
2. Ignores the handling of ingresses that are not part of AKO's ingressClass in Add and Delete ingress handler functions. To capture the transition from ingressClass non-avi-lb to avi-lb and vice versa, in the Update ingress handler function the same optimisation code is not added.

Tested scenarios and their results:
1. Ingress from non-avi lb to avi-lb ingressClass -> VS got created
2. Ingress from avi lb to non-avi lb ingressClass -> VS got deleted
3. Avi-lb not default and ingress dont have ingressClass -> ignored
4. Ingress with non-default avi lb ingressClass -> VS got created
5. ingress with default avi lb ingressClass     -> VS got created
