### PR TITLE
AV-175963 : Changes in event handler of BlockAffinity CRD to get the node name correctly for Calico CNI

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -763,7 +763,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					utils.AviLog.Warnf("calico blockaffinity spec not found: %+v", err)
 					return
 				}
-				key := utils.NodeObj + "/" + specJSON["name"]
+				key := utils.NodeObj + "/" + specJSON["node"]
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 			},
@@ -778,7 +778,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					utils.AviLog.Warnf("calico blockaffinity spec not found: %+v", err)
 					return
 				}
-				key := utils.NodeObj + "/" + specJSON["name"]
+				key := utils.NodeObj + "/" + specJSON["node"]
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
 			},


### PR DESCRIPTION
This PR includes changes for fixing a bug because of which AKO was unable to properly process BlockAffinity CRD objects at runtime. Hence, for Calico CNI, AKO was unable to add or delete static routes for BlockAffinity CRD objects created at runtime. A sample BlockAffinity object looks like the following. AKO was trying to use the **name** field instead of **node** field in the spec.
```
apiVersion: crd.projectcalico.org/v1
kind: BlockAffinity
metadata:
  name: aakash-k8s-10-133-0-0-26
spec:
  cidr: 10.133.0.0/26
  deleted: "false"
  node: aakash-k8s
  state: confirmed
```