### PR TITLE
fix: add missing keys to Helm values file

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -274,16 +274,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- with .Values.affinity }}
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                - ako
-            topologyKey: "kubernetes.io/hostname"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -95,6 +95,21 @@ resources:
     cpu: 200m
     memory: 300Mi
 
+nodeSelector: {}
+
+tolerations: []
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+          - ako
+      topologyKey: "kubernetes.io/hostname"
+
 securityContext: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
These keys were removed in 2d8141a8a6be but the templating options were partially kept.

Having these keys will give option to users to override fields of the StatefulSet

The default value of affinity is copied from 9fef18449c26