### PR TITLE
feat: add icapprofile field to HostRule

### DIFF
--- a/ako-operator/controllers/crd.go
+++ b/ako-operator/controllers/crd.go
@@ -125,6 +125,14 @@ func createHostRuleCRD(clientset *apiextension.ApiextensionsV1Client, log logr.L
 									"wafPolicy": {
 										Type: "string",
 									},
+									"icapProfiles": {
+										Type: "array",
+										Items: &apiextensionv1.JSONSchemaPropsOrArray{
+											Schema: &apiextensionv1.JSONSchemaProps{
+												Type: "string",
+											},
+										},
+									},
 									"tls": {
 										Type:     "object",
 										Required: []string{"sslKeyCertificate"},

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -658,6 +658,7 @@ var refModelMap = map[string]string{
 	"SslKeyCert":             "sslkeyandcertificate",
 	"WafPolicy":              "wafpolicy",
 	"HttpPolicySet":          "httppolicyset",
+	"IcapProfile":            "icapprofile",
 	"SslProfile":             "sslprofile",
 	"AppProfile":             "applicationprofile",
 	"AnalyticsProfile":       "analyticsprofile",

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -66,6 +66,9 @@ type AviVsEvhSniModel interface {
 	GetWafPolicyRef() string
 	SetWafPolicyRef(string)
 
+	GetIcapProfileRefs() []string
+	SetIcapProfileRefs([]string)
+
 	GetHttpPolicySetRefs() []string
 	SetHttpPolicySetRefs([]string)
 
@@ -129,6 +132,7 @@ type AviEvhVsNode struct {
 	ServiceMetadata     lib.ServiceMetadataObj
 	VrfContext          string
 	WafPolicyRef        string
+	IcapProfileRefs     []string
 	AppProfileRef       string
 	AnalyticsProfileRef string
 	ErrorPageProfileRef string
@@ -222,6 +226,14 @@ func (v *AviEvhVsNode) GetWafPolicyRef() string {
 
 func (v *AviEvhVsNode) SetWafPolicyRef(wafPolicyRef string) {
 	v.WafPolicyRef = wafPolicyRef
+}
+
+func (v *AviEvhVsNode) GetIcapProfileRefs() []string {
+	return v.IcapProfileRefs
+}
+
+func (v *AviEvhVsNode) SetIcapProfileRefs(icapProfileRefs []string) {
+	v.IcapProfileRefs = icapProfileRefs
 }
 
 func (v *AviEvhVsNode) GetHttpPolicySetRefs() []string {
@@ -612,6 +624,7 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 	// keep the order of these policies
 	policies := v.HttpPolicySetRefs
 	scripts := v.VsDatascriptRefs
+	profiles := v.IcapProfileRefs
 
 	vsRefs := v.WafPolicyRef +
 		v.AppProfileRef +
@@ -625,6 +638,10 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 
 	if len(policies) > 0 {
 		vsRefs += utils.Stringify(policies)
+	}
+
+	if len(profiles) > 0 {
+		vsRefs += utils.Stringify(profiles)
 	}
 
 	sort.Strings(checksumStringSlice)

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -401,6 +401,7 @@ type AviVsNode struct {
 	ServiceMetadata       lib.ServiceMetadataObj
 	VrfContext            string
 	WafPolicyRef          string
+	IcapProfileRefs       []string
 	AppProfileRef         string
 	AnalyticsProfileRef   string
 	ErrorPageProfileRef   string
@@ -496,6 +497,14 @@ func (v *AviVsNode) GetWafPolicyRef() string {
 
 func (v *AviVsNode) SetWafPolicyRef(wafPolicyRef string) {
 	v.WafPolicyRef = wafPolicyRef
+}
+
+func (v *AviVsNode) GetIcapProfileRefs() []string {
+	return v.IcapProfileRefs
+}
+
+func (v *AviVsNode) SetIcapProfileRefs(icapProfileRefs []string) {
+	v.IcapProfileRefs = icapProfileRefs
 }
 
 func (v *AviVsNode) GetHttpPolicySetRefs() []string {
@@ -910,6 +919,7 @@ func (v *AviVsNode) CalculateCheckSum() {
 	// keep the order of these policies
 	policies := v.HttpPolicySetRefs
 	scripts := v.VsDatascriptRefs
+	profiles := v.IcapProfileRefs
 
 	vsRefs := v.WafPolicyRef +
 		v.AppProfileRef +
@@ -923,6 +933,10 @@ func (v *AviVsNode) CalculateCheckSum() {
 
 	if len(policies) > 0 {
 		vsRefs += utils.Stringify(policies)
+	}
+
+	if len(profiles) > 0 {
+		vsRefs += utils.Stringify(profiles)
 	}
 
 	if len(v.ServiceMetadata.HostNames) > 0 {

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -55,7 +55,7 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 
 	// host specific
 	var vsWafPolicy, vsAppProfile, vsErrorPageProfile, vsAnalyticsProfile, vsSslProfile, lbIP string
-	var vsSslKeyCertificates []string
+	var vsSslKeyCertificates, vsIcapProfiles []string
 	var vsEnabled *bool
 	var crdStatus lib.CRDMetadata
 
@@ -122,6 +122,12 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 			}
 		}
 
+		for _, profile := range hostrule.Spec.VirtualHost.ICAPProfiles {
+			if !utils.HasElem(vsIcapProfiles, fmt.Sprintf("/api/icapprofile?name=%s", profile)) {
+				vsIcapProfiles = append(vsIcapProfiles, fmt.Sprintf("/api/icapprofile?name=%s", profile))
+			}
+		}
+
 		if hostrule.Spec.VirtualHost.TCPSettings != nil {
 			if vsNode.IsSharedVS() || vsNode.IsDedicatedVS() {
 				portProtocols = []AviPortHostProtocol{}
@@ -181,6 +187,7 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 
 	vsNode.SetSSLKeyCertAviRef(vsSslKeyCertificates)
 	vsNode.SetWafPolicyRef(vsWafPolicy)
+	vsNode.SetIcapProfileRefs(vsIcapProfiles)
 	vsNode.SetHttpPolicySetRefs(vsHTTPPolicySets)
 	vsNode.SetAppProfileRef(vsAppProfile)
 	vsNode.SetAnalyticsProfileRef(vsAnalyticsProfile)

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -258,6 +258,7 @@ func setDedicatedEvhVSNodeProperties(vs *avimodels.VirtualService, vs_meta *node
 		vs.ApplicationProfileRef = &vs_meta.AppProfileRef
 	}
 	vs.WafPolicyRef = &vs_meta.WafPolicyRef
+	vs.IcapRequestProfileRefs = vs_meta.IcapProfileRefs
 	vs.ErrorPageProfileRef = &vs_meta.ErrorPageProfileRef
 	vs.AnalyticsProfileRef = &vs_meta.AnalyticsProfileRef
 	vs.EastWestPlacement = proto.Bool(false)
@@ -475,21 +476,22 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 	svc_mdata_json, _ := json.Marshal(&vs_meta.ServiceMetadata)
 	svc_mdata := string(svc_mdata_json)
 	evhChild := &avimodels.VirtualService{
-		Name:                  &name,
-		CloudConfigCksum:      &checksumstr,
-		CreatedBy:             &cr,
-		NetworkProfileRef:     &network_prof,
-		ApplicationProfileRef: &app_prof,
-		EastWestPlacement:     proto.Bool(false),
-		CloudRef:              &cloudRef,
-		SeGroupRef:            &seGroupRef,
-		ServiceMetadata:       &svc_mdata,
-		WafPolicyRef:          &vs_meta.WafPolicyRef,
-		SslProfileRef:         &vs_meta.SSLProfileRef,
-		AnalyticsProfileRef:   &vs_meta.AnalyticsProfileRef,
-		ErrorPageProfileRef:   &vs_meta.ErrorPageProfileRef,
-		Enabled:               vs_meta.Enabled,
-		VhType:                proto.String(utils.VS_TYPE_VH_ENHANCED),
+		Name:                   &name,
+		CloudConfigCksum:       &checksumstr,
+		CreatedBy:              &cr,
+		NetworkProfileRef:      &network_prof,
+		ApplicationProfileRef:  &app_prof,
+		EastWestPlacement:      proto.Bool(false),
+		CloudRef:               &cloudRef,
+		SeGroupRef:             &seGroupRef,
+		ServiceMetadata:        &svc_mdata,
+		WafPolicyRef:           &vs_meta.WafPolicyRef,
+		IcapRequestProfileRefs: vs_meta.IcapProfileRefs,
+		SslProfileRef:          &vs_meta.SSLProfileRef,
+		AnalyticsProfileRef:    &vs_meta.AnalyticsProfileRef,
+		ErrorPageProfileRef:    &vs_meta.ErrorPageProfileRef,
+		Enabled:                vs_meta.Enabled,
+		VhType:                 proto.String(utils.VS_TYPE_VH_ENHANCED),
 	}
 
 	if vs_meta.VrfContext != "" {

--- a/pkg/apis/ako/v1alpha1/hostrule.go
+++ b/pkg/apis/ako/v1alpha1/hostrule.go
@@ -70,6 +70,7 @@ type HostRuleVirtualHost struct {
 	HTTPPolicy         HostRuleHTTPPolicy       `json:"httpPolicy,omitempty"`
 	Gslb               HostRuleGSLB             `json:"gslb,omitempty"`
 	TLS                HostRuleTLS              `json:"tls,omitempty"`
+	ICAPProfiles       []string                 `json:"icapProfiles,omitempty"`
 	WAFPolicy          string                   `json:"wafPolicy,omitempty"`
 	AnalyticsPolicy    *HostRuleAnalyticsPolicy `json:"analyticsPolicy,omitempty"`
 	TCPSettings        *HostRuleTCPSettings     `json:"tcpSettings,omitempty"`


### PR DESCRIPTION
feat: add icapprofile field to HostRule

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

AVI documentation:
* <https://avinetworks.com/docs/22.1/icap/>
* <https://avinetworks.com/docs/22.1/api-guide/IcapProfile/index.html>

**NOTE: this is a draft PR**

As a first time contributor I would like to ask your help to implement this feature. I got used to use `controller-gen` and `kubebuilder` for generating deepcopy objects and CRD Kubernetes manifests from Go source files but I was not able to find how to do it in this project. You are more than welcome to review and give proposals.

As of now, the API expects `[]string` however we can only set one element: 
https://github.com/vmware/alb-sdk/blob/97004221894e0dde92ba4fae5dd0f3e32b1528b1/go/models/virtual_service.go#L115-L116

Questions:
* How to generate `zz_generated.deepcopy.go` files and CRDs (yaml) to activate the new field?
* Do we need integration tests? If yes, could you please tell me what is the desired one (e.g. extending already existing test or create a new one)
* Should we follow the API naming convention in the struct (`IcapRequestProfileRefs` or `IcapProfile`)?
* Name of the field `icapProfiles` is acceptable or not? See the `[]string` note above