### PR TITLE
fix for AV-164932 

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2718,10 +2718,6 @@ func validateAndConfigureSeGroup(client *clients.AviClient, returnErr *error) bo
 // ConfigureSeGroupLabels configures labels on the SeGroup if not present already
 func ConfigureSeGroupLabels(client *clients.AviClient, seGroup *models.ServiceEngineGroup) error {
 
-	if !lib.AKOControlConfig().IsLeader() {
-		return nil
-	}
-
 	labels := seGroup.Labels
 	segName := *seGroup.Name
 	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())


### PR DESCRIPTION
This PR gives the ability to modify the SE group labels to any AKO which is coming up first irrespective of the leadership so that the labels will be present while route creation.

Tested scenarios:
1. Deleted static routes from the controller and verified whether routes are getting removed from the SE.
2. Rebooted the AKO and verified the routes are getting added in the SE.
3. Configured `deleteConfig` as false and verified the routes are getting removed from the SE.
4. Configured `deleteConfig` as true and verified the routes are getting added back in the SE.
5. Aviinfrasetting with SE group name.

