### PR TITLE
AV-153526: Avoid going through the system-namespaces on openshift and k8

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -95,6 +95,7 @@ func InitializeAKC() {
 		isPrimaryAKO = true
 	}
 	akoControlConfig.SetAKOInstanceFlag(isPrimaryAKO)
+	akoControlConfig.SetAKOBlackListedNamespaces(lib.GetGlobalBlockedNSList())
 	var crdClient *crd.Clientset
 	var advl4Client *advl4.Clientset
 	var svcAPIClient *svcapi.Clientset

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -95,7 +95,7 @@ func InitializeAKC() {
 		isPrimaryAKO = true
 	}
 	akoControlConfig.SetAKOInstanceFlag(isPrimaryAKO)
-	akoControlConfig.SetAKOBlackListedNamespaces(lib.GetGlobalBlockedNSList())
+	akoControlConfig.SetAKOBlockedNSList(lib.GetGlobalBlockedNSList())
 	var crdClient *crd.Clientset
 	var advl4Client *advl4.Clientset
 	var svcAPIClient *svcapi.Clientset

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -222,7 +222,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: avi-k8s-config
-                key: blackListedNamespaces
+                key: blockedNamespaceList
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -218,6 +218,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: enableMCI
+          - name: BLOCKED_NS_LIST
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: blackListedNamespaces
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -29,6 +29,11 @@ AKOSettings:
   servicesAPI: false # Flag that enables AKO in services API mode: https://kubernetes-sigs.github.io/service-apis/. Currently implemented only for L4. This flag uses the upstream GA APIs which are not backward compatible 
                      # with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 
   vipPerNamespace: "false" # Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
+  # This is the list of system namespaces from which AKO will not listen any Kubernetes or Openshift object event.
+  blackListedNamespaces: []
+  # blackListedNamespaces:
+  #   - kube-system
+  #   - kube-public
 
 ### This section outlines the network settings for virtualservices. 
 NetworkSettings:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -30,8 +30,8 @@ AKOSettings:
                      # with the advancedL4 APIs which uses a fork and a version of v1alpha1pre1 
   vipPerNamespace: "false" # Enabling this flag would tell AKO to create Parent VS per Namespace in EVH mode
   # This is the list of system namespaces from which AKO will not listen any Kubernetes or Openshift object event.
-  blackListedNamespaces: []
-  # blackListedNamespaces:
+  blockedNamespaceList: []
+  # blockedNamespaceList  :
   #   - kube-system
   #   - kube-public
 

--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -61,6 +61,10 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 			gw := obj.(*advl4v1alpha1pre1.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Gateway add event: namespace %s didn't qualify filter.", key, namespace)
+				return
+			}
 			utils.AviLog.Infof("key: %s, msg: ADD", key)
 
 			InformerStatusUpdatesForGateway(key, gw)
@@ -80,7 +84,10 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
 				utils.AviLog.Infof("key: %s, msg: UPDATE", key)
-
+				if lib.IsNamespaceBlackListed(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Gateway update event: namespace %s didn't qualify filter.", key, namespace)
+					return
+				}
 				InformerStatusUpdatesForGateway(key, gw)
 				checkGWForGatewayPortConflict(key, gw)
 
@@ -107,6 +114,10 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Gateway delete event: namespace %s didn't qualify filter.", key, namespace)
+				return
+			}
 			utils.AviLog.Infof("key: %s, msg: DELETE", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)

--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -61,7 +61,7 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 			gw := obj.(*advl4v1alpha1pre1.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Gateway add event: namespace %s didn't qualify filter.", key, namespace)
 				return
 			}
@@ -84,7 +84,7 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
 				utils.AviLog.Infof("key: %s, msg: UPDATE", key)
