### PR TITLE
[HA] Rest layer code changes

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -3337,3 +3337,12 @@ func ExtractUuidWithoutHash(word, pattern string) string {
 	}
 	return ""
 }
+
+func ExtractVSNameFromKey(word, pattern string) string {
+	r, _ := regexp.Compile(pattern)
+	result := r.FindAllString(word, -1)
+	if len(result) == 1 {
+		return result[0][:len(result[0])]
+	}
+	return ""
+}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -3337,12 +3337,3 @@ func ExtractUuidWithoutHash(word, pattern string) string {
 	}
 	return ""
 }
-
-func ExtractVSNameFromKey(word, pattern string) string {
-	r, _ := regexp.Compile(pattern)
-	result := r.FindAllString(word, -1)
-	if len(result) == 1 {
-		return result[0][:len(result[0])]
-	}
-	return ""
-}

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -123,7 +123,7 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "vsdatascriptset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "vsdatascriptset", key)
 	utils.AviLog.Debugf("The datascriptset object response %v", rest_op.Response)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find datascriptset obj in resp %v", key, rest_op.Response)

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -297,7 +297,7 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "httppolicyset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "httppolicyset", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find HTTP Policy Set obj in resp %v", rest_op.Response)
 		return errors.New("HTTP Policy Set object not found")
@@ -306,13 +306,13 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Name not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, Name not present in response %v", key, resp)
 			continue
 		}
 
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Uuid not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, Uuid not present in response %v", key, resp)
 			continue
 		}
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -165,7 +165,7 @@ func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avi
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "l4policyset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "l4policyset", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find L4 Policy Set obj in resp %v", rest_op.Response)
 		return errors.New("L4 Policy Set object not found")

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -229,7 +229,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "pool", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "pool", key)
 	utils.AviLog.Debugf("key: %s, msg: the pool object response %v", key, rest_op.Response)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find pool obj in resp %v", key, rest_op.Response)

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -128,7 +128,7 @@ func (rest *RestOperations) AviVrfCacheAdd(restOp *utils.RestOp, vrfKey avicache
 		utils.AviLog.Warnf("key: %s, rest_op has err or no response for vrfcontext, err: %s, response: %v", key, restOp.Err, utils.Stringify(restOp.Response))
 		return errors.New("Errored rest_op")
 	}
