### PR TITLE
[cherry-pick][fix] AV-171375: Restricts secret handling by using a flag in values.yaml

### DIFF
--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -177,6 +177,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `AKOSettings.blockedNamespaceList` | List of K8s/Openshift namespaces blocked by AKO | `Empty List` |
 | `AKOSettings.istioEnabled` | set to true if user wants to deploy AKO in istio environment (tech preview)| false |
 | `AKOSettings.ipFamily` | set to V6 if user wants to deploy AKO with V6 backend (vCenter cloud with calico CNI only) (tech preview)| V4 |
+| `AKOSettings.useDefaultSecretsOnly` | Restricts the secret handling to default secrets present in the namespace where AKO is installed in Openshift clusters if set to true | false |
 | `avicredentials.username` | Avi controller username | empty |
 | `avicredentials.password` | Avi controller password | empty |
 | `avicredentials.authtoken` | Avi controller authentication token | empty |

--- a/docs/values.md
+++ b/docs/values.md
@@ -101,6 +101,11 @@ AKO can be deployed with ipFamily as `V4` or `V6`. When ipFamily is set to `V6`,
 
 Default value is `V4`.
 
+### AKOSettings.useDefaultSecretsOnly
+
+This flag provides the ability to restrict the secret handling to default secrets present in the namespace where the AKO is installed. This flag is applicable only to Openshift clusters.
+Default value is `false`.
+
 ### NetworkSettings.nodeNetworkList
 
 The `nodeNetworkList` lists the Networks and Node CIDR's where the k8s Nodes are created. This is only used in the ClusterIP deployment of AKO and in vCenter cloud and only when disableStaticRouteSync is set to false.

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -48,3 +48,4 @@ data:
     {{ .Values.AKOSettings.blockedNamespaceList | mustToJson }}
   ipFamily: {{ .Values.AKOSettings.ipFamily | quote }}
   istioEnabled: {{ .Values.AKOSettings.istioEnabled | quote }}
+  useDefaultSecretsOnly: {{ .Values.AKOSettings.useDefaultSecretsOnly | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -256,6 +256,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: ipFamily
+          - name: USE_DEFAULT_SECRETS_ONLY
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: useDefaultSecretsOnly
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -36,7 +36,8 @@ AKOSettings:
   #   - kube-system
   #   - kube-public
   ipFamily: "" # This flag can take values V4 or V6 (default V4). This is for the backend pools to use ipv6 or ipv4. For frontside VS, use v6cidr
-
+  useDefaultSecretsOnly: "false" # If this flag is set to true, AKO will only handle default secrets from the namespace where AKO is installed.
+                                 # This flag is applicable only to Openshift clusters.
 
 ### This section outlines the network settings for virtualservices. 
 NetworkSettings:

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -93,6 +93,7 @@ const (
 	POD_NAMESPACE                 = "POD_NAMESPACE"
 	VCF_CLUSTER                   = "VCF_CLUSTER"
 	MCI_ENABLED                   = "MCI_ENABLED"
+	USE_DEFAULT_SECRETS_ONLY      = "USE_DEFAULT_SECRETS_ONLY"
 	CTRL_VERSION_22_1_3           = "22.1.3"
 	CTRL_VERSION_22_1_2           = "22.1.2"
 	Namespace                     = "Namespace"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -261,6 +261,13 @@ func NewInformers(kubeClient KubeClientIntf, registeredInformers []string, args 
 		}
 	}
 
+	// In openshift, the secret handling is restricted to the namespace where the AKO is
+	// installed if the user sets `handleSecretsFromAKONSOnly` to true.
+	if oshiftclient != nil &&
+		IsSecretsHandlingRestrictedToAKONS() {
+		akoNSBoundInformer = true
+	}
+
 	if !instantiateOnce {
 		return instantiateInformers(kubeClient, registeredInformers, oshiftclient, akoClient, namespace, akoNSBoundInformer)
 	}
@@ -587,4 +594,14 @@ func NewVersion(version string) (*Version, error) {
 		v.subversions = append(v.subversions, val)
 	}
 	return v, nil
+}
+
+// This utility returns a true/false depending on whether
+// the secret handling is restricted to the namespace where the AKO is installed.
+func IsSecretsHandlingRestrictedToAKONS() bool {
+	ok, err := strconv.ParseBool(os.Getenv(USE_DEFAULT_SECRETS_ONLY))
+	if err != nil {
+		return false
+	}
+	return ok
 }


### PR DESCRIPTION
This PR adds a flag in values.yaml by using which the secret handling can be restricted only to the namespace where the AKO is present.

Tested Scenario:
Added 14K secrets in namespace test and rebooted the AKO.
```
root@shalini-python3-dev:/home/aviuser/swathin# ock get secret -n test | wc -l
14206
root@shalini-python3-dev:/home/aviuser/swathin
```

1. With the flag set as true
```
CONTAINER           CPU %               MEM                 DISK                INODES
0f3c6e9f6f45b       0.01                26.72MB             32.77kB             19
```
2. With flag set as false
```
CONTAINER           CPU %               MEM                 DISK                INODES
b929eb67e0602       0.24                456.5MB             16.38kB             19
```