### PR TITLE
AV-168951 : Enable Application Profile configuration for L4 VS

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -229,6 +229,7 @@ const (
 	ControllerAnnotation           = "ako.vmware.com/controller-cluster-uuid"
 	SharedVipSvcLBAnnotation       = "ako.vmware.com/enable-shared-vip"
 	LoadBalancerIP                 = "ako.vmware.com/load-balancer-ip"
+	LBSvcAppProfileAnnotation      = "ako.vmware.com/application-profile"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -453,6 +453,7 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 	avi_vs_meta.AviMarkers = lib.PopulateAdvL4VSNodeMarkers(namespace, sharedVipKey)
 	var portProtocols []AviPortHostProtocol
 	var sharedPreferredVIP string
+	var appProfile string
 	var serviceObject *v1.Service
 	for i, serviceNSName := range serviceNSNames {
 		svcNSName := strings.Split(serviceNSName, "/")
@@ -470,6 +471,9 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 			}
 			if infraSettingAnnotation, ok := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok && infraSettingAnnotation != "" {
 				serviceObject = svcObj.DeepCopy()
+			}
+			if appProfileAnnotation, ok := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]; ok && appProfileAnnotation != "" {
+				appProfile = appProfileAnnotation
 			}
 		}
 
@@ -492,7 +496,11 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 	}
 
 	avi_vs_meta.PortProto = portProtocols
-	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+	if appProfile != "" {
+		avi_vs_meta.ApplicationProfile = appProfile
+	} else {
+		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+	}
 
 	if isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -90,8 +90,13 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		}
 	}
 	avi_vs_meta.PortProto = portProtocols
-	// Default case.
-	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+
+	if appProfile, ok := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]; ok && appProfile != "" {
+		avi_vs_meta.ApplicationProfile = appProfile
+	} else {
+		// Default case
+		avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+	}
 	if !isTCP {
 		if isSCTP {
 			avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -507,6 +507,7 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 	// of Type LB. Two Services must not have different AviInfraSetting annotation value.
 	var sharedVipLBIP string
 	var sharedVipInfraSetting string
+	var appProfile string
 	for i, serviceNSName := range serviceNSNames {
 		svcNSName := strings.Split(serviceNSName, "/")
 		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
@@ -528,6 +529,9 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 			if infraSettingAnnotation, ok := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok && infraSettingAnnotation != "" {
 				sharedVipInfraSetting = infraSettingAnnotation
 			}
+			if appProfileAnnotation, ok := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]; ok && appProfileAnnotation != "" {
+				appProfile = appProfileAnnotation
+			}
 		}
 		if lib.HasSpecLoadBalancerIP(svcObj) {
 			if svcObj.Spec.LoadBalancerIP != sharedVipLBIP {
@@ -546,6 +550,12 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 		infraSettingAnnotation, _ := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]
 		if i != 0 && infraSettingAnnotation != sharedVipInfraSetting {
 			utils.AviLog.Errorf("Service AviInfraSetting annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, infraSettingAnnotation, serviceNSNames[0], sharedVipInfraSetting)
+			isShareVipKeyDelete = true
+			break
+		}
+		appProfileAnnotation, _ := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]
+		if i != 0 && appProfileAnnotation != appProfile {
+			utils.AviLog.Errorf("Service application-profile annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, infraSettingAnnotation, serviceNSNames[0], sharedVipInfraSetting)
 			isShareVipKeyDelete = true
 			break
 		}


### PR DESCRIPTION
This PR includes changes for enabling Application Profile configuration for L4 VS, by adding **ako.vmware.com/application-profile** annotation in LoadBalancer Services. The user can add the preferred Application Profile as value for **ako.vmware.com/application-profile** annotation in LoadBalancer Services. AKO reads the value for this annotation and configures the corresponding virtual service with the specified application profile.