### PR TITLE
[HA] Changes in Statefulset

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "ako.labels" . | nindent 4 }}
 spec:
+  {{ if gt .Values.replicaCount 2.0 }}
+  {{ fail "ReplicaCount more than 2 is not supported." }}
+  {{ end }}
+  {{ if and (gt .Values.replicaCount 1.0) (eq .Values.AKOSettings.primaryInstance false) }}
+  {{ fail "ReplicaCount more than 1 is not supported for secondary AKO." }}
+  {{ end }}
   replicas: {{ .Values.replicaCount }}
   serviceName: ako
   selector:
@@ -263,10 +269,16 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - ako
+            topologyKey: "kubernetes.io/hostname"
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This PR introduces the following changes.

 1. Modifies the statefulset under helm to limit the number of AKOs
    to two and fails the installation/upgrade when the number of replicas
    given in values.yaml file is more than 2.

2. Adds the check to limit the number of replicas of secondary AKO
    to one.

3. Pod anti-affinity rule to schedule the ako in different nodes.

Tested scenarios:
1. Helm Install/upgrade the AKO with replicaCount as 1,2,4.
    The number of AKOs came up as 1, and 2 when replicaCount was 1 and 2. Got an error `ReplicaCount more than 2 is not supported.` when the replicaCount was 4.

2. helm install/upgrade with replicaCount more than 1 for secondary AKO
    Install/upgrade failed with error `ReplicaCount more than 1 is not supported for secondary AKO.`

3. In a 3-node cluster, kept the AKO's replicaCount as 2. The ako-0 is running in node-0 and ako-1 is running in node-1 and executed the command to drain the node-1. The new ako got scheduled in node-2.