### PR TITLE
[AV-154444] corrects the 'invalid type for address' warning logs coming in AKO log

### DIFF
--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -503,17 +503,20 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 					if ok {
 						fipEnabled = auto_allocate_floating_ip.(bool)
 					}
-					floating_ip, valid := vip["floating_ip"].(map[string]interface{})
 
-					if fipEnabled && !valid {
-						utils.AviLog.Warnf("key: %s, msg: invalid type for floating_ip in vsvip: %s", key, name)
-					} else {
-						fip_addr, valid := floating_ip["addr"].(string)
+					if fipEnabled {
+						floating_ip, valid := vip["floating_ip"].(map[string]interface{})
+
 						if !valid {
-							utils.AviLog.Warnf("key: %s, msg: invalid type for addr in vsvip: %s", key, name)
-							continue
+							utils.AviLog.Warnf("key: %s, msg: invalid type for floating_ip in vsvip: %s", key, name)
+						} else {
+							fip_addr, valid := floating_ip["addr"].(string)
+							if !valid {
+								utils.AviLog.Warnf("key: %s, msg: invalid type for addr in vsvip: %s", key, name)
+								continue
+							}
+							vsvipFips = append(vsvipFips, fip_addr)
 						}
-						vsvipFips = append(vsvipFips, fip_addr)
 					}
 					if ipamNetworkSubnet, ipamOk := vip["ipam_network_subnet"].(map[string]interface{}); ipamOk {
 						if networkRef, netRefOk := ipamNetworkSubnet["network_ref"].(string); netRefOk {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1060,17 +1060,21 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 			resp["vip"] = []interface{}{map[string]interface{}{"ip_address": map[string]string{"addr": vipAddress, "type": "V4"}}}
 			if strings.Contains(rName, "public") {
 				fipAddress := "35.250.250.1"
+				resp["vip"].([]interface{})[0].(map[string]interface{})["auto_allocate_floating_ip"] = true
 				resp["vip"].([]interface{})[0].(map[string]interface{})["floating_ip"] = map[string]string{"addr": fipAddress, "type": "V4"}
 			}
 			if strings.Contains(rName, "multivip") {
 				if strings.Contains(rName, "public") {
 					resp["vip"] = []interface{}{
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".1", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".1", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".1", "type": "V4"}},
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".2", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".2", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".2", "type": "V4"}},
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".3", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".3", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".3", "type": "V4"}},
 					}
 				} else {
 					resp["vip"] = []interface{}{
@@ -1125,16 +1129,20 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 			resp["vip"] = []interface{}{map[string]interface{}{"ip_address": map[string]string{"addr": vipAddress, "type": "V4"}}}
 
 			if strings.Contains(url, "public") {
+				resp["vip"].([]interface{})[0].(map[string]interface{})["auto_allocate_floating_ip"] = true
 				resp["vip"].([]interface{})[0].(map[string]interface{})["floating_ip"] = map[string]string{"addr": publicAddrPrefix + ".1", "type": "V4"}
 			} else if strings.Contains(url, "multivip") {
 				if strings.Contains(url, "public") {
 					resp["vip"] = []interface{}{
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".1", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".1", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".1", "type": "V4"}},
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".2", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".2", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".2", "type": "V4"}},
 						map[string]interface{}{"ip_address": map[string]string{"addr": addrPrefix + ".3", "type": "V4"},
-							"floating_ip": map[string]string{"addr": publicAddrPrefix + ".3", "type": "V4"}},
+							"auto_allocate_floating_ip": true,
+							"floating_ip":               map[string]string{"addr": publicAddrPrefix + ".3", "type": "V4"}},
 					}
 				} else {
 					resp["vip"] = []interface{}{


### PR DESCRIPTION
This PR corrects the 'invalid type for address' warning logs coming in AKO log.
fixes AV-154444