### PR TITLE
AV-151198: Do not create SNI/EVH Child VS if there is an issue with ertificate. Do not block processing of other SNI childs if there is an issue in other child.

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -392,8 +392,11 @@ func (rest *RestOperations) RestOperation(vsName string, namespace string, avimo
 		} else {
 			_, rest_ops = rest.SNINodeCU(sni_node, nil, namespace, sni_to_delete, rest_ops, key)
 		}
-		if success, _ := rest.ExecuteRestAndPopulateCache(rest_ops, vsKey, avimodel, key, false); !success {
-			return
+		if success, processNextChild := rest.ExecuteRestAndPopulateCache(rest_ops, vsKey, avimodel, key, false); !success {
+			if !processNextChild {
+				utils.AviLog.Infof("key: %s, msg: Failure in processing SNI node: %s. Not processing other child nodes.", key, sni_node.Name)
+				return
+			}
 		}
 	}
 

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -127,14 +127,8 @@ func (v *virtualserviceSchema) removeCertRef(op *utils.RestOp, objRef string) bo
 		utils.AviLog.Infof("Failed to remove SSL Cert ref, object is not of type Virtualservice")
 		return false
 	}
-	for i, v := range vs.SslKeyAndCertificateRefs {
-		if strings.EqualFold(v, objRef) {
-			vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs[:i], vs.SslKeyAndCertificateRefs[i+1:]...)
-			utils.AviLog.Infof("Successfully removed SSl Cert ref %s from VS: %s", objRef, *vs.Name)
-		}
-	}
 	op.Obj = vs
-	return true
+	return false
 }
 
 func (v *virtualserviceSchema) removePoolRef(op *utils.RestOp, objRef string) bool {


### PR DESCRIPTION
This PR avoids creation of SNI child VS and its related objects when certificate is invalid. 

TODO: As parent VS gets created first, parent VSVIP will have entry of invalid host in dns_info of parent. So we will take care of removing it in next PR.