### PR TITLE
K8s supported version upgrade to 1.26 and TestUpdateIngressClassWithoutInfraSetting UT update

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -5,7 +5,7 @@
         "minVersion": "21.1.5"
     },
     "kubernetes": {
-        "maxVersion": "1.25",
+        "maxVersion": "1.26",
         "minVersion": "1.22"
     }
 }

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -1123,7 +1123,6 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
 
 	ingressUpdate := (integrationtest.FakeIngress{

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -1116,6 +1116,11 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 		settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return settingNodes[0].ServiceEngineGroup
 	}, 40*time.Second).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
+	g.Eventually(func() int {
+		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+		settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(settingNodes[0].PoolRefs)
+	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))


### PR DESCRIPTION
This commit adds a fix for UT TestUpdateIngressClassWithoutInfraSetting failing

cc @arihantg 