-	respElems := RestRespArrToObjByType(restOp, "vrfcontext", key)
+	respElems := rest.restOperator.RestRespArrToObjByType(restOp, "vrfcontext", key)
 	if respElems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find vrfcontext obj in resp %v", key, restOp.Response)
 		return errors.New("vrfcontext not found")

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -616,8 +616,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				parentVsObj = rest.getVsCacheObj(vhParentKey.(avicache.NamespaceName), key)
 				parentVsObj.AddToSNIChildCollection(uuid)
 			} else {
-				parentVSName := ExtractVsName(vh_parent_uuid.(string))
-				parentKey := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: ExtractVsName(parentVSName)}
+				parentKey := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: ExtractVsName(vh_parent_uuid.(string))}
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(parentKey)
 				vs_cache_obj.AddToSNIChildCollection(uuid)
 				utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during SNI update %v val %v", key, parentKey,

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -607,9 +607,6 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 		if found_parent {
 			// the uuid is expected to be in the format: "https://IP:PORT/api/virtualservice/virtualservice-88fd9718-f4f9-4e2b-9552-d31336330e0e#mygateway"
 			vs_uuid := avicache.ExtractUuid(vh_parent_uuid.(string), "virtualservice-.*.#")
-			if !lib.AKOControlConfig().IsLeader() {
-				vs_uuid = avicache.ExtractUuidWithoutHash(vh_parent_uuid.(string), "virtualservice-.*.")
-			}
 			utils.AviLog.Debugf("key: %s, msg: extracted the vs uuid from parent ref: %s", key, vs_uuid)
 			// Now let's get the VS key from this uuid
 			var foundvscache bool
@@ -620,9 +617,6 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				parentVsObj.AddToSNIChildCollection(uuid)
 			} else {
 				parentVSName := ExtractVsName(vh_parent_uuid.(string))
-				if !lib.AKOControlConfig().IsLeader() {
-					parentVSName = avicache.ExtractVSNameFromKey(key, fmt.Sprintf("%s/.*", lib.GetTenant()))
-				}
 				parentKey := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: ExtractVsName(parentVSName)}
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(parentKey)
 				vs_cache_obj.AddToSNIChildCollection(uuid)

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -438,7 +438,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		}
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "vsvip", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "vsvip", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find vsvip obj in resp %v", key, rest_op.Response)
 		return errors.New("vsvip not found")

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -130,7 +130,7 @@ func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "poolgroup", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "poolgroup", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find pool group obj in resp %v", key, rest_op.Response)
 		return errors.New("poolgroup not found")

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -14,15 +14,18 @@
 package rest
 
 import (
+	"errors"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/session"
@@ -559,7 +562,119 @@ func (rest *RestOperations) deleteSniVs(vsKey avicache.NamespaceName, vs_cache_o
 }
 
 func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool) {
-	return rest.restOperator.ExecuteRestAndPopulateCache(rest_ops, aviObjKey, avimodel, key, isEvh, sslKey...)
+	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
+	shardSize := lib.GetshardSize()
+	if shardSize == 0 {
+		// Dedicated VS case
+		shardSize = 8
+	}
+	var retry, fastRetry, processNextObj bool
+	bkt := utils.Bkt(key, shardSize)
+	if len(rest.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
+		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v", key, bkt)
+		aviclient := rest.aviRestPoolClient.AviClient[bkt]
+		err := rest.AviRestOperateWrapper(aviclient, rest_ops, key)
+		if err == nil {
+			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
+			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
+
+			// Add to local obj caches
+			for _, rest_op := range rest_ops {
+				rest.PopulateOneCache(rest_op, aviObjKey, key)
+			}
+
+		} else if aviObjKey.Name == lib.DummyVSForStaleData {
+			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
+			return false, processNextObj
+		} else {
+			var publishKey string
+			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+				publishKey = avimodel.GetAviEvhVS()[0].Name
+			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+				publishKey = avimodel.GetAviVS()[0].Name
+			}
+
+			if publishKey == "" {
+				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
+				splitKeys := strings.Split(key, "/")
+				if len(splitKeys) == 2 {
+					publishKey = splitKeys[1]
+				}
+			}
+
+			if rest.restOperator.isRetryRequired(key, err) {
+				rest.PublishKeyToRetryLayer(publishKey, key)
+				return false, processNextObj
+			}
+
+			if rest.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
+				return false, processNextObj
+			}
+			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
+			models.RestStatus.UpdateAviApiRestStatus("", err)
+			for i := len(rest_ops) - 1; i >= 0; i-- {
+				// Go over each of the failed requests and enqueue them to the worker queue for retry.
+				if rest_ops[i].Err != nil {
+					// check for VSVIP errors for blocked IP address updates
+					if checkVsVipUpdateErrors(key, rest_ops[i]) {
+						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
+						continue
+					}
+
+					// If it's for a SNI child, publish the parent VS's key
+					refreshCacheForRetry := false
+					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+						refreshCacheForRetry = true
+					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+						refreshCacheForRetry = true
+					}
+					if refreshCacheForRetry {
+						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						if !ok {
+							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
+							continue
+						}
+						retryable, fastRetryable, nextObj := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
+						retry = retry || retryable
+						processNextObj = processNextObj || nextObj
+						if avimodel.GetRetryCounter() != 0 {
+							fastRetry = fastRetry || fastRetryable
+						} else {
+							fastRetry = false
+							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
+						}
+					} else {
+						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						// If it's 404, don't retry
+						if ok {
+							statuscode := aviError.HttpStatusCode
+							if statuscode != 404 {
+								rest.PublishKeyToSlowRetryLayer(publishKey, key)
+								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
+								return false, true
+							} else {
+								rest.AviVsCacheDel(rest_ops[i], aviObjKey, key)
+							}
+						}
+					}
+				} else {
+					rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
+				}
+			}
+
+			if retry {
+				if fastRetry {
+					rest.PublishKeyToRetryLayer(publishKey, key)
+				} else {
+					rest.PublishKeyToSlowRetryLayer(publishKey, key)
+				}
+			}
+			return false, processNextObj
+		}
+	}
+	return true, true
 }
 
 func checkVsVipUpdateErrors(key string, rest_op *utils.RestOp) bool {
@@ -662,6 +777,21 @@ func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, key s
 	slowRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.SLOW_RETRY_LAYER)
 	slowRetryQueue.Workqueue[bkt].AddRateLimited(parentVsKey)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to slow path retry queue: %s", key, parentVsKey)
