### PR TITLE
[AV-154711] fix for AKO restart issue

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1616,13 +1616,19 @@ func DeleteStaleDataForEvh(routeIgrObj RouteIngressModel, key string, modelList 
 			}
 		}
 		// Delete the pool corresponding to this host
+		isPassthroughVS := false
 		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
 			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, removeFqdn, removeRedir, removeRouteIngData, true)
 		} else if hostData.SecurePolicy == lib.PolicyPass {
+			isPassthroughVS = true
 			aviModel.(*AviObjectGraph).DeleteObjectsForPassthroughHost(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, infraSettingName, key, true, true, true)
 		}
 		if hostData.InsecurePolicy != lib.PolicyNone {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, removeFqdn, removeRedir, removeRouteIngData, false)
+			if isPassthroughVS {
+				aviModel.(*AviObjectGraph).DeletePoolForHostname(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
+			} else {
+				aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, removeFqdn, removeRedir, removeRouteIngData, false)
+			}
 		}
 		changedModel := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)
 		if !utils.HasElem(modelList, modelName) && changedModel {
@@ -2011,13 +2017,19 @@ func DeleteStaleDataForModelChangeForEvh(routeIgrObj RouteIngressModel, namespac
 		}
 
 		// Delete the pool corresponding to this host
+		isPassthroughVS := false
 		if hostData.SecurePolicy == lib.PolicyEdgeTerm {
 			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true, true)
 		} else if hostData.SecurePolicy == lib.PolicyPass {
+			isPassthroughVS = true
 			aviModel.(*AviObjectGraph).DeleteObjectsForPassthroughHost(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, infraSettingName, key, true, true, true)
 		}
 		if hostData.InsecurePolicy != lib.PolicyNone {
-			aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true, false)
+			if isPassthroughVS {
+				aviModel.(*AviObjectGraph).DeletePoolForHostname(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, false)
+			} else {
+				aviModel.(*AviObjectGraph).DeletePoolForHostnameForEvh(shardVsName.Name, host, routeIgrObj, hostData.PathSvc, key, infraSettingName, true, true, true, false)
+			}
 		}
 
 		ok := saveAviModel(modelName, aviModel.(*AviObjectGraph), key)

--- a/internal/nodes/avi_model_tls_passthrough.go
+++ b/internal/nodes/avi_model_tls_passthrough.go
@@ -287,13 +287,13 @@ func (o *AviObjectGraph) DeleteObjectsForPassthroughHost(vsName, hostname string
 	if removeRedir {
 		if len(vsNode[0].PassthroughChildNodes) > 0 {
 			passChild := vsNode[0].PassthroughChildNodes[0]
-			utils.AviLog.Infof("key: %s, msg: Removing redierct policy for %s from passthrough VS %s", key, hostname, passChild.Name)
+			utils.AviLog.Infof("key: %s, msg: Removing redirect policy for %s from passthrough VS %s", key, hostname, passChild.Name)
 			var hostnameSlice []string
 			hostnameSlice = append(hostnameSlice, hostname)
 			RemoveRedirectHTTPPolicyInModel(passChild, hostnameSlice, key)
 		}
 	}
 
-	utils.AviLog.Debugf("key: %s, msg: passthrough pg refs %s", utils.Stringify(dsNode[0].PoolGroupRefs))
-	utils.AviLog.Debugf("key: %s, msg: passthrough datascript %s", utils.Stringify(o.GetAviHTTPDSNode()))
+	utils.AviLog.Debugf("key: %s, msg: passthrough pg refs %s", key, utils.Stringify(dsNode[0].PoolGroupRefs))
+	utils.AviLog.Debugf("key: %s, msg: passthrough datascript %s", key, utils.Stringify(o.GetAviHTTPDSNode()))
 }


### PR DESCRIPTION
This PR fixes a crash issue during passthrough route cleanup after adding aviinfrasetting.
Also added a couple of UT fixes caused by the ingressClass optimizations.

Tested scenarios
>k8s and Openshift
1. Passthrough ingress transition from ingressClass without infraSetting to ingressClass with infraSetting
2. Passthrough ingress transition from ingressClass with infraSetting to ingressClass without infraSetting
3. Passthrough Ingress deletion
