### PR TITLE
fix for AV-156686

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -769,7 +769,8 @@ func (c *AviController) FullSyncK8s() error {
 		return err
 	}
 	for _, ns := range allNamespaces.Items {
-		if !lib.IsNamespaceBlocked(ns.GetName()) || utils.CheckIfNamespaceAccepted(ns.GetName(), ns.GetLabels(), false) {
+		if !lib.IsNamespaceBlocked(ns.GetName()) &&
+			utils.CheckIfNamespaceAccepted(ns.GetName(), ns.GetLabels(), false) {
 			acceptedNamespaces[ns.GetName()] = struct{}{}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue of AKO not blocking the namespace during bootup even though the namespace was present in the blocked namespace list.