+}
+
+func (rest *RestOperations) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	restTimeoutChan := make(chan error, 1)
+	go func() {
+		err := rest.restOperator.AviRestOperate(aviClient, rest_ops, key)
+		restTimeoutChan <- err
+	}()
+	select {
+	case err := <-restTimeoutChan:
+		return err
+	case <-time.After(lib.ControllerReqWaitTime * time.Second):
+		utils.AviLog.Warnf("timed out waiting for rest response after %d seconds", lib.ControllerReqWaitTime)
+		return errors.New("timed out waiting for rest response")
+	}
 }
 
 func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObjKey avicache.NamespaceName, rest_op *utils.RestOp, aviError session.AviError, c *clients.AviClient, avimodel *nodes.AviObjectGraph, key string, isEvh bool) (bool, bool, bool) {

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1054,7 +1054,7 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 			}
 		} else if statuscode == 408 {
 			// This status code refers to a problem with the controller timeouts. We need to re-init the session object.
-			utils.AviLog.Infof("key :%s, msg: Controller request timed out, will re-init session by retrying", key)
+			utils.AviLog.Infof("key: %s, msg: Controller request timed out, will re-init session by retrying", key)
 			processNextObj = false
 		} else if statuscode == 400 && strings.Contains(*aviError.Message, lib.NoFreeIPError) {
 			utils.AviLog.Infof("key: %s, msg:  msg: Got no free IP error, would be added to slow retry queue", key)

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -27,7 +27,15 @@ import (
 // based on the service metadata objects it finds in the cache
 // This is executed once AKO is done with populating the L3 cache in reboot scenarios
 func (rest *RestOperations) SyncObjectStatuses() {
-	vsKeys := rest.cache.VsCacheMeta.AviGetAllKeys()
+	rest.restOperator.SyncObjectStatuses()
+}
+
+// SyncObjectStatuses gets data from L3 cache and does a status update on the ingress objects
+// based on the service metadata objects it finds in the cache
+// This is executed once AKO is done with populating the L3 cache in reboot scenarios
+func (l *leader) SyncObjectStatuses() {
+
+	vsKeys := l.restOp.cache.VsCacheMeta.AviGetAllKeys()
 	utils.AviLog.Debugf("Ingress status sync for vsKeys %+v", utils.Stringify(vsKeys))
 
 	var allIngressUpdateOptions []status.UpdateOptions
@@ -37,7 +45,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		if vsKey.Name == lib.DummyVSForStaleData {
 			continue
 		}
-		vsCache, ok := rest.cache.VsCacheMeta.AviCacheGet(vsKey)
+		vsCache, ok := l.restOp.cache.VsCacheMeta.AviCacheGet(vsKey)
 		if !ok {
 			continue
 		}
@@ -49,7 +57,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 
 		parentVsKey := vsCacheObj.ParentVSRef
 		vsSvcMetadataObj := vsCacheObj.ServiceMetadataObj
-		IPAddrs := rest.GetIPAddrsFromCache(vsCacheObj)
+		IPAddrs := l.restOp.GetIPAddrsFromCache(vsCacheObj)
 		if vsSvcMetadataObj.Gateway != "" {
 			// gateway based VSes
 			allGatewayUpdateOptions = append(allGatewayUpdateOptions,
@@ -60,7 +68,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 				})
 		} else if parentVsKey != (avicache.NamespaceName{}) {
 			// secure VSes handler
-			parentVs, found := rest.cache.VsCacheMeta.AviCacheGet(parentVsKey)
+			parentVs, found := l.restOp.cache.VsCacheMeta.AviCacheGet(parentVsKey)
 			if !found {
 				continue
 			}
@@ -68,7 +76,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 			parentVsObj, _ := parentVs.(*avicache.AviVsCache)
 			if (vsSvcMetadataObj.IngressName != "" || len(vsSvcMetadataObj.NamespaceIngressName) > 0) && vsSvcMetadataObj.Namespace != "" && parentVsObj != nil {
 				for _, poolKey := range vsCacheObj.PoolKeyCollection {
-					poolCache, ok := rest.cache.PoolCache.AviCacheGet(poolKey)
+					poolCache, ok := l.restOp.cache.PoolCache.AviCacheGet(poolKey)
 					if !ok {
 						continue
 					}
@@ -91,7 +99,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		} else {
 			// insecure VSes handler
 			for _, poolKey := range vsCacheObj.PoolKeyCollection {
-				poolCache, ok := rest.cache.PoolCache.AviCacheGet(poolKey)
+				poolCache, ok := l.restOp.cache.PoolCache.AviCacheGet(poolKey)
 				if !ok {
 					continue
 				}
@@ -123,7 +131,7 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		}
 
 		if len(vsSvcMetadataObj.NamespaceServiceName) > 0 {
-			IPAddrsSvc := rest.GetIPAddrsFromCache(vsCacheObj)
+			IPAddrsSvc := l.restOp.GetIPAddrsFromCache(vsCacheObj)
 			allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
 				status.UpdateOptions{
 					Vip:                IPAddrsSvc,
@@ -151,4 +159,10 @@ func (rest *RestOperations) SyncObjectStatuses() {
 	utils.AviLog.Infof("Status syncing completed")
 	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, lib.StatusSync, "Status syncing completed")
 
+}
+
+// SyncObjectStatuses in follower does nothing.
+func (f *follower) SyncObjectStatuses() {
+	utils.AviLog.Debug("AKO is running as a follower, not updating the status")
+	return
 }

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -164,5 +164,4 @@ func (l *leader) SyncObjectStatuses() {
 // SyncObjectStatuses in follower does nothing.
 func (f *follower) SyncObjectStatuses() {
 	utils.AviLog.Debug("AKO is running as a follower, not updating the status")
-	return
 }

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -18,11 +18,16 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/session"
+	"k8s.io/apimachinery/pkg/util/runtime"
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
 )
@@ -245,7 +250,153 @@ type AviRestClientPool struct {
 	AviClient []*clients.AviClient
 }
 
-func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
+type RestOperator interface {
+	AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error
+	AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error
+	ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool)
+	SyncObjectStatuses()
+	RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{}
+}
+
+func NewRestOperator(restOp *RestOperations) RestOperator {
+	if lib.AKOControlConfig().IsLeader() {
+		return &leader{restOp: restOp}
+	}
+	return &follower{restOp: restOp}
+}
+
+type leader struct {
+	restOp *RestOperations
+}
+
+func (l *leader) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool) {
+	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
+	shardSize := lib.GetshardSize()
+	if shardSize == 0 {
+		// Dedicated VS case
+		shardSize = 8
+	}
+	var retry, fastRetry, processNextObj bool
+	bkt := utils.Bkt(key, shardSize)
+	if len(l.restOp.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
+		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v, caller %v", key, bkt, runtime.GetCaller())
+		aviclient := l.restOp.aviRestPoolClient.AviClient[bkt]
+		err := l.AviRestOperateWrapper(aviclient, rest_ops, key)
+		if err == nil {
+			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
+			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
+
+			// Add to local obj caches
+			for _, rest_op := range rest_ops {
+				l.restOp.PopulateOneCache(rest_op, aviObjKey, key)
+			}
+
+		} else if aviObjKey.Name == lib.DummyVSForStaleData {
+			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
+			return false, processNextObj
+		} else {
+			var publishKey string
+			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+				publishKey = avimodel.GetAviEvhVS()[0].Name
+			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+				publishKey = avimodel.GetAviVS()[0].Name
+			}
+
+			if publishKey == "" {
+				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
+				splitKeys := strings.Split(key, "/")
+				if len(splitKeys) == 2 {
+					publishKey = splitKeys[1]
+				}
+			}
+
+			if l.restOp.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
+				return false, processNextObj
+			}
+			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
+			models.RestStatus.UpdateAviApiRestStatus("", err)
+			for i := len(rest_ops) - 1; i >= 0; i-- {
+				// Go over each of the failed requests and enqueue them to the worker queue for retry.
+				if rest_ops[i].Err != nil {
+					// check for VSVIP errors for blocked IP address updates
+					if checkVsVipUpdateErrors(key, rest_ops[i]) {
+						l.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
+						continue
+					}
+
+					// If it's for a SNI child, publish the parent VS's key
+					refreshCacheForRetry := false
+					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+						refreshCacheForRetry = true
+					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+						refreshCacheForRetry = true
+					}
+					if refreshCacheForRetry {
+						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						if !ok {
+							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
+							continue
+						}
+						retryable, fastRetryable, nextObj := l.restOp.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
+						retry = retry || retryable
+						processNextObj = processNextObj || nextObj
+						if avimodel.GetRetryCounter() != 0 {
+							fastRetry = fastRetry || fastRetryable
+						} else {
+							fastRetry = false
+							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
+						}
+					} else {
+						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						// If it's 404, don't retry
+						if ok {
+							statuscode := aviError.HttpStatusCode
+							if statuscode != 404 {
+								l.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
+								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
+								return false, true
+							} else {
+								l.restOp.AviVsCacheDel(rest_ops[i], aviObjKey, key)
+							}
+						}
+					}
+				} else {
+					l.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
+				}
+			}
+
+			if retry {
+				if fastRetry {
+					l.restOp.PublishKeyToRetryLayer(publishKey, key)
+				} else {
+					l.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
+				}
+			}
+			return false, processNextObj
+		}
+	}
+	return true, true
+}
+
+func (l *leader) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	restTimeoutChan := make(chan error, 1)
+	go func() {
+		err := l.AviRestOperate(aviClient, rest_ops, key)
+		restTimeoutChan <- err
+	}()
+	select {
+	case err := <-restTimeoutChan:
+		return err
+	case <-time.After(lib.ControllerReqWaitTime * time.Second):
+		utils.AviLog.Warnf("key: %s, msg: timed out waiting for rest response after %d seconds", key, lib.ControllerReqWaitTime)
+		return errors.New("timed out waiting for rest response")
+	}
+}
+
+func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	var failure bool
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
@@ -270,17 +421,21 @@ func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
 			op.Err = fmt.Errorf("Unknown RestOp %v", op.Method)
 		}
 		if op.Err != nil {
-			utils.AviLog.Warnf(`RestOp method %v path %v tenant %v Obj %s returned err %s with response %s`,
-				op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
+			utils.AviLog.Warnf("key: %s, msg: RestOp method %v path %v tenant %v Obj %s returned err %s with response %s",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
 			// Wrap the error into a websync error.
 			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
 			aviErr, ok := op.Err.(session.AviError)
 			if !ok {
-				utils.AviLog.Warnf("Error in rest operation is not of type AviError, err: %v, %T", op.Err, op.Err)
+				utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)
 			} else if op.Model == "VsVip" && op.Method == utils.RestPut {
-				utils.AviLog.Debugf("Error in rest operation for VsVip Put request.")
+				utils.AviLog.Debugf("key: %s, msg: Error in rest operation for VsVip Put request.", key)
 			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
-				utils.AviLog.Warnf("Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", op.Method, op.Model, op.Err)
+				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				continue
+			} else if aviErr.HttpStatusCode == 409 && op.Method == utils.RestPost {
+				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				failure = true
 				continue
 			} else if !isErrorRetryable(aviErr.HttpStatusCode, *aviErr.Message) {
 				if op.Method != utils.RestPost {
@@ -296,8 +451,207 @@ func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
 			}
 			return err
 		} else {
-			utils.AviLog.Debugf(`RestOp method %v path %v tenant %v response %v`,
-				op.Method, op.Path, op.Tenant, utils.Stringify(op.Response))
+			utils.AviLog.Debugf("key: %s, msg: RestOp method %v path %v tenant %v response %v objName %v",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Response), op.ObjName)
+		}
+	}
+	if failure {
+		return errors.New("required to populate cache and then retry")
+	}
+	return nil
+}
+
+type follower struct {
+	restOp *RestOperations
+}
+
+func (f *follower) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool) {
+
+	// Delay the REST calls in the follower.
+	<-time.After(500 * time.Millisecond)
+
+	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
+	shardSize := lib.GetshardSize()
+	if shardSize == 0 {
+		// Dedicated VS case
+		shardSize = 8
+	}
+	var retry, fastRetry, processNextObj bool
+	bkt := utils.Bkt(key, shardSize)
+	if len(f.restOp.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
+		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v, caller %v", key, bkt, runtime.GetCaller())
+		aviclient := f.restOp.aviRestPoolClient.AviClient[bkt]
+		err := f.AviRestOperateWrapper(aviclient, rest_ops, key)
+		if err == nil {
+			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
+			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
+
+			// Add to local obj caches
+			for _, rest_op := range rest_ops {
+				f.restOp.PopulateOneCache(rest_op, aviObjKey, key)
+			}
+
+		} else if aviObjKey.Name == lib.DummyVSForStaleData {
+			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
+			return false, processNextObj
+		} else {
+			var publishKey string
+			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+				publishKey = avimodel.GetAviEvhVS()[0].Name
+			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+				publishKey = avimodel.GetAviVS()[0].Name
+			}
+
+			if publishKey == "" {
+				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
+				splitKeys := strings.Split(key, "/")
+				if len(splitKeys) == 2 {
+					publishKey = splitKeys[1]
+				}
+			}
+
+			if err.Error() == "Got empty response for non-delete operation" ||
+				err.Error() == "Got non-empty response for delete operation" {
+				utils.AviLog.Warnf("key: %s, aborted the rest operation due to an error. err %s", key, err.Error())
+				f.restOp.PublishKeyToRetryLayer(publishKey, key)
+				return false, processNextObj
+			}
+
+			if f.restOp.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
+				return false, processNextObj
+			}
+			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
+			models.RestStatus.UpdateAviApiRestStatus("", err)
+			for i := len(rest_ops) - 1; i >= 0; i-- {
+				// Go over each of the failed requests and enqueue them to the worker queue for retry.
+				if rest_ops[i].Err != nil {
+					// check for VSVIP errors for blocked IP address updates
+					if checkVsVipUpdateErrors(key, rest_ops[i]) {
+						f.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
+						continue
+					}
+
+					// If it's for a SNI child, publish the parent VS's key
+					refreshCacheForRetry := false
+					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+						refreshCacheForRetry = true
+					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+						refreshCacheForRetry = true
+					}
+					if refreshCacheForRetry {
+						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						if !ok {
+							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
+							continue
+						}
+						retryable, fastRetryable, nextObj := f.restOp.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
+						retry = retry || retryable
+						processNextObj = processNextObj || nextObj
+						if avimodel.GetRetryCounter() != 0 {
+							fastRetry = fastRetry || fastRetryable
+						} else {
+							fastRetry = false
+							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
+						}
+					} else {
+						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						// If it's 404, don't retry
+						if ok {
+							statuscode := aviError.HttpStatusCode
+							if statuscode != 404 {
+								f.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
+								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
+								return false, true
+							} else {
+								f.restOp.AviVsCacheDel(rest_ops[i], aviObjKey, key)
+							}
+						}
+					}
+				} else {
+					f.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
+				}
+			}
+
+			if retry {
+				if fastRetry {
+					f.restOp.PublishKeyToRetryLayer(publishKey, key)
+				} else {
+					f.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
+				}
+			}
+			return false, processNextObj
+		}
+	}
+	return true, true
+}
+
+func (f *follower) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	restTimeoutChan := make(chan error, 1)
+	go func() {
+		err := f.AviRestOperate(aviClient, rest_ops, key)
+		restTimeoutChan <- err
+	}()
+	select {
+	case err := <-restTimeoutChan:
+		return err
+	case <-time.After(lib.ControllerReqWaitTime * time.Second):
+		utils.AviLog.Warnf("key: %s, msg: timed out waiting for rest response after %d seconds", key, lib.ControllerReqWaitTime)
+		return errors.New("timed out waiting for rest response")
+	}
+}
+
+func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	for i, op := range rest_ops {
+		SetTenant := session.SetTenant(op.Tenant)
+		SetTenant(c.AviSession)
+		if op.Version != "" {
+			SetVersion := session.SetVersion(op.Version)
+			SetVersion(c.AviSession)
+		}
+		op.Path += "?name=" + op.ObjName
+		utils.AviLog.Debugf("key: %s, msg: Got a REST operation: %s, %s", op.ObjName, op.Path)
+		op.Err = c.AviSession.Get(op.Path, &op.Response)
+		if op.Err != nil {
+			utils.AviLog.Warnf("key: %s msg: RestOp method %v path %v tenant %v Obj %s returned err %s with response %s",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
+			// Wrap the error into a websync error.
+			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
+			aviErr, ok := op.Err.(session.AviError)
+			if !ok {
+				utils.AviLog.Warnf("key: %s msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)
+			} else if op.Model == "VsVip" && op.Method == utils.RestPut {
+				utils.AviLog.Debugf("key: %s msg: Error in rest operation for VsVip Put request.", key)
+			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
+				utils.AviLog.Warnf("key: %s msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				continue
+			} else if !isErrorRetryable(aviErr.HttpStatusCode, *aviErr.Message) {
+				if op.Method != utils.RestPost {
+					continue
+				}
+				if removeObjRefFromRestOps(rest_ops, op.ObjName, op.Model) {
+					continue
+				}
+			}
+
+			for j := i + 1; j < len(rest_ops); j++ {
+				rest_ops[j].Err = errors.New("Aborted due to prev error")
+			}
+			return err
+		} else {
+			utils.AviLog.Debugf("key: %s msg: RestOp method %v path %v tenant %v response %v objName %v",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Response), op.ObjName)
+			if op.Method == utils.RestDelete && op.Response != nil {
+				return errors.New("Got non-empty response for delete operation")
+			}
+			if resp, ok := op.Response.(map[string]interface{}); ok {
+				if count, ok := resp["count"].(float64); ok {
+					if op.Method != utils.RestDelete && count == 0 {
+						return errors.New("Got empty response for non-delete operation")
+					}
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -20,14 +20,10 @@ import (
 	"strings"
 	"time"
 
-	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/third_party/github.com/vmware/alb-sdk/go/session"
-	"k8s.io/apimachinery/pkg/util/runtime"
 
 	avimodels "github.com/vmware/alb-sdk/go/models"
 )
@@ -251,12 +247,20 @@ type AviRestClientPool struct {
 }
 
 type RestOperator interface {
-	AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error
 	AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error
-	ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool)
+	isRetryRequired(key string, err error) bool
 	SyncObjectStatuses()
 	RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{}
 }
+
+type (
+	leader struct {
+		restOp *RestOperations
+	}
+	follower struct {
+		restOp *RestOperations
+	}
+)
 
 func NewRestOperator(restOp *RestOperations) RestOperator {
 	if lib.AKOControlConfig().IsLeader() {
@@ -265,134 +269,11 @@ func NewRestOperator(restOp *RestOperations) RestOperator {
 	return &follower{restOp: restOp}
 }
 
-type leader struct {
-	restOp *RestOperations
-}
-
-func (l *leader) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool) {
-	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
-	shardSize := lib.GetshardSize()
-	if shardSize == 0 {
-		// Dedicated VS case
-		shardSize = 8
+func (l *leader) isRetryRequired(key string, err error) bool {
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: aborted the rest operation due to an error. err %s", key, err.Error())
 	}
-	var retry, fastRetry, processNextObj bool
-	bkt := utils.Bkt(key, shardSize)
-	if len(l.restOp.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
-		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v, caller %v", key, bkt, runtime.GetCaller())
-		aviclient := l.restOp.aviRestPoolClient.AviClient[bkt]
-		err := l.AviRestOperateWrapper(aviclient, rest_ops, key)
-		if err == nil {
-			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
-			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
-
-			// Add to local obj caches
-			for _, rest_op := range rest_ops {
-				l.restOp.PopulateOneCache(rest_op, aviObjKey, key)
-			}
-
-		} else if aviObjKey.Name == lib.DummyVSForStaleData {
-			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
-			return false, processNextObj
-		} else {
-			var publishKey string
-			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-				publishKey = avimodel.GetAviEvhVS()[0].Name
-			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-				publishKey = avimodel.GetAviVS()[0].Name
-			}
-
-			if publishKey == "" {
-				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
-				splitKeys := strings.Split(key, "/")
-				if len(splitKeys) == 2 {
-					publishKey = splitKeys[1]
-				}
-			}
-
-			if l.restOp.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
-				return false, processNextObj
-			}
-			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
-			models.RestStatus.UpdateAviApiRestStatus("", err)
-			for i := len(rest_ops) - 1; i >= 0; i-- {
-				// Go over each of the failed requests and enqueue them to the worker queue for retry.
-				if rest_ops[i].Err != nil {
-					// check for VSVIP errors for blocked IP address updates
-					if checkVsVipUpdateErrors(key, rest_ops[i]) {
-						l.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
-						continue
-					}
-
-					// If it's for a SNI child, publish the parent VS's key
-					refreshCacheForRetry := false
-					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-						refreshCacheForRetry = true
-					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-						refreshCacheForRetry = true
-					}
-					if refreshCacheForRetry {
-						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
-						aviError, ok := rest_ops[i].Err.(session.AviError)
-						if !ok {
-							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
-							continue
-						}
-						retryable, fastRetryable, nextObj := l.restOp.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
-						retry = retry || retryable
-						processNextObj = processNextObj || nextObj
-						if avimodel.GetRetryCounter() != 0 {
-							fastRetry = fastRetry || fastRetryable
-						} else {
-							fastRetry = false
-							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
-						}
-					} else {
-						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
-						aviError, ok := rest_ops[i].Err.(session.AviError)
-						// If it's 404, don't retry
-						if ok {
-							statuscode := aviError.HttpStatusCode
-							if statuscode != 404 {
-								l.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
-								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
-								return false, true
-							} else {
-								l.restOp.AviVsCacheDel(rest_ops[i], aviObjKey, key)
-							}
-						}
-					}
-				} else {
-					l.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
-				}
-			}
-
-			if retry {
-				if fastRetry {
-					l.restOp.PublishKeyToRetryLayer(publishKey, key)
-				} else {
-					l.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
-				}
-			}
-			return false, processNextObj
-		}
-	}
-	return true, true
-}
-
-func (l *leader) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
-	restTimeoutChan := make(chan error, 1)
-	go func() {
-		err := l.AviRestOperate(aviClient, rest_ops, key)
-		restTimeoutChan <- err
-	}()
-	select {
-	case err := <-restTimeoutChan:
-		return err
-	case <-time.After(lib.ControllerReqWaitTime * time.Second):
-		utils.AviLog.Warnf("key: %s, msg: timed out waiting for rest response after %d seconds", key, lib.ControllerReqWaitTime)
-		return errors.New("timed out waiting for rest response")
-	}
+	return false
 }
 
 func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
@@ -461,148 +342,24 @@ func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, 
 	return nil
 }
 
-type follower struct {
-	restOp *RestOperations
+func (f *follower) isRetryRequired(key string, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err.Error() {
+	case "Got empty response for non-delete operation",
+		"Got non-empty response for delete operation":
+		utils.AviLog.Warnf("key: %s, msg: aborted the rest operation due to an error. err %s", key, err.Error())
+		return true
+	}
+	return false
 }
 
-func (f *follower) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp, aviObjKey avicache.NamespaceName, avimodel *nodes.AviObjectGraph, key string, isEvh bool, sslKey ...utils.NamespaceName) (bool, bool) {
+func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
 
 	// Delay the REST calls in the follower.
 	<-time.After(500 * time.Millisecond)
 
-	// Choose a avi client based on the model name hash. This would ensure that the same worker queue processes updates for a given VS all the time.
-	shardSize := lib.GetshardSize()
-	if shardSize == 0 {
-		// Dedicated VS case
-		shardSize = 8
-	}
-	var retry, fastRetry, processNextObj bool
-	bkt := utils.Bkt(key, shardSize)
-	if len(f.restOp.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
-		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v, caller %v", key, bkt, runtime.GetCaller())
-		aviclient := f.restOp.aviRestPoolClient.AviClient[bkt]
-		err := f.AviRestOperateWrapper(aviclient, rest_ops, key)
-		if err == nil {
-			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
-			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
-
-			// Add to local obj caches
-			for _, rest_op := range rest_ops {
-				f.restOp.PopulateOneCache(rest_op, aviObjKey, key)
-			}
-
-		} else if aviObjKey.Name == lib.DummyVSForStaleData {
-			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
-			return false, processNextObj
-		} else {
-			var publishKey string
-			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-				publishKey = avimodel.GetAviEvhVS()[0].Name
-			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-				publishKey = avimodel.GetAviVS()[0].Name
-			}
-
-			if publishKey == "" {
-				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
-				splitKeys := strings.Split(key, "/")
-				if len(splitKeys) == 2 {
-					publishKey = splitKeys[1]
-				}
-			}
-
-			if err.Error() == "Got empty response for non-delete operation" ||
-				err.Error() == "Got non-empty response for delete operation" {
-				utils.AviLog.Warnf("key: %s, aborted the rest operation due to an error. err %s", key, err.Error())
-				f.restOp.PublishKeyToRetryLayer(publishKey, key)
-				return false, processNextObj
-			}
-
-			if f.restOp.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
-				return false, processNextObj
-			}
-			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
-			models.RestStatus.UpdateAviApiRestStatus("", err)
-			for i := len(rest_ops) - 1; i >= 0; i-- {
-				// Go over each of the failed requests and enqueue them to the worker queue for retry.
-				if rest_ops[i].Err != nil {
-					// check for VSVIP errors for blocked IP address updates
-					if checkVsVipUpdateErrors(key, rest_ops[i]) {
-						f.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
-						continue
-					}
-
-					// If it's for a SNI child, publish the parent VS's key
-					refreshCacheForRetry := false
-					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-						refreshCacheForRetry = true
-					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-						refreshCacheForRetry = true
-					}
-					if refreshCacheForRetry {
-						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
-						aviError, ok := rest_ops[i].Err.(session.AviError)
-						if !ok {
-							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
-							continue
-						}
-						retryable, fastRetryable, nextObj := f.restOp.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
-						retry = retry || retryable
-						processNextObj = processNextObj || nextObj
-						if avimodel.GetRetryCounter() != 0 {
-							fastRetry = fastRetry || fastRetryable
-						} else {
-							fastRetry = false
-							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
-						}
-					} else {
-						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
-						aviError, ok := rest_ops[i].Err.(session.AviError)
-						// If it's 404, don't retry
-						if ok {
-							statuscode := aviError.HttpStatusCode
-							if statuscode != 404 {
-								f.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
-								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
-								return false, true
-							} else {
-								f.restOp.AviVsCacheDel(rest_ops[i], aviObjKey, key)
-							}
-						}
-					}
-				} else {
-					f.restOp.PopulateOneCache(rest_ops[i], aviObjKey, key)
-				}
-			}
-
-			if retry {
-				if fastRetry {
-					f.restOp.PublishKeyToRetryLayer(publishKey, key)
-				} else {
-					f.restOp.PublishKeyToSlowRetryLayer(publishKey, key)
-				}
-			}
-			return false, processNextObj
-		}
-	}
-	return true, true
-}
-
-func (f *follower) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
-	restTimeoutChan := make(chan error, 1)
-	go func() {
-		err := f.AviRestOperate(aviClient, rest_ops, key)
-		restTimeoutChan <- err
-	}()
-	select {
-	case err := <-restTimeoutChan:
-		return err
-	case <-time.After(lib.ControllerReqWaitTime * time.Second):
-		utils.AviLog.Warnf("key: %s, msg: timed out waiting for rest response after %d seconds", key, lib.ControllerReqWaitTime)
-		return errors.New("timed out waiting for rest response")
-	}
-}
-
-func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
@@ -610,7 +367,10 @@ func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp
 			SetVersion := session.SetVersion(op.Version)
 			SetVersion(c.AviSession)
 		}
