### PR TITLE
AV-166170 : Adding script to get build path for SRP data submission

### DIFF
--- a/hack/jenkins/get_build_path.sh
+++ b/hack/jenkins/get_build_path.sh
@@ -1,0 +1,40 @@
+# Copyright 2019-2023 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+set -xe
+
+if [ $# -lt 2 ] ; then
+    echo "Usage: ./get_build_path.sh <branch> <build_num>";
+    exit 1
+fi
+
+BRANCH=$1
+BUILD_NUMBER=$2
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# Function to get GIT workspace root location
+function get_git_ws {
+    git_ws=$(git rev-parse --show-toplevel)
+    [ -z "$git_ws" ] && echo "Couldn't find git workspace root" && exit 1
+    echo $git_ws
+}
+
+BUILD_VERSION_SCRIPT=$SCRIPTPATH/get_build_version.sh
+build_version=$(bash $BUILD_VERSION_SCRIPT "dummy" $BUILD_NUMBER)
+
+target_path=/mnt/builds/ako_OS/$BRANCH/ci-build-$build_version
+echo $target_path


### PR DESCRIPTION
This PR is for adding a script to AKO repository, for getting the path where a specific build is stored in the build server. The script will take build number and branch name as parameters for computing the path. This script will be used by a Jenkins job, created for getting and submitting the SRP provenance data based on build number and branch.