-				if lib.IsNamespaceBlackListed(namespace) {
+				if lib.IsNamespaceBlocked(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Gateway update event: namespace %s didn't qualify filter.", key, namespace)
 					return
 				}
@@ -114,7 +114,7 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Gateway delete event: namespace %s didn't qualify filter.", key, namespace)
 				return
 			}

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -767,7 +767,7 @@ func (c *AviController) FullSyncK8s() error {
 		return err
 	}
 	for _, ns := range allNamespaces.Items {
-		if !lib.IsNamespaceBlackListed(ns.GetName()) || utils.CheckIfNamespaceAccepted(ns.GetName(), ns.GetLabels(), false) {
+		if !lib.IsNamespaceBlocked(ns.GetName()) || utils.CheckIfNamespaceAccepted(ns.GetName(), ns.GetLabels(), false) {
 			acceptedNamespaces[ns.GetName()] = struct{}{}
 		}
 	}
@@ -813,7 +813,7 @@ func (c *AviController) FullSyncK8s() error {
 		for _, podObj := range podObjs {
 			podLabel := utils.ObjKey(podObj)
 			ns := strings.Split(podLabel, "/")
-			if lib.IsNamespaceBlackListed(ns[0]) {
+			if lib.IsNamespaceBlocked(ns[0]) {
 				continue
 			}
 			key := utils.Pod + "/" + podLabel
@@ -1002,7 +1002,7 @@ func (c *AviController) FullSyncK8s() error {
 			for _, gatewayObj := range gatewayObjs {
 				gatewayLabel := utils.ObjKey(gatewayObj)
 				ns := strings.Split(gatewayLabel, "/")
-				if !lib.IsNamespaceBlackListed(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
+				if !lib.IsNamespaceBlocked(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
 					key := lib.Gateway + "/" + gatewayLabel
 					meta, err := meta.Accessor(gatewayObj)
 					if err == nil {
@@ -1038,7 +1038,7 @@ func (c *AviController) FullSyncK8s() error {
 			for _, mciObj := range mciObjs {
 				mciLabel := utils.ObjKey(mciObj)
 				ns := strings.Split(mciLabel, "/")
-				if !lib.IsNamespaceBlackListed(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
+				if !lib.IsNamespaceBlocked(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
 					key := lib.MultiClusterIngress + "/" + mciLabel
 					meta, err := meta.Accessor(mciObj)
 					if err == nil {
@@ -1056,7 +1056,7 @@ func (c *AviController) FullSyncK8s() error {
 			for _, siObj := range siObjs {
 				siLabel := utils.ObjKey(siObj)
 				ns := strings.Split(siLabel, "/")
-				if !lib.IsNamespaceBlackListed(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
+				if !lib.IsNamespaceBlocked(ns[0]) && utils.CheckIfNamespaceAccepted(ns[0]) {
 					key := lib.MultiClusterIngress + "/" + siLabel
 					meta, err := meta.Accessor(siObj)
 					if err == nil {
@@ -1078,7 +1078,7 @@ func (c *AviController) FullSyncK8s() error {
 		for _, gatewayObj := range gatewayObjs {
 			gatewayLabel := utils.ObjKey(gatewayObj)
 			ns := strings.Split(gatewayLabel, "/")
-			if lib.IsNamespaceBlackListed(ns[0]) {
+			if lib.IsNamespaceBlocked(ns[0]) {
 				continue
 			}
 			key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -384,7 +384,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			route := obj.(*routev1.Route)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Route add event: Namespace: %s didn't qualify filter. Not adding route", key, namespace)
 				return
 			}
@@ -419,7 +419,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
 			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Route delete event: Namespace: %s didn't qualify filter. Not deleting route", key, namespace)
 				return
 			}
@@ -437,7 +437,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			if oldRoute.ResourceVersion != newRoute.ResourceVersion || !reflect.DeepEqual(newRoute.Annotations, oldRoute.Annotations) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newRoute))
 				key := utils.OshiftRoute + "/" + utils.ObjKey(newRoute)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Route update event: Namespace: %s didn't qualify filter. Not updating route", key, namespace)
 					return
 				}
@@ -462,7 +462,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			pod := obj.(*corev1.Pod)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key : %s, msg: Pod Add event: Namespace: %s didn't qualify filter", key, namespace)
 				return
 			}
@@ -498,7 +498,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Pod Delete event: Namespace: %s didn't qualify filter", key, namespace)
 				return
 			}
@@ -520,7 +520,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			if !reflect.DeepEqual(newPod, oldPod) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newPod))
 				key := utils.Pod + "/" + utils.ObjKey(oldPod)
-				if lib.IsNamespaceBlackListed(namespace) {
+				if lib.IsNamespaceBlocked(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Pod Update event: Namespace: %s didn't qualify filter", key, namespace)
 					return
 				}
@@ -550,7 +550,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			ep := obj.(*corev1.Endpoints)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ep))
 			key := utils.Endpoints + "/" + utils.ObjKey(ep)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Endpoint Add event: Namespace: %s didn't qualify filter", key, namespace)
 				return
 			}
@@ -578,7 +578,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ep))
 			key := utils.Endpoints + "/" + utils.ObjKey(ep)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Endpoint Update event: Namespace: %s didn't qualify filter", key, namespace)
 				return
 			}
@@ -595,7 +595,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if !reflect.DeepEqual(cep.Subsets, oep.Subsets) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(cep))
 				key := utils.Endpoints + "/" + utils.ObjKey(cep)
-				if lib.IsNamespaceBlackListed(namespace) {
+				if lib.IsNamespaceBlocked(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Endpoint Update event: Namespace: %s didn't qualify filter", key, namespace)
 					return
 				}
@@ -618,7 +618,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isSvcLb && !lib.GetLayer7Only() {
 				//L4 Namespace sync not applicable for advance L4 and service API
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.IsServiceNSValid(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", key, namespace)
 					return
 				}
@@ -632,7 +632,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 				}
 			} else {
-				if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				if lib.UseServicesAPI() {
@@ -672,7 +672,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 			if isSvcLb && !lib.GetLayer7Only() {
 				key = utils.L4LBService + "/" + utils.ObjKey(svc)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.IsServiceNSValid(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: L4 Service delete event: Namespace: %s didn't qualify filter. Not deleting service.", key, namespace)
 					return
 				}
@@ -683,7 +683,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 				}
 			} else {
-				if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
@@ -706,7 +706,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				var key string
 				if isSvcLb && !lib.GetLayer7Only() {
 					key = utils.L4LBService + "/" + utils.ObjKey(svc)
-					if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+					if lib.IsNamespaceBlocked(namespace) || !utils.IsServiceNSValid(namespace) {
 						utils.AviLog.Debugf("key: %s, msg: L4 Service update event: Namespace: %s didn't qualify filter. Not updating service.", key, namespace)
 						return
 					}
@@ -718,7 +718,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 						key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 					}
 				} else {
-					if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+					if lib.IsNamespaceBlocked(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 						return
 					}
 					if lib.UseServicesAPI() {
@@ -837,7 +837,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			secret := obj.(*corev1.Secret)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 			key := "Secret" + "/" + utils.ObjKey(secret)
-			if lib.IsNamespaceBlackListed(namespace) {
+			if lib.IsNamespaceBlocked(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: secret add event. namespace: %s didn't qualify filter", key, namespace)
 				return
 			}
@@ -865,7 +865,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if checkAviSecretUpdateAndShutdown(secret) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 				key := "Secret" + "/" + utils.ObjKey(secret)
-				if lib.IsNamespaceBlackListed(namespace) {
+				if lib.IsNamespaceBlocked(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: secret delete event. namespace: %s didn't qualify filter", key, namespace)
 					return
 				}
@@ -885,7 +885,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					// Only add the key if the resource versions have changed.
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 					key := "Secret" + "/" + utils.ObjKey(secret)
-					if lib.IsNamespaceBlackListed(namespace) {
+					if lib.IsNamespaceBlocked(namespace) {
 						utils.AviLog.Debugf("key: %s, msg: secret update event. namespace: %s didn't qualify filter", key, namespace)
 						return
 					}
@@ -919,7 +919,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			ingress := obj.(*networkingv1.Ingress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Ingress add event: Namespace: %s didn't qualify filter. Not adding ingress", key, namespace)
 				return
 			}
@@ -953,7 +953,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			key := utils.Ingress + "/" + utils.ObjKey(ingress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Ingress Delete event: Namespace: %s didn't qualify filter. Not deleting ingress", key, namespace)
 				return
 			}
@@ -972,7 +972,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isIngressUpdated(oldobj, ingress) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
 				key := utils.Ingress + "/" + utils.ObjKey(ingress)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Ingress Update event: Namespace: %s didn't qualify filter. Not updating ingress", key, namespace)
 					return
 				}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -383,11 +383,11 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			}
 			route := obj.(*routev1.Route)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Route add event: Namespace: %s didn't qualify filter. Not adding route", namespace)
+			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Route add event: Namespace: %s didn't qualify filter. Not adding route", key, namespace)
 				return
 			}
-			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == route.ResourceVersion {
 				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
@@ -418,11 +418,11 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 				}
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(route))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Route delete event: Namespace: %s didn't qualify filter. Not deleting route", namespace)
+			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Route delete event: Namespace: %s didn't qualify filter. Not deleting route", key, namespace)
 				return
 			}
-			key := utils.OshiftRoute + "/" + utils.ObjKey(route)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			objects.SharedResourceVerInstanceLister().Delete(key)
@@ -436,11 +436,11 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			newRoute := cur.(*routev1.Route)
 			if oldRoute.ResourceVersion != newRoute.ResourceVersion || !reflect.DeepEqual(newRoute.Annotations, oldRoute.Annotations) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newRoute))
-				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Debugf("Route update event: Namespace: %s didn't qualify filter. Not updating route", namespace)
+				key := utils.OshiftRoute + "/" + utils.ObjKey(newRoute)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Route update event: Namespace: %s didn't qualify filter. Not updating route", key, namespace)
 					return
 				}
-				key := utils.OshiftRoute + "/" + utils.ObjKey(newRoute)
 				bkt := utils.Bkt(namespace, numWorkers)
 				if !lib.HasValidBackends(newRoute.Spec, newRoute.Name, namespace, key) {
 					status.UpdateRouteStatusWithErrMsg(key, newRoute.Name, namespace, lib.DuplicateBackends)
@@ -462,6 +462,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			pod := obj.(*corev1.Pod)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key : %s, msg: Pod Add event: Namespace: %s didn't qualify filter", key, namespace)
+				return
+			}
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == pod.ResourceVersion {
 				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
@@ -494,6 +498,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(pod))
 			key := utils.Pod + "/" + utils.ObjKey(pod)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Pod Delete event: Namespace: %s didn't qualify filter", key, namespace)
+				return
+			}
 			if _, ok := pod.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
 				utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
 				return
@@ -512,6 +520,10 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			if !reflect.DeepEqual(newPod, oldPod) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(newPod))
 				key := utils.Pod + "/" + utils.ObjKey(oldPod)
+				if lib.IsNamespaceBlackListed(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Pod Update event: Namespace: %s didn't qualify filter", key, namespace)
+					return
+				}
 				if _, ok := newPod.GetAnnotations()[lib.NPLPodAnnotation]; !ok {
 					utils.AviLog.Warnf("key : %s, msg: 'nodeportlocal.antrea.io' annotation not found, ignoring the pod", key)
 					return
@@ -538,6 +550,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			ep := obj.(*corev1.Endpoints)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ep))
 			key := utils.Endpoints + "/" + utils.ObjKey(ep)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Endpoint Add event: Namespace: %s didn't qualify filter", key, namespace)
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -562,6 +578,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ep))
 			key := utils.Endpoints + "/" + utils.ObjKey(ep)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Endpoint Update event: Namespace: %s didn't qualify filter", key, namespace)
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
@@ -575,6 +595,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if !reflect.DeepEqual(cep.Subsets, oep.Subsets) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(cep))
 				key := utils.Endpoints + "/" + utils.ObjKey(cep)
