### PR TITLE
fix for AV-176917

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -29,6 +29,8 @@ spec:
                   applicationProfile:
                     type: string
                   icapProfile:
+                    items:
+                      type: string
                     type: array
                   enableVirtualHost:
                     type: boolean

--- a/helm/ako/crds/ako.vmware.com_hostrules.yaml
+++ b/helm/ako/crds/ako.vmware.com_hostrules.yaml
@@ -29,6 +29,8 @@ spec:
                   applicationProfile:
                     type: string
                   icapProfile:
+                    items:
+                      type: string
                     type: array
                   enableVirtualHost:
                     type: boolean


### PR DESCRIPTION
This PR corrects one issue in the hostrule CRD yaml file.

**Results**
```
swathins@swathinsQMD6M load-balancer-and-ingress-services-for-kubernetes % kubectl apply -f helm/ako/crds/ako.vmware.com_hostrules.yaml
customresourcedefinition.apiextensions.k8s.io/hostrules.ako.vmware.com created
swathins@swathinsQMD6M load-balancer-and-ingress-services-for-kubernetes %
```