### PR TITLE
fix for AV-150791

### DIFF
--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -121,6 +121,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 						} else {
 							vip.IPAMNetworkSubnet = vsvip.Vip[0].IPAMNetworkSubnet
 						}
+						vip.DiscoveredNetworks = vsvip.Vip[0].DiscoveredNetworks
 					} else {
 						vip.IPAMNetworkSubnet = &avimodels.IPNetworkSubnet{}
 					}


### PR DESCRIPTION
This commit fixes an issue where the VS VIP goes down with the error message `No network/subnet matched Virtual Service IP`.

On debugging the code, the AKO was not filling the discovered networks correctly in one PUT operation of VS VIP resulting in this error.

This commit ensures that the discovered network is filled correctly in VS VIP before the PUT operations.

Tested scenarios:
1. Deleted the ingress which resulted in a VS VIP PUT operation with the discovered networks in its payload.