+				if lib.IsNamespaceBlackListed(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Endpoint Update event: Namespace: %s didn't qualify filter", key, namespace)
+					return
+				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
@@ -593,11 +617,12 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			var key string
 			if isSvcLb && !lib.GetLayer7Only() {
 				//L4 Namespace sync not applicable for advance L4 and service API
-				if !utils.IsServiceNSValid(namespace) {
-					utils.AviLog.Debugf("L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", namespace)
+				key = utils.L4LBService + "/" + utils.ObjKey(svc)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: L4 Service add event: Namespace: %s didn't qualify filter. Not adding service.", key, namespace)
 					return
 				}
-				key = utils.L4LBService + "/" + utils.ObjKey(svc)
+
 				if lib.GetAdvancedL4() {
 					checkSvcForGatewayPortConflict(svc, key)
 				}
@@ -607,7 +632,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 				}
 			} else {
-				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				if lib.UseServicesAPI() {
@@ -646,18 +671,19 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			var key string
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
 			if isSvcLb && !lib.GetLayer7Only() {
-				if !utils.IsServiceNSValid(namespace) {
-					utils.AviLog.Debugf("L4 Service delete event: Namespace: %s didn't qualify filter. Not deleting service.", namespace)
+				key = utils.L4LBService + "/" + utils.ObjKey(svc)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: L4 Service delete event: Namespace: %s didn't qualify filter. Not deleting service.", key, namespace)
 					return
 				}
-				key = utils.L4LBService + "/" + utils.ObjKey(svc)
+
 				if svc.Annotations[lib.SharedVipSvcLBAnnotation] != "" {
 					// mark the object type as ShareVipSvc
 					// to separate these out from regulare clusterip, svclb services
 					key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 				}
 			} else {
-				if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 					return
 				}
 				key = utils.Service + "/" + utils.ObjKey(svc)
@@ -679,11 +705,12 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				isSvcLb := isServiceLBType(svc)
 				var key string
 				if isSvcLb && !lib.GetLayer7Only() {
-					if !utils.IsServiceNSValid(namespace) {
-						utils.AviLog.Debugf("L4 Service update event: Namespace: %s didn't qualify filter. Not updating service.", namespace)
+					key = utils.L4LBService + "/" + utils.ObjKey(svc)
+					if lib.IsNamespaceBlackListed(namespace) || !utils.IsServiceNSValid(namespace) {
+						utils.AviLog.Debugf("key: %s, msg: L4 Service update event: Namespace: %s didn't qualify filter. Not updating service.", key, namespace)
 						return
 					}
-					key = utils.L4LBService + "/" + utils.ObjKey(svc)
+
 					if lib.GetAdvancedL4() {
 						checkSvcForGatewayPortConflict(svc, key)
 					}
@@ -691,7 +718,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 						key = lib.SharedVipServiceKey + "/" + utils.ObjKey(svc)
 					}
 				} else {
-					if lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
+					if lib.IsNamespaceBlackListed(namespace) || lib.GetAdvancedL4() || !utils.CheckIfNamespaceAccepted(namespace) {
 						return
 					}
 					if lib.UseServicesAPI() {
@@ -810,6 +837,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			secret := obj.(*corev1.Secret)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 			key := "Secret" + "/" + utils.ObjKey(secret)
+			if lib.IsNamespaceBlackListed(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: secret add event. namespace: %s didn't qualify filter", key, namespace)
+				return
+			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -834,6 +865,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if checkAviSecretUpdateAndShutdown(secret) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 				key := "Secret" + "/" + utils.ObjKey(secret)
+				if lib.IsNamespaceBlackListed(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: secret delete event. namespace: %s didn't qualify filter", key, namespace)
+					return
+				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: DELETE", key)
@@ -850,6 +885,10 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					// Only add the key if the resource versions have changed.
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(secret))
 					key := "Secret" + "/" + utils.ObjKey(secret)
+					if lib.IsNamespaceBlackListed(namespace) {
+						utils.AviLog.Debugf("key: %s, msg: secret update event. namespace: %s didn't qualify filter", key, namespace)
+						return
+					}
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
@@ -879,11 +918,12 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			ingress := obj.(*networkingv1.Ingress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Ingress add event: Namespace: %s didn't qualify filter. Not adding ingress", namespace)
+			key := utils.Ingress + "/" + utils.ObjKey(ingress)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Ingress add event: Namespace: %s didn't qualify filter. Not adding ingress", key, namespace)
 				return
 			}
-			key := utils.Ingress + "/" + utils.ObjKey(ingress)
+
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == ingress.ResourceVersion {
 				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
@@ -911,12 +951,13 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					return
 				}
 			}
+			key := utils.Ingress + "/" + utils.ObjKey(ingress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Ingress Delete event: Namespace: %s didn't qualify filter. Not deleting ingress", namespace)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Ingress Delete event: Namespace: %s didn't qualify filter. Not deleting ingress", key, namespace)
 				return
 			}
-			key := utils.Ingress + "/" + utils.ObjKey(ingress)
+
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
@@ -930,11 +971,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			ingress := cur.(*networkingv1.Ingress)
 			if isIngressUpdated(oldobj, ingress) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(ingress))
-				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Debugf("Ingress Update event: Namespace: %s didn't qualify filter. Not updating ingress", namespace)
+				key := utils.Ingress + "/" + utils.ObjKey(ingress)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Ingress Update event: Namespace: %s didn't qualify filter. Not updating ingress", key, namespace)
 					return
 				}
-				key := utils.Ingress + "/" + utils.ObjKey(ingress)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -515,11 +515,11 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			}
 			mci := obj.(*akov1alpha1.MultiClusterIngress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Multi-cluster Ingress add event: Namespace: %s didn't qualify filter. Not adding multi-cluster ingress", namespace)
+			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress add event: Namespace: %s didn't qualify filter. Not adding multi-cluster ingress", key, namespace)
 				return
 			}
-			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
 			if err := validateMultiClusterIngressObj(key, mci); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: Validation of MultiClusterIngress failed: %v", key, err)
 				return
@@ -536,11 +536,11 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			mci := new.(*akov1alpha1.MultiClusterIngress)
 			if !reflect.DeepEqual(oldObj.Spec, mci.Spec) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
-				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Debugf("Multi-cluster Ingress update event: Namespace: %s didn't qualify filter. Not updating multi-cluster ingress", namespace)
+				key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress update event: Namespace: %s didn't qualify filter. Not updating multi-cluster ingress", key, namespace)
 					return
 				}
