### PR TITLE
AV-160077 Add AVI default SSL profile to pool to support older AVI versions

### DIFF
--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1523,6 +1523,7 @@ func (v *AviPoolNode) CopyNode() AviModelNode {
 func (v *AviPoolNode) UpdatePoolNodeForIstio() {
 	v.PkiProfileRef = fmt.Sprintf("/api/pkiprofile?name=%s", lib.GetIstioPKIProfileName())
 	v.SslKeyAndCertificateRef = fmt.Sprintf("/api/sslkeyandcertificate?name=%s", lib.GetIstioWorkloadCertificateName())
+	v.SslProfileRef = fmt.Sprintf("/api/sslprofile?name=%s", lib.DefaultPoolSSLProfile)
 }
 func (o *AviObjectGraph) GetAviPoolNodesByIngress(tenant string, ingName string) []*AviPoolNode {
 	var aviPool []*AviPoolNode


### PR DESCRIPTION
this will overwrite any ssl profile provided through CRDs