### PR TITLE
AV-168535: Delete VS when ingress/route deleted if there is no child associated with it

### DIFF
--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1949,10 +1949,10 @@ func RouteIngrDeletePoolsByHostnameForEvh(routeIgrObj RouteIngressModel, namespa
 
 	utils.AviLog.Debugf("key: %s, msg: hosts to delete are :%s", key, utils.Stringify(hostMap))
 	for host, hostData := range hostMap {
-		_, shardVsName := DeriveShardVSForEvh(host, key, routeIgrObj)
+		shardVsName, _ := DeriveShardVSForEvh(host, key, routeIgrObj)
 		deleteVS := false
 		if hostData.SecurePolicy == lib.PolicyPass {
-			_, shardVsName.Name = DerivePassthroughVS(host, key, routeIgrObj)
+			shardVsName.Name, _ = DerivePassthroughVS(host, key, routeIgrObj)
 		}
 
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName.Name)

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -412,10 +412,10 @@ func RouteIngrDeletePoolsByHostname(routeIgrObj RouteIngressModel, namespace, ob
 	utils.AviLog.Debugf("key: %s, msg: hosts to delete are :%s", key, utils.Stringify(hostMap))
 	for host, hostData := range hostMap {
 		deleteVS := false
-		_, shardVsName := DeriveShardVS(host, key, routeIgrObj)
+		shardVsName, _ := DeriveShardVS(host, key, routeIgrObj)
 
 		if hostData.SecurePolicy == lib.PolicyPass {
-			_, shardVsName.Name = DerivePassthroughVS(host, key, routeIgrObj)
+			shardVsName.Name, _ = DerivePassthroughVS(host, key, routeIgrObj)
 		}
 
 		modelName := lib.GetModelName(lib.GetTenant(), shardVsName.Name)


### PR DESCRIPTION
`Issue`: In dedicated mode, when Aviinfrasetting is applied to ingress, on deletion of such ingress, AKO is not cleaning up VS and VS VIP.

`Fix`: This PR addresses this issue.

Testing: Create and delete ingress
1. Secure and Insecure SNI and EVH with aviinfrasetting applied and not applied.