-				key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
 				if err := validateMultiClusterIngressObj(key, mci); err != nil {
 					utils.AviLog.Warnf("key: %s, msg: Validation of MultiClusterIngress failed: %v", key, err)
 					return
@@ -568,11 +568,11 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 				}
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Multi-cluster Ingress delete event: Namespace: %s didn't qualify filter. Not deleting multi-cluster ingress", namespace)
+			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress delete event: Namespace: %s didn't qualify filter. Not deleting multi-cluster ingress", key, namespace)
 				return
 			}
-			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
@@ -593,11 +593,11 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			}
 			si := obj.(*akov1alpha1.ServiceImport)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Service Import add event: Namespace: %s didn't qualify filter. Not adding Service Import", namespace)
+			key := lib.ServiceImport + "/" + utils.ObjKey(si)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Service Import add event: Namespace: %s didn't qualify filter. Not adding Service Import", key, namespace)
 				return
 			}
-			key := lib.ServiceImport + "/" + utils.ObjKey(si)
 			if err := validateServiceImportObj(key, si); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: Validation of ServiceImport failed: %v", key, err)
 				return
@@ -614,11 +614,11 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			si := new.(*akov1alpha1.ServiceImport)
 			if !reflect.DeepEqual(oldObj.Spec, si.Spec) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
