### PR TITLE
AV-177293 fix 

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -246,6 +246,9 @@ const (
 	ACCESS_TOKEN_TYPE_JWT          = "ACCESS_TOKEN_TYPE_JWT"
 	ACCESS_TOKEN_TYPE_OPAQUE       = "ACCESS_TOKEN_TYPE_OPAQUE"
 	SAML_AUTHN_REQ_ACS_TYPE_INDEX  = "SAML_AUTHN_REQ_ACS_TYPE_INDEX"
+
+	// License types
+	LicenseTypeEnterprise = "ENTERPRISE"
 )
 
 // Cache Indexer constants.

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -259,7 +259,12 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 	if isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
 	} else if isTCP && !isUDP {
-		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		license := lib.AKOControlConfig().GetLicenseType()
+		if license == lib.LicenseTypeEnterprise {
+			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+		} else {
+			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		}
 	} else if isUDP && !isTCP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 	} else {

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -110,7 +110,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	} else {
 		license := lib.AKOControlConfig().GetLicenseType()
 
-		if license == "ENTERPRISE" {
+		if license == lib.LicenseTypeEnterprise {
 			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
 		} else {
 			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH


### PR DESCRIPTION
This commit adds the changes to set System-TCP-Proxy as the network profile for the L4 VSes created from gateways when the license is ENTERPRISE. Also added a UT to test it.

UT result
```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^TestServicesAPINetworkProfileBasedOnLicense$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/servicesapitests

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/servicesapitests	15.153s
```