### PR TITLE
Cherry-pick of  issue fix in populating VS DataScript cache

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1166,7 +1166,7 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 	var uri string
 	akoUser := lib.AKOUser
 
-	uri = "/api/vsdatascript?name=" + objName + "&created_by=" + akoUser
+	uri = "/api/vsdatascriptset?name=" + objName + "&created_by=" + akoUser
 
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1039,7 +1039,7 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 				switch rest_op.Obj.(type) {
 				case utils.AviRestObjMacro:
 					VSDataScriptSet = *rest_op.Obj.(utils.AviRestObjMacro).Data.(avimodels.VSDataScriptSet).Name
-				case avimodels.VSDataScript:
+				case avimodels.VSDataScriptSet:
 					VSDataScriptSet = *rest_op.Obj.(avimodels.VSDataScriptSet).Name
 				}
 				aviObjCache.AviPopulateOneVsDSCache(c, utils.CloudName, VSDataScriptSet)


### PR DESCRIPTION
This PR contains the issue fix in populating VS DataScript cache when AKO encounters a 409 error for POST requests.