### PR TITLE
AV-182960 : Fix to support mixed protocols for ports in LoadBalancer services and Gateway Services API

### DIFF
--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -121,25 +121,7 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 	avi_vs_meta.PortProto = portProtocols
 	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
 
-	// In case the VS has services that are a mix of TCP and UDP sockets,
-	// we create the VS with global network profile TCP Fast Path,
-	// and override required services with UDP Fast Path. Having a separate
-	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-	// on existing VSes.
-	if isSCTP && !isTCP && !isUDP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP && !isSCTP {
-		license := lib.AKOControlConfig().GetLicenseType()
-		if license == lib.LicenseTypeEnterprise {
-			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
-		} else {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		}
-	} else if isUDP && !isTCP && !isSCTP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-	} else {
-		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-	}
+	avi_vs_meta.NetworkProfile = getNetworkProfile(isSCTP, isTCP, isUDP)
 
 	vsVipNode := &AviVSVIPNode{
 		Name:        lib.GetL4VSVipName(gatewayName, namespace),
@@ -257,25 +239,7 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 	avi_vs_meta.PortProto = portProtocols
 	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
 
-	// In case the VS has services that are a mix of TCP and UDP sockets,
-	// we create the VS with global network profile TCP Fast Path,
-	// and override required services with UDP Fast Path. Having a separate
-	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
-	// on existing VSes.
-	if isSCTP && !isTCP && !isUDP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP && !isSCTP {
-		license := lib.AKOControlConfig().GetLicenseType()
-		if license == lib.LicenseTypeEnterprise {
-			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
-		} else {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		}
-	} else if isUDP && !isTCP && !isSCTP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-	} else {
-		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-	}
+	avi_vs_meta.NetworkProfile = getNetworkProfile(isSCTP, isTCP, isUDP)
 
 	vsVipNode := &AviVSVIPNode{
 		Name:        lib.GetL4VSVipName(gatewayName, namespace),
@@ -537,20 +501,7 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 	avi_vs_meta.PortProto = portProtocols
 	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
 
-	if isSCTP && !isTCP && !isUDP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP && !isSCTP {
-		license := lib.AKOControlConfig().GetLicenseType()
-		if license == lib.LicenseTypeEnterprise {
-			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
-		} else {
-			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-		}
-	} else if isUDP && !isTCP && !isSCTP {
-		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
-	} else {
-		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
-	}
+	avi_vs_meta.NetworkProfile = getNetworkProfile(isSCTP, isTCP, isUDP)
 
 	vsVipNode := &AviVSVIPNode{
 		Name:        lib.GetL4VSVipName(sharedVipKey, namespace),

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -129,7 +129,12 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 	if isSCTP && !isTCP && !isUDP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
 	} else if isTCP && !isUDP && !isSCTP {
-		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		license := lib.AKOControlConfig().GetLicenseType()
+		if license == lib.LicenseTypeEnterprise {
+			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+		} else {
+			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		}
 	} else if isUDP && !isTCP && !isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 	} else {
@@ -535,7 +540,12 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 	if isSCTP && !isTCP && !isUDP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
 	} else if isTCP && !isUDP && !isSCTP {
-		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		license := lib.AKOControlConfig().GetLicenseType()
+		if license == lib.LicenseTypeEnterprise {
+			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+		} else {
+			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+		}
 	} else if isUDP && !isTCP && !isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 	} else {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -126,11 +126,11 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 	// and override required services with UDP Fast Path. Having a separate
 	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
 	// on existing VSes.
-	if isSCTP {
+	if isSCTP && !isTCP && !isUDP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP {
+	} else if isTCP && !isUDP && !isSCTP {
 		avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
-	} else if isUDP && !isTCP {
+	} else if isUDP && !isTCP && !isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 	} else {
 		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE
@@ -257,16 +257,16 @@ func (o *AviObjectGraph) ConstructSvcApiL4VsNode(gatewayName, namespace, key str
 	// and override required services with UDP Fast Path. Having a separate
 	// internally used network profile (MIXED_NET_PROFILE) helps ensure PUT calls
 	// on existing VSes.
-	if isSCTP {
+	if isSCTP && !isTCP && !isUDP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP {
+	} else if isTCP && !isUDP && !isSCTP {
 		license := lib.AKOControlConfig().GetLicenseType()
 		if license == lib.LicenseTypeEnterprise {
 			avi_vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
 		} else {
 			avi_vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
 		}
-	} else if isUDP && !isTCP {
+	} else if isUDP && !isTCP && !isSCTP {
 		avi_vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 	} else {
 		avi_vs_meta.NetworkProfile = utils.MIXED_NET_PROFILE

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -659,13 +659,15 @@ func buildPoolWithL4Rule(key string, pool *AviPoolNode, l4Rule *akov1alpha2.L4Ru
 func getNetworkProfile(isSCTP, isTCP, isUDP bool) string {
 	if isSCTP && !isTCP && !isUDP {
 		return utils.SYSTEM_SCTP_PROXY
-	} else if isTCP && !isUDP && !isSCTP {
+	}
+	if isTCP && !isUDP && !isSCTP {
 		license := lib.AKOControlConfig().GetLicenseType()
 		if license == lib.LicenseTypeEnterprise {
 			return utils.DEFAULT_TCP_NW_PROFILE
 		}
 		return utils.TCP_NW_FAST_PATH
-	} else if isUDP && !isTCP && !isSCTP {
+	}
+	if isUDP && !isTCP && !isSCTP {
 		return utils.SYSTEM_UDP_FAST_PATH
 	}
 	return utils.MIXED_NET_PROFILE

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -160,9 +160,9 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			vs.Services = append(vs.Services, &svc)
 		}
 
-		// In case the VS has services that are a mix of TCP and UDP sockets,
-		// we create the VS with global network profile TCP Fast Path,
-		// and override required services with UDP Fast Path.
+		// In case the VS has services that are a mix of TCP and UDP/SCTP sockets,
+		// we create the VS with global network profile TCP Proxy or Fast Path based on license,
+		// and override required services with UDP Fast Path or SCTP proxy.
 		if vs_meta.NetworkProfile == utils.MIXED_NET_PROFILE {
 			if isTCPPortPresent {
 				license := lib.AKOControlConfig().GetLicenseType()

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -165,7 +165,12 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 		// and override required services with UDP Fast Path.
 		if vs_meta.NetworkProfile == utils.MIXED_NET_PROFILE {
 			if isTCPPortPresent {
-				vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+				license := lib.AKOControlConfig().GetLicenseType()
+				if license == lib.LicenseTypeEnterprise {
+					vs_meta.NetworkProfile = utils.DEFAULT_TCP_NW_PROFILE
+				} else {
+					vs_meta.NetworkProfile = utils.TCP_NW_FAST_PATH
+				}
 			} else {
 				vs_meta.NetworkProfile = utils.SYSTEM_UDP_FAST_PATH
 			}


### PR DESCRIPTION
This PR adds support for mixed protocols for ports in LoadBalancer services and Gateway Services API. This support was missing due to error in implementation.