-				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Debugf("Service Import update event: Namespace: %s didn't qualify filter. Not updating Service Import", namespace)
+				key := lib.ServiceImport + "/" + utils.ObjKey(si)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Service Import update event: Namespace: %s didn't qualify filter. Not updating Service Import", key, namespace)
 					return
 				}
-				key := lib.ServiceImport + "/" + utils.ObjKey(si)
 				if err := validateServiceImportObj(key, si); err != nil {
 					utils.AviLog.Warnf("key: %s, msg: Validation of ServiceImport failed: %v", key, err)
 					return
@@ -646,11 +646,11 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 				}
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Service Import delete event: Namespace: %s didn't qualify filter. Not deleting Service Import", namespace)
+			key := lib.ServiceImport + "/" + utils.ObjKey(si)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Service Import delete event: Namespace: %s didn't qualify filter. Not deleting Service Import", key, namespace)
 				return
 			}
-			key := lib.ServiceImport + "/" + utils.ObjKey(si)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -516,7 +516,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			mci := obj.(*akov1alpha1.MultiClusterIngress)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
 			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress add event: Namespace: %s didn't qualify filter. Not adding multi-cluster ingress", key, namespace)
 				return
 			}
@@ -537,7 +537,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			if !reflect.DeepEqual(oldObj.Spec, mci.Spec) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
 				key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress update event: Namespace: %s didn't qualify filter. Not updating multi-cluster ingress", key, namespace)
 					return
 				}
