### PR TITLE
AKO 1.8.2 support for 22.1.4

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@ AKO version 1.8.2 support for Kubernetes, Openshift, Avi Controller is as below:
 | --------- | ----------- |
 | `Kubernetes` | 1.21 - 1.24 |
 | `Openshift` | 4.6 - 4.10 |
-| `Avi Controller` | 21.1.3 - 22.1.2 |
+| `Avi Controller` | 21.1.3 - 22.1.4 |
 
 ### FAQ
 


### PR DESCRIPTION
AKO 1.8.2 will support Avi controller version 22.1.3 and 22.1.4 with API version set as 22.1.2.