-		op.Path += "?name=" + op.ObjName
+
+		op.Path += "?name=" + op.ObjName + "&include_name=true&cloud_ref.name=" +
+			utils.CloudName + "&created_by=" + lib.AKOUser
+
 		utils.AviLog.Debugf("key: %s, msg: Got a REST operation: %s, %s", op.ObjName, op.Path)
 		op.Err = c.AviSession.Get(op.Path, &op.Response)
 		if op.Err != nil {

--- a/internal/rest/rest_utils.go
+++ b/internal/rest/rest_utils.go
@@ -45,8 +45,8 @@ func (l *follower) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string
 			if !ok {
 				return resp_elems
 			}
-			utils.AviLog.Debugf("Got a response path %v tenant %v response %v",
-				rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))
+			utils.AviLog.Debugf("key: %s, msg: Got a response path %v tenant %v response %v",
+				key, rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))
 		}
 		resp_elems = append(resp_elems, restResponse)
 		return resp_elems

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -122,7 +122,7 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "sslkeyandcertificate", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "sslkeyandcertificate", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find SSLKeyCert obj in resp %v", rest_op.Response)
 		return errors.New("SSLKeyCert not found")
@@ -151,6 +151,9 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			SSLKeyAndCertificate = rest_op.Obj.(utils.AviRestObjMacro).Data.(avimodels.SSLKeyAndCertificate)
 		case avimodels.SSLKeyAndCertificate:
 			SSLKeyAndCertificate = rest_op.Obj.(avimodels.SSLKeyAndCertificate)
