### PR TITLE
[HA] Status layer code changes

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -1211,6 +1211,7 @@ func DeleteNPLAnnotations() {
 	if !lib.AutoAnnotateNPLSvc() {
 		return
 	}
+	publisher := status.NewStatusPublisher()
 	// Delete NPL annotations from the Services
 	allSvcIntf := objects.SharedClusterIpLister().GetAll()
 	allSvcs, ok := allSvcIntf.(map[string]interface{})
@@ -1219,7 +1220,7 @@ func DeleteNPLAnnotations() {
 	} else {
 		for nsSvc := range allSvcs {
 			ns, _, svc := lib.ExtractTypeNameNamespace(nsSvc)
-			status.DeleteNPLAnnotation(nsSvc, ns, svc)
+			publisher.DeleteNPLAnnotation(nsSvc, ns, svc)
 		}
 	}
 	objects.SharedlbLister().GetAll()
@@ -1230,7 +1231,7 @@ func DeleteNPLAnnotations() {
 	} else {
 		for nsSvc := range allLBSvcs {
 			ns, _, svc := lib.ExtractTypeNameNamespace(nsSvc)
-			status.DeleteNPLAnnotation(nsSvc, ns, svc)
+			publisher.DeleteNPLAnnotation(nsSvc, ns, svc)
 		}
 	}
 }
@@ -1285,7 +1286,8 @@ func SyncFromNodesLayer(key interface{}, wg *sync.WaitGroup) error {
 }
 
 func SyncFromStatusQueue(key interface{}, wg *sync.WaitGroup) error {
-	status.DequeueStatus(key)
+	publisher := status.NewStatusPublisher()
+	publisher.DequeueStatus(key)
 	return nil
 }
 

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -134,17 +134,18 @@ func (rest *RestOperations) SyncObjectStatuses() {
 		}
 	}
 
+	publisher := status.NewStatusPublisher()
 	if lib.GetAdvancedL4() {
-		status.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
-		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		publisher.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
+		publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 	} else {
 		if lib.UseServicesAPI() {
-			status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
-			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+			publisher.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
+			publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 		}
-		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
+		publisher.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
 		if !lib.GetLayer7Only() {
-			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+			publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 		}
 	}
 

--- a/internal/status/multicluster_ing_status.go
+++ b/internal/status/multicluster_ing_status.go
@@ -30,7 +30,7 @@ import (
 
 // DeleteMultiClusterIngressStatusAndAnnotation is a wrapper function which gets the Multi-cluster ingress object and deletes the
 // status/annotations.
-func DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+func (l *leader) DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
 	ns := option.ServiceMetadata.Namespace
 	ingName := option.ServiceMetadata.IngressName
 	mciObj, err := utils.GetInformers().MultiClusterIngressInformer.Lister().MultiClusterIngresses(ns).Get(ingName)
@@ -50,7 +50,7 @@ func DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOpti
 
 // UpdateMultiClusterIngressStatusAndAnnotation is a wrapper function which gets the Multi-cluster ingress object and updates the
 // status/annotations.
-func UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+func (l *leader) UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
 	ns := option.ServiceMetadata.Namespace
 	ingName := option.ServiceMetadata.IngressName
 	mciObj, err := utils.GetInformers().MultiClusterIngressInformer.Lister().MultiClusterIngresses(ns).Get(ingName)
@@ -126,4 +126,12 @@ func UpdateMultiClusterIngressAnnotations(mci *akov1alpha1.MultiClusterIngress, 
 		return err
 	}
 	return nil
+}
+
+func (f *follower) UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not updating the Multi-Cluster Ingress status", option.Key)
+}
+
+func (f *follower) DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not deleting the Multi-Cluster Ingress status", key)
 }

--- a/internal/status/status_publisher.go
+++ b/internal/status/status_publisher.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+)
+
+type StatusPublisher interface {
+	DequeueStatus(objIntf interface{}) error
+
+	UpdateL4LBStatus(options []UpdateOptions, bulk bool)
+	DeleteL4LBStatus(svc_mdata_obj lib.ServiceMetadataObj, vsName, key string) error
+
+	UpdateIngressStatus(options []UpdateOptions, bulk bool)
+	DeleteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateRouteStatus(options []UpdateOptions, bulk bool)
+	DeleteRouteStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateRouteIngressStatus(options []UpdateOptions, bulk bool)
+	DeleteRouteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool)
+	DeleteGatewayStatusAddress(svcMetadataObj lib.ServiceMetadataObj, key string) error
+
+	UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool)
+	DeleteSvcApiGatewayStatusAddress(key string, svcMetadataObj lib.ServiceMetadataObj) error
+
+	UpdateNPLAnnotation(key, namespace, name string)
+	DeleteNPLAnnotation(key, namespace, name string)
+
+	UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
+	DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
+}
+
+type (
+	leader   struct{}
+	follower struct{}
+)
+
+func NewStatusPublisher() StatusPublisher {
+	if lib.AKOControlConfig().IsLeader() {
+		return &leader{}
+	}
+	return &follower{}
+}

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -42,7 +42,7 @@ func CheckNPLSvcAnnotation(key, namespace, name string) bool {
 
 // UpdateSvcAnnotation updates a Service with NPL annotation, if not already annotated.
 // If the annotation is already pressent return true
-func UpdateNPLAnnotation(key, namespace, name string) {
+func (l *leader) UpdateNPLAnnotation(key, namespace, name string) {
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
 		utils.AviLog.Infof("key: %s, returning without updating NPL annotation, err %v", key, err)
@@ -78,7 +78,7 @@ func UpdateNPLAnnotation(key, namespace, name string) {
 	return
 }
 
-func DeleteNPLAnnotation(key, namespace, name string) {
+func (l *leader) DeleteNPLAnnotation(key, namespace, name string) {
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
 		return
@@ -108,4 +108,12 @@ func DeleteNPLAnnotation(key, namespace, name string) {
 		return
 	}
 	utils.AviLog.Infof("key: %s, msg: Deleted NPL annotation from Service: %s/%s", key, namespace, name)
+}
+
+func (f *follower) UpdateNPLAnnotation(key, namespace, name string) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not updating the NPL Annotation", key)
+}
+
+func (f *follower) DeleteNPLAnnotation(key, namespace, name string) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not deleting the NPL Annotation", key)
 }


### PR DESCRIPTION
This PR contains the status layer changes for HA. The following changes are added:
1. Converts status layer functions as methods. There will be two versions for active and passive ako. Active AKO updates the status and Passive AKO logs a message and returns.