### PR TITLE
AV-183627 : Remove CTRL_CA_DATA env variable from AKO Statefulset definition as it violates CNTR-K8-001160

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -64,13 +64,6 @@ spec:
               exec:
                 command: ["/bin/sh","/var/pre_stop_hook.sh"]
           env:
-          {{ if .Values.avicredentials.certificateAuthorityData  }}
-          - name: CTRL_CA_DATA
-            valueFrom:
-              secretKeyRef:
-                name: avi-secret
-                key: certificateAuthorityData
-            {{ end }}
           - name: CTRL_IPADDRESS
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This PR is for removing **CTRL_CA_DATA** env variable from AKO Statefulset definition as it is created from a **secretKeyRef** and violates **CNTR-K8-001160** ([CNTR-K8-001160 - Secrets in Kubernetes must not be stored as e...](https://www.tenable.com/audits/items/DISA_STIG_Kubernetes_v1r5.audit:fdb2906c002a74a6f822c62bef0d8ed0) ). This was detected as part of https://jira.eng.vmware.com/browse/TKG-20458. The fix will just include removal of **CTRL_CA_DATA** env variable as it is not used by AKO. Instead, AKO reads the **certificateAuthorityData** directly from **avi-secret** (a kubernetes secret object) in the **avi-system** namespace.