### PR TITLE
AV-180534: Handle Concurrent update to VRFContext

### DIFF
--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -313,6 +313,8 @@ func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, 
 			} else if aviErr.HttpStatusCode == 404 && op.Method == utils.RestDelete {
 				utils.AviLog.Warnf("key: %s, msg: Error during rest operation: %v, object of type %s not found in the controller. Ignoring err: %v", key, op.Method, op.Model, op.Err)
 				continue
+			} else if op.Model == "VrfContext" && aviErr.HttpStatusCode == 412 {
+				utils.AviLog.Debugf("key: %s, msg: Error in rest operation for VrfContext Put request.", key)
 			} else if !isErrorRetryable(aviErr.HttpStatusCode, *aviErr.Message) {
 				if op.Method != utils.RestPost {
 					continue


### PR DESCRIPTION
Scenario tested:
1. Delete/Change static routes from Avi controller and check routes are properly synced or not.
2. Test concurrent update scenario (with delay introduced in vrfcontext code path) and check AKO is syncing vrfcontext to proper state or not.
3. `deleteConfig=true/false` in configmap and check static route sync.
4. `deleteConfig=true/false` in configmap and check static route sync in concurrent update scenario.