### PR TITLE
AKO HA code changes

### DIFF
--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+func (c *AviController) OnStartedLeading(readyCh chan struct{}) {
+	lib.AKOControlConfig().SetIsLeaderFlag(true)
+	utils.AviLog.Debugf("AKO became a leader")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a leader")
+	if isReady(readyCh) {
+		c.publishAllVSKeysToRestLayer()
+	}
+}
+
+func (c *AviController) OnNewLeader(readyCh chan struct{}) {
+	lib.AKOControlConfig().SetIsLeaderFlag(false)
+	utils.AviLog.Debugf("AKO became a follower")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a follower")
+	if isReady(readyCh) {
+		c.publishAllVSKeysToRestLayer()
+	}
+}
+
+func (c *AviController) OnStoppedLeading(readyCh chan struct{}) {
+	lib.AKOControlConfig().SetIsLeaderFlag(false)
+	utils.AviLog.Debugf("AKO lost the leadership, rebooting the AKO")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO lost the leadership")
+}
+
+func isReady(readyCh chan struct{}) bool {
+	// ok returns false if the ready channel is closed.
+	_, ok := <-readyCh
+	return !ok
+}

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,6 +115,10 @@ type akoControlConfig struct {
 
 	//blockedNS contains map of blocked namespaces and checksum of it
 	blockedNS BlockedNamespaces
+
+	// leadership status of AKO
+	isLeader     bool
+	isLeaderLock sync.RWMutex
 }
 
 var akoControlConfigInstance *akoControlConfig
@@ -123,6 +128,18 @@ func AKOControlConfig() *akoControlConfig {
 		akoControlConfigInstance = &akoControlConfig{}
 	}
 	return akoControlConfigInstance
+}
+
+func (c *akoControlConfig) SetIsLeaderFlag(flag bool) {
+	c.isLeaderLock.Lock()
+	defer c.isLeaderLock.Unlock()
+	c.isLeader = flag
+}
+
+func (c *akoControlConfig) IsLeader() bool {
+	c.isLeaderLock.RLock()
+	defer c.isLeaderLock.RUnlock()
+	return c.isLeader
 }
 
 func (c *akoControlConfig) SetAKOInstanceFlag(flag bool) {

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -305,9 +305,13 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("Name not present in response %v", resp)
 			continue
+		}
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
 		}
 
 		uuid, ok := resp["uuid"].(string)

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -238,9 +238,14 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("key: %s, msg: Name not present in response %v", key, resp)
 			continue
+		}
+
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
 		}
 
 		uuid, ok := resp["uuid"].(string)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -578,9 +578,13 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("key: %s, msg: name not present in response %v", key, resp)
 			return errors.New("Name not present in response")
+		}
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
 		}
 
 		uuid, ok := resp["uuid"].(string)

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -138,9 +138,13 @@ func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("key: %s, msg: name not present in response %v", key, resp)
 			continue
+		}
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
 		}
 
 		uuid, ok := resp["uuid"].(string)

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -27,6 +27,12 @@ import (
 // based on the service metadata objects it finds in the cache
 // This is executed once AKO is done with populating the L3 cache in reboot scenarios
 func (rest *RestOperations) SyncObjectStatuses() {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the status")
+		return
+	}
+
 	vsKeys := rest.cache.VsCacheMeta.AviGetAllKeys()
 	utils.AviLog.Debugf("Ingress status sync for vsKeys %+v", utils.Stringify(vsKeys))
 

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -130,10 +130,16 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("Name not present in response %v", resp)
 			continue
 		}
+
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
+		}
+
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
 			utils.AviLog.Warnf("Uuid not present in response %v", resp)
@@ -151,6 +157,9 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			SSLKeyAndCertificate = rest_op.Obj.(utils.AviRestObjMacro).Data.(avimodels.SSLKeyAndCertificate)
 		case avimodels.SSLKeyAndCertificate:
 			SSLKeyAndCertificate = rest_op.Obj.(avimodels.SSLKeyAndCertificate)