@@ -569,7 +569,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(mci))
 			key := lib.MultiClusterIngress + "/" + utils.ObjKey(mci)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress delete event: Namespace: %s didn't qualify filter. Not deleting multi-cluster ingress", key, namespace)
 				return
 			}
@@ -594,7 +594,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			si := obj.(*akov1alpha1.ServiceImport)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
 			key := lib.ServiceImport + "/" + utils.ObjKey(si)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Service Import add event: Namespace: %s didn't qualify filter. Not adding Service Import", key, namespace)
 				return
 			}
@@ -615,7 +615,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			if !reflect.DeepEqual(oldObj.Spec, si.Spec) {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
 				key := lib.ServiceImport + "/" + utils.ObjKey(si)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Service Import update event: Namespace: %s didn't qualify filter. Not updating Service Import", key, namespace)
 					return
 				}
@@ -647,7 +647,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(si))
 			key := lib.ServiceImport + "/" + utils.ObjKey(si)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Service Import delete event: Namespace: %s didn't qualify filter. Not deleting Service Import", key, namespace)
 				return
 			}

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -193,7 +193,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", key, namespace)
 				return
 			}
@@ -216,7 +216,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
-				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 					utils.AviLog.Debugf("key: %s, msg: Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", key, namespace)
 					return
 				}
