### PR TITLE
Fixes few issues with log and issue with caching Nodes in NodePort mode

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -67,7 +67,7 @@ func InitializeAKOApi() {
 func InitializeAKC() {
 	var err error
 	kubeCluster := false
-	utils.AviLog.Info("AKO is running with version: ", version)
+	utils.AviLog.Infof("AKO is running with version: %s", version)
 
 	// set the logger for k8s as AviLogger.
 	klog.SetLogger(utils.AviLog)

--- a/cmd/infra-main/main.go
+++ b/cmd/infra-main/main.go
@@ -46,7 +46,7 @@ func InitializeAKOInfra() {
 
 	var err error
 	kubeCluster := false
-	utils.AviLog.Info("AKO-Infra is running with version: ", version)
+	utils.AviLog.Infof("AKO-Infra is running with version: %s", version)
 	// Check if we are running inside kubernetes. Hence try authenticating with service token
 	cfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/internal/objects/nodes.go
+++ b/internal/objects/nodes.go
@@ -51,7 +51,7 @@ func (o *K8sNodeStore) PopulateAllNodes(cs *kubernetes.Clientset, isNodePort boo
 	}
 	//filter out nodes if labels are set for nodeport mode
 	allNodes, err := cs.CoreV1().Nodes().List(context.TODO(), labelOption)
-	if err != nil {
+	if err == nil {
 		utils.AviLog.Infof("Got %d nodes", len(allNodes.Items))
 		for i, node := range allNodes.Items {
 			o.AddOrUpdate(node.Name, &allNodes.Items[i])

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -185,7 +185,7 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			} else {
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(vsKey)
 				vs_cache_obj.AddToSSLKeyCertCollection(k)
-				utils.AviLog.Info("Added VS cache key during SSLKeyCert update %v val %v", vsKey, utils.Stringify(vs_cache_obj))
+				utils.AviLog.Infof("Added VS cache key during SSLKeyCert update %v val %v", vsKey, utils.Stringify(vs_cache_obj))
 			}
 			utils.AviLog.Info(spew.Sprintf("Added SSLKeyCert cache k %v val %v", k,
 				ssl_cache_obj))

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -52,7 +52,7 @@ func (aviLogger *AviLogger) Infof(template string, args ...interface{}) {
 }
 
 func (aviLogger AviLogger) Info(msg string, args ...interface{}) {
-	aviLogger.sugar.Info(msg, args)
+	aviLogger.sugar.Info(msg)
 }
 
 func (aviLogger *AviLogger) Warnf(template string, args ...interface{}) {


### PR DESCRIPTION
This PR fixes the below issues:
1. an issue with caching the Node objects in secondary AKO deployed in NodePort mode.
2. INFO logs were coming with extra square brackets.