+		}
+		if SSLKeyAndCertificate.Certificate == nil {
+			continue
 		}
 		cert = *SSLKeyAndCertificate.Certificate.Certificate
 		hasCA := false
@@ -281,7 +284,7 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "pkiprofile", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "pkiprofile", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find PkiProfile obj in resp %v", rest_op.Response)
 		return errors.New("PkiProfile not found")

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -293,13 +293,13 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Name not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, msg: Name not present in response %v", key, resp)
 			continue
 		}
 
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Uuid not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, msg: Uuid not present in response %v", key, resp)
 			continue
 		}
 


### PR DESCRIPTION
This PR includes the following changes in the rest layer:

1. Adds a time delay before doing any REST operation towards the controller in the passive AKO to give the active AKO enough time to create objects in the controller.

2. In the passive AKO, all the REST operations are modified into GET operations, and the path in POST operation is modified to `path + "?name=" + objname`. Sometimes the GET operation for the path `path + "?name=" + objname` returns 0, added a retry so that active AKO creates the object and passive AKO reads the object in the subsequent GET calls.

3. During failover, there is a high chance to get 409 (object already exists) errors from the controller. The rest operation code is modified to build the cache and retry on getting a 409 error.

4. In passive AKO, the GET could sometimes return non-404 errors for an Ingress/Route/L4 Svc deletion. The code is modified to retry the GET in such scenarios.

5. For a GET call, the controller returns parent_UUID in the format `http://<controller-ip>/api/virtualservice/<uuid>` but AKO expects the uuid in the format `http://<controller-ip>/api/virtualservice/<uuid>#<parent-vs-name>` while building the cache. The commit also modifies this behavior for a passive AKO to expect only the uuid in the response and get the parent vs name from the key published.
**NOTE:** This was coming because of a missing query parameter in the URI which is resolved in the recent commits.

6. Modifies the status sync function to honor the state(leader/follower) of the AKO.