+		}
+		if SSLKeyAndCertificate.Certificate == nil {
+			continue
 		}
 		cert = *SSLKeyAndCertificate.Certificate.Certificate
 		hasCA := false
@@ -289,9 +298,13 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
-		if !ok {
+		if !ok && rest_op.ObjName == "" {
 			utils.AviLog.Warnf("Name not present in response %v", resp)
 			continue
+		}
+		if name == "" {
+			name = rest_op.ObjName
+			utils.AviLog.Warnf("key %s: Name is empty and it is filled with name %s from the request", key, name)
 		}
 
 		uuid, ok := resp["uuid"].(string)

--- a/internal/status/crd_status.go
+++ b/internal/status/crd_status.go
@@ -36,6 +36,12 @@ type UpdateCRDStatusOptions struct {
 
 // UpdateHostRuleStatus HostRule status updates
 func UpdateHostRuleStatus(key string, hr *akov1alpha1.HostRule, updateStatus UpdateCRDStatusOptions, retryNum ...int) {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the status")
+		return
+	}
+
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
@@ -106,6 +112,12 @@ func HostRuleEventBroadcast(vsName string, vsCacheMetadataOld, vsMetadataNew lib
 
 // UpdateHTTPRuleStatus HttpRule status updates
 func UpdateHTTPRuleStatus(key string, rr *akov1alpha1.HTTPRule, updateStatus UpdateCRDStatusOptions, retryNum ...int) {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the status")
+		return
+	}
+
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]
@@ -176,6 +188,12 @@ func HttpRuleEventBroadcast(poolName string, poolCacheMetadataOld, vsMetadataNew
 
 // UpdateAviInfraSettingStatus AviInfraSetting status updates
 func UpdateAviInfraSettingStatus(key string, infraSetting *akov1alpha1.AviInfraSetting, updateStatus UpdateCRDStatusOptions, retryNum ...int) {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the status")
+		return
+	}
+
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -93,6 +93,12 @@ func ResetStatefulSetAnnotation() {
 }
 
 func AddStatefulSetAnnotation(reason string) {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the annotation")
+		return
+	}
+
 	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)

--- a/internal/status/status_toiler.go
+++ b/internal/status/status_toiler.go
@@ -36,6 +36,12 @@ func PublishToStatusQueue(key string, statusOption StatusOptions) {
 }
 
 func DequeueStatus(objIntf interface{}) error {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debugf("AKO is not a leader, not updating the status")
+		return nil
+	}
+
 	obj, ok := objIntf.(StatusOptions)
 	if !ok {
 		utils.AviLog.Warnf("key: %s, object is not of type StatusOptions, %T", obj.Options.Key, objIntf)

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -79,6 +79,12 @@ func UpdateNPLAnnotation(key, namespace, name string) {
 }
 
 func DeleteNPLAnnotation(key, namespace, name string) {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debug("AKO is running as a follower, not updating the annotation")
+		return
+	}
+
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
 		return

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -14,6 +14,8 @@
 
 package utils
 
+import "time"
+
 const (
 	GraphLayer                    = "GraphLayer"
 	ObjectIngestionLayer          = "ObjectIngestionLayer"
@@ -97,4 +99,10 @@ const (
 	AVIAPI_INITIATING   = "INITIATING"
 	AVIAPI_CONNECTED    = "CONNECTED"
 	AVIAPI_DISCONNECTED = "DISCONNECTED"
+
+	// Constants used for leader election
+	leaseDuration = 3 * time.Second
+	renewDeadline = 2 * time.Second
+	retryPeriod   = 1 * time.Second
+	leaseLockName = "ako-lease-lock"
 )

--- a/pkg/utils/full_sync_worker.go
+++ b/pkg/utils/full_sync_worker.go
@@ -24,7 +24,7 @@ type FullSyncThread struct {
 	QuickSyncChan     chan string
 	Interval          time.Duration
 	SyncFunction      func()
-	QuickSyncFunction func() error
+	QuickSyncFunction func(chan struct{}) error
 }
 
 func NewFullSyncThread(interval time.Duration) *FullSyncThread {
@@ -48,7 +48,7 @@ func (w *FullSyncThread) Run() {
 			// First the regular sync function - that syncs the cache
 			w.SyncFunction()
 			// Second the function that syncs the k8s objects.
-			w.QuickSyncFunction()
+			w.QuickSyncFunction(nil)
 			break
 		case <-time.After(w.Interval):
 			// Just the cache sync functions.

--- a/pkg/utils/leader_election.go
+++ b/pkg/utils/leader_election.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+type callBackFunc func(ready chan struct{})
+
+type leaderElector struct {
+	identity      string
+	leaderElector *leaderelection.LeaderElector
+	readyCh       chan struct{}
+}
+
+type LeaderElector interface {
+	Run(ctx context.Context, wg *sync.WaitGroup) chan struct{}
+}
+
+func NewLeaderElector(clientset kubernetes.Interface,
+	OnStartedLeadingCallback, OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) (LeaderElector, error) {
+
+	leaderElector := &leaderElector{}
+	leaderElector.identity = os.Getenv("POD_NAME")
+	leaderElector.readyCh = make(chan struct{})
+
+	leaderConfig := leaderElector.GetLeaderConfig(
+		clientset,
+		OnStartedLeadingCallback,
+		OnStoppedLeadingCallback,
+		OnNewLeaderCallback,
+	)
+	var err error
+	leaderElector.leaderElector, err = leaderelection.NewLeaderElector(leaderConfig)
+	if err != nil {
+		return nil, err
+	}
+	return leaderElector, nil
+}
+
+func (le *leaderElector) GetLeaderConfig(clientset kubernetes.Interface, OnStartedLeadingCallback,
+	OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) leaderelection.LeaderElectionConfig {
+	return leaderelection.LeaderElectionConfig{
+		Name:            le.identity,
+		Lock:            le.GetLeaseLock(clientset),
+		ReleaseOnCancel: true,
+		LeaseDuration:   leaseDuration,
+		RenewDeadline:   renewDeadline,
+		RetryPeriod:     retryPeriod,
+		Callbacks:       le.GetLeaderCallbacks(OnStartedLeadingCallback, OnStoppedLeadingCallback, OnNewLeaderCallback),
+	}
+}
+
+func (le *leaderElector) GetLeaseLock(clientset kubernetes.Interface) *resourcelock.LeaseLock {
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      leaseLockName,
+			Namespace: os.Getenv("POD_NAMESPACE"),
+		},
+		Client: clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: le.identity,
+		},
+	}
+}
+
+func (le *leaderElector) GetLeaderCallbacks(OnStartedLeadingCallback,
+	OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) leaderelection.LeaderCallbacks {
+	return leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			OnStartedLeadingCallback(le.readyCh)
+			// le.OnNewLeaderElected()
+		},
+		OnStoppedLeading: func() {
+			OnStoppedLeadingCallback(le.readyCh)
+		},
+		OnNewLeader: func(identity string) {
+			if identity == le.identity {
+				return
+			}
+			OnNewLeaderCallback(le.readyCh)
+			// le.OnNewLeaderElected()
+		},
+	}
+}
+
+var once sync.Once
+
+func (le *leaderElector) OnNewLeaderElected() {
+	once.Do(func() {
+		close(le.readyCh)
+	})
+}
+
+func (le *leaderElector) Run(ctx context.Context, wg *sync.WaitGroup) chan struct{} {
+	AviLog.Debug("Leader election is in-progress")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		le.leaderElector.Run(ctx)
+		AviLog.Debug("leader election goroutine exited")
+	}()
+	return le.readyCh
+}


### PR DESCRIPTION
This PR introduces the following changes:
1. leader election code which can be reused in AMKO.
2. Bootstrap code for leader election in AKO.
3. Limits the follower from making any status updates.
4. Fills the name of the pool, pool group, http policy set, and SSL key certificates with the name in the request when the name is empty in response.