### PR TITLE
[HA] Clusterrole changes

### DIFF
--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -51,6 +51,9 @@ rules:
   - apiGroups: ["ako.vmware.com"]
     resources: ["multiclusteringresses/status","serviceimports/status"]
     verbs: ["get","patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]
 {{- if .Values.rbac.pspEnable }}
   - apiGroups:
     - policy


### PR DESCRIPTION
This PR contains the cluster role changes to create, get, and update lease objects in the coordination.k8s.io API group.