@@ -249,7 +249,7 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
-			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+			if lib.IsNamespaceBlocked(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
 				utils.AviLog.Debugf("key: %s, msg: Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", key, namespace)
 				return
 			}

--- a/internal/k8s/services_api.go
+++ b/internal/k8s/services_api.go
@@ -192,11 +192,12 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 			}
 			gw := obj.(*servicesapi.Gateway)
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", namespace)
+			key := lib.Gateway + "/" + utils.ObjKey(gw)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Gateway add event. Namespace %s didn't qualify filter. Not adding gateway.", key, namespace)
 				return
 			}
-			key := lib.Gateway + "/" + utils.ObjKey(gw)
+
 			utils.AviLog.Infof("key: %s, msg: ADD", key)
 
 			InformerStatusUpdatesForSvcApiGateway(key, gw)
@@ -214,11 +215,12 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 
 			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
-				if !utils.CheckIfNamespaceAccepted(namespace) {
-					utils.AviLog.Debugf("Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", namespace)
+				key := lib.Gateway + "/" + utils.ObjKey(gw)
+				if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+					utils.AviLog.Debugf("key: %s, msg: Gateway update event. Namespace %s didn't qualify filter. Not updating gateway.", key, namespace)
 					return
 				}
-				key := lib.Gateway + "/" + utils.ObjKey(gw)
+
 				utils.AviLog.Infof("key: %s, msg: UPDATE", key)
 
 				InformerStatusUpdatesForSvcApiGateway(key, gw)
