### PR TITLE
AV-180407: CRD validation after failover

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -63,6 +63,7 @@ type AviController struct {
 	dynamicInformers *lib.DynamicInformers
 	workqueue        []workqueue.RateLimitingInterface
 	DisableSync      bool
+	State            *State
 }
 
 type K8sinformers struct {
@@ -79,6 +80,7 @@ func SharedAviController() *AviController {
 			informers:        utils.GetInformers(),
 			dynamicInformers: lib.GetDynamicInformers(),
 			DisableSync:      true,
+			State:            &State{},
 		}
 	})
 	return controllerInstance

--- a/internal/k8s/leader_election_callbacks.go
+++ b/internal/k8s/leader_election_callbacks.go
@@ -15,7 +15,7 @@
 package k8s
 
 import (
-	"sync"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -25,33 +25,159 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-var once sync.Once
-
+// Leader election callback functions
 func (c *AviController) OnStartedLeading() {
-	lib.AKOControlConfig().SetIsLeaderFlag(true)
-	utils.AviLog.Debugf("AKO became a leader")
-	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a leader")
+	event, ok := c.NewFSM().Event[fmt.Sprintf("%d-%d", c.State.current, LEADER)]
+	if !ok {
+		utils.AviLog.Fatalf("Invalid transition. Allowed Current state: %d, Next state: %d", UNKNOWN, LEADER)
+		return
+	}
+	event.Handle()
+}
+
+func (c *AviController) OnNewLeader() {
+	event, ok := c.NewFSM().Event[fmt.Sprintf("%d-%d", c.State.current, FOLLOWER)]
+	if !ok {
+		utils.AviLog.Fatalf("Invalid transition. Allowed Current state: %d, Next state: %d", UNKNOWN, FOLLOWER)
+		return
+	}
+	event.Handle()
+}
+
+func (c *AviController) OnStoppedLeading() {
+	event, ok := c.NewFSM().Event[fmt.Sprintf("%d-%d", c.State.current, FOLLOWER)]
+	if !ok {
+		utils.AviLog.Fatalf("Invalid transition. Allowed Current state: %d, Next state: %d", LEADER, FOLLOWER)
+		return
+	}
+	event.Handle()
+}
+
+// Event Handler functions
+func (c *AviController) OnStartedLeadingDuringBootup() {
 	c.publishAllParentVSKeysToRestLayer()
-
-	once.Do(c.cleanupStaleVSes)
-
+	c.cleanupStaleVSes()
 	// once the l3 cache is populated, we can call the updatestatus functions from here
 	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
 	restlayer.SyncObjectStatuses()
 }
 
-func (c *AviController) OnNewLeader() {
-	lib.AKOControlConfig().SetIsLeaderFlag(false)
-	utils.AviLog.Debugf("AKO became a follower")
-	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a follower")
+func (c *AviController) OnStartedLeadingAfterFailover() {
 	c.publishAllParentVSKeysToRestLayer()
+	c.SyncCRDObjects()
+	// once the l3 cache is populated, we can call the updatestatus functions from here
+	restlayer := rest.NewRestOperations(avicache.SharedAviObjCache(), avicache.SharedAVIClients())
+	restlayer.SyncObjectStatuses()
+}
 
+func (c *AviController) OnNewLeaderDuringBootup() {
+	c.publishAllParentVSKeysToRestLayer()
 	c.cleanupStaleVSes()
 }
 
-func (c *AviController) OnStoppedLeading() {
+func (c *AviController) OnLostLeadership() {
 	lib.AKOControlConfig().SetIsLeaderFlag(false)
 	c.DisableSync = true
 	lib.SetDisableSync(true)
 	utils.AviLog.Fatal("AKO lost the leadership")
+}
+
+// Transition functions
+func (c *AviController) TransitionToLeader() {
+
+	lib.AKOControlConfig().SetIsLeaderFlag(true)
+
+	// Transition the state to leader
+	c.State.previous = c.State.current
+	c.State.current = LEADER
+
+	// inform the user about state transition
+	utils.AviLog.Debugf("AKO became a leader")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a leader")
+}
+
+func (c *AviController) TransitionToFollower() {
+
+	lib.AKOControlConfig().SetIsLeaderFlag(false)
+
+	// Transition the state to follower
+	c.State.previous = c.State.current
+	c.State.current = FOLLOWER
+
+	// inform the user about state transition
+	utils.AviLog.Debugf("AKO became a follower")
+	lib.AKOControlConfig().PodEventf(v1.EventTypeNormal, "LeaderElection", "AKO became a follower")
+}
+
+func (c *AviController) NoOperation() {}
+
+const (
+
+	// All possible states
+	UNKNOWN uint8 = iota
+	LEADER
+	FOLLOWER
+
+	// Name of the events
+	BOOT_UP_AS_LEADER   = "BOOT_UP_AS_LEADER"
+	BOOT_UP_AS_FOLLOWER = "BOOT_UP_AS_FOLLOWER"
+	FOLLOWER_TO_LEADER  = "FOLLOWER_TO_LEADER"
+	LOST_LEADERSHIP     = "LOST_LEADERSHIP"
+)
+
+type State struct {
+	previous uint8
+	current  uint8
+}
+
+type FSM struct {
+	// key -> current state-next state
+	Event map[string]*Event
+}
+
+type Event struct {
+	Name       string
+	Handler    func()
+	Transition func()
+}
+
+func (c *AviController) NewFSM() *FSM {
+	fsm := &FSM{}
+	fsm.Event = make(map[string]*Event)
+
+	// Booting up as a leader
+	fsm.Event[fmt.Sprintf("%d-%d", UNKNOWN, LEADER)] = &Event{
+		Name:       BOOT_UP_AS_LEADER,
+		Transition: c.TransitionToLeader,
+		Handler:    c.OnStartedLeadingDuringBootup,
+	}
+
+	// Booting up as a follower
+	fsm.Event[fmt.Sprintf("%d-%d", UNKNOWN, FOLLOWER)] = &Event{
+		Name:       BOOT_UP_AS_FOLLOWER,
+		Transition: c.TransitionToFollower,
+		Handler:    c.OnNewLeaderDuringBootup,
+	}
+
+	// failover from follower to leader
+	fsm.Event[fmt.Sprintf("%d-%d", FOLLOWER, LEADER)] = &Event{
+		Name:       FOLLOWER_TO_LEADER,
+		Transition: c.TransitionToLeader,
+		Handler:    c.OnStartedLeadingAfterFailover,
+	}
+
+	// leader lost leadership
+	fsm.Event[fmt.Sprintf("%d-%d", LEADER, FOLLOWER)] = &Event{
+		Name:       LOST_LEADERSHIP,
+		Transition: c.NoOperation,
+		Handler:    c.OnLostLeadership,
+	}
+	return fsm
+}
+
+func (e *Event) Handle() {
+	utils.AviLog.Debugf("Triggering the event %s", e.Name)
+	e.Transition()
+	e.Handler()
+	utils.AviLog.Debugf("Finished the event %s", e.Name)
 }


### PR DESCRIPTION
This PR adds the logic to go over all the CRDs present in the cluster and validate it. The validation would trigger an UPDATE event that will update the models and eventually, the configurations will get applied on the AVI objects when the CRD is marked as Accepted.

This PR also adds the code to track the state of AKO and a state machine to handle the transition during leader elections.