### PR TITLE
[HA] Sync HA code to master

### DIFF
--- a/ako-infra/avirest/handle_netinfo.go
+++ b/ako-infra/avirest/handle_netinfo.go
@@ -551,11 +551,12 @@ func executeRestOp(key string, client *clients.AviClient, restOp *utils.RestOp, 
 		utils.AviLog.Infof("key: %s, Retrying to execute rest request", key)
 		retry = retryNum[0]
 		if retry >= 3 {
-			utils.AviLog.Errorf("key %s, rest request execution aborted after reqtrying 3 times", key)
+			utils.AviLog.Errorf("key %s, rest request execution aborted after retrying 3 times", key)
 			return
 		}
 	}
-	err := rest.AviRestOperateWrapper(client, []*utils.RestOp{restOp})
+	restLayer := rest.NewRestOperations(nil, nil, true)
+	err := restLayer.AviRestOperateWrapper(client, []*utils.RestOp{restOp}, key)
 	if err != nil {
 		utils.AviLog.Infof("key %s, Got error in executing rest request: %v", key, err)
 		if checkAndRetry(key, err) {

--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -327,6 +327,8 @@ func InitializeAKC() {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	if lib.IsIstioEnabled() {
 		utils.AviLog.Infof("Waiting on Istio resources creation")
@@ -343,6 +345,7 @@ func InitializeAKC() {
 		wgGraph.Wait()
 		wgFastRetry.Wait()
 		wgStatus.Wait()
+		wgLeaderElection.Wait()
 	}()
 	// Timeout after 60 seconds.
 	timeout := 60 * time.Second

--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -51,6 +51,9 @@ rules:
   - apiGroups: ["ako.vmware.com"]
     resources: ["multiclusteringresses/status","serviceimports/status"]
     verbs: ["get","patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]
 {{- if .Values.rbac.pspEnable }}
   - apiGroups:
     - policy

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "ako.labels" . | nindent 4 }}
 spec:
+  {{ if gt .Values.replicaCount 2.0 }}
+  {{ fail "ReplicaCount more than 2 is not supported." }}
+  {{ end }}
+  {{ if and (gt .Values.replicaCount 1.0) (eq .Values.AKOSettings.primaryInstance false) }}
+  {{ fail "ReplicaCount more than 1 is not supported for secondary AKO." }}
+  {{ end }}
   replicas: {{ .Values.replicaCount }}
   serviceName: ako
   selector:
@@ -263,10 +269,16 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - ako
+            topologyKey: "kubernetes.io/hostname"
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2715,6 +2715,11 @@ func validateAndConfigureSeGroup(client *clients.AviClient, returnErr *error) bo
 
 // ConfigureSeGroupLabels configures labels on the SeGroup if not present already
 func ConfigureSeGroupLabels(client *clients.AviClient, seGroup *models.ServiceEngineGroup) error {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		return nil
+	}
+
 	labels := seGroup.Labels
 	segName := *seGroup.Name
 	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
@@ -2753,6 +2758,11 @@ func ConfigureSeGroupLabels(client *clients.AviClient, seGroup *models.ServiceEn
 
 // DeConfigureSeGroupLabels deconfigures labels on the SeGroup.
 func DeConfigureSeGroupLabels() {
+
+	if !lib.AKOControlConfig().IsLeader() {
+		return
+	}
+
 	if len(lib.GetLabels()) == 0 {
 		return
 	}

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -1211,6 +1211,7 @@ func DeleteNPLAnnotations() {
 	if !lib.AutoAnnotateNPLSvc() {
 		return
 	}
+	publisher := status.NewStatusPublisher()
 	// Delete NPL annotations from the Services
 	allSvcIntf := objects.SharedClusterIpLister().GetAll()
 	allSvcs, ok := allSvcIntf.(map[string]interface{})
@@ -1219,7 +1220,7 @@ func DeleteNPLAnnotations() {
 	} else {
 		for nsSvc := range allSvcs {
 			ns, _, svc := lib.ExtractTypeNameNamespace(nsSvc)
-			status.DeleteNPLAnnotation(nsSvc, ns, svc)
+			publisher.DeleteNPLAnnotation(nsSvc, ns, svc)
 		}
 	}
 	objects.SharedlbLister().GetAll()
@@ -1230,7 +1231,7 @@ func DeleteNPLAnnotations() {
 	} else {
 		for nsSvc := range allLBSvcs {
 			ns, _, svc := lib.ExtractTypeNameNamespace(nsSvc)
-			status.DeleteNPLAnnotation(nsSvc, ns, svc)
+			publisher.DeleteNPLAnnotation(nsSvc, ns, svc)
 		}
 	}
 }
@@ -1285,7 +1286,8 @@ func SyncFromNodesLayer(key interface{}, wg *sync.WaitGroup) error {
 }
 
 func SyncFromStatusQueue(key interface{}, wg *sync.WaitGroup) error {
-	status.DequeueStatus(key)
+	publisher := status.NewStatusPublisher()
+	publisher.DequeueStatus(key)
 	return nil
 }
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -581,10 +581,9 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 
 	// Leader election happens after populating controller cache and fullsynck8s.
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	leaderElector, err := utils.NewLeaderElector(informers.Cs, c.OnStartedLeading, c.OnStoppedLeading, c.OnNewLeader)
 	if err != nil {
-		utils.AviLog.Fatalf("Leader election failed, shutting down AKO", err)
+		utils.AviLog.Fatalf("Leader election failed with error %v, shutting down AKO.", err)
 	}
 
 	leReadyCh := leaderElector.Run(ctx, leaderElectionWG)

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -101,6 +101,27 @@ func PopulateCache() error {
 	return nil
 }
 
+func cleanupStaleVSes() {
+	avi_obj_cache := avicache.SharedAviObjCache()
+	// Delete Stale objects by deleting model for dummy VS
+	aviclient := avicache.SharedAVIClients()
+	restlayer := rest.NewRestOperations(avi_obj_cache, aviclient)
+	staleVSKey := lib.GetTenant() + "/" + lib.DummyVSForStaleData
+	if _, err := lib.IsClusterNameValid(); err != nil {
+		utils.AviLog.Errorf("AKO cluster name is invalid.")
+		return
+	}
+	if aviclient != nil && len(aviclient.AviClient) > 0 {
+		utils.AviLog.Infof("Starting clean up of stale objects")
+		restlayer.CleanupVS(staleVSKey, true)
+		staleCacheKey := avicache.NamespaceName{
+			Name:      lib.DummyVSForStaleData,
+			Namespace: lib.GetTenant(),
+		}
+		avi_obj_cache.VsCacheMeta.AviCacheDelete(staleCacheKey)
+	}
+}
+
 func deleteAviObjects(parentVSKeys []avicache.NamespaceName, avi_obj_cache *avicache.AviObjCache, avi_rest_client_pool *utils.AviRestClientPool) {
 	for _, pvsKey := range parentVSKeys {
 		// Fetch the parent VS cache and update the SNI child
@@ -480,6 +501,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	var fastretrywg *sync.WaitGroup
 	var slowretrywg *sync.WaitGroup
 	var statusWG *sync.WaitGroup
+	var leaderElectionWG *sync.WaitGroup
 	if len(waitGroupMap) > 0 {
 		// Fetch all the waitgroups
 		ingestionwg, _ = waitGroupMap[0]["ingestion"]
@@ -487,6 +509,7 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 		fastretrywg, _ = waitGroupMap[0]["fastretry"]
 		slowretrywg, _ = waitGroupMap[0]["slowretry"]
 		statusWG, _ = waitGroupMap[0]["status"]
+		leaderElectionWG, _ = waitGroupMap[0]["leaderElection"]
 	}
 
 	/** Sequence:
@@ -530,12 +553,6 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	}
 	c.Start(stopCh)
 
-	// once the l3 cache is populated, we can call the updatestatus functions from here
-	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
-	restlayer.SyncObjectStatuses()
-
-	graphQueue.SyncFunc = SyncFromNodesLayer
-	graphQueue.Run(stopCh, graphwg)
 	fullSyncInterval := os.Getenv(utils.FULL_SYNC_INTERVAL)
 	interval, err := strconv.ParseInt(fullSyncInterval, 10, 64)
 
@@ -574,6 +591,27 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 			go tokenWorker.Run()
 		}
 	}
+
+	// Leader election happens after populating controller cache and fullsynck8s.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	leaderElector, err := utils.NewLeaderElector(informers.Cs, c.OnStartedLeading, c.OnStoppedLeading, c.OnNewLeader)
+	if err != nil {
+		utils.AviLog.Fatalf("Leader election failed, shutting down AKO", err)
+	}
+
+	leReadyCh := leaderElector.Run(ctx, leaderElectionWG)
+	<-leReadyCh
+
+	cleanupStaleVSes()
+
+	// once the l3 cache is populated, we can call the updatestatus functions from here
+	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
+	restlayer.SyncObjectStatuses()
+
+	graphQueue.SyncFunc = SyncFromNodesLayer
+	graphQueue.Run(stopCh, graphwg)
+
 	c.SetupEventHandlers(informers)
 	if lib.DisableSync {
 		lib.AKOControlConfig().PodEventf(corev1.EventTypeNormal, lib.AKODeleteConfigSet, "AKO is in disable sync state")
@@ -609,6 +647,10 @@ LABEL:
 	if worker != nil {
 		worker.Shutdown()
 	}
+
+	// Cancel the Leader election goroutines
+	cancel()
+	<-ctx.Done()
 
 	ingestionQueue.StopWorkers(stopCh)
 	graphQueue.StopWorkers(stopCh)
@@ -845,7 +887,7 @@ func (c *AviController) FullSyncK8s() error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
-				if err := validateHostRuleObj(key, hostRuleObj); err != nil {
+				if err := c.GetValidator().ValidateHostRuleObj(key, hostRuleObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
 				}
 				nodes.DequeueIngestion(key, true)
@@ -863,7 +905,7 @@ func (c *AviController) FullSyncK8s() error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
-				if err := validateHTTPRuleObj(key, httpRuleObj); err != nil {
+				if err := c.GetValidator().ValidateHTTPRuleObj(key, httpRuleObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HTTPRule: %v", key, err)
 				}
 				nodes.DequeueIngestion(key, true)
@@ -881,7 +923,7 @@ func (c *AviController) FullSyncK8s() error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
-				if err := validateAviInfraSetting(key, aviInfraObj); err != nil {
+				if err := c.GetValidator().ValidateAviInfraSetting(key, aviInfraObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of AviInfraSetting: %v", key, err)
 				}
 				nodes.DequeueIngestion(key, true)
@@ -1055,18 +1097,23 @@ func (c *AviController) FullSyncK8s() error {
 			nodes.DequeueIngestion(key, true)
 		}
 	}
+	return nil
+}
 
+func (c *AviController) publishAllParentVSKeysToRestLayer() {
 	cache := avicache.SharedAviObjCache()
 	vsKeys := cache.VsCacheMeta.AviCacheGetAllParentVSKeys()
 	utils.AviLog.Debugf("Got the VS keys: %s", vsKeys)
 	allModelsMap := objects.SharedAviGraphLister().GetAll()
-	var allModels []string
+	allModels := make(map[string]struct{})
+	vrfModelName := lib.GetModelName(lib.GetTenant(), lib.GetVrf())
 	for modelName := range allModelsMap.(map[string]interface{}) {
 		// ignore vrf model, as it has been published already
 		if modelName != vrfModelName && !lib.IsIstioKey(modelName) {
-			allModels = append(allModels, modelName)
+			allModels[modelName] = struct{}{}
 		}
 	}
+	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 	syncNamespace := lib.GetNamespaceToSync()
 	for _, vsCacheKey := range vsKeys {
 		modelName := vsCacheKey.Namespace + "/" + vsCacheKey.Name
@@ -1075,24 +1122,21 @@ func (c *AviController) FullSyncK8s() error {
 			shardVsPrefix := lib.ShardVSPrefix
 			if shardVsPrefix != "" {
 				if strings.HasPrefix(vsCacheKey.Name, shardVsPrefix) {
-					if utils.HasElem(allModels, modelName) {
-						allModels = utils.Remove(allModels, modelName)
-					}
+					delete(allModels, modelName)
 					utils.AviLog.Infof("Model published L7 VS during namespace based sync: %s", modelName)
 					nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
 				}
 			}
 			// For namespace based syncs, the L4 VSes would be named: clusterName + "--" + namespace
 			if strings.HasPrefix(vsCacheKey.Name, lib.GetNamePrefix()+syncNamespace) {
-				if utils.HasElem(allModels, modelName) {
-					allModels = utils.Remove(allModels, modelName)
-				}
+				delete(allModels, modelName)
 				utils.AviLog.Infof("Model published L4 VS during namespace based sync: %s", modelName)
 				nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
 			}
 		} else {
-			if utils.HasElem(allModels, modelName) {
-				allModels = utils.Remove(allModels, modelName)
+			delete(allModels, modelName)
+			if vsCacheKey.Name == lib.DummyVSForStaleData {
+				continue
 			}
 			utils.AviLog.Infof("Model published in full sync %s", modelName)
 			nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
@@ -1101,12 +1145,9 @@ func (c *AviController) FullSyncK8s() error {
 	// Now also publish the newly generated models (if any)
 	// Publish all the models to REST layer.
 	utils.AviLog.Debugf("Newly generated models that do not exist in cache %s", utils.Stringify(allModels))
-	if allModels != nil {
-		for _, modelName := range allModels {
-			nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
-		}
+	for modelName := range allModels {
+		nodes.PublishKeyToRestLayer(modelName, "fullsync", sharedQueue)
 	}
-	return nil
 }
 
 // DeleteModels : Delete models and add the model name in the queue.

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -1329,3 +1329,7 @@ func (c *AviController) Run(stopCh <-chan struct{}) error {
 
 	return nil
 }
+
+func (c *AviController) GetValidator() Validator {
+	return NewValidator()
+}

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
 	"time"
 
 	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -29,7 +28,6 @@ import (
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
 	akocrd "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/clientset/versioned"
 	akoinformers "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/informers/externalversions"
@@ -120,7 +118,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				hostrule := obj.(*akov1alpha1.HostRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 				key := lib.HostRule + "/" + utils.ObjKey(hostrule)
-				if err := validateHostRuleObj(key, hostrule); err != nil {
+				if err := c.GetValidator().ValidateHostRuleObj(key, hostrule); err != nil {
 					utils.AviLog.Warnf("key: %s, msg: Error retrieved during validation of HostRule: %v", key, err)
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -136,7 +134,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				if isHostRuleUpdated(oldObj, hostrule) {
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(hostrule))
 					key := lib.HostRule + "/" + utils.ObjKey(hostrule)
-					if err := validateHostRuleObj(key, hostrule); err != nil {
+					if err := c.GetValidator().ValidateHostRuleObj(key, hostrule); err != nil {
 						utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
 					}
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
@@ -182,7 +180,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				httprule := obj.(*akov1alpha1.HTTPRule)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(httprule))
 				key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
-				if err := validateHTTPRuleObj(key, httprule); err != nil {
+				if err := c.GetValidator().ValidateHTTPRuleObj(key, httprule); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -200,7 +198,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				if isHTTPRuleUpdated(oldObj, httprule) {
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(httprule))
 					key := lib.HTTPRule + "/" + utils.ObjKey(httprule)
-					if err := validateHTTPRuleObj(key, httprule); err != nil {
+					if err := c.GetValidator().ValidateHTTPRuleObj(key, httprule); err != nil {
 						utils.AviLog.Warnf("Error retrieved during validation of HTTPRule: %v", err)
 					}
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
@@ -247,7 +245,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				aviinfra := obj.(*akov1alpha1.AviInfraSetting)
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(aviinfra))
 				key := lib.AviInfraSetting + "/" + utils.ObjKey(aviinfra)
-				if err := validateAviInfraSetting(key, aviinfra); err != nil {
+				if err := c.GetValidator().ValidateAviInfraSetting(key, aviinfra); err != nil {
 					utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
 				}
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
@@ -263,7 +261,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				if isAviInfraUpdated(oldObj, aviInfra) {
 					namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(aviInfra))
 					key := lib.AviInfraSetting + "/" + utils.ObjKey(aviInfra)
-					if err := validateAviInfraSetting(key, aviInfra); err != nil {
+					if err := c.GetValidator().ValidateAviInfraSetting(key, aviInfra); err != nil {
 						utils.AviLog.Warnf("Error retrieved during validation of AviInfraSetting: %v", err)
 					}
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
@@ -520,7 +518,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 				utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress add event: Namespace: %s didn't qualify filter. Not adding multi-cluster ingress", key, namespace)
 				return
 			}
-			if err := validateMultiClusterIngressObj(key, mci); err != nil {
+			if err := c.GetValidator().ValidateMultiClusterIngressObj(key, mci); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: Validation of MultiClusterIngress failed: %v", key, err)
 				return
 			}
@@ -541,7 +539,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 					utils.AviLog.Debugf("key: %s, msg: Multi-cluster Ingress update event: Namespace: %s didn't qualify filter. Not updating multi-cluster ingress", key, namespace)
 					return
 				}
-				if err := validateMultiClusterIngressObj(key, mci); err != nil {
+				if err := c.GetValidator().ValidateMultiClusterIngressObj(key, mci); err != nil {
 					utils.AviLog.Warnf("key: %s, msg: Validation of MultiClusterIngress failed: %v", key, err)
 					return
 				}
@@ -598,7 +596,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: Service Import add event: Namespace: %s didn't qualify filter. Not adding Service Import", key, namespace)
 				return
 			}
-			if err := validateServiceImportObj(key, si); err != nil {
+			if err := c.GetValidator().ValidateServiceImportObj(key, si); err != nil {
 				utils.AviLog.Warnf("key: %s, msg: Validation of ServiceImport failed: %v", key, err)
 				return
 			}
@@ -619,7 +617,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: Service Import update event: Namespace: %s didn't qualify filter. Not updating Service Import", key, namespace)
 					return
 				}
-				if err := validateServiceImportObj(key, si); err != nil {
+				if err := c.GetValidator().ValidateServiceImportObj(key, si); err != nil {
 					utils.AviLog.Warnf("key: %s, msg: Validation of ServiceImport failed: %v", key, err)
 					return
 				}
@@ -658,197 +656,6 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 		},
 	}
 	c.informers.ServiceImportInformer.Informer().AddEventHandler(serviceImportEventHandler)
-}
-
-// validateHostRuleObj would do validation checks
-// update internal CRD caches, and push relevant ingresses to ingestion
-func validateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
-	var err error
-	fqdn := hostrule.Spec.VirtualHost.Fqdn
-	foundHost, foundHR := objects.SharedCRDLister().GetFQDNToHostruleMapping(fqdn)
-	if foundHost && foundHR != hostrule.Namespace+"/"+hostrule.Name {
-		err = fmt.Errorf("duplicate fqdn %s found in %s", fqdn, foundHR)
-		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-		return err
-	}
-
-	// If it is not a Shared VS but TCP Settings are provided, then we reject it since these
-	// TCP settings are not valid for the child VS.
-	// TODO: move to translator?
-	// if !strings.Contains(fqdn, lib.ShardVSSubstring) && hostrule.Spec.VirtualHost.TCPSettings != nil {
-	// 	err = fmt.Errorf("Hostrule tcpSettings with fqdn %s cannot be applied to child Virtualservices", fqdn)
-	// 	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-	// 	return err
-	// }
-
-	if hostrule.Spec.VirtualHost.TCPSettings != nil && hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP != "" {
-		re := regexp.MustCompile(lib.IPRegex)
-		if !re.MatchString(hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP) {
-			err = fmt.Errorf("loadBalancerIP %s is not a valid IP", hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP)
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-	}
-
-	if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" {
-		if fqdn == hostrule.Spec.VirtualHost.Gslb.Fqdn {
-			err = fmt.Errorf("GSLB FQDN and local FQDN are same")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-	}
-
-	if hostrule.Spec.VirtualHost.TCPSettings != nil && len(hostrule.Spec.VirtualHost.TCPSettings.Listeners) > 0 {
-		sslEnabled := false
-		for _, listener := range hostrule.Spec.VirtualHost.TCPSettings.Listeners {
-			if listener.EnableSSL {
-				sslEnabled = true
-				break
-			}
-		}
-		if !sslEnabled {
-			err = fmt.Errorf("Hosting parent virtualservice must have SSL enabled")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-	}
-
-	if hostrule.Spec.VirtualHost.Aliases != nil {
-		if hostrule.Spec.VirtualHost.FqdnType != akov1alpha1.Exact {
-			err = fmt.Errorf("Aliases is supported only when FQDN type is set as Exact")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-
-		if utils.HasElem(hostrule.Spec.VirtualHost.Aliases, fqdn) {
-			err = fmt.Errorf("Duplicate entry found. Aliases field has same entry as the FQDN field")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-
-		if utils.ContainsDuplicate(hostrule.Spec.VirtualHost.Aliases) {
-			err = fmt.Errorf("Aliases must be unique")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-
-		if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" &&
-			utils.HasElem(hostrule.Spec.VirtualHost.Aliases, hostrule.Spec.VirtualHost.Gslb.Fqdn) {
-			err = fmt.Errorf("Aliases must not contain GSLB FQDN")
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-
-		for cachedFQDN, cachedAliases := range objects.SharedCRDLister().GetAllFQDNToAliasesMapping() {
-			if cachedFQDN == fqdn {
-				continue
-			}
-			aliases := cachedAliases.([]string)
-			for _, alias := range hostrule.Spec.VirtualHost.Aliases {
-				if utils.HasElem(aliases, alias) {
-					err = fmt.Errorf("%s is already in use by hostrule %s", alias, cachedFQDN)
-					status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-					return err
-				}
-			}
-		}
-	}
-
-	refData := map[string]string{
-		hostrule.Spec.VirtualHost.WAFPolicy:          "WafPolicy",
-		hostrule.Spec.VirtualHost.ApplicationProfile: "AppProfile",
-		hostrule.Spec.VirtualHost.TLS.SSLProfile:     "SslProfile",
-		hostrule.Spec.VirtualHost.AnalyticsProfile:   "AnalyticsProfile",
-		hostrule.Spec.VirtualHost.ErrorPageProfile:   "ErrorPageProfile",
-	}
-	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Type == akov1alpha1.HostRuleSecretTypeAviReference {
-		refData[hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Name] = "SslKeyCert"
-	}
-
-	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Type == akov1alpha1.HostRuleSecretTypeSecretReference {
-		_, err := utils.GetInformers().SecretInformer.Lister().Secrets(hostrule.Namespace).Get(hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Name)
-		if err != nil {
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-	}
-	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Type == akov1alpha1.HostRuleSecretTypeAviReference {
-		refData[hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Name] = "SslKeyCert"
-	}
-
-	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Type == akov1alpha1.HostRuleSecretTypeSecretReference {
-		_, err := utils.GetInformers().SecretInformer.Lister().Secrets(hostrule.Namespace).Get(hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Name)
-		if err != nil {
-			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-			return err
-		}
-	}
-
-	for _, policy := range hostrule.Spec.VirtualHost.HTTPPolicy.PolicySets {
-		refData[policy] = "HttpPolicySet"
-	}
-
-	for _, script := range hostrule.Spec.VirtualHost.Datascripts {
-		refData[script] = "VsDatascript"
-	}
-
-	if err := checkRefsOnController(key, refData); err != nil {
-		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
-		return err
-	}
-
-	// No need to update status of hostrule object as accepted since it was accepted before.
-	if hostrule.Status.Status == lib.StatusAccepted {
-		return nil
-	}
-
-	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusAccepted, Error: ""})
-	return nil
-}
-
-// validateMultiClusterIngressObj validates the MCI CRD changes before pushing it to ingestion
-func validateMultiClusterIngressObj(key string, multiClusterIngress *akov1alpha1.MultiClusterIngress) error {
-
-	var err error
-	statusToUpdate := &akov1alpha1.MultiClusterIngressStatus{}
-	defer func() {
-		if err == nil {
-			statusToUpdate.Status.Accepted = true
-			status.UpdateMultiClusterIngressStatus(key, multiClusterIngress, statusToUpdate)
-			return
-		}
-		statusToUpdate.Status.Accepted = false
-		statusToUpdate.Status.Reason = err.Error()
-		status.UpdateMultiClusterIngressStatus(key, multiClusterIngress, statusToUpdate)
-	}()
-
-	// Currently, we support only NodePort ServiceType.
-	if !lib.IsNodePortMode() {
-		err = fmt.Errorf("ServiceType must be of type NodePort")
-		return err
-	}
-
-	// Currently, we support EVH mode only.
-	if !lib.IsEvhEnabled() {
-		err = fmt.Errorf("AKO must be in EVH mode")
-		return err
-	}
-
-	if len(multiClusterIngress.Spec.Config) == 0 {
-		err = fmt.Errorf("config must not be empty")
-		return err
-	}
-
-	return nil
-}
-
-// validateServiceImportObj validates the SI CRD changes before pushing it to ingestion
-func validateServiceImportObj(key string, serviceImport *akov1alpha1.ServiceImport) error {
-
-	// CHECK ME: AMKO creates this and validation required?
-	// TODO: validations needs a status field
-
-	return nil
 }
 
 func checkRefsOnController(key string, refMap map[string]string) error {
@@ -960,121 +767,6 @@ func checkRefOnController(key, refKey, refValue string) error {
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Ref found for %s/%s", key, refModelMap[refKey], refValue)
-	return nil
-}
-
-// validateHTTPRuleObj would do validation checks
-// update internal CRD caches, and push relevant ingresses to ingestion
-func validateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
-	refData := make(map[string]string)
-	for _, path := range httprule.Spec.Paths {
-		if path.TLS.PKIProfile != "" && path.TLS.DestinationCA != "" {
-			//if both pkiProfile and destCA set, reject httprule
-			status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
-				Status: lib.StatusRejected,
-				Error:  lib.HttpRulePkiAndDestCASetErr,
-			})
-			return fmt.Errorf("key: %s, msg: %s", key, lib.HttpRulePkiAndDestCASetErr)
-		}
-		refData[path.TLS.SSLProfile] = "SslProfile"
-		refData[path.ApplicationPersistence] = "ApplicationPersistence"
-		if path.TLS.PKIProfile != "" {
-			refData[path.TLS.PKIProfile] = "PKIProfile"
-		}
-
-		for _, hm := range path.HealthMonitors {
-			refData[hm] = "HealthMonitor"
-		}
-	}
-
-	if err := checkRefsOnController(key, refData); err != nil {
-		status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
-			Status: lib.StatusRejected,
-			Error:  err.Error(),
-		})
-		return err
-	}
-
-	// No need to update status of httprule object as accepted since it was accepted before.
-	if httprule.Status.Status == lib.StatusAccepted {
-		return nil
-	}
-
-	status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
-		Status: lib.StatusAccepted,
-		Error:  "",
-	})
-	return nil
-}
-
-// validateAviInfraSetting would do validaion checks on the
-// ingested AviInfraSetting objects
-func validateAviInfraSetting(key string, infraSetting *akov1alpha1.AviInfraSetting) error {
-	if ((infraSetting.Spec.Network.EnableRhi != nil && !*infraSetting.Spec.Network.EnableRhi) || infraSetting.Spec.Network.EnableRhi == nil) &&
-		len(infraSetting.Spec.Network.BgpPeerLabels) > 0 {
-		err := fmt.Errorf("BGPPeerLabels cannot be set if EnableRhi is false.")
-		status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
-			Status: lib.StatusRejected,
-			Error:  err.Error(),
-		})
-		return err
-	}
-
-	refData := make(map[string]string)
-	for _, vipNetwork := range infraSetting.Spec.Network.VipNetworks {
-		if vipNetwork.Cidr != "" {
-			re := regexp.MustCompile(lib.IPCIDRRegex)
-			if !re.MatchString(vipNetwork.Cidr) {
-				err := fmt.Errorf("invalid CIDR configuration %s detected for networkName %s in vipNetworkList", vipNetwork.Cidr, vipNetwork.NetworkName)
-				status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
-					Status: lib.StatusRejected,
-					Error:  err.Error(),
-				})
-				return err
-			}
-		}
-		if vipNetwork.V6Cidr != "" {
-			re := regexp.MustCompile(lib.IPV6CIDRRegex)
-			if !re.MatchString(vipNetwork.V6Cidr) {
-				err := fmt.Errorf("invalid IPv6 CIDR configuration %s detected for networkName %s in vipNetworkList", vipNetwork.V6Cidr, vipNetwork.NetworkName)
-				status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
-					Status: lib.StatusRejected,
-					Error:  err.Error(),
-				})
-				return err
-			}
-		}
-		refData[vipNetwork.NetworkName] = "Network"
-	}
-
-	if infraSetting.Spec.SeGroup.Name != "" {
-		refData[infraSetting.Spec.SeGroup.Name] = "ServiceEngineGroup"
-	}
-
-	if err := checkRefsOnController(key, refData); err != nil {
-		status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
-			Status: lib.StatusRejected,
-			Error:  err.Error(),
-		})
-		return err
-	}
-
-	// This would add SEG labels only if they are not configured yet. In case there is a label mismatch
-	// to any pre-existing SEG labels, the AviInfraSettig CR will get Rejected from the checkRefsOnController
-	// step before this.
-	if infraSetting.Spec.SeGroup.Name != "" {
-		addSeGroupLabel(key, infraSetting.Spec.SeGroup.Name)
-	}
-
-	// No need to update status of infra setting object as accepted since it was accepted before.
-	if infraSetting.Status.Status == lib.StatusAccepted {
-		return nil
-	}
-
-	status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
-		Status: lib.StatusAccepted,
-		Error:  "",
-	})
 	return nil
 }
 

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -37,9 +37,7 @@ func (c *AviController) OnNewLeader() {
 
 func (c *AviController) OnStoppedLeading() {
 	lib.AKOControlConfig().SetIsLeaderFlag(false)
-	utils.AviLog.Debugf("AKO lost the leadership")
-	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO lost the leadership")
-	lib.ShutdownApi()
 	c.DisableSync = true
 	lib.SetDisableSync(true)
+	utils.AviLog.Fatal("AKO lost the leadership")
 }

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+func (c *AviController) OnStartedLeading() {
+	lib.AKOControlConfig().SetIsLeaderFlag(true)
+	utils.AviLog.Debugf("AKO became a leader")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a leader")
+	c.publishAllParentVSKeysToRestLayer()
+}
+
+func (c *AviController) OnNewLeader() {
+	lib.AKOControlConfig().SetIsLeaderFlag(false)
+	utils.AviLog.Debugf("AKO became a follower")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a follower")
+	c.publishAllParentVSKeysToRestLayer()
+}
+
+func (c *AviController) OnStoppedLeading() {
+	lib.AKOControlConfig().SetIsLeaderFlag(false)
+	utils.AviLog.Debugf("AKO lost the leadership")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO lost the leadership")
+}

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -39,4 +39,7 @@ func (c *AviController) OnStoppedLeading() {
 	lib.AKOControlConfig().SetIsLeaderFlag(false)
 	utils.AviLog.Debugf("AKO lost the leadership")
 	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO lost the leadership")
+	lib.ShutdownApi()
+	c.DisableSync = true
+	lib.SetDisableSync(true)
 }

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2022-2023 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/internal/k8s/validator.go
+++ b/internal/k8s/validator.go
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2022-2023 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package k8s
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
+	akov1alpha1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1alpha1"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type Validator interface {
+	ValidateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error
+	ValidateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error
+	ValidateAviInfraSetting(key string, infraSetting *akov1alpha1.AviInfraSetting) error
+	ValidateMultiClusterIngressObj(key string, multiClusterIngress *akov1alpha1.MultiClusterIngress) error
+	ValidateServiceImportObj(key string, serviceImport *akov1alpha1.ServiceImport) error
+}
+
+type (
+	follower struct{}
+	leader   struct{}
+)
+
+func NewValidator() Validator {
+	if lib.AKOControlConfig().IsLeader() {
+		return &leader{}
+	}
+	return &follower{}
+}
+
+// validateHostRuleObj would do validation checks
+// update internal CRD caches, and push relevant ingresses to ingestion
+func (l *leader) ValidateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
+
+	var err error
+	fqdn := hostrule.Spec.VirtualHost.Fqdn
+	foundHost, foundHR := objects.SharedCRDLister().GetFQDNToHostruleMapping(fqdn)
+	if foundHost && foundHR != hostrule.Namespace+"/"+hostrule.Name {
+		err = fmt.Errorf("duplicate fqdn %s found in %s", fqdn, foundHR)
+		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+		return err
+	}
+
+	// If it is not a Shared VS but TCP Settings are provided, then we reject it since these
+	// TCP settings are not valid for the child VS.
+	// TODO: move to translator?
+	// if !strings.Contains(fqdn, lib.ShardVSSubstring) && hostrule.Spec.VirtualHost.TCPSettings != nil {
+	// 	err = fmt.Errorf("Hostrule tcpSettings with fqdn %s cannot be applied to child Virtualservices", fqdn)
+	// 	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+	// 	return err
+	// }
+
+	if hostrule.Spec.VirtualHost.TCPSettings != nil && hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP != "" {
+		re := regexp.MustCompile(lib.IPRegex)
+		if !re.MatchString(hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP) {
+			err = fmt.Errorf("loadBalancerIP %s is not a valid IP", hostrule.Spec.VirtualHost.TCPSettings.LoadBalancerIP)
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+	}
+
+	if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" {
+		if fqdn == hostrule.Spec.VirtualHost.Gslb.Fqdn {
+			err = fmt.Errorf("GSLB FQDN and local FQDN are same")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+	}
+
+	if hostrule.Spec.VirtualHost.TCPSettings != nil && len(hostrule.Spec.VirtualHost.TCPSettings.Listeners) > 0 {
+		sslEnabled := false
+		for _, listener := range hostrule.Spec.VirtualHost.TCPSettings.Listeners {
+			if listener.EnableSSL {
+				sslEnabled = true
+				break
+			}
+		}
+		if !sslEnabled {
+			err = fmt.Errorf("Hosting parent virtualservice must have SSL enabled")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+	}
+
+	if hostrule.Spec.VirtualHost.Aliases != nil {
+		if hostrule.Spec.VirtualHost.FqdnType != akov1alpha1.Exact {
+			err = fmt.Errorf("Aliases is supported only when FQDN type is set as Exact")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+
+		if utils.HasElem(hostrule.Spec.VirtualHost.Aliases, fqdn) {
+			err = fmt.Errorf("Duplicate entry found. Aliases field has same entry as the FQDN field")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+
+		if utils.ContainsDuplicate(hostrule.Spec.VirtualHost.Aliases) {
+			err = fmt.Errorf("Aliases must be unique")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+
+		if hostrule.Spec.VirtualHost.Gslb.Fqdn != "" &&
+			utils.HasElem(hostrule.Spec.VirtualHost.Aliases, hostrule.Spec.VirtualHost.Gslb.Fqdn) {
+			err = fmt.Errorf("Aliases must not contain GSLB FQDN")
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+
+		for cachedFQDN, cachedAliases := range objects.SharedCRDLister().GetAllFQDNToAliasesMapping() {
+			if cachedFQDN == fqdn {
+				continue
+			}
+			aliases := cachedAliases.([]string)
+			for _, alias := range hostrule.Spec.VirtualHost.Aliases {
+				if utils.HasElem(aliases, alias) {
+					err = fmt.Errorf("%s is already in use by hostrule %s", alias, cachedFQDN)
+					status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+					return err
+				}
+			}
+		}
+	}
+
+	refData := map[string]string{
+		hostrule.Spec.VirtualHost.WAFPolicy:          "WafPolicy",
+		hostrule.Spec.VirtualHost.ApplicationProfile: "AppProfile",
+		hostrule.Spec.VirtualHost.TLS.SSLProfile:     "SslProfile",
+		hostrule.Spec.VirtualHost.AnalyticsProfile:   "AnalyticsProfile",
+		hostrule.Spec.VirtualHost.ErrorPageProfile:   "ErrorPageProfile",
+	}
+	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Type == akov1alpha1.HostRuleSecretTypeAviReference {
+		refData[hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Name] = "SslKeyCert"
+	}
+
+	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Type == akov1alpha1.HostRuleSecretTypeSecretReference {
+		_, err := utils.GetInformers().SecretInformer.Lister().Secrets(hostrule.Namespace).Get(hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.Name)
+		if err != nil {
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+	}
+	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Type == akov1alpha1.HostRuleSecretTypeAviReference {
+		refData[hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Name] = "SslKeyCert"
+	}
+
+	if hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Type == akov1alpha1.HostRuleSecretTypeSecretReference {
+		_, err := utils.GetInformers().SecretInformer.Lister().Secrets(hostrule.Namespace).Get(hostrule.Spec.VirtualHost.TLS.SSLKeyCertificate.AlternateCertificate.Name)
+		if err != nil {
+			status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+			return err
+		}
+	}
+
+	for _, policy := range hostrule.Spec.VirtualHost.HTTPPolicy.PolicySets {
+		refData[policy] = "HttpPolicySet"
+	}
+
+	for _, script := range hostrule.Spec.VirtualHost.Datascripts {
+		refData[script] = "VsDatascript"
+	}
+
+	if err := checkRefsOnController(key, refData); err != nil {
+		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
+		return err
+	}
+
+	// No need to update status of hostrule object as accepted since it was accepted before.
+	if hostrule.Status.Status == lib.StatusAccepted {
+		return nil
+	}
+
+	status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusAccepted, Error: ""})
+	return nil
+}
+
+// validateHTTPRuleObj would do validation checks
+// update internal CRD caches, and push relevant ingresses to ingestion
+func (l *leader) ValidateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
+
+	refData := make(map[string]string)
+	for _, path := range httprule.Spec.Paths {
+		if path.TLS.PKIProfile != "" && path.TLS.DestinationCA != "" {
+			//if both pkiProfile and destCA set, reject httprule
+			status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
+				Status: lib.StatusRejected,
+				Error:  lib.HttpRulePkiAndDestCASetErr,
+			})
+			return fmt.Errorf("key: %s, msg: %s", key, lib.HttpRulePkiAndDestCASetErr)
+		}
+		refData[path.TLS.SSLProfile] = "SslProfile"
+		refData[path.ApplicationPersistence] = "ApplicationPersistence"
+		if path.TLS.PKIProfile != "" {
+			refData[path.TLS.PKIProfile] = "PKIProfile"
+		}
+
+		for _, hm := range path.HealthMonitors {
+			refData[hm] = "HealthMonitor"
+		}
+	}
+
+	if err := checkRefsOnController(key, refData); err != nil {
+		status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
+			Status: lib.StatusRejected,
+			Error:  err.Error(),
+		})
+		return err
+	}
+
+	// No need to update status of httprule object as accepted since it was accepted before.
+	if httprule.Status.Status == lib.StatusAccepted {
+		return nil
+	}
+
+	status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
+		Status: lib.StatusAccepted,
+		Error:  "",
+	})
+	return nil
+}
+
+// validateAviInfraSetting would do validaion checks on the
+// ingested AviInfraSetting objects
+func (l *leader) ValidateAviInfraSetting(key string, infraSetting *akov1alpha1.AviInfraSetting) error {
+
+	if ((infraSetting.Spec.Network.EnableRhi != nil && !*infraSetting.Spec.Network.EnableRhi) || infraSetting.Spec.Network.EnableRhi == nil) &&
+		len(infraSetting.Spec.Network.BgpPeerLabels) > 0 {
+		err := fmt.Errorf("BGPPeerLabels cannot be set if EnableRhi is false.")
+		status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
+			Status: lib.StatusRejected,
+			Error:  err.Error(),
+		})
+		return err
+	}
+
+	refData := make(map[string]string)
+	for _, vipNetwork := range infraSetting.Spec.Network.VipNetworks {
+		if vipNetwork.Cidr != "" {
+			re := regexp.MustCompile(lib.IPCIDRRegex)
+			if !re.MatchString(vipNetwork.Cidr) {
+				err := fmt.Errorf("invalid CIDR configuration %s detected for networkName %s in vipNetworkList", vipNetwork.Cidr, vipNetwork.NetworkName)
+				status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
+					Status: lib.StatusRejected,
+					Error:  err.Error(),
+				})
+				return err
+			}
+		}
+		if vipNetwork.V6Cidr != "" {
+			re := regexp.MustCompile(lib.IPV6CIDRRegex)
+			if !re.MatchString(vipNetwork.V6Cidr) {
+				err := fmt.Errorf("invalid IPv6 CIDR configuration %s detected for networkName %s in vipNetworkList", vipNetwork.V6Cidr, vipNetwork.NetworkName)
+				status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
+					Status: lib.StatusRejected,
+					Error:  err.Error(),
+				})
+				return err
+			}
+		}
+		refData[vipNetwork.NetworkName] = "Network"
+	}
+
+	if infraSetting.Spec.SeGroup.Name != "" {
+		refData[infraSetting.Spec.SeGroup.Name] = "ServiceEngineGroup"
+	}
+
+	if err := checkRefsOnController(key, refData); err != nil {
+		status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
+			Status: lib.StatusRejected,
+			Error:  err.Error(),
+		})
+		return err
+	}
+
+	// This would add SEG labels only if they are not configured yet. In case there is a label mismatch
+	// to any pre-existing SEG labels, the AviInfraSettig CR will get Rejected from the checkRefsOnController
+	// step before this.
+	if infraSetting.Spec.SeGroup.Name != "" {
+		addSeGroupLabel(key, infraSetting.Spec.SeGroup.Name)
+	}
+
+	// No need to update status of infra setting object as accepted since it was accepted before.
+	if infraSetting.Status.Status == lib.StatusAccepted {
+		return nil
+	}
+
+	status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
+		Status: lib.StatusAccepted,
+		Error:  "",
+	})
+	return nil
+}
+
+// validateMultiClusterIngressObj validates the MCI CRD changes before pushing it to ingestion
+func (l *leader) ValidateMultiClusterIngressObj(key string, multiClusterIngress *akov1alpha1.MultiClusterIngress) error {
+
+	var err error
+	statusToUpdate := &akov1alpha1.MultiClusterIngressStatus{}
+	defer func() {
+		if err == nil {
+			statusToUpdate.Status.Accepted = true
+			status.UpdateMultiClusterIngressStatus(key, multiClusterIngress, statusToUpdate)
+			return
+		}
+		statusToUpdate.Status.Accepted = false
+		statusToUpdate.Status.Reason = err.Error()
+		status.UpdateMultiClusterIngressStatus(key, multiClusterIngress, statusToUpdate)
+	}()
+
+	// Currently, we support only NodePort ServiceType.
+	if !lib.IsNodePortMode() {
+		err = fmt.Errorf("ServiceType must be of type NodePort")
+		return err
+	}
+
+	// Currently, we support EVH mode only.
+	if !lib.IsEvhEnabled() {
+		err = fmt.Errorf("AKO must be in EVH mode")
+		return err
+	}
+
+	if len(multiClusterIngress.Spec.Config) == 0 {
+		err = fmt.Errorf("config must not be empty")
+		return err
+	}
+
+	return nil
+}
+
+// validateServiceImportObj validates the SI CRD changes before pushing it to ingestion
+func (l *leader) ValidateServiceImportObj(key string, serviceImport *akov1alpha1.ServiceImport) error {
+
+	// CHECK ME: AMKO creates this and validation required?
+	// TODO: validations needs a status field
+
+	return nil
+}
+
+func (f *follower) ValidateHTTPRuleObj(key string, httprule *akov1alpha1.HTTPRule) error {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not validating HTTPRule object", key)
+	return nil
+}
+
+func (f *follower) ValidateHostRuleObj(key string, hostrule *akov1alpha1.HostRule) error {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not validating HostRule object", key)
+	return nil
+}
+
+func (f *follower) ValidateAviInfraSetting(key string, infraSetting *akov1alpha1.AviInfraSetting) error {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not validating AviInfraSetting object", key)
+	return nil
+}
+
+func (f *follower) ValidateMultiClusterIngressObj(key string, multiClusterIngress *akov1alpha1.MultiClusterIngress) error {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not validating MultiClusterIngress object", key)
+	return nil
+}
+
+func (f *follower) ValidateServiceImportObj(key string, serviceImport *akov1alpha1.ServiceImport) error {
+
+	// CHECK ME: AMKO creates this and validation required?
+	// TODO: validations needs a status field
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not validating ServiceImport object", key)
+	return nil
+}

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,6 +115,10 @@ type akoControlConfig struct {
 
 	//blockedNS contains map of blocked namespaces and checksum of it
 	blockedNS BlockedNamespaces
+
+	// leadership status of AKO
+	isLeader     bool
+	isLeaderLock sync.RWMutex
 }
 
 var akoControlConfigInstance *akoControlConfig
@@ -123,6 +128,18 @@ func AKOControlConfig() *akoControlConfig {
 		akoControlConfigInstance = &akoControlConfig{}
 	}
 	return akoControlConfigInstance
+}
+
+func (c *akoControlConfig) SetIsLeaderFlag(flag bool) {
+	c.isLeaderLock.Lock()
+	defer c.isLeaderLock.Unlock()
+	c.isLeader = flag
+}
+
+func (c *akoControlConfig) IsLeader() bool {
+	c.isLeaderLock.RLock()
+	defer c.isLeaderLock.RUnlock()
+	return c.isLeader
 }
 
 func (c *akoControlConfig) SetAKOInstanceFlag(flag bool) {

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -123,7 +123,7 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "vsdatascriptset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "vsdatascriptset", key)
 	utils.AviLog.Debugf("The datascriptset object response %v", rest_op.Response)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find datascriptset obj in resp %v", key, rest_op.Response)

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -297,7 +297,7 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "httppolicyset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "httppolicyset", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find HTTP Policy Set obj in resp %v", rest_op.Response)
 		return errors.New("HTTP Policy Set object not found")
@@ -306,13 +306,13 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Name not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, Name not present in response %v", key, resp)
 			continue
 		}
 
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Uuid not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, Uuid not present in response %v", key, resp)
 			continue
 		}
 

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -165,7 +165,7 @@ func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avi
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "l4policyset", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "l4policyset", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find L4 Policy Set obj in resp %v", rest_op.Response)
 		return errors.New("L4 Policy Set object not found")

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -229,7 +229,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "pool", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "pool", key)
 	utils.AviLog.Debugf("key: %s, msg: the pool object response %v", key, rest_op.Response)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find pool obj in resp %v", key, rest_op.Response)

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -128,7 +128,7 @@ func (rest *RestOperations) AviVrfCacheAdd(restOp *utils.RestOp, vrfKey avicache
 		utils.AviLog.Warnf("key: %s, rest_op has err or no response for vrfcontext, err: %s, response: %v", key, restOp.Err, utils.Stringify(restOp.Response))
 		return errors.New("Errored rest_op")
 	}
-	respElems := RestRespArrToObjByType(restOp, "vrfcontext", key)
+	respElems := rest.restOperator.RestRespArrToObjByType(restOp, "vrfcontext", key)
 	if respElems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find vrfcontext obj in resp %v", key, restOp.Response)
 		return errors.New("vrfcontext not found")

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -570,7 +570,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 		return errors.New("Error rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "virtualservice", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "virtualservice", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find vs obj in resp %v", key, rest_op.Response)
 		return errors.New("vs not found")
@@ -619,7 +619,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 				parentKey := avicache.NamespaceName{Namespace: rest_op.Tenant, Name: ExtractVsName(vh_parent_uuid.(string))}
 				vs_cache_obj := rest.cache.VsCacheMeta.AviCacheAddVS(parentKey)
 				vs_cache_obj.AddToSNIChildCollection(uuid)
-				utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during SNI update %v val %v", key, vhParentKey,
+				utils.AviLog.Info(spew.Sprintf("key: %s, msg: added VS cache key during SNI update %v val %v", key, parentKey,
 					vs_cache_obj))
 			}
 		}

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -448,7 +448,7 @@ func (rest *RestOperations) AviVsVipCacheAdd(rest_op *utils.RestOp, vsKey avicac
 		}
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "vsvip", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "vsvip", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find vsvip obj in resp %v", key, rest_op.Response)
 		return errors.New("vsvip not found")

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -130,7 +130,7 @@ func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "poolgroup", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "poolgroup", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("key: %s, msg: unable to find pool group obj in resp %v", key, rest_op.Response)
 		return errors.New("poolgroup not found")

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -39,11 +39,11 @@ type RestOperations struct {
 	restOperator      RestOperator
 }
 
-func NewRestOperations(cache *avicache.AviObjCache, aviRestPoolClient *utils.AviRestClientPool) RestOperations {
+func NewRestOperations(cache *avicache.AviObjCache, aviRestPoolClient *utils.AviRestClientPool, overrideLeaderFlag ...bool) RestOperations {
 	restOp := RestOperations{}
 	restOp.cache = cache
 	restOp.aviRestPoolClient = aviRestPoolClient
-	restOp.restOperator = NewRestOperator(&restOp)
+	restOp.restOperator = NewRestOperator(&restOp, overrideLeaderFlag...)
 	return restOp
 }
 
@@ -614,7 +614,7 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 			models.RestStatus.UpdateAviApiRestStatus("", err)
 			for i := len(rest_ops) - 1; i >= 0; i-- {
 				// Go over each of the failed requests and enqueue them to the worker queue for retry.
-				if rest_ops[i].Err != nil {
+				if rest_ops[i].Err != nil || rest_ops[i].Model == "VirtualService" {
 					// check for VSVIP errors for blocked IP address updates
 					if checkVsVipUpdateErrors(key, rest_ops[i]) {
 						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -36,10 +36,15 @@ import (
 type RestOperations struct {
 	cache             *avicache.AviObjCache
 	aviRestPoolClient *utils.AviRestClientPool
+	restOperator      RestOperator
 }
 
 func NewRestOperations(cache *avicache.AviObjCache, aviRestPoolClient *utils.AviRestClientPool) RestOperations {
-	return RestOperations{cache: cache, aviRestPoolClient: aviRestPoolClient}
+	restOp := RestOperations{}
+	restOp.cache = cache
+	restOp.aviRestPoolClient = aviRestPoolClient
+	restOp.restOperator = NewRestOperator(&restOp)
+	return restOp
 }
 
 func (rest *RestOperations) CleanupVS(key string, skipVS bool) {
@@ -564,106 +569,109 @@ func (rest *RestOperations) ExecuteRestAndPopulateCache(rest_ops []*utils.RestOp
 		shardSize = 8
 	}
 	var retry, fastRetry, processNextObj bool
-	if shardSize != 0 {
-		bkt := utils.Bkt(key, shardSize)
-		if len(rest.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
-			utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v", key, bkt)
-			aviclient := rest.aviRestPoolClient.AviClient[bkt]
-			err := AviRestOperateWrapper(aviclient, rest_ops)
-			if err == nil {
-				models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
-				utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
+	bkt := utils.Bkt(key, shardSize)
+	if len(rest.aviRestPoolClient.AviClient) > 0 && len(rest_ops) > 0 {
+		utils.AviLog.Infof("key: %s, msg: processing in rest queue number: %v", key, bkt)
+		aviclient := rest.aviRestPoolClient.AviClient[bkt]
+		err := rest.AviRestOperateWrapper(aviclient, rest_ops, key)
+		if err == nil {
+			models.RestStatus.UpdateAviApiRestStatus(utils.AVIAPI_CONNECTED, nil)
+			utils.AviLog.Debugf("key: %s, msg: rest call executed successfully, will update cache", key)
 
-				// Add to local obj caches
-				for _, rest_op := range rest_ops {
-					rest.PopulateOneCache(rest_op, aviObjKey, key)
-				}
+			// Add to local obj caches
+			for _, rest_op := range rest_ops {
+				rest.PopulateOneCache(rest_op, aviObjKey, key)
+			}
 
-			} else if aviObjKey.Name == lib.DummyVSForStaleData {
-				utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
-				return false, processNextObj
-			} else {
-				var publishKey string
-				if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-					publishKey = avimodel.GetAviEvhVS()[0].Name
-				} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-					publishKey = avimodel.GetAviVS()[0].Name
-				}
+		} else if aviObjKey.Name == lib.DummyVSForStaleData {
+			utils.AviLog.Warnf("key: %s, msg: error in rest request %v, for %s, won't retry", key, err.Error(), aviObjKey.Name)
+			return false, processNextObj
+		} else {
+			var publishKey string
+			if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+				publishKey = avimodel.GetAviEvhVS()[0].Name
+			} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+				publishKey = avimodel.GetAviVS()[0].Name
+			}
 
-				if publishKey == "" {
-					// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
-					splitKeys := strings.Split(key, "/")
-					if len(splitKeys) == 2 {
-						publishKey = splitKeys[1]
-					}
+			if publishKey == "" {
+				// This is a delete case for the virtualservice. Derive the virtualservice from the 'key'
+				splitKeys := strings.Split(key, "/")
+				if len(splitKeys) == 2 {
+					publishKey = splitKeys[1]
 				}
+			}
 
-				if rest.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
-					return false, processNextObj
-				}
-				utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
-				models.RestStatus.UpdateAviApiRestStatus("", err)
-				for i := len(rest_ops) - 1; i >= 0; i-- {
-					// Go over each of the failed requests and enqueue them to the worker queue for retry.
-					if rest_ops[i].Err != nil {
-						// check for VSVIP errors for blocked IP address updates
-						if checkVsVipUpdateErrors(key, rest_ops[i]) {
-							rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
-							continue
-						}
-
-						// If it's for a SNI child, publish the parent VS's key
-						refreshCacheForRetry := false
-						if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
-							refreshCacheForRetry = true
-						} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
-							refreshCacheForRetry = true
-						}
-						if refreshCacheForRetry {
-							utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
-							aviError, ok := rest_ops[i].Err.(session.AviError)
-							if !ok {
-								utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
-								continue
-							}
-							retryable, fastRetryable, nextObj := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
-							retry = retry || retryable
-							processNextObj = processNextObj || nextObj
-							if avimodel.GetRetryCounter() != 0 {
-								fastRetry = fastRetry || fastRetryable
-							} else {
-								fastRetry = false
-								utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
-							}
-						} else {
-							utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
-							aviError, ok := rest_ops[i].Err.(session.AviError)
-							// If it's 404, don't retry
-							if ok {
-								statuscode := aviError.HttpStatusCode
-								if statuscode != 404 {
-									rest.PublishKeyToSlowRetryLayer(publishKey, key)
-									//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
-									return false, true
-								} else {
-									rest.AviVsCacheDel(rest_ops[i], aviObjKey, key)
-								}
-							}
-						}
-					} else {
-						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
-					}
-				}
-
-				if retry {
-					if fastRetry {
-						rest.PublishKeyToRetryLayer(publishKey, key)
-					} else {
-						rest.PublishKeyToSlowRetryLayer(publishKey, key)
-					}
-				}
+			if rest.restOperator.isRetryRequired(key, err) {
+				rest.PublishKeyToRetryLayer(publishKey, key)
 				return false, processNextObj
 			}
+
+			if rest.CheckAndPublishForRetry(err, publishKey, key, avimodel) {
+				return false, processNextObj
+			}
+			utils.AviLog.Warnf("key: %s, msg: there was an error sending the macro %v", key, err.Error())
+			models.RestStatus.UpdateAviApiRestStatus("", err)
+			for i := len(rest_ops) - 1; i >= 0; i-- {
+				// Go over each of the failed requests and enqueue them to the worker queue for retry.
+				if rest_ops[i].Err != nil {
+					// check for VSVIP errors for blocked IP address updates
+					if checkVsVipUpdateErrors(key, rest_ops[i]) {
+						rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
+						continue
+					}
+
+					// If it's for a SNI child, publish the parent VS's key
+					refreshCacheForRetry := false
+					if avimodel != nil && isEvh && len(avimodel.GetAviEvhVS()) > 0 {
+						refreshCacheForRetry = true
+					} else if avimodel != nil && !isEvh && len(avimodel.GetAviVS()) > 0 {
+						refreshCacheForRetry = true
+					}
+					if refreshCacheForRetry {
+						utils.AviLog.Warnf("key: %s, msg: Retrieved key for Retry:%s, object: %s", key, publishKey, rest_ops[i].ObjName)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						if !ok {
+							utils.AviLog.Infof("key: %s, msg: Error is not of type AviError, err: %v, %T", key, rest_ops[i].Err, rest_ops[i].Err)
+							continue
+						}
+						retryable, fastRetryable, nextObj := rest.RefreshCacheForRetryLayer(publishKey, aviObjKey, rest_ops[i], aviError, aviclient, avimodel, key, isEvh)
+						retry = retry || retryable
+						processNextObj = processNextObj || nextObj
+						if avimodel.GetRetryCounter() != 0 {
+							fastRetry = fastRetry || fastRetryable
+						} else {
+							fastRetry = false
+							utils.AviLog.Warnf("key: %s, msg: retry count exhausted, would be added to slow retry queue", key)
+						}
+					} else {
+						utils.AviLog.Warnf("key: %s, msg: Avi model not set, possibly a DELETE call", key)
+						aviError, ok := rest_ops[i].Err.(session.AviError)
+						// If it's 404, don't retry
+						if ok {
+							statuscode := aviError.HttpStatusCode
+							if statuscode != 404 {
+								rest.PublishKeyToSlowRetryLayer(publishKey, key)
+								//Here as it is 404 for specific object in a current child, AKO can go ahead with next child
+								return false, true
+							} else {
+								rest.AviVsCacheDel(rest_ops[i], aviObjKey, key)
+							}
+						}
+					}
+				} else {
+					rest.PopulateOneCache(rest_ops[i], aviObjKey, key)
+				}
+			}
+
+			if retry {
+				if fastRetry {
+					rest.PublishKeyToRetryLayer(publishKey, key)
+				} else {
+					rest.PublishKeyToSlowRetryLayer(publishKey, key)
+				}
+			}
+			return false, processNextObj
 		}
 	}
 	return true, true
@@ -687,7 +695,7 @@ func checkVsVipUpdateErrors(key string, rest_op *utils.RestOp) bool {
 func (rest *RestOperations) PopulateOneCache(rest_op *utils.RestOp, aviObjKey avicache.NamespaceName, key string) {
 	aviErr, ok := rest_op.Err.(session.AviError)
 	if !ok && rest_op.Err != nil {
-		utils.AviLog.Warnf("Error in rest operation is not of type AviError, err: %v, %T", rest_op.Err, rest_op.Err)
+		utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, rest_op.Err, rest_op.Err)
 	}
 	if (rest_op.Err == nil || rest_op.Message != "") &&
 		(rest_op.Method == utils.RestPost ||
@@ -771,10 +779,10 @@ func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, key s
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to slow path retry queue: %s", key, parentVsKey)
 }
 
-func AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp) error {
+func (rest *RestOperations) AviRestOperateWrapper(aviClient *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
 	restTimeoutChan := make(chan error, 1)
 	go func() {
-		err := AviRestOperate(aviClient, rest_ops)
+		err := rest.restOperator.AviRestOperate(aviClient, rest_ops, key)
 		restTimeoutChan <- err
 	}()
 	select {
@@ -1046,7 +1054,7 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 			}
 		} else if statuscode == 408 {
 			// This status code refers to a problem with the controller timeouts. We need to re-init the session object.
-			utils.AviLog.Infof("key :%s, msg: Controller request timed out, will re-init session by retrying", key)
+			utils.AviLog.Infof("key: %s, msg: Controller request timed out, will re-init session by retrying", key)
 			processNextObj = false
 		} else if statuscode == 400 && strings.Contains(*aviError.Message, lib.NoFreeIPError) {
 			utils.AviLog.Infof("key: %s, msg:  msg: Got no free IP error, would be added to slow retry queue", key)
@@ -1424,6 +1432,14 @@ func (rest *RestOperations) DatascriptCU(ds_nodes []*nodes.AviHTTPDataScriptNode
 							if restOp != nil {
 								rest_ops = append(rest_ops, restOp)
 							}
+						}
+					}
+				} else {
+					// If the DS Is not found - let's do a POST call.
+					for _, ds := range ds_nodes {
+						restOp := rest.AviDSBuild(ds, nil, key)
+						if restOp != nil {
+							rest_ops = append(rest_ops, restOp)
 						}
 					}
 				}

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -142,17 +142,18 @@ func (l *leader) SyncObjectStatuses() {
 		}
 	}
 
+	publisher := status.NewStatusPublisher()
 	if lib.GetAdvancedL4() {
-		status.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
-		status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+		publisher.UpdateGatewayStatusAddress(allGatewayUpdateOptions, true)
+		publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 	} else {
 		if lib.UseServicesAPI() {
-			status.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
-			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+			publisher.UpdateSvcApiGatewayStatusAddress(allGatewayUpdateOptions, true)
+			publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 		}
-		status.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
+		publisher.UpdateRouteIngressStatus(allIngressUpdateOptions, true)
 		if !lib.GetLayer7Only() {
-			status.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
+			publisher.UpdateL4LBStatus(allServiceLBUpdateOptions, true)
 		}
 	}
 

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -389,8 +389,6 @@ func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp
 			aviErr, ok := op.Err.(session.AviError)
 			if !ok {
 				utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)
-			} else if op.Model == "VsVip" && op.Method == utils.RestPut {
-				utils.AviLog.Debugf("key: %s, msg: Error in rest operation for VsVip Put request.", key)
 			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
 				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
 				continue

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -262,8 +262,9 @@ type (
 	}
 )
 
-func NewRestOperator(restOp *RestOperations) RestOperator {
-	if lib.AKOControlConfig().IsLeader() {
+func NewRestOperator(restOp *RestOperations, overrideLeaderFlag ...bool) RestOperator {
+	if lib.AKOControlConfig().IsLeader() ||
+		len(overrideLeaderFlag) > 0 && overrideLeaderFlag[0] {
 		return &leader{restOp: restOp}
 	}
 	return &follower{restOp: restOp}

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -245,7 +246,35 @@ type AviRestClientPool struct {
 	AviClient []*clients.AviClient
 }
 
-func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
+type RestOperator interface {
+	AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error
+	isRetryRequired(key string, err error) bool
+	SyncObjectStatuses()
+	RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{}
+}
+
+type (
+	leader struct {
+		restOp *RestOperations
+	}
+	follower struct {
+		restOp *RestOperations
+	}
+)
+
+func NewRestOperator(restOp *RestOperations) RestOperator {
+	if lib.AKOControlConfig().IsLeader() {
+		return &leader{restOp: restOp}
+	}
+	return &follower{restOp: restOp}
+}
+
+func (l *leader) isRetryRequired(key string, err error) bool {
+	return false
+}
+
+func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+	var failure bool
 	for i, op := range rest_ops {
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
@@ -270,17 +299,21 @@ func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
 			op.Err = fmt.Errorf("Unknown RestOp %v", op.Method)
 		}
 		if op.Err != nil {
-			utils.AviLog.Warnf(`RestOp method %v path %v tenant %v Obj %s returned err %s with response %s`,
-				op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
+			utils.AviLog.Warnf("key: %s, msg: RestOp method %v path %v tenant %v Obj %s returned err %s with response %s",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
 			// Wrap the error into a websync error.
 			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
 			aviErr, ok := op.Err.(session.AviError)
 			if !ok {
-				utils.AviLog.Warnf("Error in rest operation is not of type AviError, err: %v, %T", op.Err, op.Err)
+				utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)
 			} else if op.Model == "VsVip" && op.Method == utils.RestPut {
-				utils.AviLog.Debugf("Error in rest operation for VsVip Put request.")
+				utils.AviLog.Debugf("key: %s, msg: Error in rest operation for VsVip Put request.", key)
 			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
-				utils.AviLog.Warnf("Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", op.Method, op.Model, op.Err)
+				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				continue
+			} else if aviErr.HttpStatusCode == 409 && op.Method == utils.RestPost {
+				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				failure = true
 				continue
 			} else if !isErrorRetryable(aviErr.HttpStatusCode, *aviErr.Message) {
 				if op.Method != utils.RestPost {
@@ -296,8 +329,96 @@ func AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp) error {
 			}
 			return err
 		} else {
-			utils.AviLog.Debugf(`RestOp method %v path %v tenant %v response %v`,
-				op.Method, op.Path, op.Tenant, utils.Stringify(op.Response))
+			utils.AviLog.Debugf("key: %s, msg: RestOp method %v path %v tenant %v response %v objName %v",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Response), op.ObjName)
+		}
+	}
+	if failure {
+		return errors.New("required to populate cache and then retry")
+	}
+	return nil
+}
+
+func (f *follower) isRetryRequired(key string, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err.Error() {
+	case "Got empty response for non-delete operation",
+		"Got non-empty response for delete operation":
+		utils.AviLog.Debugf("key: %s, msg: aborted the rest operation due the reason: %s", key, err.Error())
+		return true
+	}
+	return false
+}
+
+func (f *follower) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, key string) error {
+
+	// Adding a delay of 500ms before doing a GET operation in the follower AKO.
+	// 500ms is selected to give leader AKO enough time to create the objects in the controller,
+	// before the follower AKO does a GET operation. In case of a 404(object not found) error, the
+	// follower AKO pushes the key to retry layer for retry.
+	<-time.After(500 * time.Millisecond)
+
+	for i, op := range rest_ops {
+		SetTenant := session.SetTenant(op.Tenant)
+		SetTenant(c.AviSession)
+		if op.Version != "" {
+			SetVersion := session.SetVersion(op.Version)
+			SetVersion(c.AviSession)
+		}
+
+		// Path for GET operation is appended with include_name and created_by to make
+		// the result unique. But in case of VS VIP objects, the created_by is not required
+		// because of this reason, it is omitted.
+		op.Path += "?name=" + op.ObjName + "&include_name=true"
+		if op.Model == "VsVip" {
+			op.Path += "&cloud_ref.name=" + utils.CloudName
+		} else {
+			op.Path += "&created_by=" + lib.AKOUser
+		}
+
+		utils.AviLog.Debugf("key: %s, msg: Got a REST operation: %s, %s", key, op.ObjName, op.Path)
+		op.Err = c.AviSession.Get(op.Path, &op.Response)
+		if op.Err != nil {
+			utils.AviLog.Warnf("key: %s, msg: RestOp method %v path %v tenant %v Obj %s returned err %s with response %s",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
+			// Wrap the error into a websync error.
+			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
+			aviErr, ok := op.Err.(session.AviError)
+			if !ok {
+				utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)
+			} else if op.Model == "VsVip" && op.Method == utils.RestPut {
+				utils.AviLog.Debugf("key: %s, msg: Error in rest operation for VsVip Put request.", key)
+			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
+				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
+				continue
+			} else if !isErrorRetryable(aviErr.HttpStatusCode, *aviErr.Message) {
+				if op.Method != utils.RestPost {
+					continue
+				}
+				if removeObjRefFromRestOps(rest_ops, op.ObjName, op.Model) {
+					continue
+				}
+			}
+
+			for j := i + 1; j < len(rest_ops); j++ {
+				rest_ops[j].Err = errors.New("Aborted due to prev error")
+			}
+			return err
+		} else {
+			utils.AviLog.Debugf("key: %s, msg: RestOp method %v path %v tenant %v response %v objName %v",
+				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Response), op.ObjName)
+			if op.Method == utils.RestDelete && op.Response != nil {
+				return errors.New("Got non-empty response for delete operation")
+			}
+			if resp, ok := op.Response.(map[string]interface{}); ok {
+				if count, ok := resp["count"].(float64); ok {
+					if op.Method != utils.RestDelete && count == 0 {
+						return errors.New("Got empty response for non-delete operation")
+					}
+				}
+			}
 		}
 	}
 	return nil

--- a/internal/rest/rest_utils.go
+++ b/internal/rest/rest_utils.go
@@ -20,9 +20,34 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-func RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{} {
+func (l *leader) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{} {
 	var resp_elems []map[string]interface{}
 	if restResponse, ok := rest_op.Response.(map[string]interface{}); ok {
+		resp_elems = append(resp_elems, restResponse)
+		return resp_elems
+	}
+	return nil
+}
+
+func (l *follower) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{} {
+	var resp_elems []map[string]interface{}
+	if restResponse, ok := rest_op.Response.(map[string]interface{}); ok {
+		if rest_op.Method == utils.RestPost {
+			// response has format {count:1, results:[{}]}
+			response, ok := restResponse["results"].([]interface{})
+			if !ok {
+				return resp_elems
+			}
+			if len(response) == 0 {
+				return resp_elems
+			}
+			restResponse, ok = response[0].(map[string]interface{})
+			if !ok {
+				return resp_elems
+			}
+			utils.AviLog.Debugf("key: %s, msg: Got a response path %v tenant %v response %v",
+				key, rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))
+		}
 		resp_elems = append(resp_elems, restResponse)
 		return resp_elems
 	}

--- a/internal/rest/rest_utils.go
+++ b/internal/rest/rest_utils.go
@@ -32,22 +32,20 @@ func (l *leader) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, 
 func (l *follower) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{} {
 	var resp_elems []map[string]interface{}
 	if restResponse, ok := rest_op.Response.(map[string]interface{}); ok {
-		if rest_op.Method == utils.RestPost {
-			// response has format {count:1, results:[{}]}
-			response, ok := restResponse["results"].([]interface{})
-			if !ok {
-				return resp_elems
-			}
-			if len(response) == 0 {
-				return resp_elems
-			}
-			restResponse, ok = response[0].(map[string]interface{})
-			if !ok {
-				return resp_elems
-			}
-			utils.AviLog.Debugf("key: %s, msg: Got a response path %v tenant %v response %v",
-				key, rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))
+		// response has format {count:1, results:[{ /* some data */ }]}
+		response, ok := restResponse["results"].([]interface{})
+		if !ok {
+			return resp_elems
 		}
+		if len(response) == 0 {
+			return resp_elems
+		}
+		restResponse, ok = response[0].(map[string]interface{})
+		if !ok {
+			return resp_elems
+		}
+		utils.AviLog.Debugf("key: %s, msg: Got a response path %v tenant %v response %v",
+			key, rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))
 		resp_elems = append(resp_elems, restResponse)
 		return resp_elems
 	}

--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -122,7 +122,7 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 		return errors.New("errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "sslkeyandcertificate", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "sslkeyandcertificate", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find SSLKeyCert obj in resp %v", rest_op.Response)
 		return errors.New("SSLKeyCert not found")
@@ -151,6 +151,9 @@ func (rest *RestOperations) AviSSLKeyCertAdd(rest_op *utils.RestOp, vsKey avicac
 			SSLKeyAndCertificate = rest_op.Obj.(utils.AviRestObjMacro).Data.(avimodels.SSLKeyAndCertificate)
 		case avimodels.SSLKeyAndCertificate:
 			SSLKeyAndCertificate = rest_op.Obj.(avimodels.SSLKeyAndCertificate)
+		}
+		if SSLKeyAndCertificate.Certificate == nil {
+			continue
 		}
 		cert = *SSLKeyAndCertificate.Certificate.Certificate
 		hasCA := false
@@ -281,7 +284,7 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 		return errors.New("Errored rest_op")
 	}
 
-	resp_elems := RestRespArrToObjByType(rest_op, "pkiprofile", key)
+	resp_elems := rest.restOperator.RestRespArrToObjByType(rest_op, "pkiprofile", key)
 	if resp_elems == nil {
 		utils.AviLog.Warnf("Unable to find PkiProfile obj in resp %v", rest_op.Response)
 		return errors.New("PkiProfile not found")
@@ -290,13 +293,13 @@ func (rest *RestOperations) AviPkiProfileAdd(rest_op *utils.RestOp, poolKey avic
 	for _, resp := range resp_elems {
 		name, ok := resp["name"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Name not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, msg: Name not present in response %v", key, resp)
 			continue
 		}
 
 		uuid, ok := resp["uuid"].(string)
 		if !ok {
-			utils.AviLog.Warnf("Uuid not present in response %v", resp)
+			utils.AviLog.Warnf("key: %s, msg: Uuid not present in response %v", key, resp)
 			continue
 		}
 

--- a/internal/status/multicluster_ing_status.go
+++ b/internal/status/multicluster_ing_status.go
@@ -30,7 +30,7 @@ import (
 
 // DeleteMultiClusterIngressStatusAndAnnotation is a wrapper function which gets the Multi-cluster ingress object and deletes the
 // status/annotations.
-func DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+func (l *leader) DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
 	ns := option.ServiceMetadata.Namespace
 	ingName := option.ServiceMetadata.IngressName
 	mciObj, err := utils.GetInformers().MultiClusterIngressInformer.Lister().MultiClusterIngresses(ns).Get(ingName)
@@ -50,7 +50,7 @@ func DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOpti
 
 // UpdateMultiClusterIngressStatusAndAnnotation is a wrapper function which gets the Multi-cluster ingress object and updates the
 // status/annotations.
-func UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+func (l *leader) UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
 	ns := option.ServiceMetadata.Namespace
 	ingName := option.ServiceMetadata.IngressName
 	mciObj, err := utils.GetInformers().MultiClusterIngressInformer.Lister().MultiClusterIngresses(ns).Get(ingName)
@@ -126,4 +126,12 @@ func UpdateMultiClusterIngressAnnotations(mci *akov1alpha1.MultiClusterIngress, 
 		return err
 	}
 	return nil
+}
+
+func (f *follower) UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not updating the Multi-Cluster Ingress status", option.Key)
+}
+
+func (f *follower) DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not deleting the Multi-Cluster Ingress status", key)
 }

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -86,7 +85,6 @@ func (l *leader) ResetStatefulSetAnnotation() {
 		return
 	}
 	utils.AviLog.Infof("Successfully removed annotation %s from ako statefulset", ObjectDeletionStatus)
-	lib.AKOControlConfig().PodEventf(corev1.EventTypeNormal, lib.AKODeleteConfigUnset, "DeleteConfig unset in configmap, sync would be enabled")
 
 	//Remove any status from previous versions of AKO
 	ResetStatefulSetStatus()

--- a/internal/status/statefulset_status.go
+++ b/internal/status/statefulset_status.go
@@ -56,7 +56,7 @@ func ResetStatefulSetStatus() {
 	utils.AviLog.Debugf("Successfully reset ako statefulset: %v", u)
 }
 
-func ResetStatefulSetAnnotation() {
+func (l *leader) ResetStatefulSetAnnotation() {
 	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
@@ -92,7 +92,7 @@ func ResetStatefulSetAnnotation() {
 	ResetStatefulSetStatus()
 }
 
-func AddStatefulSetAnnotation(reason string) {
+func (l *leader) AddStatefulSetAnnotation(reason string) {
 	ss, err := utils.GetInformers().ClientSet.AppsV1().StatefulSets(utils.GetAKONamespace()).Get(context.TODO(), lib.AKOStatefulSet, metav1.GetOptions{})
 	if err != nil {
 		utils.AviLog.Warnf("Error in getting ako statefulset: %v", err)
@@ -122,4 +122,12 @@ func AddStatefulSetAnnotation(reason string) {
 		return
 	}
 	utils.AviLog.Debugf("Successfully updated annotation %s in ako statefulset", ObjectDeletionStatus)
+}
+
+func (f *follower) AddStatefulSetAnnotation(reason string) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not updating the StatefulSet Annotation")
+}
+
+func (f *follower) ResetStatefulSetAnnotation() {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not deleting the StatefulSet Annotation")
 }

--- a/internal/status/status_publisher.go
+++ b/internal/status/status_publisher.go
@@ -44,6 +44,9 @@ type StatusPublisher interface {
 
 	UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
 	DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
+
+	AddStatefulSetAnnotation(reason string)
+	ResetStatefulSetAnnotation()
 }
 
 type (

--- a/internal/status/status_publisher.go
+++ b/internal/status/status_publisher.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+)
+
+type StatusPublisher interface {
+	DequeueStatus(objIntf interface{}) error
+
+	UpdateL4LBStatus(options []UpdateOptions, bulk bool)
+	DeleteL4LBStatus(svc_mdata_obj lib.ServiceMetadataObj, vsName, key string) error
+
+	UpdateIngressStatus(options []UpdateOptions, bulk bool)
+	DeleteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateRouteStatus(options []UpdateOptions, bulk bool)
+	DeleteRouteStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateRouteIngressStatus(options []UpdateOptions, bulk bool)
+	DeleteRouteIngressStatus(options []UpdateOptions, isVSDelete bool, key string) error
+
+	UpdateGatewayStatusAddress(options []UpdateOptions, bulk bool)
+	DeleteGatewayStatusAddress(svcMetadataObj lib.ServiceMetadataObj, key string) error
+
+	UpdateSvcApiGatewayStatusAddress(options []UpdateOptions, bulk bool)
+	DeleteSvcApiGatewayStatusAddress(key string, svcMetadataObj lib.ServiceMetadataObj) error
+
+	UpdateNPLAnnotation(key, namespace, name string)
+	DeleteNPLAnnotation(key, namespace, name string)
+
+	UpdateMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
+	DeleteMultiClusterIngressStatusAndAnnotation(key string, option *UpdateOptions)
+}
+
+type (
+	leader   struct{}
+	follower struct{}
+)
+
+func NewStatusPublisher() StatusPublisher {
+	if lib.AKOControlConfig().IsLeader() {
+		return &leader{}
+	}
+	return &follower{}
+}

--- a/internal/status/svc_annotation.go
+++ b/internal/status/svc_annotation.go
@@ -42,7 +42,7 @@ func CheckNPLSvcAnnotation(key, namespace, name string) bool {
 
 // UpdateSvcAnnotation updates a Service with NPL annotation, if not already annotated.
 // If the annotation is already pressent return true
-func UpdateNPLAnnotation(key, namespace, name string) {
+func (l *leader) UpdateNPLAnnotation(key, namespace, name string) {
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
 		utils.AviLog.Infof("key: %s, returning without updating NPL annotation, err %v", key, err)
@@ -78,7 +78,7 @@ func UpdateNPLAnnotation(key, namespace, name string) {
 	return
 }
 
-func DeleteNPLAnnotation(key, namespace, name string) {
+func (l *leader) DeleteNPLAnnotation(key, namespace, name string) {
 	service, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
 	if err != nil {
 		return
@@ -108,4 +108,12 @@ func DeleteNPLAnnotation(key, namespace, name string) {
 		return
 	}
 	utils.AviLog.Infof("key: %s, msg: Deleted NPL annotation from Service: %s/%s", key, namespace, name)
+}
+
+func (f *follower) UpdateNPLAnnotation(key, namespace, name string) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not updating the NPL Annotation", key)
+}
+
+func (f *follower) DeleteNPLAnnotation(key, namespace, name string) {
+	utils.AviLog.Debugf("key: %s, AKO is not a leader, not deleting the NPL Annotation", key)
 }

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -14,6 +14,8 @@
 
 package utils
 
+import "time"
+
 const (
 	GraphLayer                    = "GraphLayer"
 	ObjectIngestionLayer          = "ObjectIngestionLayer"
@@ -97,4 +99,10 @@ const (
 	AVIAPI_INITIATING   = "INITIATING"
 	AVIAPI_CONNECTED    = "CONNECTED"
 	AVIAPI_DISCONNECTED = "DISCONNECTED"
+
+	// Constants used for leader election
+	leaseDuration = 15 * time.Second
+	renewDeadline = 10 * time.Second
+	retryPeriod   = 2 * time.Second
+	leaseLockName = "ako-lease-lock"
 )

--- a/pkg/utils/full_sync_worker.go
+++ b/pkg/utils/full_sync_worker.go
@@ -24,7 +24,7 @@ type FullSyncThread struct {
 	QuickSyncChan     chan string
 	Interval          time.Duration
 	SyncFunction      func()
-	QuickSyncFunction func() error
+	QuickSyncFunction func(bool) error
 }
 
 func NewFullSyncThread(interval time.Duration) *FullSyncThread {
@@ -48,7 +48,7 @@ func (w *FullSyncThread) Run() {
 			// First the regular sync function - that syncs the cache
 			w.SyncFunction()
 			// Second the function that syncs the k8s objects.
-			w.QuickSyncFunction()
+			w.QuickSyncFunction(true)
 			break
 		case <-time.After(w.Interval):
 			// Just the cache sync functions.

--- a/pkg/utils/leader_election.go
+++ b/pkg/utils/leader_election.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019-2020 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+type callBackFunc func()
+
+type leaderElector struct {
+	identity      string
+	leaderElector *leaderelection.LeaderElector
+	readyCh       chan struct{}
+}
+
+type LeaderElector interface {
+	Run(ctx context.Context, wg *sync.WaitGroup) chan struct{}
+}
+
+func NewLeaderElector(clientset kubernetes.Interface,
+	OnStartedLeadingCallback, OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) (LeaderElector, error) {
+
+	leaderElector := &leaderElector{}
+	leaderElector.identity = os.Getenv("POD_NAME")
+	leaderElector.readyCh = make(chan struct{})
+
+	leaderConfig := leaderElector.GetLeaderConfig(
+		clientset,
+		OnStartedLeadingCallback,
+		OnStoppedLeadingCallback,
+		OnNewLeaderCallback,
+	)
+	var err error
+	leaderElector.leaderElector, err = leaderelection.NewLeaderElector(leaderConfig)
+	if err != nil {
+		return nil, err
+	}
+	return leaderElector, nil
+}
+
+func (le *leaderElector) GetLeaderConfig(clientset kubernetes.Interface, OnStartedLeadingCallback,
+	OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) leaderelection.LeaderElectionConfig {
+	return leaderelection.LeaderElectionConfig{
+		Name:            le.identity,
+		Lock:            le.GetLeaseLock(clientset),
+		ReleaseOnCancel: true,
+		LeaseDuration:   leaseDuration,
+		RenewDeadline:   renewDeadline,
+		RetryPeriod:     retryPeriod,
+		Callbacks:       le.GetLeaderCallbacks(OnStartedLeadingCallback, OnStoppedLeadingCallback, OnNewLeaderCallback),
+	}
+}
+
+func (le *leaderElector) GetLeaseLock(clientset kubernetes.Interface) *resourcelock.LeaseLock {
+	return &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      leaseLockName,
+			Namespace: os.Getenv("POD_NAMESPACE"),
+		},
+		Client: clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: le.identity,
+		},
+	}
+}
+
+func (le *leaderElector) GetLeaderCallbacks(OnStartedLeadingCallback,
+	OnStoppedLeadingCallback, OnNewLeaderCallback callBackFunc) leaderelection.LeaderCallbacks {
+	return leaderelection.LeaderCallbacks{
+		OnStartedLeading: func(ctx context.Context) {
+			OnStartedLeadingCallback()
+			le.OnNewLeaderElected()
+		},
+		OnStoppedLeading: func() {
+			OnStoppedLeadingCallback()
+		},
+		OnNewLeader: func(identity string) {
+			if identity == le.identity {
+				return
+			}
+			OnNewLeaderCallback()
+			le.OnNewLeaderElected()
+		},
+	}
+}
+
+var once sync.Once
+
+func (le *leaderElector) OnNewLeaderElected() {
+	once.Do(func() {
+		close(le.readyCh)
+	})
+}
+
+func (le *leaderElector) Run(ctx context.Context, wg *sync.WaitGroup) chan struct{} {
+	AviLog.Debug("Leader election is in-progress")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		le.leaderElector.Run(ctx)
+		AviLog.Debug("leader election goroutine exited")
+	}()
+	return le.readyCh
+}

--- a/pkg/utils/leader_election.go
+++ b/pkg/utils/leader_election.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 VMware, Inc.
+ * Copyright 2022-2023 VMware, Inc.
  * All Rights Reserved.
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -101,6 +101,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	ctrl.SetSEGroupCloudName()

--- a/tests/dedicatedvstests/l7_dedicated_crd_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_crd_test.go
@@ -38,9 +38,12 @@ func TestHostruleFQDNAliasesForDedicatedVS(t *testing.T) {
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
-		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-		return len(nodes)
-	}, 10*time.Second).Should(gomega.Equal(1))
+		nodes, ok := aviModel.(*avinodes.AviObjectGraph)
+		if !ok {
+			return 0
+		}
+		return len(nodes.GetAviVS())
+	}, 20*time.Second).Should(gomega.Equal(1))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/fqdn-aliases-hr-foo", true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -105,6 +105,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	integrationtest.PollForSyncStart(ctrl, 10)

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -136,6 +136,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
@@ -218,7 +220,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	g.Eventually(func() string {
 		hostrule, _ := CRDClient.AkoV1alpha1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
 		return hostrule.Status.Status
-	}, 10*time.Second).Should(gomega.Equal("Accepted"))
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)

--- a/tests/ingresstests/crd_test.go
+++ b/tests/ingresstests/crd_test.go
@@ -43,7 +43,7 @@ func TestCreateDeleteHostRule(t *testing.T) {
 	g.Eventually(func() string {
 		hostrule, _ := CRDClient.AkoV1alpha1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
 		return hostrule.Status.Status
-	}, 10*time.Second).Should(gomega.Equal("Accepted"))
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
 	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -1252,7 +1252,7 @@ func TestFullSyncCacheNoOp(t *testing.T) {
 
 	//call fullsync
 	ctrl.FullSync()
-	ctrl.FullSyncK8s()
+	ctrl.FullSyncK8s(true)
 
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	integrationtest.PollForCompletion(t, modelName, 5)

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -114,6 +114,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	integrationtest.PollForSyncStart(ctrl, 10)

--- a/tests/ingresstests/l7_nodeport_test.go
+++ b/tests/ingresstests/l7_nodeport_test.go
@@ -1143,7 +1143,7 @@ func TestFullSyncCacheNoOpInNodePort(t *testing.T) {
 
 	//call fullsync
 	ctrl.FullSync()
-	ctrl.FullSyncK8s()
+	ctrl.FullSyncK8s(true)
 
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	integrationtest.PollForCompletion(t, modelName, 5)

--- a/tests/integrationtest/l4_nodeport_service_test.go
+++ b/tests/integrationtest/l4_nodeport_service_test.go
@@ -38,8 +38,8 @@ func TestNodeAddInNodePortMode(t *testing.T) {
 	SetNodePortMode()
 	defer SetClusterIPMode()
 	nodeIP := "10.1.1.2"
-	CreateNode(t, "testNodeNP", nodeIP)
-	defer DeleteNode(t, "testNodeNP")
+	CreateNode(t, "testNode1", nodeIP)
+	defer DeleteNode(t, "testNode1")
 	modelName := "admin/global"
 	found, _ := objects.SharedAviGraphLister().Get(modelName)
 	if found {

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -138,6 +138,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	AddConfigMap(KubeClient)
 	ctrl.SetSEGroupCloudName()

--- a/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
+++ b/tests/multiclusteringresstests/multicluster_ingress_graph_test.go
@@ -117,6 +117,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	integrationtest.PollForSyncStart(ctrl, 10)
@@ -306,7 +308,7 @@ func TestL7ModelForEvh(t *testing.T) {
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
-	}, 5*time.Second).Should(gomega.Equal(true))
+	}, 20*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(len(nodes)).To(gomega.Equal(1))

--- a/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
+++ b/tests/namespacesynctests/l7_ingress_namespace_sync_test.go
@@ -107,6 +107,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	ctrl.SetSEGroupCloudName()

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -224,6 +224,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	ctrl.SetSEGroupCloudName()

--- a/tests/oshiftroutetests/oshift_route_model_test.go
+++ b/tests/oshiftroutetests/oshift_route_model_test.go
@@ -179,6 +179,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	integrationtest.PollForSyncStart(ctrl, 10)

--- a/tests/servicesapitests/servicesapi_l4_test.go
+++ b/tests/servicesapitests/servicesapi_l4_test.go
@@ -116,6 +116,8 @@ func TestMain(m *testing.M) {
 	waitGroupMap["graph"] = wgGraph
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
 
 	integrationtest.AddConfigMap(KubeClient)
 	ctrl.SetSEGroupCloudName()


### PR DESCRIPTION
This PR contains all the code changes for AKO feature.

FT results:
> test_ingress.py 
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_ingress.py                                  |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Ingress_NonDedicated_Shard.test_create_ingress                              |     PASSED     |       00:00:48      |   15:01:43  |   15:02:32  |
| Test_Ingress_NonDedicated_Shard.test_update_ingress_path                         |     PASSED     |       00:01:06      |   15:02:32  |   15:03:38  |
| Test_Ingress_NonDedicated_Shard.test_create_multihost_ingress                    |     PASSED     |       00:00:25      |   15:03:38  |   15:04:04  |
| Test_Ingress_NonDedicated_Shard.test_create_multipath_ingress                    |     PASSED     |       00:00:29      |   15:04:04  |   15:04:33  |
| Test_Ingress_NonDedicated_Shard.test_create_update_delete_multipath_multihost_in |     PASSED     |                     |             |             |
| gress                                                                            |                |       00:01:22      |   15:04:33  |   15:05:56  |
| Test_Ingress_NonDedicated_Shard.test_CDC_ingress                                 |     PASSED     |       00:00:24      |   15:05:56  |   15:06:20  |
| Test_Ingress_NonDedicated_Shard.test_ingress_scale_pods                          |     PASSED     |       00:01:10      |   15:06:20  |   15:07:31  |
| Test_Ingress_NonDedicated_Shard.test_ingress_delete_service                      |     PASSED     |       00:00:02      |   15:07:31  |   15:07:34  |
| Test_Ingress_NonDedicated_Shard.test_ingress_update_wrong_service                |     PASSED     |       00:00:00      |   15:07:34  |   15:07:34  |
| Test_Ingress_NonDedicated_Shard.test_ingress_create_wrong_subdomain              |     PASSED     |       00:00:00      |   15:07:34  |   15:07:35  |
| Test_Ingress_NonDedicated_Shard.test_create_multiple_ingresses_same_host         |     PASSED     |       00:01:15      |   15:07:35  |   15:08:50  |
| Test_Ingress_NonDedicated_Shard.test_update_multiple_ingresses_same_host         |     PASSED     |       00:01:09      |   15:08:50  |   15:10:00  |
| Test_Ingress_NonDedicated_Shard.test_create_ingress_multiport_svc_with_port_name |     PASSED     |       00:00:22      |   15:10:00  |   15:10:23  |
| Test_Ingress_NonDedicated_Shard.test_create_ingress_multiport_svc_with_port_numb |     PASSED     |                     |             |             |
| er                                                                               |                |       00:00:22      |   15:10:23  |   15:10:45  |
| Test_Ingress_NonDedicated_Shard.test_create_ingress_wrong_port_multiport_svc     |     PASSED     |       00:00:22      |   15:10:45  |   15:11:08  |
| Test_Ingress_NonDedicated_Shard.test_delete_apps                                 |     PASSED     |       00:00:01      |   15:11:08  |   15:11:09  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 16   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:0   | Total Time:00:09:26 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_ingress.py                                  |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Ingress_Dedicated_Shard.test_create_ingress                                 |     PASSED     |       00:06:36      |   16:42:05  |   16:48:41  |
| Test_Ingress_Dedicated_Shard.test_update_ingress_path                            |     PASSED     |       00:00:39      |   16:48:41  |   16:49:21  |
| Test_Ingress_Dedicated_Shard.test_create_multihost_ingress                       |     PASSED     |       00:01:04      |   16:49:21  |   16:50:25  |
| Test_Ingress_Dedicated_Shard.test_create_multipath_ingress                       |     PASSED     |       00:01:05      |   16:50:25  |   16:51:31  |
| Test_Ingress_Dedicated_Shard.test_create_update_delete_multipath_multihost_ingre |     PASSED     |                     |             |             |
| ss                                                                               |                |       00:01:48      |   16:51:31  |   16:53:20  |
| Test_Ingress_Dedicated_Shard.test_CDC_ingress                                    |     PASSED     |       00:00:48      |   16:53:20  |   16:54:09  |
| Test_Ingress_Dedicated_Shard.test_ingress_scale_pods                             |     PASSED     |       00:01:21      |   16:54:09  |   16:55:30  |
| Test_Ingress_Dedicated_Shard.test_ingress_delete_service                         |     PASSED     |       00:01:38      |   16:55:30  |   16:57:08  |
| Test_Ingress_Dedicated_Shard.test_ingress_update_wrong_service                   |     PASSED     |       00:00:00      |   16:57:08  |   16:57:09  |
| Test_Ingress_Dedicated_Shard.test_ingress_create_wrong_subdomain                 |     PASSED     |       00:00:00      |   16:57:09  |   16:57:10  |
| Test_Ingress_Dedicated_Shard.test_create_multiple_ingresses_same_host            |     PASSED     |       00:01:58      |   16:57:10  |   16:59:08  |
| Test_Ingress_Dedicated_Shard.test_update_multiple_ingresses_same_host            |     PASSED     |       00:01:21      |   16:59:08  |   17:00:29  |
| Test_Ingress_Dedicated_Shard.test_create_ingress_multiport_svc_with_port_name    |     PASSED     |       00:00:46      |   17:00:29  |   17:01:16  |
| Test_Ingress_Dedicated_Shard.test_create_ingress_multiport_svc_with_port_number  |     PASSED     |       00:00:58      |   17:01:16  |   17:02:15  |
| Test_Ingress_Dedicated_Shard.test_create_ingress_wrong_port_multiport_svc        |     PASSED     |       00:00:43      |   17:02:15  |   17:02:59  |
| Test_Ingress_Dedicated_Shard.test_delete_apps                                    |     PASSED     |       00:00:30      |   17:02:59  |   17:03:30  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 16   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:0   | Total Time:00:21:25 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```
 > test_hostrules.py k8s
 ```
 +----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_host_rules.py                               |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Host_Rules_SNI.test_create_config                                           |     PASSED     |       00:01:09      |   09:58:20  |   09:59:29  |
| Test_Host_Rules_SNI.test_insecure_to_secure                                      |     PASSED     |       00:01:31      |   09:59:29  |   10:01:01  |
| Test_Host_Rules_SNI.test_hostrule_secure_vs                                      |     PASSED     |       00:00:59      |   10:01:01  |   10:02:01  |
| Test_Host_Rules_SNI.test_hostrule_allrefs_set_unset                              |     PASSED     |       00:03:10      |   10:02:01  |   10:05:11  |
| Test_Host_Rules_SNI.test_hostrule_switch                                         |     PASSED     |       00:00:49      |   10:05:11  |   10:06:00  |
| Test_Host_Rules_SNI.test_hostrule_analytics_policy                               |     PASSED     |       00:00:28      |   10:06:00  |   10:06:28  |
| Test_Host_Rules_SNI.test_hostrule_fdqn_aliases                                   |     PASSED     |       00:00:28      |   10:06:28  |   10:06:56  |
| Test_Host_Rules_SNI.test_hostrule_for_parent_vs_customports                      |     PASSED     |       00:01:04      |   10:06:56  |   10:08:01  |
| Test_Host_Rules_SNI.test_hostrule_matchparam_update                              |     PASSED     |       00:00:42      |   10:08:01  |   10:08:43  |
| Test_Host_Rules_SNI.test_hostrule_k8s_secret_create_delete                       |     PASSED     |       00:00:32      |   10:08:43  |   10:09:16  |
| Test_Host_Rules_SNI.test_hostrule_k8s_secret_invalid_to_valid                    |     PASSED     |       00:02:03      |   10:09:16  |   10:11:19  |
| Test_Host_Rules_SNI.test_delete_config_hostrule                                  |     PASSED     |       00:00:50      |   10:11:19  |   10:12:10  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 12   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 12                                                            |    Skipped:0   | Total Time:00:13:50 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_host_rules.py                               |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Host_Rules_EVH.test_create_config                                           |     PASSED     |       00:00:24      |   10:20:10  |   10:20:35  |
| Test_Host_Rules_EVH.test_insecure_to_secure                                      |     PASSED     |       00:01:49      |   10:20:35  |   10:22:24  |
| Test_Host_Rules_EVH.test_hostrule_secure_vs                                      |     PASSED     |       00:01:00      |   10:22:24  |   10:23:24  |
| Test_Host_Rules_EVH.test_hostrule_allrefs_set_unset                              |     PASSED     |       00:03:07      |   10:23:24  |   10:26:32  |
| Test_Host_Rules_EVH.test_hostrule_switch                                         |     PASSED     |       00:00:48      |   10:26:32  |   10:27:21  |
| Test_Host_Rules_EVH.test_hostrule_analytics_policy                               |     PASSED     |       00:00:28      |   10:27:21  |   10:27:49  |
| Test_Host_Rules_EVH.test_hostrule_fdqn_aliases                                   |     PASSED     |       00:00:31      |   10:27:49  |   10:28:21  |
| Test_Host_Rules_EVH.test_hostrule_for_parent_vs_customports                      |     PASSED     |       00:01:32      |   10:28:21  |   10:29:54  |
| Test_Host_Rules_EVH.test_hostrule_matchparam_update                              |     PASSED     |       00:00:41      |   10:29:54  |   10:30:35  |
| Test_Host_Rules_EVH.test_hostrule_k8s_secret_create_delete                       |     PASSED     |       00:00:18      |   10:30:35  |   10:30:54  |
| Test_Host_Rules_EVH.test_hostrule_k8s_secret_invalid_to_valid                    |     PASSED     |       00:01:48      |   10:30:54  |   10:32:43  |
| Test_Host_Rules_EVH.test_delete_config_hostrule                                  |     PASSED     |       00:00:51      |   10:32:43  |   10:33:34  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 12   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 12                                                            |    Skipped:0   | Total Time:00:13:24 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
 ```
> hostrules in openshift
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_host_rules.py                               |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Host_Rules_SNI.test_create_config                                           |     PASSED     |       00:01:02      |   15:41:14  |   15:42:16  |
| Test_Host_Rules_SNI.test_insecure_to_secure                                      |     PASSED     |       00:01:24      |   15:42:16  |   15:43:41  |
| Test_Host_Rules_SNI.test_hostrule_secure_vs                                      |     PASSED     |       00:01:10      |   15:43:41  |   15:44:51  |
| Test_Host_Rules_SNI.test_hostrule_allrefs_set_unset                              |     PASSED     |       00:03:20      |   15:44:51  |   15:48:12  |
| Test_Host_Rules_SNI.test_hostrule_switch                                         |     PASSED     |       00:00:49      |   15:48:12  |   15:49:01  |
| Test_Host_Rules_SNI.test_hostrule_analytics_policy                               |     PASSED     |       00:00:28      |   15:49:01  |   15:49:30  |
| Test_Host_Rules_SNI.test_hostrule_fdqn_aliases                                   |     PASSED     |       00:00:34      |   15:49:30  |   15:50:05  |
| Test_Host_Rules_SNI.test_hostrule_for_parent_vs_customports                      |    SKIPPED     |       00:00:00      |   15:50:05  |   15:50:05  |
| Test_Host_Rules_SNI.test_hostrule_matchparam_update                              |    SKIPPED     |       00:00:00      |   15:50:05  |   15:50:05  |
| Test_Host_Rules_SNI.test_hostrule_k8s_secret_create_delete                       |    SKIPPED     |       00:00:00      |   15:50:05  |   15:50:05  |
| Test_Host_Rules_SNI.test_hostrule_k8s_secret_invalid_to_valid                    |    SKIPPED     |       00:00:00      |   15:50:05  |   15:50:05  |
| Test_Host_Rules_SNI.test_delete_config_hostrule                                  |     PASSED     |       00:00:43      |   15:50:05  |   15:50:48  |
| Test_Host_Rules_EVH.test_create_config                                           |     PASSED     |       00:00:29      |   15:50:48  |   15:51:18  |
| Test_Host_Rules_EVH.test_insecure_to_secure                                      |     PASSED     |       00:01:13      |   15:51:18  |   15:52:31  |
| Test_Host_Rules_EVH.test_hostrule_secure_vs                                      |     PASSED     |       00:01:16      |   15:52:31  |   15:53:48  |
| Test_Host_Rules_EVH.test_hostrule_allrefs_set_unset                              |     PASSED     |       00:03:14      |   15:53:48  |   15:57:03  |
| Test_Host_Rules_EVH.test_hostrule_switch                                         |     PASSED     |       00:02:04      |   15:57:03  |   15:59:07  |
| Test_Host_Rules_EVH.test_hostrule_analytics_policy                               |     PASSED     |       00:00:28      |   15:59:07  |   15:59:36  |
| Test_Host_Rules_EVH.test_hostrule_fdqn_aliases                                   |     PASSED     |       00:00:28      |   15:59:36  |   16:00:04  |
| Test_Host_Rules_EVH.test_hostrule_for_parent_vs_customports                      |    SKIPPED     |       00:00:00      |   16:00:04  |   16:00:05  |
| Test_Host_Rules_EVH.test_hostrule_matchparam_update                              |    SKIPPED     |       00:00:00      |   16:00:05  |   16:00:05  |
| Test_Host_Rules_EVH.test_hostrule_k8s_secret_create_delete                       |    SKIPPED     |       00:00:00      |   16:00:05  |   16:00:05  |
| Test_Host_Rules_EVH.test_hostrule_k8s_secret_invalid_to_valid                    |    SKIPPED     |       00:00:00      |   16:00:05  |   16:00:05  |
| Test_Host_Rules_EVH.test_delete_config_hostrule                                  |     PASSED     |       00:00:51      |   16:00:05  |   16:00:56  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 16   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 24                                                            |    Skipped:8   | Total Time:00:19:41 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+

```
> routes
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_routes.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Route.test_create_route                                                     |     PASSED     |       00:01:32      |   12:36:55  |   12:38:28  |
| Test_Route.test_update_route_path                                                |     PASSED     |       00:00:12      |   12:38:28  |   12:38:41  |
| Test_Route.test_CDC_route                                                        |     PASSED     |       00:00:11      |   12:38:41  |   12:38:53  |
| Test_Route.test_delete_service                                                   |     PASSED     |       00:00:16      |   12:38:53  |   12:39:10  |
| Test_Route.test_route_update_wrong_service                                       |     PASSED     |       00:00:00      |   12:39:10  |   12:39:10  |
| Test_Route.test_route_create_wrong_subdomain                                     |     PASSED     |       00:00:00      |   12:39:10  |   12:39:11  |
| Test_Route.test_create_multiple_routes_same_host                                 |     PASSED     |       00:00:51      |   12:39:11  |   12:40:02  |
| Test_Route.test_create_alternate_backend_route                                   |     PASSED     |       00:00:13      |   12:40:02  |   12:40:15  |
| Test_Route.test_delete_alternate_backend_route                                   |     PASSED     |       00:00:24      |   12:40:15  |   12:40:40  |
| Test_Route.test_svc_infrasetting_update_segroup                                  |    SKIPPED     |       00:00:00      |   12:40:40  |   12:40:40  |
| Test_Route.test_svc_infrasetting_update_network                                  |    SKIPPED     |       00:00:00      |   12:40:40  |   12:40:40  |
| Test_Route.test_delete_apps                                                      |     PASSED     |       00:00:00      |   12:40:40  |   12:40:40  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 10   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 12                                                            |    Skipped:2   | Total Time:00:03:44 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```
> routes_evh
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_routes_evh.py                               |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Route_EVH.test_create_route                                                 |     PASSED     |       00:00:45      |   12:31:11  |   12:31:56  |
| Test_Route_EVH.test_update_route_path                                            |     PASSED     |       00:00:13      |   12:31:56  |   12:32:09  |
| Test_Route_EVH.test_CDC_route                                                    |     PASSED     |       00:00:12      |   12:32:09  |   12:32:22  |
| Test_Route_EVH.test_delete_service                                               |     PASSED     |       00:00:19      |   12:32:22  |   12:32:41  |
| Test_Route_EVH.test_route_update_wrong_service                                   |     PASSED     |       00:00:11      |   12:32:41  |   12:32:53  |
| Test_Route_EVH.test_route_create_wrong_subdomain                                 |     PASSED     |       00:00:00      |   12:32:53  |   12:32:53  |
| Test_Route_EVH.test_create_multiple_routes_same_host                             |     PASSED     |       00:00:47      |   12:32:53  |   12:33:41  |
| Test_Route_EVH.test_create_alternate_backend_route                               |     PASSED     |       00:00:42      |   12:33:41  |   12:34:23  |
| Test_Route_EVH.test_delete_alternate_backend_route                               |     PASSED     |       00:00:28      |   12:34:23  |   12:34:51  |
| Test_Route_EVH.test_delete_apps                                                  |     PASSED     |       00:00:01      |   12:34:51  |   12:34:53  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 10   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 10                                                            |    Skipped:0   | Total Time:00:03:42 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```
> httprules in openshift
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_http_rules.py                               |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_config                        |     PASSED     |       00:00:16      |   12:47:28  |   12:47:44  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule                      |     PASSED     |       00:01:07      |   12:47:44  |   12:48:52  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_httprule_allrefs_set_unset           |     PASSED     |       00:01:04      |   12:48:52  |   12:49:57  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_httprule_with_reencrypt              |     PASSED     |       00:00:53      |   12:49:57  |   12:50:50  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule_for_nested_paths     |     PASSED     |       00:00:53      |   12:50:50  |   12:51:43  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_delete_rules                         |     PASSED     |       00:00:03      |   12:51:43  |   12:51:46  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_config      |     PASSED     |       00:00:59      |   12:51:46  |   12:52:46  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_multi_ingre |     PASSED     |                     |             |             |
| ss                                                                               |                |       00:00:15      |   12:52:46  |   12:53:02  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_update_http |     PASSED     |                     |             |             |
| _rule                                                                            |                |       00:00:12      |   12:53:02  |   12:53:14  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_multipath_i |     PASSED     |                     |             |             |
| ngress                                                                           |                |       00:00:22      |   12:53:14  |   12:53:37  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_teardown_hostrule_ |     PASSED     |                     |             |             |
| switch_objects                                                                   |                |       00:00:42      |   12:53:37  |   12:54:20  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_delete_config      |     PASSED     |       00:00:04      |   12:54:20  |   12:54:24  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_config                           |     PASSED     |       00:00:16      |   12:54:24  |   12:54:40  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule                         |     PASSED     |       00:01:06      |   12:54:40  |   12:55:47  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_httprule_allrefs_set_unset              |     PASSED     |       00:01:04      |   12:55:47  |   12:56:52  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_httprule_with_reencrypt                 |     PASSED     |       00:00:53      |   12:56:52  |   12:57:45  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule_for_nested_paths        |     PASSED     |       00:00:43      |   12:57:45  |   12:58:29  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_delete_rules                            |     PASSED     |       00:00:02      |   12:58:29  |   12:58:32  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_config         |     PASSED     |       00:00:58      |   12:58:32  |   12:59:30  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_multi_ingress  |     PASSED     |       00:00:16      |   12:59:30  |   12:59:46  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_update_http_ru |     PASSED     |                     |             |             |
| le                                                                               |                |       00:00:32      |   12:59:46  |   13:00:19  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_multipath_ingr |     PASSED     |                     |             |             |
| ess                                                                              |                |       00:00:12      |   13:00:19  |   13:00:32  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_teardown_hostrule_swi |     PASSED     |                     |             |             |
| tch_objects                                                                      |                |       00:00:42      |   13:00:32  |   13:01:14  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_delete_config         |     PASSED     |       00:00:04      |   13:01:14  |   13:01:18  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_config                        |     PASSED     |       00:00:16      |   13:01:18  |   13:01:34  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule                      |     PASSED     |       00:01:06      |   13:01:34  |   13:02:41  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_httprule_allrefs_set_unset           |     PASSED     |       00:01:04      |   13:02:41  |   13:03:46  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_httprule_with_reencrypt              |     PASSED     |       00:00:53      |   13:03:46  |   13:04:39  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule_for_nested_paths     |     PASSED     |       00:00:42      |   13:04:39  |   13:05:22  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_delete_rules                         |     PASSED     |       00:00:02      |   13:05:22  |   13:05:25  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_config      |     PASSED     |       00:00:56      |   13:05:25  |   13:06:22  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_multi_ingre |     PASSED     |                     |             |             |
| ss                                                                               |                |       00:00:15      |   13:06:22  |   13:06:38  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_update_http |     PASSED     |                     |             |             |
| _rule                                                                            |                |       00:00:12      |   13:06:38  |   13:06:50  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_multipath_i |     PASSED     |                     |             |             |
| ngress                                                                           |                |       00:00:22      |   13:06:50  |   13:07:13  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_teardown_hostrule_ |     PASSED     |                     |             |             |
| switch_objects                                                                   |                |       00:00:43      |   13:07:13  |   13:07:56  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_delete_config      |     PASSED     |       00:00:04      |   13:07:56  |   13:08:00  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_config                           |     PASSED     |       00:00:15      |   13:08:00  |   13:08:16  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule                         |     PASSED     |       00:01:06      |   13:08:16  |   13:09:22  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_httprule_allrefs_set_unset              |     PASSED     |       00:01:06      |   13:09:22  |   13:10:29  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_httprule_with_reencrypt                 |     PASSED     |       00:00:53      |   13:10:29  |   13:11:22  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule_for_nested_paths        |     PASSED     |       00:00:43      |   13:11:22  |   13:12:05  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_delete_rules                            |     PASSED     |       00:00:02      |   13:12:05  |   13:12:08  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_config         |     PASSED     |       00:00:56      |   13:12:08  |   13:13:05  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_multi_ingress  |     PASSED     |       00:00:16      |   13:13:05  |   13:13:21  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_update_http_ru |     PASSED     |                     |             |             |
| le                                                                               |                |       00:00:12      |   13:13:21  |   13:13:34  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_multipath_ingr |     PASSED     |                     |             |             |
| ess                                                                              |                |       00:00:12      |   13:13:34  |   13:13:46  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_teardown_hostrule_swi |     PASSED     |                     |             |             |
| tch_objects                                                                      |                |       00:00:52      |   13:13:46  |   13:14:39  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_delete_config         |     PASSED     |       00:00:02      |   13:14:39  |   13:14:42  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 48   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 48                                                            |    Skipped:0   | Total Time:00:27:13 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```
> lb_svc openshift
```

+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcSNI_NonDedicated_Shard.test_app_creation                               |     PASSED     |       00:00:59      |   18:53:07  |   18:54:06  |
| Test_LBSvcSNI_NonDedicated_Shard.test_update_service                             |     PASSED     |       00:01:32      |   18:54:06  |   18:55:38  |
| Test_LBSvcSNI_NonDedicated_Shard.test_update_deployment_replicas                 |     PASSED     |       00:00:17      |   18:55:38  |   18:55:56  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services                   |     PASSED     |       00:00:21      |   18:55:56  |   18:56:17  |
| Test_LBSvcSNI_NonDedicated_Shard.test_delete_multiple_services                   |     PASSED     |       00:00:17      |   18:56:17  |   18:56:35  |
| Test_LBSvcSNI_NonDedicated_Shard.test_app_no_pod                                 |     PASSED     |       00:00:15      |   18:56:35  |   18:56:50  |
| Test_LBSvcSNI_NonDedicated_Shard.test_service_static_ip                          |     PASSED     |       00:01:08      |   18:56:50  |   18:57:59  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip  |     PASSED     |       00:01:13      |   18:57:59  |   18:59:12  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_auto_fqdn                              |     PASSED     |       00:02:15      |   18:59:12  |   19:01:27  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_fqdn_annotation                        |     PASSED     |       00:00:48      |   19:01:27  |   19:02:16  |
| Test_LBSvcSNI_NonDedicated_Shard.test_svc_infrasetting_update_segroup            |    SKIPPED     |       00:00:00      |   19:02:16  |   19:02:16  |
| Test_LBSvcSNI_NonDedicated_Shard.test_svc_infrasetting_update_network            |     PASSED     |       00:00:43      |   19:02:16  |   19:02:59  |
| Test_LBSvcSNI_NonDedicated_Shard.test_public_ip_allocation                       |    SKIPPED     |       00:00:00      |   19:02:59  |   19:02:59  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services_shared_vip        |     PASSED     |       00:01:04      |   19:02:59  |   19:04:04  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services_shared_vip_static |     PASSED     |                     |             |             |
| _ip                                                                              |                |       00:01:05      |   19:04:04  |   19:05:09  |
| Test_LBSvcSNI_NonDedicated_Shard.test_delete_apps                                |     PASSED     |       00:00:01      |   19:05:09  |   19:05:11  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 14   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:2   | Total Time:00:12:03 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+

+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcSNI_Dedicated_Shard.test_app_creation                                  |     PASSED     |       00:02:04      |   19:15:41  |   19:17:46  |
| Test_LBSvcSNI_Dedicated_Shard.test_update_service                                |     PASSED     |       00:00:16      |   19:17:46  |   19:18:03  |
| Test_LBSvcSNI_Dedicated_Shard.test_update_deployment_replicas                    |     PASSED     |       00:00:17      |   19:18:03  |   19:18:20  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services                      |     PASSED     |       00:00:20      |   19:18:20  |   19:18:41  |
| Test_LBSvcSNI_Dedicated_Shard.test_delete_multiple_services                      |     PASSED     |       00:00:02      |   19:18:41  |   19:18:44  |
| Test_LBSvcSNI_Dedicated_Shard.test_app_no_pod                                    |     PASSED     |       00:00:15      |   19:18:44  |   19:18:59  |
| Test_LBSvcSNI_Dedicated_Shard.test_service_static_ip                             |     PASSED     |       00:01:08      |   19:18:59  |   19:20:08  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip     |     PASSED     |       00:01:13      |   19:20:08  |   19:21:21  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_auto_fqdn                                 |     PASSED     |       00:02:17      |   19:21:21  |   19:23:39  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_fqdn_annotation                           |     PASSED     |       00:00:44      |   19:23:39  |   19:24:24  |
| Test_LBSvcSNI_Dedicated_Shard.test_svc_infrasetting_update_segroup               |    SKIPPED     |       00:00:00      |   19:24:24  |   19:24:24  |
| Test_LBSvcSNI_Dedicated_Shard.test_svc_infrasetting_update_network               |     PASSED     |       00:00:43      |   19:24:24  |   19:25:07  |
| Test_LBSvcSNI_Dedicated_Shard.test_public_ip_allocation                          |    SKIPPED     |       00:00:00      |   19:25:07  |   19:25:07  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services_shared_vip           |     PASSED     |       00:01:04      |   19:25:07  |   19:26:12  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services_shared_vip_static_ip |     PASSED     |       00:01:05      |   19:26:12  |   19:27:17  |
| Test_LBSvcSNI_Dedicated_Shard.test_delete_apps                                   |     PASSED     |       00:00:51      |   19:27:17  |   19:28:08  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 14   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:2   | Total Time:00:12:26 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+

+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcEVH_NonDedicated_Shard.test_app_creation                               |     PASSED     |       00:01:04      |   19:29:04  |   19:30:08  |
| Test_LBSvcEVH_NonDedicated_Shard.test_update_service                             |     PASSED     |       00:00:16      |   19:30:08  |   19:30:25  |
| Test_LBSvcEVH_NonDedicated_Shard.test_update_deployment_replicas                 |     PASSED     |       00:00:17      |   19:30:25  |   19:30:43  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services                   |     PASSED     |       00:00:21      |   19:30:43  |   19:31:04  |
| Test_LBSvcEVH_NonDedicated_Shard.test_delete_multiple_services                   |     PASSED     |       00:00:02      |   19:31:04  |   19:31:06  |
| Test_LBSvcEVH_NonDedicated_Shard.test_app_no_pod                                 |     PASSED     |       00:00:15      |   19:31:06  |   19:31:22  |
| Test_LBSvcEVH_NonDedicated_Shard.test_service_static_ip                          |     PASSED     |       00:01:08      |   19:31:22  |   19:32:31  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip  |     PASSED     |       00:01:13      |   19:32:31  |   19:33:45  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_auto_fqdn                              |     PASSED     |       00:02:15      |   19:33:45  |   19:36:00  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_fqdn_annotation                        |     PASSED     |       00:00:44      |   19:36:00  |   19:36:45  |
| Test_LBSvcEVH_NonDedicated_Shard.test_svc_infrasetting_update_segroup            |    SKIPPED     |       00:00:00      |   19:36:45  |   19:36:45  |
| Test_LBSvcEVH_NonDedicated_Shard.test_svc_infrasetting_update_network            |     PASSED     |       00:00:43      |   19:36:45  |   19:37:29  |
| Test_LBSvcEVH_NonDedicated_Shard.test_public_ip_allocation                       |    SKIPPED     |       00:00:00      |   19:37:29  |   19:37:29  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services_shared_vip        |     PASSED     |       00:01:56      |   19:37:29  |   19:39:26  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services_shared_vip_static |     PASSED     |                     |             |             |
| _ip                                                                              |                |       00:01:04      |   19:39:26  |   19:40:30  |
| Test_LBSvcEVH_NonDedicated_Shard.test_delete_apps                                |     PASSED     |       00:00:01      |   19:40:30  |   19:40:32  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 14   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:2   | Total Time:00:11:27 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+

+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcEVH_Dedicated_Shard.test_app_creation                                  |     PASSED     |       00:01:05      |   19:50:31  |   19:51:36  |
| Test_LBSvcEVH_Dedicated_Shard.test_update_service                                |     PASSED     |       00:00:16      |   19:51:36  |   19:51:53  |
| Test_LBSvcEVH_Dedicated_Shard.test_update_deployment_replicas                    |     PASSED     |       00:00:16      |   19:51:53  |   19:52:10  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services                      |     PASSED     |       00:00:21      |   19:52:10  |   19:52:32  |
| Test_LBSvcEVH_Dedicated_Shard.test_delete_multiple_services                      |     PASSED     |       00:00:02      |   19:52:32  |   19:52:34  |
| Test_LBSvcEVH_Dedicated_Shard.test_app_no_pod                                    |     PASSED     |       00:00:15      |   19:52:34  |   19:52:50  |
| Test_LBSvcEVH_Dedicated_Shard.test_service_static_ip                             |     PASSED     |       00:01:08      |   19:52:50  |   19:53:58  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip     |     PASSED     |       00:01:13      |   19:53:58  |   19:55:12  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_auto_fqdn                                 |     PASSED     |       00:02:13      |   19:55:12  |   19:57:25  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_fqdn_annotation                           |     PASSED     |       00:00:45      |   19:57:25  |   19:58:10  |
| Test_LBSvcEVH_Dedicated_Shard.test_svc_infrasetting_update_segroup               |    SKIPPED     |       00:00:00      |   19:58:10  |   19:58:10  |
| Test_LBSvcEVH_Dedicated_Shard.test_svc_infrasetting_update_network               |     PASSED     |       00:00:43      |   19:58:10  |   19:58:53  |
| Test_LBSvcEVH_Dedicated_Shard.test_public_ip_allocation                          |    SKIPPED     |       00:00:00      |   19:58:53  |   19:58:53  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services_shared_vip           |     PASSED     |       00:01:10      |   19:58:53  |   20:00:04  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services_shared_vip_static_ip |     PASSED     |       00:01:57      |   20:00:04  |   20:02:02  |
| Test_LBSvcEVH_Dedicated_Shard.test_delete_apps                                   |     PASSED     |       00:00:01      |   20:02:02  |   20:02:03  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 14   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 16                                                            |    Skipped:2   | Total Time:00:11:32 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```

> lb svc k8s
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcSNI_NonDedicated_Shard.test_app_creation                               |     PASSED     |       00:01:10      |   13:43:44  |   13:44:54  |
| Test_LBSvcSNI_NonDedicated_Shard.test_update_service                             |     PASSED     |       00:00:25      |   13:44:54  |   13:45:20  |
| Test_LBSvcSNI_NonDedicated_Shard.test_update_deployment_replicas                 |     PASSED     |       00:00:12      |   13:45:20  |   13:45:32  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services                   |     PASSED     |       00:00:26      |   13:45:32  |   13:45:59  |
| Test_LBSvcSNI_NonDedicated_Shard.test_delete_multiple_services                   |     PASSED     |       00:00:17      |   13:45:59  |   13:46:16  |
| Test_LBSvcSNI_NonDedicated_Shard.test_app_no_pod                                 |     PASSED     |       00:00:15      |   13:46:16  |   13:46:31  |
| Test_LBSvcSNI_NonDedicated_Shard.test_service_static_ip                          |     PASSED     |       00:01:02      |   13:46:31  |   13:47:34  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip  |     PASSED     |       00:01:26      |   13:47:34  |   13:49:00  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_auto_fqdn                              |     PASSED     |       00:01:49      |   13:49:00  |   13:50:49  |
| Test_LBSvcSNI_NonDedicated_Shard.test_ako_fqdn_annotation                        |     PASSED     |       00:00:49      |   13:50:49  |   13:51:39  |
| Test_LBSvcSNI_NonDedicated_Shard.test_svc_infrasetting_update_segroup            |    SKIPPED     |       00:00:00      |   13:51:39  |   13:51:39  |
| Test_LBSvcSNI_NonDedicated_Shard.test_svc_infrasetting_update_network            |     PASSED     |       00:00:43      |   13:51:39  |   13:52:23  |
| Test_LBSvcSNI_NonDedicated_Shard.test_public_ip_allocation                       |    SKIPPED     |       00:00:00      |   13:52:23  |   13:52:23  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services_shared_vip        |     PASSED     |       00:00:59      |   13:52:23  |   13:53:22  |
| Test_LBSvcSNI_NonDedicated_Shard.test_create_multiple_services_shared_vip_static |     PASSED     |                     |             |             |
| _ip                                                                              |                |       00:00:59      |   13:53:22  |   13:54:22  |
| Test_LBSvcSNI_NonDedicated_Shard.test_delete_apps                                |     PASSED     |       00:00:02      |   13:54:22  |   13:54:25  |
| Test_LBSvcSNI_Dedicated_Shard.test_app_creation                                  |     PASSED     |       00:00:58      |   13:54:25  |   13:55:24  |
| Test_LBSvcSNI_Dedicated_Shard.test_update_service                                |     PASSED     |       00:00:22      |   13:55:24  |   13:55:46  |
| Test_LBSvcSNI_Dedicated_Shard.test_update_deployment_replicas                    |     PASSED     |       00:00:13      |   13:55:46  |   13:56:00  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services                      |     PASSED     |       00:00:37      |   13:56:00  |   13:56:37  |
| Test_LBSvcSNI_Dedicated_Shard.test_delete_multiple_services                      |     PASSED     |       00:00:17      |   13:56:37  |   13:56:54  |
| Test_LBSvcSNI_Dedicated_Shard.test_app_no_pod                                    |     PASSED     |       00:00:15      |   13:56:54  |   13:57:10  |
| Test_LBSvcSNI_Dedicated_Shard.test_service_static_ip                             |     PASSED     |       00:00:59      |   13:57:10  |   13:58:10  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip     |     PASSED     |       00:01:42      |   13:58:10  |   13:59:52  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_auto_fqdn                                 |     PASSED     |       00:01:49      |   13:59:52  |   14:01:42  |
| Test_LBSvcSNI_Dedicated_Shard.test_ako_fqdn_annotation                           |     PASSED     |       00:00:50      |   14:01:42  |   14:02:32  |
| Test_LBSvcSNI_Dedicated_Shard.test_svc_infrasetting_update_segroup               |    SKIPPED     |       00:00:00      |   14:02:32  |   14:02:32  |
| Test_LBSvcSNI_Dedicated_Shard.test_svc_infrasetting_update_network               |     PASSED     |       00:00:43      |   14:02:32  |   14:03:16  |
| Test_LBSvcSNI_Dedicated_Shard.test_public_ip_allocation                          |    SKIPPED     |       00:00:00      |   14:03:16  |   14:03:16  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services_shared_vip           |     PASSED     |       00:01:02      |   14:03:16  |   14:04:19  |
| Test_LBSvcSNI_Dedicated_Shard.test_create_multiple_services_shared_vip_static_ip |     PASSED     |       00:00:59      |   14:04:19  |   14:05:19  |
| Test_LBSvcSNI_Dedicated_Shard.test_delete_apps                                   |     PASSED     |       00:00:02      |   14:05:19  |   14:05:21  |
| Test_LBSvcEVH_NonDedicated_Shard.test_app_creation                               |     PASSED     |       00:00:58      |   14:05:21  |   14:06:20  |
| Test_LBSvcEVH_NonDedicated_Shard.test_update_service                             |     PASSED     |       00:00:23      |   14:06:20  |   14:06:43  |
| Test_LBSvcEVH_NonDedicated_Shard.test_update_deployment_replicas                 |     PASSED     |       00:00:12      |   14:06:43  |   14:06:55  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services                   |     PASSED     |       00:00:27      |   14:06:55  |   14:07:23  |
| Test_LBSvcEVH_NonDedicated_Shard.test_delete_multiple_services                   |     PASSED     |       00:00:16      |   14:07:23  |   14:07:40  |
| Test_LBSvcEVH_NonDedicated_Shard.test_app_no_pod                                 |     PASSED     |       00:00:22      |   14:07:40  |   14:08:02  |
| Test_LBSvcEVH_NonDedicated_Shard.test_service_static_ip                          |     PASSED     |       00:00:58      |   14:08:02  |   14:09:01  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip  |     PASSED     |       00:01:26      |   14:09:01  |   14:10:28  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_auto_fqdn                              |     PASSED     |       00:01:50      |   14:10:28  |   14:12:18  |
| Test_LBSvcEVH_NonDedicated_Shard.test_ako_fqdn_annotation                        |     PASSED     |       00:00:50      |   14:12:18  |   14:13:08  |
| Test_LBSvcEVH_NonDedicated_Shard.test_svc_infrasetting_update_segroup            |    SKIPPED     |       00:00:00      |   14:13:08  |   14:13:08  |
| Test_LBSvcEVH_NonDedicated_Shard.test_svc_infrasetting_update_network            |     PASSED     |       00:00:29      |   14:13:08  |   14:13:38  |
| Test_LBSvcEVH_NonDedicated_Shard.test_public_ip_allocation                       |    SKIPPED     |       00:00:00      |   14:13:38  |   14:13:38  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services_shared_vip        |     PASSED     |       00:00:59      |   14:13:38  |   14:14:37  |
| Test_LBSvcEVH_NonDedicated_Shard.test_create_multiple_services_shared_vip_static |     PASSED     |                     |             |             |
| _ip                                                                              |                |       00:01:07      |   14:14:37  |   14:15:45  |
| Test_LBSvcEVH_NonDedicated_Shard.test_delete_apps                                |     PASSED     |       00:00:02      |   14:15:45  |   14:15:47  |
| Test_LBSvcEVH_Dedicated_Shard.test_app_creation                                  |     PASSED     |       00:00:59      |   14:15:47  |   14:16:46  |
| Test_LBSvcEVH_Dedicated_Shard.test_update_service                                |     PASSED     |       00:00:22      |   14:16:46  |   14:17:09  |
| Test_LBSvcEVH_Dedicated_Shard.test_update_deployment_replicas                    |     PASSED     |       00:00:12      |   14:17:09  |   14:17:21  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services                      |     PASSED     |       00:00:27      |   14:17:21  |   14:17:49  |
| Test_LBSvcEVH_Dedicated_Shard.test_delete_multiple_services                      |     PASSED     |       00:00:16      |   14:17:49  |   14:18:05  |
| Test_LBSvcEVH_Dedicated_Shard.test_app_no_pod                                    |     PASSED     |       00:00:15      |   14:18:05  |   14:18:21  |
| Test_LBSvcEVH_Dedicated_Shard.test_service_static_ip                             |     PASSED     |       00:00:58      |   14:18:21  |   14:19:20  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_delete_pod_with_vs_deletion_static_ip     |     PASSED     |       00:01:26      |   14:19:20  |   14:20:46  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_auto_fqdn                                 |     PASSED     |       00:01:55      |   14:20:46  |   14:22:42  |
| Test_LBSvcEVH_Dedicated_Shard.test_ako_fqdn_annotation                           |     PASSED     |       00:00:49      |   14:22:42  |   14:23:32  |
| Test_LBSvcEVH_Dedicated_Shard.test_svc_infrasetting_update_segroup               |    SKIPPED     |       00:00:00      |   14:23:32  |   14:23:32  |
| Test_LBSvcEVH_Dedicated_Shard.test_svc_infrasetting_update_network               |     PASSED     |       00:00:43      |   14:23:32  |   14:24:15  |
| Test_LBSvcEVH_Dedicated_Shard.test_public_ip_allocation                          |    SKIPPED     |       00:00:00      |   14:24:15  |   14:24:15  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services_shared_vip           |     PASSED     |       00:00:59      |   14:24:15  |   14:25:14  |
| Test_LBSvcEVH_Dedicated_Shard.test_create_multiple_services_shared_vip_static_ip |     PASSED     |       00:00:59      |   14:25:14  |   14:26:14  |
| Test_LBSvcEVH_Dedicated_Shard.test_delete_apps                                   |     PASSED     |       00:00:01      |   14:26:14  |   14:26:16  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 56   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 64                                                            |    Skipped:8   | Total Time:00:42:31 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```

> length validation k8s
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_length_validation.py                        |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_Length_Validation.test_create_insecure_ingress                              |     PASSED     |       00:01:32      |   15:39:33  |   15:41:05  |
| Test_Length_Validation.test_validate_object_length_insecure_ingress              |     PASSED     |       00:00:01      |   15:41:05  |   15:41:07  |
| Test_Length_Validation.test_update_insecure_ingress_path_VIV                     |     PASSED     |       00:00:01      |   15:41:07  |   15:41:08  |
| Test_Length_Validation.test_delete_namespace                                     |     PASSED     |       00:00:45      |   15:41:08  |   15:41:54  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 4   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 4                                                             |    Skipped:0   | Total Time:00:02:20 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```