### PR TITLE
AV-179484: Fixes the issue of no status when insecure Edge Termination Policy set as Allow

### DIFF
--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -41,6 +41,10 @@ func ParseOptionsFromMetadata(options []UpdateOptions, bulk bool) ([]string, map
 	updateIngressOptions := make(map[string]UpdateOptions)
 
 	for _, option := range options {
+		if option.ServiceMetadata.InsecureEdgeTermAllow {
+			utils.AviLog.Infof("Skipping update of parent VS annotation since the route :%v has InsecureEdgeTerminationAllow set to true", option.ServiceMetadata.IngressName)
+			continue
+		}
 		if len(option.ServiceMetadata.NamespaceIngressName) > 0 {
 			// secure VSes, service metadata comes from SNI VS.
 			for _, ingressns := range option.ServiceMetadata.NamespaceIngressName {
@@ -284,10 +288,6 @@ func routeStatusCheck(key string, oldStatus []routev1.RouteIngress, hostname str
 
 func updateRouteObject(mRoute *routev1.Route, updateOption UpdateOptions, retryNum ...int) error {
 	if len(updateOption.Vip) == 0 {
-		return nil
-	}
-	if updateOption.ServiceMetadata.InsecureEdgeTermAllow {
-		utils.AviLog.Infof("Skipping update of parent VS annotation since the route :%v has InsecureEdgeTerminationAllow set to true", mRoute.Name)
 		return nil
 	}
 


### PR DESCRIPTION
**Fix**: The code to ignore the route status update when the insecure Edge Termination Policy set as `Allow` was at the wrong place which was preventing the status update in case of an AKO reboot.

**RCA**: AKO was posting the below data, which contains the details about the route, namespace, service metadata, etc, to the status layer during the AKO bootup.
```
[
  ...
  {
    "IngSvc": "",
    "Vip": [
      "10.10.7.24"
    ],
    "ServiceMetadata": {
      "namespace_ingress_name": null,
      "ingress_name": "c5-010-rt-010",
      "namespace": "c5-010",
      "hostnames": [
        "c5-010-rt-010.cluster5.vcd.k8s-systest.com"
      ],
      "namespace_svc_name": null,
      "crd_status": {
        "type": "",
        "value": "",
        "status": ""
      },
      "pool_ratio": 50,
      "passthrough_parent_ref": "",
      "passthrough_child_ref": "",
      "gateway": "",
      "insecureedgetermallow": true,
      "is_mci_ingress": false
    },
    "Key": "syncstatus",
    "VirtualServiceUUID": "virtualservice-9b835ff6-ba0a-48d1-b731-192be6664276",
    "VSName": ""
  },
  {
    "IngSvc": "",
    "Vip": [
      "10.10.7.24"
    ],
    "ServiceMetadata": {
      "namespace_ingress_name": null,
      "ingress_name": "c5-010-rt-010",
      "namespace": "c5-010",
      "hostnames": [
        "c5-010-rt-010.cluster5.vcd.k8s-systest.com"
      ],
      "namespace_svc_name": null,
      "crd_status": {
        "type": "",
        "value": "",
        "status": ""
      },
      "pool_ratio": 50,
      "passthrough_parent_ref": "",
      "passthrough_child_ref": "",
      "gateway": "",
      "insecureedgetermallow": true,
      "is_mci_ingress": false
    },
    "Key": "syncstatus",
    "VirtualServiceUUID": "virtualservice-9b835ff6-ba0a-48d1-b731-192be6664276",
    "VSName": ""
  },
  {
    "IngSvc": "",
    "Vip": [
      "10.10.7.24"
    ],
    "ServiceMetadata": {
      "namespace_ingress_name": null,
      "ingress_name": "c5-010-rt-010",
      "namespace": "c5-010",
      "hostnames": [
        "c5-010-rt-010.cluster5.vcd.k8s-systest.com"
      ],
      "namespace_svc_name": null,
      "crd_status": {
        "type": "",
        "value": "",
        "status": ""
      },
      "pool_ratio": 50,
      "passthrough_parent_ref": "",
      "passthrough_child_ref": "",
      "gateway": "",
      "insecureedgetermallow": false,
      "is_mci_ingress": false
    },
    "Key": "syncstatus",
    "VirtualServiceUUID": "virtualservice-667f0a20-a0ea-46c8-bf25-4e336bede88a",
    "VSName": ""
  },
  {
    "IngSvc": "",
    "Vip": [
      "10.10.7.24"
    ],
    "ServiceMetadata": {
      "namespace_ingress_name": null,
      "ingress_name": "c5-010-rt-010",
      "namespace": "c5-010",
      "hostnames": [
        "c5-010-rt-010.cluster5.vcd.k8s-systest.com"
      ],
      "namespace_svc_name": null,
      "crd_status": {
        "type": "",
        "value": "",
        "status": ""
      },
      "pool_ratio": 50,
      "passthrough_parent_ref": "",
      "passthrough_child_ref": "",
      "gateway": "",
      "insecureedgetermallow": false,
      "is_mci_ingress": false
    },
    "Key": "syncstatus",
    "VirtualServiceUUID": "virtualservice-667f0a20-a0ea-46c8-bf25-4e336bede88a",
    "VSName": ""
  }
  ...
]
```
At the status layer, the above data were merged into a single value with the key in the format `<namespace>/<route name>/<VIP>` and `ServiceMetadata` as the value. The function that does this merging was taking only the first occurrence of the route’s data into account.

That is, in the above data, only the following data with `ServiceMetadata.insecureedgeallow` is set as `true` was taken into account for `"ingress_name": "c5-010-rt-010"`.
```
{
  "IngSvc": "",
  "Vip": [
    "10.10.7.24"
  ],
  "ServiceMetadata": {
    "namespace_ingress_name": null,
    "ingress_name": "c5-010-rt-010",
    "namespace": "c5-010",
    "hostnames": [
      "c5-010-rt-010.cluster5.vcd.k8s-systest.com"
    ],
    "namespace_svc_name": null,
    "crd_status": {
      "type": "",
      "value": "",
      "status": ""
    },
    "pool_ratio": 50,
    "passthrough_parent_ref": "",
    "passthrough_child_ref": "",
    "gateway": "",
    "insecureedgetermallow": true,
    "is_mci_ingress": false
  },
  "Key": "syncstatus",
  "VirtualServiceUUID": "virtualservice-9b835ff6-ba0a-48d1-b731-192be6664276",
  "VSName": ""
}
```
The status layer ignores the route’s status update when the `ServiceMetadata.insecureedgeallow` is set as `true` (more information about this can be found [here](https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/515)).

This is the root cause of this issue. The merging function should have ignored the data which has `ServiceMetadata.insecureedgeallow` set as `true` before grouping.

**Testing**: 
  1. Manually changed the replicas to 0 and re-created the route to remove the status from the route. Scaled up the replicas to 1 and verified that AKO is adding back the status.