### PR TITLE
fix for AV-165125

### DIFF
--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -329,6 +329,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 						statusOption := status.StatusOptions{
 							ObjType: utils.L4LBService,
 							Op:      lib.UpdateStatus,
+							Key:     key,
 							Options: &updateOptions,
 						}
 						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
@@ -411,6 +412,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,
 					Op:      lib.DeleteStatus,
+					Key:     key,
 					Options: &updateOptions,
 				}
 				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", pool_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
@@ -425,6 +427,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					ObjType: utils.Ingress,
 					Op:      lib.DeleteStatus,
 					IsVSDel: isVSDelete,
+					Key:     key,
 					Options: &updateOptions,
 				}
 				if utils.GetInformers().RouteInformer != nil {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -473,6 +473,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 						statusOption := status.StatusOptions{
 							ObjType: utils.L4LBService,
 							Op:      lib.UpdateStatus,
+							Key:     key,
 							Options: &updateOptions,
 						}
 						utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
@@ -488,6 +489,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 						statusOption := status.StatusOptions{
 							ObjType: utils.Ingress,
 							Op:      lib.UpdateStatus,
+							Key:     key,
 							Options: &updateOptions,
 						}
 						if utils.GetInformers().RouteInformer != nil {
@@ -519,6 +521,7 @@ func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCac
 		statusOption := status.StatusOptions{
 			ObjType: lib.Gateway,
 			Op:      lib.UpdateStatus,
+			Key:     key,
 			Options: &updateOptions,
 		}
 		if lib.UseServicesAPI() {
@@ -537,6 +540,7 @@ func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCac
 		statusOption := status.StatusOptions{
 			ObjType: utils.L4LBService,
 			Op:      lib.UpdateStatus,
+			Key:     key,
 			Options: &updateOptions,
 		}
 		utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.NamespaceServiceName[0], utils.Stringify(statusOption))
@@ -742,6 +746,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				statusOption := status.StatusOptions{
 					ObjType: lib.Gateway,
 					Op:      lib.DeleteStatus,
+					Key:     key,
 					Options: &updateOptions,
 				}
 				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.Gateway, utils.Stringify(statusOption))
@@ -761,6 +766,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,
 					Op:      lib.DeleteStatus,
+					Key:     key,
 					Options: &updateOptions,
 				}
 				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", vs_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))

--- a/internal/status/status_toiler.go
+++ b/internal/status/status_toiler.go
@@ -38,9 +38,10 @@ func PublishToStatusQueue(key string, statusOption StatusOptions) {
 func (l *leader) DequeueStatus(objIntf interface{}) error {
 	obj, ok := objIntf.(StatusOptions)
 	if !ok {
-		utils.AviLog.Warnf("key: %s, object is not of type StatusOptions, %T", obj.Options.Key, objIntf)
+		utils.AviLog.Warnf("Object is not of type StatusOptions, %T", objIntf)
 		return nil
 	}
+	utils.AviLog.Infof("key: %s, msg: start status layer sync.", obj.Key)
 	switch obj.ObjType {
 	case utils.L4LBService:
 		if obj.Op == lib.UpdateStatus {
@@ -91,9 +92,9 @@ func (l *leader) DequeueStatus(objIntf interface{}) error {
 func (f *follower) DequeueStatus(objIntf interface{}) error {
 	obj, ok := objIntf.(StatusOptions)
 	if !ok {
-		utils.AviLog.Warnf("key: %s, object is not of type StatusOptions, %T", obj.Options.Key, objIntf)
+		utils.AviLog.Warnf("Object is not of type StatusOptions, %T", objIntf)
 		return nil
 	}
-	utils.AviLog.Debugf("key: %s, AKO is not running as a leader", obj.Options.Key)
+	utils.AviLog.Debugf("key: %s, AKO is not running as a leader", obj.Key)
 	return nil
 }


### PR DESCRIPTION
This PR fixes a crash issue seen in NPL deployments.

For NPL deployments the parameter `Key` was not filled in the `StatusOptions` from the rest layer and it was getting accessed at the follower AKO dequeue status method. Hence the crash.

With this commit, the parameter `Key` will be filled by the rest layer in all cases.