### PR TITLE
[Bug fix] Fix for VSVIP key collection coming as empty in VS cache

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2134,14 +2134,11 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				if vs["vsvip_ref"] != nil {
 					// find the vsvip name from the vsvip cache
 					vsVipUuid := ExtractUuidWithoutHash(vs["vsvip_ref"].(string), "vsvip-.*.")
-					vsVip, foundVip := c.VSVIPCache.AviCacheGet(vsVipUuid)
+					vsVipName, foundVip := c.VSVIPCache.AviCacheGetNameByUuid(vsVipUuid)
 
 					if foundVip {
-						vsVipData, ok := vsVip.(*AviVSVIPCache)
-						if ok {
-							vipKey := NamespaceName{Namespace: lib.GetTenant(), Name: vsVipData.Name}
-							vsVipKey = append(vsVipKey, vipKey)
-						}
+						vipKey := NamespaceName{Namespace: lib.GetTenant(), Name: vsVipName.(string)}
+						vsVipKey = append(vsVipKey, vipKey)
 					}
 				}
 


### PR DESCRIPTION
This PR fixes an issue where the VSVIP key collection was empty in VS cache because of a wrong function call.

A wrong function `AviCacheGet` was called to get the VSVIP name by passing UUID. This PR corrects the code to call the function `AviCacheGetNameByUuid` with UUID to get the VSVIP name.
