### PR TITLE
fix for AV-165655

### DIFF
--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -589,8 +589,6 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 	leReadyCh := leaderElector.Run(ctx, leaderElectionWG)
 	<-leReadyCh
 
-	c.cleanupStaleVSes()
-
 	graphQueue.SyncFunc = SyncFromNodesLayer
 	graphQueue.Run(stopCh, graphwg)
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -591,10 +591,6 @@ func (c *AviController) InitController(informers K8sinformers, registeredInforme
 
 	c.cleanupStaleVSes()
 
-	// once the l3 cache is populated, we can call the updatestatus functions from here
-	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
-	restlayer.SyncObjectStatuses()
-
 	graphQueue.SyncFunc = SyncFromNodesLayer
 	graphQueue.Run(stopCh, graphwg)
 

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -17,7 +17,9 @@ package k8s
 import (
 	v1 "k8s.io/api/core/v1"
 
+	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/rest"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
@@ -26,6 +28,10 @@ func (c *AviController) OnStartedLeading() {
 	utils.AviLog.Debugf("AKO became a leader")
 	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a leader")
 	c.publishAllParentVSKeysToRestLayer()
+
+	// once the l3 cache is populated, we can call the updatestatus functions from here
+	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
+	restlayer.SyncObjectStatuses()
 }
 
 func (c *AviController) OnNewLeader() {

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -94,8 +94,11 @@ func AviGetRaw(client *clients.AviClient, uri string, retryNum ...int) ([]byte, 
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
 		checkForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
-		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
-			return nil, err
+		if aviError, ok := err.(session.AviError); ok {
+			if aviError.HttpStatusCode == 403 ||
+				strings.Contains(aviError.Error(), VSVIPNotFoundError) {
+				return nil, err
+			}
 		}
 		return AviGetRaw(client, uri, retry+1)
 	}

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -127,6 +127,7 @@ const (
 	SyncStatusKey                              = "syncstatus"
 	NoFreeIPError                              = "No available free IPs"
 	ConfigDisallowedDuringUpgradeError         = "Configuration is disallowed during upgrade"
+	VSVIPNotFoundError                         = "VsVip object not found"
 	DataScript                                 = "Vsdatascript"
 	EVHVS                                      = "EVH VirtualService"
 	HTTPPS                                     = "HTTPPolicySet"

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -33,8 +33,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const VSVIP_NOTFOUND = "VsVip object not found"
-
 // TODO: convert it to generalized function to be used by evh and sni both.
 func setDedicatedVSNodeProperties(vs *avimodels.VirtualService, vs_meta *nodes.AviVsNode) {
 	var datascriptCollection []*avimodels.VSDataScripts

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -279,7 +279,7 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 			vsvip_cache_obj, _ := vsvip_cache.(*avicache.AviVSVIPCache)
 			vsvip_avi, err := rest.AviVsVipGet(key, vsvip_cache_obj.Uuid, name)
 			if err != nil {
-				if strings.Contains(err.Error(), VSVIP_NOTFOUND) {
+				if strings.Contains(err.Error(), lib.VSVIPNotFoundError) {
 					// Clear the cache for this key
 					rest.cache.VSVIPCache.AviCacheDelete(vsvip_key)
 					utils.AviLog.Warnf("key: %s, Removed the vsvip object from the cache", key)

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -979,16 +979,6 @@ func (rest *RestOperations) RefreshCacheForRetryLayer(parentVsKey string, aviObj
 					poolObjName = *rest_op.Obj.(avimodels.Pool).Name
 				}
 				aviObjCache.AviPopulateOnePoolCache(c, utils.CloudName, poolObjName)
-				vsObjMeta, ok := rest.cache.VsCacheMeta.AviCacheGet(aviObjKey)
-				if !ok {
-					// VS Object not present
-					utils.AviLog.Warnf("key: %s, msg: VS object not present during retry of pool", key)
-				} else {
-					vsCopy, done := vsObjMeta.(*avicache.AviVsCache).GetVSCopy()
-					if done {
-						rest.StatusUpdateForPool(rest_op.Method, vsCopy, key)
-					}
-				}
 			case "PoolGroup":
 				var pgObjName string
 				switch rest_op.Obj.(type) {

--- a/internal/rest/rest_utils.go
+++ b/internal/rest/rest_utils.go
@@ -32,17 +32,19 @@ func (l *leader) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, 
 func (l *follower) RestRespArrToObjByType(rest_op *utils.RestOp, obj_type string, key string) []map[string]interface{} {
 	var resp_elems []map[string]interface{}
 	if restResponse, ok := rest_op.Response.(map[string]interface{}); ok {
-		// response has format {count:1, results:[{ /* some data */ }]}
-		response, ok := restResponse["results"].([]interface{})
-		if !ok {
-			return resp_elems
-		}
-		if len(response) == 0 {
-			return resp_elems
-		}
-		restResponse, ok = response[0].(map[string]interface{})
-		if !ok {
-			return resp_elems
+		if rest_op.Method == utils.RestPost {
+			// response has format {count:1, results:[{ /* some data */ }]}
+			response, ok := restResponse["results"].([]interface{})
+			if !ok {
+				return resp_elems
+			}
+			if len(response) == 0 {
+				return resp_elems
+			}
+			restResponse, ok = response[0].(map[string]interface{})
+			if !ok {
+				return resp_elems
+			}
 		}
 		utils.AviLog.Debugf("key: %s, msg: Got a response path %v tenant %v response %v",
 			key, rest_op.Path, rest_op.Tenant, utils.Stringify(restResponse))


### PR DESCRIPTION
This PR fixes an issue of status IP not getting updated for service type LoadBalancer in NodePortLocal deployments.

Tested scenario:
1. Created service of type LoadBalancer and immediately deleted the Leader AKO.

Results - Openshift:
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_ako_high_availability.py                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| TestHighAvailabilitySNINonDedicated.test_create_config                           |     PASSED     |       00:00:01      |   15:31:40  |   15:31:42  |
| TestHighAvailabilitySNINonDedicated.test_create_ingress_or_route                 |     PASSED     |       00:01:28      |   15:31:42  |   15:33:10  |
| TestHighAvailabilitySNINonDedicated.test_failover_leader                         |     PASSED     |       00:01:11      |   15:33:10  |   15:34:22  |
| TestHighAvailabilitySNINonDedicated.test_override_leader                         |    SKIPPED     |       00:00:00      |   15:34:22  |   15:34:22  |
| TestHighAvailabilitySNINonDedicated.test_delete_lease_object                     |    SKIPPED     |       00:00:00      |   15:34:22  |   15:34:22  |
| TestHighAvailabilitySNINonDedicated.test_failover_after_ingress_or_route_additio |     PASSED     |                     |             |             |
| n                                                                                |                |       00:01:02      |   15:34:22  |   15:35:24  |
| TestHighAvailabilitySNINonDedicated.test_failover_after_ingress_or_route_deletio |     PASSED     |                     |             |             |
| n                                                                                |                |       00:01:11      |   15:35:24  |   15:36:36  |
| TestHighAvailabilitySNINonDedicated.test_failover_after_delete_config_set_to_tru |     PASSED     |                     |             |             |
| e                                                                                |                |       00:00:59      |   15:36:36  |   15:37:35  |
| TestHighAvailabilitySNINonDedicated.test_failover_after_delete_config_set_to_fal |     PASSED     |                     |             |             |
| se                                                                               |                |       00:00:59      |   15:37:35  |   15:38:34  |
| TestHighAvailabilitySNINonDedicated.test_failover_before_delete_config_set_to_tr |     PASSED     |                     |             |             |
| ue                                                                               |                |       00:01:16      |   15:38:34  |   15:39:50  |
| TestHighAvailabilitySNINonDedicated.test_failover_before_delete_config_set_to_fa |     PASSED     |                     |             |             |
| lse                                                                              |                |       00:01:15      |   15:39:50  |   15:41:05  |
| TestHighAvailabilitySNINonDedicated.test_reboot_both_ako_after_delete_config_set |     PASSED     |                     |             |             |
| _to_true                                                                         |                |       00:01:21      |   15:41:05  |   15:42:27  |
| TestHighAvailabilitySNINonDedicated.test_reboot_both_ako_after_delete_config_set |     PASSED     |                     |             |             |
| _to_false                                                                        |                |       00:01:11      |   15:42:27  |   15:43:39  |
| TestHighAvailabilitySNINonDedicated.test_failover_before_ingress_or_route_additi |     PASSED     |                     |             |             |
| on                                                                               |                |       00:00:54      |   15:43:39  |   15:44:33  |
| TestHighAvailabilitySNINonDedicated.test_failover_before_ingress_or_route_deleti |     PASSED     |                     |             |             |
| on                                                                               |                |       00:00:41      |   15:44:33  |   15:45:15  |
| TestHighAvailabilitySNINonDedicated.test_delete_config                           |     PASSED     |       00:00:03      |   15:45:15  |   15:45:19  |
| TestHighAvailabilitySNIDedicated.test_create_config                              |     PASSED     |       00:00:11      |   15:45:19  |   15:45:30  |
| TestHighAvailabilitySNIDedicated.test_create_ingress_or_route                    |     PASSED     |       00:01:01      |   15:45:30  |   15:46:32  |
| TestHighAvailabilitySNIDedicated.test_failover_leader                            |     PASSED     |       00:01:00      |   15:46:32  |   15:47:33  |
| TestHighAvailabilitySNIDedicated.test_override_leader                            |    SKIPPED     |       00:00:00      |   15:47:33  |   15:47:33  |
| TestHighAvailabilitySNIDedicated.test_delete_lease_object                        |    SKIPPED     |       00:00:00      |   15:47:33  |   15:47:33  |
| TestHighAvailabilitySNIDedicated.test_failover_after_ingress_or_route_addition   |     PASSED     |       00:00:52      |   15:47:33  |   15:48:25  |
| TestHighAvailabilitySNIDedicated.test_failover_after_ingress_or_route_deletion   |     PASSED     |       00:00:44      |   15:48:25  |   15:49:10  |
| TestHighAvailabilitySNIDedicated.test_failover_after_delete_config_set_to_true   |     PASSED     |       00:00:53      |   15:49:10  |   15:50:03  |
| TestHighAvailabilitySNIDedicated.test_failover_after_delete_config_set_to_false  |     PASSED     |       00:00:54      |   15:50:03  |   15:50:58  |
| TestHighAvailabilitySNIDedicated.test_failover_before_delete_config_set_to_true  |     PASSED     |       00:00:57      |   15:50:58  |   15:51:56  |
| TestHighAvailabilitySNIDedicated.test_failover_before_delete_config_set_to_false |     PASSED     |       00:01:03      |   15:51:56  |   15:52:59  |
| TestHighAvailabilitySNIDedicated.test_reboot_both_ako_after_delete_config_set_to |     PASSED     |                     |             |             |
| _true                                                                            |                |       00:00:52      |   15:52:59  |   15:53:51  |
| TestHighAvailabilitySNIDedicated.test_reboot_both_ako_after_delete_config_set_to |     PASSED     |                     |             |             |
| _false                                                                           |                |       00:01:04      |   15:53:51  |   15:54:55  |
| TestHighAvailabilitySNIDedicated.test_failover_before_ingress_or_route_addition  |     PASSED     |       00:00:37      |   15:54:55  |   15:55:33  |
| TestHighAvailabilitySNIDedicated.test_failover_before_ingress_or_route_deletion  |     PASSED     |       00:00:30      |   15:55:33  |   15:56:04  |
| TestHighAvailabilitySNIDedicated.test_delete_config                              |     PASSED     |       00:00:03      |   15:56:04  |   15:56:08  |
| TestHighAvailabilityEVHNonDedicated.test_create_config                           |     PASSED     |       00:00:11      |   15:56:08  |   15:56:19  |
| TestHighAvailabilityEVHNonDedicated.test_create_ingress_or_route                 |     PASSED     |       00:01:26      |   15:56:19  |   15:57:46  |
| TestHighAvailabilityEVHNonDedicated.test_failover_leader                         |     PASSED     |       00:01:10      |   15:57:46  |   15:58:56  |
| TestHighAvailabilityEVHNonDedicated.test_override_leader                         |    SKIPPED     |       00:00:00      |   15:58:56  |   15:58:56  |
| TestHighAvailabilityEVHNonDedicated.test_delete_lease_object                     |    SKIPPED     |       00:00:00      |   15:58:56  |   15:58:56  |
| TestHighAvailabilityEVHNonDedicated.test_failover_after_ingress_or_route_additio |     PASSED     |                     |             |             |
| n                                                                                |                |       00:00:59      |   15:58:56  |   15:59:56  |
| TestHighAvailabilityEVHNonDedicated.test_failover_after_ingress_or_route_deletio |     PASSED     |                     |             |             |
| n                                                                                |                |       00:00:52      |   15:59:56  |   16:00:49  |
| TestHighAvailabilityEVHNonDedicated.test_failover_after_delete_config_set_to_tru |     PASSED     |                     |             |             |
| e                                                                                |                |       00:00:54      |   16:00:49  |   16:01:43  |
| TestHighAvailabilityEVHNonDedicated.test_failover_after_delete_config_set_to_fal |     PASSED     |                     |             |             |
| se                                                                               |                |       00:01:03      |   16:01:43  |   16:02:47  |
| TestHighAvailabilityEVHNonDedicated.test_failover_before_delete_config_set_to_tr |     PASSED     |                     |             |             |
| ue                                                                               |                |       00:01:12      |   16:02:47  |   16:04:00  |
| TestHighAvailabilityEVHNonDedicated.test_failover_before_delete_config_set_to_fa |     PASSED     |                     |             |             |
| lse                                                                              |                |       00:01:14      |   16:04:00  |   16:05:14  |
| TestHighAvailabilityEVHNonDedicated.test_reboot_both_ako_after_delete_config_set |     PASSED     |                     |             |             |
| _to_true                                                                         |                |       00:01:06      |   16:05:14  |   16:06:20  |
| TestHighAvailabilityEVHNonDedicated.test_reboot_both_ako_after_delete_config_set |     PASSED     |                     |             |             |
| _to_false                                                                        |                |       00:01:12      |   16:06:20  |   16:07:33  |
| TestHighAvailabilityEVHNonDedicated.test_failover_before_ingress_or_route_additi |     PASSED     |                     |             |             |
| on                                                                               |                |       00:00:48      |   16:07:33  |   16:08:21  |
| TestHighAvailabilityEVHNonDedicated.test_failover_before_ingress_or_route_deleti |     PASSED     |                     |             |             |
| on                                                                               |                |       00:00:39      |   16:08:21  |   16:09:01  |
| TestHighAvailabilityEVHNonDedicated.test_delete_config                           |     PASSED     |       00:00:03      |   16:09:01  |   16:09:04  |
| TestHighAvailabilityEVHDedicated.test_create_config                              |     PASSED     |       00:00:11      |   16:09:04  |   16:09:16  |
| TestHighAvailabilityEVHDedicated.test_create_ingress_or_route                    |     PASSED     |       00:01:21      |   16:09:16  |   16:10:38  |
| TestHighAvailabilityEVHDedicated.test_failover_leader                            |     PASSED     |       00:00:48      |   16:10:38  |   16:11:26  |
| TestHighAvailabilityEVHDedicated.test_override_leader                            |    SKIPPED     |       00:00:00      |   16:11:26  |   16:11:26  |
| TestHighAvailabilityEVHDedicated.test_delete_lease_object                        |    SKIPPED     |       00:00:00      |   16:11:26  |   16:11:26  |
| TestHighAvailabilityEVHDedicated.test_failover_after_ingress_or_route_addition   |     PASSED     |       00:00:49      |   16:11:26  |   16:12:16  |
| TestHighAvailabilityEVHDedicated.test_failover_after_ingress_or_route_deletion   |     PASSED     |       00:00:44      |   16:12:16  |   16:13:00  |
| TestHighAvailabilityEVHDedicated.test_failover_after_delete_config_set_to_true   |     PASSED     |       00:00:42      |   16:13:00  |   16:13:42  |
| TestHighAvailabilityEVHDedicated.test_failover_after_delete_config_set_to_false  |     PASSED     |       00:01:04      |   16:13:42  |   16:14:47  |
| TestHighAvailabilityEVHDedicated.test_failover_before_delete_config_set_to_true  |     PASSED     |       00:01:07      |   16:14:47  |   16:15:55  |
| TestHighAvailabilityEVHDedicated.test_failover_before_delete_config_set_to_false |     PASSED     |       00:01:03      |   16:15:55  |   16:16:59  |
| TestHighAvailabilityEVHDedicated.test_reboot_both_ako_after_delete_config_set_to |     PASSED     |                     |             |             |
| _true                                                                            |                |       00:00:58      |   16:16:59  |   16:17:57  |
| TestHighAvailabilityEVHDedicated.test_reboot_both_ako_after_delete_config_set_to |     PASSED     |                     |             |             |
| _false                                                                           |                |       00:01:04      |   16:17:57  |   16:19:01  |
| TestHighAvailabilityEVHDedicated.test_failover_before_ingress_or_route_addition  |     PASSED     |       00:00:46      |   16:19:01  |   16:19:48  |
| TestHighAvailabilityEVHDedicated.test_failover_before_ingress_or_route_deletion  |     PASSED     |       00:00:31      |   16:19:48  |   16:20:19  |
| TestHighAvailabilityEVHDedicated.test_delete_config                              |     PASSED     |       00:00:55      |   16:20:19  |   16:21:14  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 56   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 64                                                            |    Skipped:8   | Total Time:00:49:33 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```