### PR TITLE
AV-177170: [L4 CRD] Shared VIP support

### DIFF
--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -249,3 +249,12 @@ func CorrectLabelToSatisfyRFC1035(name *string, prefix string) {
 	}
 
 }
+
+func HasSharedVIPAnnotation(svcName, namespace string) bool {
+	svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(svcName)
+	if err != nil {
+		return false
+	}
+	_, ok := svcObj.Annotations[SharedVipSvcLBAnnotation]
+	return ok
+}

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -160,10 +160,27 @@ func DequeueIngestion(key string, fullsync bool) {
 
 	// L4Rule CRD processing.
 	if objType == lib.L4Rule {
+
+		// L4 Service
 		svcNames, found := schema.GetParentServices(name, namespace, key)
 		if found && utils.CheckIfNamespaceAccepted(namespace) {
 			for _, svcNSNameKey := range svcNames {
 				handleL4Service(utils.L4LBService+"/"+svcNSNameKey, fullsync)
+			}
+		}
+
+		// L4 Service with shared vip annotation
+		for _, svc := range svcNames {
+			svcName := strings.Split(svc, "/")[1]
+			sharedVipKeys, keysFound := ServiceChanges(svcName, namespace, key)
+			utils.AviLog.Debugf("key: %s, msg: shared vip keys got %v", key, sharedVipKeys)
+			if len(sharedVipKeys) == 0 {
+				continue
+			}
+			if keysFound && utils.CheckIfNamespaceAccepted(namespace) {
+				for _, sharedVipKey := range sharedVipKeys {
+					handleL4SharedVipService(sharedVipKey, key, fullsync)
+				}
 			}
 		}
 	}
@@ -541,7 +558,7 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 	// of Type LB. Two Services must not have different AviInfraSetting annotation value.
 	var sharedVipLBIP string
 	var sharedVipInfraSetting string
-	var appProfile string
+	var sharedL4Rule string
 	for i, serviceNSName := range serviceNSNames {
 		svcNSName := strings.Split(serviceNSName, "/")
 		svcObj, err := utils.GetInformers().ServiceInformer.Lister().Services(svcNSName[0]).Get(svcNSName[1])
@@ -563,8 +580,8 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 			if infraSettingAnnotation, ok := svcObj.GetAnnotations()[lib.InfraSettingNameAnnotation]; ok && infraSettingAnnotation != "" {
 				sharedVipInfraSetting = infraSettingAnnotation
 			}
-			if appProfileAnnotation, ok := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]; ok && appProfileAnnotation != "" {
-				appProfile = appProfileAnnotation
+			if l4RuleName, ok := svcObj.GetAnnotations()[lib.L4RuleAnnotation]; ok && l4RuleName != "" {
+				sharedL4Rule = l4RuleName
 			}
 		}
 		if lib.HasSpecLoadBalancerIP(svcObj) {
@@ -587,9 +604,9 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 			isShareVipKeyDelete = true
 			break
 		}
-		appProfileAnnotation, _ := svcObj.GetAnnotations()[lib.LBSvcAppProfileAnnotation]
-		if i != 0 && appProfileAnnotation != appProfile {
-			utils.AviLog.Errorf("Service application-profile annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, infraSettingAnnotation, serviceNSNames[0], sharedVipInfraSetting)
+		l4RuleName := svcObj.GetAnnotations()[lib.L4RuleAnnotation]
+		if i != 0 && l4RuleName != sharedL4Rule {
+			utils.AviLog.Errorf("L4Rule annotation value is not consistent with Services grouped using shared-vip annotation. Conflict found for Services [%s: %s %s: %s]", serviceNSName, l4RuleName, serviceNSNames[0], sharedL4Rule)
 			isShareVipKeyDelete = true
 			break
 		}

--- a/tests/integrationtest/l4_crd_test.go
+++ b/tests/integrationtest/l4_crd_test.go
@@ -1009,3 +1009,102 @@ func TestL4RuleLbAlgorithm(t *testing.T) {
 	TearDownTestForSvcLB(t, g)
 	TeardownL4Rule(t, L4RuleName, NAMESPACE)
 }
+
+func TestSharedVIPSvcWithL4Rule(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	L4RuleName := "test-l4rule"
+	ports := []int{8080}
+	modelName := "admin/cluster--red-ns-" + SHAREDVIPKEY
+
+	SetUpTestForSharedVIPSvcLB(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 30*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", NAMESPACE, SHAREDVIPKEY)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+
+	// Check for the pools
+	g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(2))
+	addresses := map[string]struct{}{
+		"1.1.1.1": {},
+		"2.1.1.1": {},
+	}
+	for _, poolRef := range nodes[0].PoolRefs {
+		ipAddr := poolRef.Servers[0].Ip.Addr
+		delete(addresses, *ipAddr)
+	}
+	g.Expect(addresses).To(gomega.HaveLen(0))
+
+	// Create the L4Rule
+	SetupL4Rule(t, L4RuleName, NAMESPACE, ports)
+
+	g.Eventually(func() string {
+		l4Rule, _ := lib.AKOControlConfig().V1alpha2CRDClientset().AkoV1alpha2().L4Rules(NAMESPACE).Get(context.TODO(), L4RuleName, metav1.GetOptions{})
+		return l4Rule.Status.Status
+	}, 30*time.Second).Should(gomega.Equal("Accepted"))
+
+	// Apply the L4Rule to first Service
+	svcObj01 := (FakeService{
+		Name:         SHAREDVIPSVC01,
+		Namespace:    NAMESPACE,
+		Type:         corev1.ServiceTypeLoadBalancer,
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
+	}).Service()
+	svcObj01.Annotations = map[string]string{lib.L4RuleAnnotation: L4RuleName, lib.SharedVipSvcLBAnnotation: SHAREDVIPKEY}
+	svcObj01.ResourceVersion = "2"
+	_, err := KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcObj01, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating Service: %v", err)
+	}
+
+	// Apply the L4Rule to second Service
+	svcObj02 := (FakeService{
+		Name:         SHAREDVIPSVC02,
+		Namespace:    NAMESPACE,
+		Type:         corev1.ServiceTypeLoadBalancer,
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
+	}).Service()
+	svcObj01.Annotations = map[string]string{lib.L4RuleAnnotation: L4RuleName, lib.SharedVipSvcLBAnnotation: SHAREDVIPKEY}
+	svcObj02.ResourceVersion = "2"
+	_, err = KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcObj02, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in updating Service: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return false
+		}
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return g.Expect(nodes[0].AviVsNodeCommonFields).NotTo(gomega.BeZero()) &&
+			g.Expect(nodes[0].AviVsNodeGeneratedFields).NotTo(gomega.BeZero()) &&
+			g.Expect(nodes[0].PoolRefs[0].AviPoolCommonFields).NotTo(gomega.BeZero()) &&
+			g.Expect(nodes[0].PoolRefs[0].AviPoolGeneratedFields).NotTo(gomega.BeZero())
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	l4Rule := FakeL4Rule{
+		Name:      L4RuleName,
+		Namespace: NAMESPACE,
+		Ports:     ports,
+	}
+	obj := l4Rule.L4Rule()
+
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+
+	validateCRDValues(t, g, obj.Spec, nodes[0].AviVsNodeGeneratedFields, nodes[0].AviVsNodeCommonFields)
+
+	validateCRDValues(t, g, obj.Spec.BackendProperties[0],
+		nodes[0].PoolRefs[0].AviPoolGeneratedFields, nodes[0].PoolRefs[0].AviPoolCommonFields)
+
+	TearDownTestForSharedVIPSvcLB(t, g)
+	TeardownL4Rule(t, L4RuleName, NAMESPACE)
+}

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -54,7 +54,7 @@ func TearDownTestForSvcLB(t *testing.T, g *gomega.GomegaWithT) {
 	DelSVC(t, NAMESPACE, SINGLEPORTSVC)
 	DelEP(t, NAMESPACE, SINGLEPORTSVC)
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", SINGLEPORTSVC, NAMESPACE)}
+	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", NAMESPACE, SINGLEPORTSVC)}
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
 		return found
@@ -73,7 +73,55 @@ func TearDownTestForSvcLBMultiport(t *testing.T, g *gomega.GomegaWithT) {
 	DelSVC(t, NAMESPACE, MULTIPORTSVC)
 	DelEP(t, NAMESPACE, MULTIPORTSVC)
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", MULTIPORTSVC, NAMESPACE)}
+	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", NAMESPACE, MULTIPORTSVC)}
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(false))
+}
+
+func SetUpTestForSharedVIPSvcLB(t *testing.T) {
+	modelSvc01 := "admin/cluster--red-ns-" + SHAREDVIPSVC01
+	objects.SharedAviGraphLister().Delete(modelSvc01)
+	svcObj := ConstructService(NAMESPACE, SHAREDVIPSVC01, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	svcObj.Annotations = map[string]string{lib.SharedVipSvcLBAnnotation: SHAREDVIPKEY}
+	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, NAMESPACE, SHAREDVIPSVC01, false, false, "1.1.1")
+	PollForCompletion(t, modelSvc01, 5)
+
+	modelSvc02 := "admin/cluster--red-ns-" + SHAREDVIPSVC02
+	objects.SharedAviGraphLister().Delete(modelSvc01)
+	svcObj = ConstructService(NAMESPACE, SHAREDVIPSVC02, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	svcObj.Annotations = map[string]string{lib.SharedVipSvcLBAnnotation: SHAREDVIPKEY}
+	_, err = KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, NAMESPACE, SHAREDVIPSVC02, false, false, "2.1.1")
+	PollForCompletion(t, modelSvc02, 5)
+}
+
+func TearDownTestForSharedVIPSvcLB(t *testing.T, g *gomega.GomegaWithT) {
+	modelSvc01 := "admin/cluster--red-ns-" + SHAREDVIPSVC01
+	objects.SharedAviGraphLister().Delete(modelSvc01)
+	DelSVC(t, NAMESPACE, SHAREDVIPSVC01)
+	DelEP(t, NAMESPACE, SHAREDVIPSVC01)
+	mcache := cache.SharedAviObjCache()
+	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", NAMESPACE, SHAREDVIPSVC01)}
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(false))
+
+	modelSvc02 := "admin/cluster--red-ns-" + SHAREDVIPSVC02
+	objects.SharedAviGraphLister().Delete(modelSvc02)
+	DelSVC(t, NAMESPACE, SHAREDVIPSVC02)
+	DelEP(t, NAMESPACE, SHAREDVIPSVC02)
+	mcache = cache.SharedAviObjCache()
+	vsKey = cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", NAMESPACE, SHAREDVIPSVC02)}
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
 		return found

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -66,6 +66,9 @@ const (
 	DefaultIngressClass = "avi-lb"
 	SSOTypeOAuth        = "OAuth"
 	SSOTypeSAML         = "SAML"
+	SHAREDVIPKEY        = "shared-vip-key"
+	SHAREDVIPSVC01      = "shared-vip-svc-01"
+	SHAREDVIPSVC02      = "shared-vip-svc-02"
 )
 
 var KubeClient *k8sfake.Clientset


### PR DESCRIPTION
This PR adds the l4rule support for shared VIP services.

FT Results:

> EVH - Non-dedicated
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_l4_rules.py                                 |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_L4_Rules_EVH_Non_Dedicated.test_create_config                               |     PASSED     |       00:00:06      |   06:49:42  |   06:49:48  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_with_single_port_svc             |     PASSED     |       00:00:59      |   06:49:48  |   06:50:48  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_with_multi_port_svc              |     PASSED     |       00:00:41      |   06:50:48  |   06:51:30  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_update                           |     PASSED     |       00:00:52      |   06:51:30  |   06:52:22  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_invalid_to_valid                 |     PASSED     |       00:00:46      |   06:52:22  |   06:53:09  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_with_custom_app_profile          |     PASSED     |       00:03:33      |   06:53:09  |   06:56:42  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_with_load_balancer_ip            |     PASSED     |       00:00:33      |   06:56:42  |   06:57:16  |
| Test_L4_Rules_EVH_Non_Dedicated.test_l4rule_crd_with_shared_vip_svc              |     PASSED     |       00:01:23      |   06:57:16  |   06:58:39  |
| Test_L4_Rules_EVH_Non_Dedicated.test_delete_config                               |     PASSED     |       00:00:00      |   06:58:39  |   06:58:40  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:08:57 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```

> EVH - Dedicated
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_l4_rules.py                                 |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_L4_Rules_EVH_Dedicated.test_create_config                                   |     PASSED     |       00:00:21      |   06:37:22  |   06:37:43  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_with_single_port_svc                 |     PASSED     |       00:00:59      |   06:37:43  |   06:38:42  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_with_multi_port_svc                  |     PASSED     |       00:00:41      |   06:38:42  |   06:39:24  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_update                               |     PASSED     |       00:00:52      |   06:39:24  |   06:40:17  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_invalid_to_valid                     |     PASSED     |       00:00:42      |   06:40:17  |   06:41:00  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_with_custom_app_profile              |     PASSED     |       00:01:06      |   06:41:00  |   06:42:06  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_with_load_balancer_ip                |     PASSED     |       00:01:00      |   06:42:06  |   06:43:06  |
| Test_L4_Rules_EVH_Dedicated.test_l4rule_crd_with_shared_vip_svc                  |     PASSED     |       00:01:20      |   06:43:06  |   06:44:26  |
| Test_L4_Rules_EVH_Dedicated.test_delete_config                                   |     PASSED     |       00:00:00      |   06:44:26  |   06:44:27  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:07:05 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```

> SNI - Non-dedicated
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_l4_rules.py                                 |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_L4_Rules_SNI_Non_Dedicated.test_create_config                               |     PASSED     |       00:00:06      |   06:13:01  |   06:13:07  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_with_single_port_svc             |     PASSED     |       00:00:59      |   06:13:07  |   06:14:07  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_with_multi_port_svc              |     PASSED     |       00:00:48      |   06:14:07  |   06:14:55  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_update                           |     PASSED     |       00:00:52      |   06:14:55  |   06:15:48  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_invalid_to_valid                 |     PASSED     |       00:00:42      |   06:15:48  |   06:16:30  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_with_custom_app_profile          |     PASSED     |       00:01:03      |   06:16:30  |   06:17:33  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_with_load_balancer_ip            |     PASSED     |       00:00:33      |   06:17:34  |   06:18:07  |
| Test_L4_Rules_SNI_Non_Dedicated.test_l4rule_crd_with_shared_vip_svc              |     PASSED     |       00:02:14      |   06:18:07  |   06:20:22  |
| Test_L4_Rules_SNI_Non_Dedicated.test_delete_config                               |     PASSED     |       00:00:00      |   06:20:22  |   06:20:22  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:07:20 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```

> SNI - Dedicated
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_l4_rules.py                                 |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_L4_Rules_SNI_Dedicated.test_create_config                                   |     PASSED     |       00:00:05      |   06:28:01  |   06:28:07  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_with_single_port_svc                 |     PASSED     |       00:00:58      |   06:28:07  |   06:29:06  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_with_multi_port_svc                  |     PASSED     |       00:00:42      |   06:29:06  |   06:29:48  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_update                               |     PASSED     |       00:01:06      |   06:29:48  |   06:30:55  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_invalid_to_valid                     |     PASSED     |       00:00:42      |   06:30:55  |   06:31:38  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_with_custom_app_profile              |     PASSED     |       00:01:04      |   06:31:38  |   06:32:42  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_with_load_balancer_ip                |     PASSED     |       00:00:32      |   06:32:42  |   06:33:15  |
| Test_L4_Rules_SNI_Dedicated.test_l4rule_crd_with_shared_vip_svc                  |     PASSED     |       00:01:19      |   06:33:15  |   06:34:34  |
| Test_L4_Rules_SNI_Dedicated.test_delete_config                                   |     PASSED     |       00:00:00      |   06:34:34  |   06:34:35  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:06:34 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```