@@ -246,11 +248,11 @@ func (c *AviController) SetupSvcApiEventHandlers(numWorkers uint32) {
 				}
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
-			if !utils.CheckIfNamespaceAccepted(namespace) {
-				utils.AviLog.Debugf("Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", namespace)
+			key := lib.Gateway + "/" + utils.ObjKey(gw)
+			if lib.IsNamespaceBlackListed(namespace) || !utils.CheckIfNamespaceAccepted(namespace) {
+				utils.AviLog.Debugf("key: %s, msg: Gateway delete event. Namespace %s didn't qualify filter. Not deleting gateway.", key, namespace)
 				return
 			}
-			key := lib.Gateway + "/" + utils.ObjKey(gw)
 			utils.AviLog.Infof("key: %s, msg: DELETE", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -36,6 +36,7 @@ const (
 	VIP_NETWORK_LIST                           = "VIP_NETWORK_LIST"
 	BGP_PEER_LABELS                            = "BGP_PEER_LABELS"
 	SEG_NAME                                   = "SEG_NAME"
+	BLOCKED_NS_LIST                            = "BLOCKED_NS_LIST"
 	DEFAULT_SE_GROUP                           = "Default-Group"
 	NODE_NETWORK_LIST                          = "NODE_NETWORK_LIST"
 	NODE_NETWORK_MAX_ENTRIES                   = 5

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -131,7 +131,7 @@ func (c *akoControlConfig) SetAKOInstanceFlag(flag bool) {
 func (c *akoControlConfig) GetAKOInstanceFlag() bool {
 	return c.primaryaAKO
 }
-func (c *akoControlConfig) SetAKOBlackListedNamespaces(nsList []string) {
+func (c *akoControlConfig) SetAKOBlockedNSList(nsList []string) {
 	sort.Strings(nsList)
 	val := strings.Join(nsList, ":")
 	cksum := utils.Hash(val)
@@ -144,7 +144,7 @@ func (c *akoControlConfig) SetAKOBlackListedNamespaces(nsList []string) {
 		c.blockedNS.BlockedNSMap = nsMap
 	}
 }
-func (c *akoControlConfig) GetAKOBlackListedNamespaces() map[string]struct{} {
+func (c *akoControlConfig) GetAKOBlockedNSList() map[string]struct{} {
 	return c.blockedNS.BlockedNSMap
 }
 func (c *akoControlConfig) SetAdvL4Clientset(cs advl4crd.Interface) {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1408,8 +1408,8 @@ func GetAKOIDPrefix() string {
 }
 
 //TODO: Optimize
-func IsNamespaceBlackListed(namespace string) bool {
-	nsBlockedList := AKOControlConfig().GetAKOBlackListedNamespaces()
+func IsNamespaceBlocked(namespace string) bool {
+	nsBlockedList := AKOControlConfig().GetAKOBlockedNSList()
 	_, ok := nsBlockedList[namespace]
 	return ok
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -698,6 +698,16 @@ func GetGlobalBgpPeerLabels() []string {
 	return bgpPeerLabels
 }
 
+func GetGlobalBlockedNSList() []string {
+	var blockedNs []string
+	blockedNSStr := os.Getenv(BLOCKED_NS_LIST)
+	err := json.Unmarshal([]byte(blockedNSStr), &blockedNs)
+	if err != nil {
+		utils.AviLog.Warnf("Unable to fetch Blocked namespaces from environment variables. %v", err)
+	}
+	return blockedNs
+}
+
 var t1LrPath string
 
 func SetT1LRPath(lr string) {
@@ -1396,6 +1406,14 @@ func GetAKOIDPrefix() string {
 	}
 	return akoID
 }
+
+//TODO: Optimize
+func IsNamespaceBlackListed(namespace string) bool {
+	nsBlockedList := AKOControlConfig().GetAKOBlackListedNamespaces()
+	_, ok := nsBlockedList[namespace]
+	return ok
+}
+
 func GetPassthroughShardVSName(s, aviInfraSettingName, key string, shardSize uint32) string {
 	var vsNum uint32
 	shardVsPrefix := GetClusterName() + "--" + GetAKOIDPrefix() + PassthroughPrefix

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -257,12 +257,6 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 		}
 	}
 
-	// In Openshift cluster use NS bound informer for secret as certificates for routes are specified in the route itself. Also,
-	// there are many secrets installed by default in Openshift cluster which have to be handled if NS bound informer is not used.
-	if HasElem(registeredInformers, RouteInformer) {
-		akoNSBoundInformer = true
-	}
-
 	if !instantiateOnce {
 		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, akoClient, namespace, akoNSBoundInformer)
 	}


### PR DESCRIPTION
As part of this PR
1. Introduced changes to stop processing events from namespaces mentioned in values.yaml
2. Removed logic where AKO was listening on AKO deployed namespace only for secrets.

As part of this PR, we did not handle runtime update to `blackListedNamespaces` variable as it will overload AKO with fetching updates from all un-blocked namespaces in bulk. So if customer does update to `blackListedNamespaces` list, then AKO needs to be re-started.

Testing done:
1. K8 cluster: without providing any blocked namespaces and with blocked system namespaces.
2. Openshift cluster: Without providing any blocked namespace and with blocked system namespaces.
>> Result on Openshift (with 2 master and 3 worker nodes. more than 1k secrets present)
  a. Without blackListedNamespace: Took 2 to 4 min to complete existing object processing after AKO rebooted.
  b. With blackListedNamespaces: Took 12 seconds to complete existing object processing after AKO rebooted.

3. Creating routes on un-blocked namespaces and rebooting AKO.
4.  Boot up AKO without `blackListedNamespaces` in values.yaml to check backward compatibility or where configmap or values.yaml doesn't update automatically such as wcp.