### PR TITLE
AV-149833 : SRP tool integration in AKO

### DIFF
--- a/hack/jenkins/save_build.sh
+++ b/hack/jenkins/save_build.sh
@@ -18,14 +18,16 @@
 set -xe
 
 
-if [ $# -lt 2 ] ; then
-    echo "Usage: ./save_build.sh <BRANCH> <BUILD_NUMBER>";
+if [ $# -lt 5 ] ; then
+    echo "Usage: ./save_build.sh <BRANCH> <BUILD_NUMBER> <WORKSPACE> <JENKINS_JOB_NAME> <JENKINS_URL>";
     exit 1
 fi
 
 BRANCH=$1
 BUILD_NUMBER=$2
-
+WORKSPACE=$3
+JENKINS_JOB_NAME=$4
+JENKINS_URL=$5
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
@@ -35,6 +37,12 @@ function get_git_ws {
     [ -z "$git_ws" ] && echo "Couldn't find git workspace root" && exit 1
     echo $git_ws
 }
+
+BRANCH_VERSION_SCRIPT=$SCRIPTPATH/get_branch_version.sh
+# Compute base_build_num
+base_build_num=$(cat $(get_git_ws)/base_build_num)
+version_build_num=$(expr "$base_build_num" + "$BUILD_NUMBER")
+branch_version=$(bash $BRANCH_VERSION_SCRIPT)
 
 BUILD_VERSION_SCRIPT=$SCRIPTPATH/get_build_version.sh
 CHARTS_PATH="$(get_git_ws)/helm/ako"
@@ -62,3 +70,31 @@ fi
 set -e
 
 sudo sed -i --regexp-extended "s/^(\s*)(appVersion\s*:\s*latest\s*$)/\1appVersion: $build_version/" $target_path/Chart.yaml
+
+#collecting source provenance data
+PRODUCT_NAME="Avi Kubernetes Operator"
+JENKINS_INSTANCE=$(echo $JENKINS_URL | sed -E 's/^\s*.*:\/\///g' | sed -E 's/:.*//g')
+COMP_UID="uid.obj.build.jenkins(instance='$JENKINS_INSTANCE',job_name='$JENKINS_JOB_NAME',build_number='$BUILD_NUMBER')"
+provenance_source_file="$WORKSPACE/provenance/source.json"
+
+# Function to run srp source provenance command
+function source_provenance() {
+    sudo /srp-tools/srp provenance source --scm-type git --name "$PRODUCT_NAME" --path ./ --saveto $provenance_source_file --comp-uid $COMP_UID --build-number ${version_build_num} --version $branch_version --all-ephemeral true --build-type release $@
+}
+
+output=( $(find $WORKSPACE/ -type d  -not -path "$WORKSPACE/build/*" -name '.git') )
+for line in "${output[@]}"
+do
+    cd $(dirname $line)
+    if [ -f  $provenance_source_file ]
+    then
+        source_provenance --append
+    else
+        source_provenance
+    fi
+done
+cd $WORKSPACE
+sudo /srp-tools/srp provenance merge --source ./provenance/source.json --network ./provenance/provenance.json --saveto ./provenance/merged.json
+provenance_path=$target_path/provenance
+sudo mkdir -p $provenance_path
+sudo cp $WORKSPACE/provenance/*json $provenance_path/;


### PR DESCRIPTION
This PR includes changes to generate SRP provenance data in our Jenkins build pipeline. We use srp tool and observer tool in our build pipeline to generate provenance data dynamically. Please go though the following JIRA for more details. The JIRA also contains links to srp related documents to check for details.
https://avinetworks.atlassian.net/browse/AV-149833

I have created a new job at https://prodjenkins.eng.vmware.com:8443/job/ako_OS-master-ci-build_srp/. This job is created by copying from https://prodjenkins.eng.vmware.com:8443/job/ako_OS-master-ci-build/

A new shell script needs to be added in an Execute shell in the job manually. This will download the srp and observer tools and generate the observer provenance data.
[srp.sh.zip](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/files/9664127/srp.sh.zip)

The save_build.sh file has been modified to additionally generate source provenance data and merged provenance data, and copy the provenance data to the target build path. The save_build.sh script now takes 5 arguments and the three new arguments namely WORKSPACE, JENKINS_JOB_NAME and JENKINS_URL are used for provenance data generation.

Please find the console output for the last successful build at https://prodjenkins.eng.vmware.com:8443/job/ako_OS-master-ci-build_srp/39/consoleFull
The build output can be found at the following build path /mnt/builds/ako_OS/feature-AV-149833/ci-build-1.8.1-5039
I am also attaching the provenance json data below.
[provenance.zip](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/files/9675578/provenance.zip)