### PR TITLE
AV-183085: [GatewayAPI] HTTPRoute Ingestion layer validation and Status layer code

### DIFF
--- a/ako-gateway-api/k8s/ako_init.go
+++ b/ako-gateway-api/k8s/ako_init.go
@@ -189,6 +189,20 @@ func (c *GatewayController) addIndexers() {
 			},
 		},
 	)
+	gwinformer.GatewayClassInformer.Informer().AddIndexers(
+		cache.Indexers{
+			akogatewayapilib.GatewayClassGatewayControllerIndex: func(obj interface{}) ([]string, error) {
+				gwClass, ok := obj.(*gatewayv1beta1.GatewayClass)
+				if !ok {
+					return []string{}, nil
+				}
+				if gwClass.Spec.ControllerName == akogatewayapilib.GatewayController {
+					return []string{akogatewayapilib.GatewayController}, nil
+				}
+				return []string{}, nil
+			},
+		},
+	)
 }
 
 func (c *GatewayController) FullSyncK8s(sync bool) error {

--- a/ako-gateway-api/k8s/validator.go
+++ b/ako-gateway-api/k8s/validator.go
@@ -252,7 +252,7 @@ func validateParentReference(key string, httpRoute *gatewayv1beta1.HTTPRoute, ht
 	i := akogatewayapilib.FindListenerByName(string(listenerName), gateway.Spec.Listeners)
 	if i == -1 {
 		// listener is not present in gateway
-		utils.AviLog.Errorf("key: %s, msg: not able to find the listener from the Section Name %s in Parent Reference %s", key, name, listenerName)
+		utils.AviLog.Errorf("key: %s, msg: unable to find the listener from the Section Name %s in Parent Reference %s", key, name, listenerName)
 		err := fmt.Errorf("Invalid listener name provided")
 		defaultCondition.
 			Message(err.Error()).

--- a/ako-gateway-api/k8s/validator.go
+++ b/ako-gateway-api/k8s/validator.go
@@ -16,19 +16,22 @@ package k8s
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/status"
+	akogatewayapiobjects "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/objects"
+	akogatewayapistatus "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
 func IsValidGateway(key string, gateway *gatewayv1beta1.Gateway) bool {
 	spec := gateway.Spec
 
-	defaultCondition := status.NewCondition().
+	defaultCondition := akogatewayapistatus.NewCondition().
 		Type(string(gatewayv1beta1.GatewayConditionAccepted)).
 		Reason(string(gatewayv1beta1.GatewayReasonInvalid)).
 		Status(metav1.ConditionFalse).
@@ -42,7 +45,7 @@ func IsValidGateway(key string, gateway *gatewayv1beta1.Gateway) bool {
 		defaultCondition.
 			Message("No listeners found").
 			SetIn(&gatewayStatus.Conditions)
-		status.Record(key, gateway, &status.Status{GatewayStatus: *gatewayStatus})
+		akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
 		return false
 	}
 
@@ -52,15 +55,16 @@ func IsValidGateway(key string, gateway *gatewayv1beta1.Gateway) bool {
 		defaultCondition.
 			Message("More than one address is not supported").
 			SetIn(&gatewayStatus.Conditions)
-		status.Record(key, gateway, &status.Status{GatewayStatus: *gatewayStatus})
+		akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
 		return false
 	}
+
 	if len(spec.Addresses) == 1 && *spec.Addresses[0].Type != "IPAddress" {
 		utils.AviLog.Errorf("gateway address is not of type IPAddress %+v", gateway.Name)
 		defaultCondition.
 			Message("Only IPAddress as AddressType is supported").
 			SetIn(&gatewayStatus.Conditions)
-		status.Record(key, gateway, &status.Status{GatewayStatus: *gatewayStatus})
+		akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
 		return false
 	}
 
@@ -80,7 +84,7 @@ func IsValidGateway(key string, gateway *gatewayv1beta1.Gateway) bool {
 			Reason(string(gatewayv1beta1.GatewayReasonListenersNotValid)).
 			Message(fmt.Sprintf("Gateway contains %d invalid listener(s)", invalidListenerCount)).
 			SetIn(&gatewayStatus.Conditions)
-		status.Record(key, gateway, &status.Status{GatewayStatus: *gatewayStatus})
+		akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
 		return false
 	}
 
@@ -89,7 +93,7 @@ func IsValidGateway(key string, gateway *gatewayv1beta1.Gateway) bool {
 		Status(metav1.ConditionTrue).
 		Message("Gateway configuration is valid").
 		SetIn(&gatewayStatus.Conditions)
-	status.Record(key, gateway, &status.Status{GatewayStatus: *gatewayStatus})
+	akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
 	utils.AviLog.Infof("key: %s, msg: Gateway %s is valid", key, gateway.Name)
 	return true
 }
@@ -101,7 +105,7 @@ func isValidListener(key string, gateway *gatewayv1beta1.Gateway, gatewayStatus 
 	gatewayStatus.Listeners[index].SupportedKinds = akogatewayapilib.SupportedKinds[listener.Protocol]
 	gatewayStatus.Listeners[index].AttachedRoutes = akogatewayapilib.ZeroAttachedRoutes
 
-	defaultCondition := status.NewCondition().
+	defaultCondition := akogatewayapistatus.NewCondition().
 		Type(string(gatewayv1beta1.GatewayConditionAccepted)).
 		Reason(string(gatewayv1beta1.GatewayReasonListenersNotValid)).
 		Status(metav1.ConditionFalse).
@@ -161,4 +165,150 @@ func isValidListener(key string, gateway *gatewayv1beta1.Gateway, gatewayStatus 
 		SetIn(&gatewayStatus.Listeners[index].Conditions)
 	utils.AviLog.Infof("key: %s, msg: Listener %s/%s is valid", key, gateway.Name, listener.Name)
 	return true
+}
+
+func IsHTTPRouteValid(key string, obj *gatewayv1beta1.HTTPRoute) bool {
+
+	httpRoute := obj.DeepCopy()
+	if len(httpRoute.Spec.ParentRefs) == 0 {
+		utils.AviLog.Errorf("key: %s, msg: Parent Reference is empty for the HTTPRoute %s", key, httpRoute.Name)
+		return false
+	}
+
+	for _, hostname := range httpRoute.Spec.Hostnames {
+		if strings.Contains(string(hostname), "*") {
+			utils.AviLog.Errorf("key: %s, msg: Wildcard in hostname is not supported for the HTTPRoute %s", key, httpRoute.Name)
+			return false
+		}
+	}
+
+	httpRouteStatus := obj.Status.DeepCopy()
+	httpRouteStatus.Parents = make([]gatewayv1beta1.RouteParentStatus, 0, len(httpRoute.Spec.ParentRefs))
+	var invalidParentRefCount int
+	for index := range httpRoute.Spec.ParentRefs {
+		err := validateParentReference(key, httpRoute, httpRouteStatus, index)
+		if err != nil {
+			invalidParentRefCount++
+			parentRefName := httpRoute.Spec.ParentRefs[index].Name
+			utils.AviLog.Warnf("key: %s, msg: Parent Reference %s of HTTPRoute object %s is not valid, err: %v", key, parentRefName, httpRoute.Name, err)
+		}
+	}
+	akogatewayapistatus.Record(key, httpRoute, &akogatewayapistatus.Status{HTTPRouteStatus: *httpRouteStatus})
+
+	// No valid attachment, we can't proceed with this HTTPRoute object.
+	if invalidParentRefCount == len(httpRoute.Spec.ParentRefs) {
+		utils.AviLog.Errorf("key: %s, msg: HTTPRoute object %s is not valid", key, httpRoute.Name)
+		return false
+	}
+	utils.AviLog.Infof("key: %s, msg: HTTPRoute object %s is valid", key, httpRoute.Name)
+	return true
+}
+
+func validateParentReference(key string, httpRoute *gatewayv1beta1.HTTPRoute, httpRouteStatus *gatewayv1beta1.HTTPRouteStatus, index int) error {
+
+	name := string(httpRoute.Spec.ParentRefs[index].Name)
+	namespace := httpRoute.Namespace
+	if httpRoute.Spec.ParentRefs[index].Namespace != nil {
+		namespace = string(*httpRoute.Spec.ParentRefs[index].Namespace)
+	}
+
+	obj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayInformer.Lister().Gateways(namespace).Get(name)
+	if err != nil {
+		utils.AviLog.Errorf("key: %s, msg: unable to get the gateway object. err: %s", key, err)
+		return err
+	}
+	gateway := obj.DeepCopy()
+
+	gwClass := string(gateway.Spec.GatewayClassName)
+	_, isAKOCtrl := akogatewayapiobjects.GatewayApiLister().IsGatewayClassControllerAKO(gwClass)
+	if !isAKOCtrl {
+		utils.AviLog.Warnf("key: %s, msg: controller for the parent reference %s of HTTPRoute object %s is not ako", key, name, httpRoute.Name)
+		return fmt.Errorf("controller for the parent reference %s of HTTPRoute object %s is not ako", name, httpRoute.Name)
+	}
+	// creates the Parent status only when the AKO is the gateway controller
+	httpRouteStatus.Parents = append(httpRouteStatus.Parents, gatewayv1beta1.RouteParentStatus{})
+	httpRouteStatus.Parents[index].ControllerName = akogatewayapilib.GatewayController
+	httpRouteStatus.Parents[index].ParentRef.Name = gatewayv1beta1.ObjectName(name)
+	httpRouteStatus.Parents[index].ParentRef.Namespace = (*gatewayv1beta1.Namespace)(&namespace)
+
+	defaultCondition := akogatewayapistatus.NewCondition().
+		Type(string(gatewayv1beta1.GatewayConditionAccepted)).
+		Reason(string(gatewayv1beta1.GatewayReasonInvalid)).
+		Status(metav1.ConditionFalse).
+		ObservedGeneration(httpRoute.ObjectMeta.Generation)
+
+	if httpRoute.Spec.ParentRefs[index].SectionName == nil {
+		// can't attach to any so update the httproute status
+		utils.AviLog.Errorf("key: %s, msg: Section Name in Parent Reference %s is empty, HTTPRoute object %s cannot be attached to a listener", key, name, httpRoute.Name)
+		err := fmt.Errorf("Listener not specified")
+		defaultCondition.
+			Message(err.Error()).
+			SetIn(&httpRouteStatus.Parents[index].Conditions)
+		return err
+	}
+
+	listenerName := *httpRoute.Spec.ParentRefs[index].SectionName
+	httpRouteStatus.Parents[index].ParentRef.SectionName = &listenerName
+	i := akogatewayapilib.FindListenerByName(string(listenerName), gateway.Spec.Listeners)
+	if i == -1 {
+		// listener is not present in gateway
+		utils.AviLog.Errorf("key: %s, msg: not able to find the listener from the Section Name %s in Parent Reference %s", key, name, listenerName)
+		err := fmt.Errorf("Invalid listener name provided")
+		defaultCondition.
+			Message(err.Error()).
+			SetIn(&httpRouteStatus.Parents[index].Conditions)
+		return err
+	}
+
+	hostsInListener := gateway.Spec.Listeners[i].Hostname
+
+	// replace the wildcard character with a regex
+	replacedHostname := strings.Replace(string(*hostsInListener), "*", "([a-zA-Z0-9-]{1,})", 1)
+
+	// create the expression for pattern matching
+	pattern := fmt.Sprintf("^%s$", replacedHostname)
+	expr, err := regexp.Compile(pattern)
+	if err != nil {
+		utils.AviLog.Errorf("key: %s, msg: unable to match the hostname with listener hostname. err: %s", key, err)
+		err := fmt.Errorf("Invalid hostname in parent reference")
+		defaultCondition.
+			Message(err.Error()).
+			SetIn(&httpRouteStatus.Parents[index].Conditions)
+		return err
+	}
+	var matched bool
+	for _, host := range httpRoute.Spec.Hostnames {
+		matched = matched || expr.MatchString(string(host))
+	}
+	if !matched {
+		utils.AviLog.Errorf("key: %s, msg: Gateway object %s don't have any listeners that matches the hostnames in HTTPRoute %s", key, gateway.Name, httpRoute.Name)
+		err := fmt.Errorf("Hostname in Gateway Listener doesn't match with any of the hostnames in HTTPRoute")
+		defaultCondition.
+			Message(err.Error()).
+			SetIn(&httpRouteStatus.Parents[index].Conditions)
+		return err
+	}
+
+	// Increment the attached routes of the listener in the Gateway object
+	gatewayStatus := gateway.Status.DeepCopy()
+	i = akogatewayapilib.FindListenerStatusByName(string(listenerName), gatewayStatus.Listeners)
+	if i == -1 {
+		utils.AviLog.Errorf("key: %s, msg: Gateway status is missing for the listener with name %s", key, listenerName)
+		err := fmt.Errorf("Couldn't find the listener %s in the Gateway status", listenerName)
+		defaultCondition.
+			Message(err.Error()).
+			SetIn(&httpRouteStatus.Parents[index].Conditions)
+		return err
+	}
+
+	gatewayStatus.Listeners[index].AttachedRoutes += 1
+	akogatewayapistatus.Record(key, gateway, &akogatewayapistatus.Status{GatewayStatus: *gatewayStatus})
+
+	defaultCondition.
+		Reason(string(gatewayv1beta1.GatewayReasonAccepted)).
+		Status(metav1.ConditionTrue).
+		Message("Parent reference is valid").
+		SetIn(&httpRouteStatus.Parents[index].Conditions)
+	utils.AviLog.Infof("key: %s, msg: Parent Reference %s of HTTPRoute object %s is valid", key, name, httpRoute.Name)
+	return nil
 }

--- a/ako-gateway-api/lib/constants.go
+++ b/ako-gateway-api/lib/constants.go
@@ -15,10 +15,14 @@
 package lib
 
 const (
-	Prefix = "ako-gw-"
+	Prefix            = "ako-gw-"
 	GatewayController = "ako.vmware.com/avi-lb"
 )
 
 const (
 	ZeroAttachedRoutes = 0
+)
+
+const (
+	GatewayClassGatewayControllerIndex = "GatewayClassGatewayController"
 )

--- a/ako-gateway-api/lib/lib.go
+++ b/ako-gateway-api/lib/lib.go
@@ -15,9 +15,11 @@
 package lib
 
 import (
+	"k8s.io/client-go/kubernetes"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
-	"k8s.io/client-go/kubernetes"
 )
 
 func InformersToRegister(kclient *kubernetes.Clientset) ([]string, error) {
@@ -42,4 +44,22 @@ func GetGatewayParentName(namespace, gwName string) string {
 
 func CheckGatewayClassController(controllerName string) bool {
 	return controllerName == lib.AviIngressController
+}
+
+func FindListenerByName(name string, listener []gatewayv1beta1.Listener) int {
+	for i := range listener {
+		if string(listener[i].Name) == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func FindListenerStatusByName(name string, status []gatewayv1beta1.ListenerStatus) int {
+	for i := range status {
+		if string(status[i].Name) == name {
+			return i
+		}
+	}
+	return -1
 }

--- a/ako-gateway-api/status/httproute_status.go
+++ b/ako-gateway-api/status/httproute_status.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-2024 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type httproute struct{}
+
+func (o *httproute) Get(key string, name string, namespace string) *gatewayv1beta1.HTTPRoute {
+
+	obj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(namespace).Get(name)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: unable to get the HTTPRoute object. err: %s", key, err)
+		return nil
+	}
+	utils.AviLog.Debugf("key: %s, msg: Successfully retrieved the HTTPRoute object %s", key, name)
+	return obj.DeepCopy()
+}
+
+func (o *httproute) GetAll(key string) map[string]*gatewayv1beta1.HTTPRoute {
+
+	objs, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().List(labels.Everything())
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: unable to get the HTTPRoute objects. err: %s", key, err)
+		return nil
+	}
+
+	httpRouteMap := make(map[string]*gatewayv1beta1.HTTPRoute)
+	for _, obj := range objs {
+		httpRouteMap[obj.Namespace+"/"+obj.Name] = obj.DeepCopy()
+	}
+
+	utils.AviLog.Debugf("key: %s, msg: Successfully retrieved the HTTPRoute objects", key)
+	return httpRouteMap
+}
+
+func (o *httproute) Delete(key string, option status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *httproute) Update(key string, option status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *httproute) BulkUpdate(key string, options []status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *httproute) Patch(key string, obj runtime.Object, status *Status, retryNum ...int) {
+	retry := 0
+	if len(retryNum) > 0 {
+		retry = retryNum[0]
+		if retry >= 5 {
+			utils.AviLog.Errorf("key: %s, msg: Patch retried 5 times, aborting", key)
+			return
+		}
+	}
+
+	httpRoute := obj.(*gatewayv1beta1.HTTPRoute)
+	if o.isStatusEqual(&httpRoute.Status, &status.HTTPRouteStatus) {
+		return
+	}
+
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": status,
+	})
+	_, err := akogatewayapilib.AKOControlConfig().GatewayAPIClientset().GatewayV1beta1().HTTPRoutes(httpRoute.Namespace).Patch(context.TODO(), httpRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: there was an error in updating the gateway status. err: %+v, retry: %d", key, err, retry)
+		updatedGW, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(httpRoute.Namespace).Get(httpRoute.Name)
+		if err != nil {
+			utils.AviLog.Warnf("gateway not found %v", err)
+			return
+		}
+		o.Patch(key, updatedGW, status, retry+1)
+	}
+
+	utils.AviLog.Infof("key: %s, msg: Successfully updated the HTTPRoute %s/%s status %+v", key, httpRoute.Namespace, httpRoute.Name, utils.Stringify(status))
+}
+
+func (o *httproute) isStatusEqual(old, new *gatewayv1beta1.HTTPRouteStatus) bool {
+	oldStatus, newStatus := old.DeepCopy(), new.DeepCopy()
+	currentTime := metav1.Now()
+	for i := range oldStatus.Parents {
+		for j := range oldStatus.Parents[i].Conditions {
+			oldStatus.Parents[i].Conditions[j].LastTransitionTime = currentTime
+		}
+	}
+	for i := range newStatus.Parents {
+		for j := range newStatus.Parents[i].Conditions {
+			newStatus.Parents[i].Conditions[j].LastTransitionTime = currentTime
+		}
+	}
+	return reflect.DeepEqual(oldStatus, newStatus)
+}

--- a/ako-gateway-api/status/status.go
+++ b/ako-gateway-api/status/status.go
@@ -26,18 +26,21 @@ import (
 type StatusUpdater interface {
 	Update(key string, option status.StatusOptions)
 	BulkUpdate(key string, options []status.StatusOptions)
-	Patch(key string, gw runtime.Object, status *Status, retryNum ...int)
+	Patch(key string, obj runtime.Object, status *Status, retryNum ...int)
 	Delete(key string, option status.StatusOptions)
 }
 
 type Status struct {
 	gatewayv1beta1.GatewayStatus
+	gatewayv1beta1.HTTPRouteStatus
 }
 
 func New(ObjectType string) StatusUpdater {
 	switch ObjectType {
 	case lib.Gateway:
 		return &gateway{}
+	case lib.HTTPRoute:
+		return &httproute{}
 	}
 	return nil
 }
@@ -70,6 +73,8 @@ func Record(key string, obj runtime.Object, status *Status) {
 	switch obj.(type) {
 	case *gatewayv1beta1.Gateway:
 		objectType = lib.Gateway
+	case *gatewayv1beta1.HTTPRoute:
+		objectType = lib.HTTPRoute
 	default:
 		utils.AviLog.Warnf("key %s, msg: Unsupported object received at the status layer, %T", key, obj)
 		return

--- a/ako-gateway-api/tests/ingestion/gateway_test.go
+++ b/ako-gateway-api/tests/ingestion/gateway_test.go
@@ -21,23 +21,22 @@ import (
 	"testing"
 	"time"
 
-	akogatewayapik8s "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/k8s"
-	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+
+	akogatewayapik8s "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/k8s"
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapiobjects "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/objects"
+	akogatewayapitests "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 )
 
-var KubeClient *k8sfake.Clientset
-var GatewayClient *gatewayfake.Clientset
 var keyChan chan string
-var ctrl *akogatewayapik8s.GatewayController
 
 func waitAndverify(t *testing.T, key string) {
 	waitChan := make(chan int)
@@ -53,7 +52,7 @@ func waitAndverify(t *testing.T, key string) {
 		} else if data != key {
 			t.Fatalf("error in match expected: %v, got: %v", key, data)
 		}
-	case _ = <-waitChan:
+	case <-waitChan:
 		if key != "" {
 			t.Fatalf("timed out waiting for %v", key)
 		}
@@ -79,16 +78,20 @@ func setupQueue(stopCh <-chan struct{}) {
 }
 
 func TestMain(m *testing.M) {
-	KubeClient = k8sfake.NewSimpleClientset()
-	GatewayClient = gatewayfake.NewSimpleClientset()
+	akogatewayapitests.KubeClient = k8sfake.NewSimpleClientset()
+	akogatewayapitests.GatewayClient = gatewayfake.NewSimpleClientset()
 
 	os.Setenv("CLUSTER_NAME", "cluster")
 	os.Setenv("CLOUD_NAME", "CLOUD_VCENTER")
 	os.Setenv("SEG_NAME", "Default-Group")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 
+	// Set the user with prefix
+	_ = lib.AKOControlConfig()
+	lib.SetAKOUser(akogatewayapilib.Prefix)
+	lib.SetNamePrefix(akogatewayapilib.Prefix)
 	akoControlConfig := akogatewayapilib.AKOControlConfig()
-	akoControlConfig.SetEventRecorder(lib.AKOGatewayEventComponent, KubeClient, true)
+	akoControlConfig.SetEventRecorder(lib.AKOGatewayEventComponent, akogatewayapitests.KubeClient, true)
 	registeredInformers := []string{
 		utils.ServiceInformer,
 		utils.EndpointInformer,
@@ -96,21 +99,21 @@ func TestMain(m *testing.M) {
 		utils.NSInformer,
 	}
 	args := make(map[string]interface{})
-	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers, args)
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: akogatewayapitests.KubeClient}, registeredInformers, args)
+	akoApi := integrationtest.InitializeFakeAKOAPIServer()
+	defer akoApi.ShutDown()
 
-	integrationtest.InitializeFakeAKOAPIServer()
 	defer integrationtest.AviFakeClientInstance.Close()
-
-	ctrl = akogatewayapik8s.SharedGatewayController()
-	ctrl.InitGatewayAPIInformers(GatewayClient)
-
+	ctrl := akogatewayapik8s.SharedGatewayController()
+	ctrl.InitGatewayAPIInformers(akogatewayapitests.GatewayClient)
+	akoControlConfig.SetGatewayAPIClientset(akogatewayapitests.GatewayClient)
 	stopCh := utils.SetupSignalHandler()
 	ctrl.Start(stopCh)
 	keyChan = make(chan string)
 
 	ctrl.DisableSync = false
 
-	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: KubeClient})
+	ctrl.SetupEventHandlers(k8s.K8sinformers{Cs: akogatewayapitests.KubeClient})
 	numWorkers := uint32(1)
 	ctrl.SetupGatewayApiEventHandlers(numWorkers)
 	setupQueue(stopCh)
@@ -130,12 +133,12 @@ func TestGatewayCUD(t *testing.T) {
 		Spec:   gatewayv1beta1.GatewaySpec{},
 		Status: gatewayv1beta1.GatewayStatus{},
 	}
-	tests.SetGatewayGatewayClass(&gateway, "gw-class-example")
-	tests.AddGatewayListener(&gateway, "listener-example", 80, gatewayv1beta1.HTTPProtocolType, false)
-	tests.SetListenerHostname(&gateway.Spec.Listeners[0], "foo.example.com")
+	akogatewayapitests.SetGatewayGatewayClass(&gateway, "gw-class-example")
+	akogatewayapitests.AddGatewayListener(&gateway, "listener-example", 80, gatewayv1beta1.HTTPProtocolType, false)
+	akogatewayapitests.SetListenerHostname(&gateway.Spec.Listeners[0], "foo.example.com")
 
 	//create
-	gw, err := GatewayClient.GatewayV1beta1().Gateways("default").Create(context.TODO(), &gateway, metav1.CreateOptions{})
+	gw, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways("default").Create(context.TODO(), &gateway, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't create, err: %+v", err)
 	}
@@ -143,8 +146,8 @@ func TestGatewayCUD(t *testing.T) {
 	waitAndverify(t, "Gateway/default/gw-example")
 
 	//update
-	tests.SetGatewayGatewayClass(&gateway, "gw-class-new")
-	gw, err = GatewayClient.GatewayV1beta1().Gateways("default").Update(context.TODO(), &gateway, metav1.UpdateOptions{})
+	akogatewayapitests.SetGatewayGatewayClass(&gateway, "gw-class-new")
+	gw, err = akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways("default").Update(context.TODO(), &gateway, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't update, err: %+v", err)
 	}
@@ -152,7 +155,7 @@ func TestGatewayCUD(t *testing.T) {
 	waitAndverify(t, "Gateway/default/gw-example")
 
 	//delete
-	err = GatewayClient.GatewayV1beta1().Gateways("default").Delete(context.TODO(), gateway.Name, metav1.DeleteOptions{})
+	err = akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways("default").Delete(context.TODO(), gateway.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't delete, err: %+v", err)
 	}
@@ -160,7 +163,7 @@ func TestGatewayCUD(t *testing.T) {
 	waitAndverify(t, "Gateway/default/gw-example")
 }
 
-func TestGatewaClassyCUD(t *testing.T) {
+func TestGatewayClassCUD(t *testing.T) {
 	gatewayClass := gatewayv1beta1.GatewayClass{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "gateway.networking.k8s.io/v1beta1",
@@ -176,7 +179,7 @@ func TestGatewaClassyCUD(t *testing.T) {
 	}
 
 	//create
-	gw, err := GatewayClient.GatewayV1beta1().GatewayClasses().Create(context.TODO(), &gatewayClass, metav1.CreateOptions{})
+	gw, err := akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Create(context.TODO(), &gatewayClass, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't create, err: %+v", err)
 	}
@@ -186,7 +189,7 @@ func TestGatewaClassyCUD(t *testing.T) {
 	//update
 	testDesc := "test description for update"
 	gatewayClass.Spec.Description = &testDesc
-	gw, err = GatewayClient.GatewayV1beta1().GatewayClasses().Update(context.TODO(), &gatewayClass, metav1.UpdateOptions{})
+	gw, err = akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Update(context.TODO(), &gatewayClass, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't update gatewayClass, err: %+v", err)
 	}
@@ -194,10 +197,44 @@ func TestGatewaClassyCUD(t *testing.T) {
 	waitAndverify(t, "GatewayClass/gw-class-example")
 
 	//delete
-	err = GatewayClient.GatewayV1beta1().GatewayClasses().Delete(context.TODO(), gatewayClass.Name, metav1.DeleteOptions{})
+	err = akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Delete(context.TODO(), gatewayClass.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't delete, err: %+v", err)
 	}
 	t.Logf("Deleted %+v", gw.Name)
 	waitAndverify(t, "GatewayClass/gw-class-example")
+}
+
+func TestHTTPRouteCUD(t *testing.T) {
+	gatewayClassName := "gateway-class-01"
+	gatewayName := "gateway-01"
+	httpRouteName := "httproute-01"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+	key := "HTTPRoute" + "/" + namespace + "/" + httpRouteName
+	akogatewayapiobjects.GatewayApiLister().UpdateGatewayClass(gatewayClassName, true)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	t.Logf("Created GatewayClass %s", gatewayClassName)
+	waitAndverify(t, "GatewayClass/gateway-class-01")
+
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+	t.Logf("Created GatewayClass %s", gatewayClassName)
+	waitAndverify(t, "Gateway/default/gateway-01")
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+	waitAndverify(t, key)
+
+	// update
+	hostnames = []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+	waitAndverify(t, key)
+
+	// delete
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	waitAndverify(t, key)
 }

--- a/ako-gateway-api/tests/status/gateway_test.go
+++ b/ako-gateway-api/tests/status/gateway_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 	os.Setenv("SEG_NAME", "Default-Group")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 
+	utils.AviLog.SetLevel("DEBUG")
 	// Set the user with prefix
 	_ = lib.AKOControlConfig()
 	lib.SetAKOUser(akogatewayapilib.Prefix)
@@ -91,7 +92,6 @@ func TestMain(m *testing.M) {
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
-	ctrl.Start(stopCh)
 
 	waitGroupMap := make(map[string]*sync.WaitGroup)
 	wgIngestion := &sync.WaitGroup{}

--- a/ako-gateway-api/tests/status/httproute_test.go
+++ b/ako-gateway-api/tests/status/httproute_test.go
@@ -1,0 +1,666 @@
+/*
+ * Copyright 2023-2024 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapitests "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests"
+)
+
+/* Positive test cases
+ * - HTTPRoute with valid configurations (both parent reference and hostnames)
+ * - HTTPRoute with valid rules (TODO: end-to-end code is required to check this)
+ * - HTTPRoute update with new parent reference (adding one more parent reference)
+ */
+func TestHTTPRouteWithValidConfig(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-01"
+	gatewayName := "gateway-hr-01"
+	httpRouteName := "httproute-01"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.FindStatusCondition(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.FindStatusCondition(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil &&
+			apimeta.FindStatusCondition(httpRoute.Status.Parents[1].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := make(map[string][]metav1.Condition)
+
+	for _, port := range ports {
+		conditions := make([]metav1.Condition, 0, 1)
+		condition := metav1.Condition{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonAccepted),
+			Status:  metav1.ConditionTrue,
+			Message: "Parent reference is valid",
+		}
+		conditions = append(conditions, condition)
+		conditionMap[fmt.Sprintf("%s-%d", gatewayName, port)] = conditions
+	}
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteWithAtleastOneParentReferenceValid(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-02"
+	gatewayName := "gateway-hr-02"
+	httpRouteName := "httproute-02"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8080 and 8082
+	listeners := akogatewayapitests.GetListenersV1Beta1([]int32{8080, 8082})
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates a httproute with parent which has listeners 8080, 8081
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) &&
+			apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[1].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := make(map[string][]metav1.Condition)
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8080)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonAccepted),
+			Status:  metav1.ConditionTrue,
+			Message: "Parent reference is valid",
+		},
+	}
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8081)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+			Status:  metav1.ConditionFalse,
+			Message: "Invalid listener name provided",
+		},
+	}
+
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+/* Transition test cases
+ * - HTTPRoute transition from invalid to valid
+ * - HTTPRoute transition from valid to invalid
+ */
+func TestHTTPRouteTransitionFromInvalidToValid(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-03"
+	gatewayName := "gateway-hr-03"
+	httpRouteName := "httproute-03"
+	namespace := "default"
+	ports := []int32{8080}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8080
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates an invalid httproute with parent which has listeners 8081
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, []int32{8081})
+	hostnames := []gatewayv1beta1.Hostname{"foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := make(map[string][]metav1.Condition)
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8081)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+			Status:  metav1.ConditionFalse,
+			Message: "Invalid listener name provided",
+		},
+	}
+
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, []int32{8081}, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	// update the httproute with valid configuration
+	parentRefs = akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames = []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8080)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonAccepted),
+			Status:  metav1.ConditionTrue,
+			Message: "Parent reference is valid",
+		},
+	}
+	expectedRouteStatus = akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+	httpRoute, err = akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteTransitionFromValidToInvalid(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-04"
+	gatewayName := "gateway-hr-04"
+	httpRouteName := "httproute-04"
+	namespace := "default"
+	ports := []int32{8080}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8080
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.FindStatusCondition(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates an invalid httproute with parent which has listeners 8080
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := make(map[string][]metav1.Condition)
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8081)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonAccepted),
+			Status:  metav1.ConditionTrue,
+			Message: "Parent reference is valid",
+		},
+	}
+
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	parentRefs = akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, []int32{8081})
+	hostnames = []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap[fmt.Sprintf("%s-%d", gatewayName, 8081)] = []metav1.Condition{
+		{
+			Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+			Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+			Status:  metav1.ConditionFalse,
+			Message: "Invalid listener name provided",
+		},
+	}
+	expectedRouteStatus = akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, []int32{8081}, conditionMap)
+	httpRoute, err = akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+/* Negative test cases
+ * - HTTPRoute with no parent reference
+ * - HTTPRoute with all parent reference invalid
+ * - HTTPRoute with non existing gateway reference
+ * - HTTPRoute with non existing listener reference
+ * - HTTPRoute with non AKO gateway controller reference (TODO: transition case need to be taken care)
+ * - HTTPRoute with no hostnames
+ */
+func TestHTTPRouteWithNoParentReference(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-05"
+	gatewayName := "gateway-hr-05"
+	httpRouteName := "httproute-05"
+	namespace := "default"
+	ports := []int32{8080}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8080
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.FindStatusCondition(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates a httproute with no parent reference which has listeners 8080
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, nil, hostnames, rules)
+
+	time.Sleep(10 * time.Second)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		return len(httpRoute.Status.Parents) == 0
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteWithAllParentReferenceInvalid(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-06"
+	gatewayName := "gateway-hr-06"
+	httpRouteName := "httproute-06"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8082 and 8083
+	listeners := akogatewayapitests.GetListenersV1Beta1([]int32{8082, 8083})
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates a httproute with parent which has listeners 8080, 8081
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) &&
+			apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[1].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := map[string][]metav1.Condition{
+		fmt.Sprintf("%s-%d", gatewayName, 8080): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Invalid listener name provided",
+			},
+		},
+		fmt.Sprintf("%s-%d", gatewayName, 8081): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Invalid listener name provided",
+			},
+		},
+	}
+
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteWithNonExistingGatewayReference(t *testing.T) {
+	gatewayName := "gateway-hr-07"
+	httpRouteName := "httproute-07"
+	namespace := "default"
+	ports := []int32{8080}
+
+	// creates a httproute with no parent reference which has listeners 8080
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	time.Sleep(10 * time.Second)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		return len(httpRoute.Status.Parents) == 0
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+}
+
+func TestHTTPRouteWithNonExistingListenerReference(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-08"
+	gatewayName := "gateway-hr-08"
+	httpRouteName := "httproute-08"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	// creates a gateway with listeners 8082 and 8083
+	listeners := akogatewayapitests.GetListenersV1Beta1([]int32{8082})
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	// creates a httproute with parent which has listeners 8080, 8081
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) &&
+			apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[1].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := map[string][]metav1.Condition{
+		fmt.Sprintf("%s-%d", gatewayName, 8080): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Invalid listener name provided",
+			},
+		},
+		fmt.Sprintf("%s-%d", gatewayName, 8081): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Invalid listener name provided",
+			},
+		},
+	}
+
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteWithNoHostnames(t *testing.T) {
+	gatewayClassName := "gateway-class-hr-10"
+	gatewayName := "gateway-hr-10"
+	httpRouteName := "httproute-10"
+	namespace := "default"
+	ports := []int32{8080, 8081}
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gateway, err := akogatewayapitests.GatewayClient.GatewayV1beta1().Gateways(namespace).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if err != nil || gateway == nil {
+			t.Logf("Couldn't get the gateway, err: %+v", err)
+			return false
+		}
+		return apimeta.FindStatusCondition(gateway.Status.Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) != nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
+	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, nil, rules)
+
+	g.Eventually(func() bool {
+		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+		if err != nil || httpRoute == nil {
+			t.Logf("Couldn't get the HTTPRoute, err: %+v", err)
+			return false
+		}
+		if len(httpRoute.Status.Parents) != len(ports) {
+			return false
+		}
+		return apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[0].Conditions, string(gatewayv1beta1.GatewayConditionAccepted)) &&
+			apimeta.IsStatusConditionFalse(httpRoute.Status.Parents[1].Conditions, string(gatewayv1beta1.GatewayConditionAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	conditionMap := map[string][]metav1.Condition{
+		fmt.Sprintf("%s-%d", gatewayName, 8080): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Hostname in Gateway Listener doesn't match with any of the hostnames in HTTPRoute",
+			},
+		},
+		fmt.Sprintf("%s-%d", gatewayName, 8081): {
+			{
+				Type:    string(gatewayv1beta1.GatewayConditionAccepted),
+				Reason:  string(gatewayv1beta1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "Hostname in Gateway Listener doesn't match with any of the hostnames in HTTPRoute",
+			},
+		},
+	}
+	expectedRouteStatus := akogatewayapitests.GetRouteStatusV1Beta1([]string{gatewayName}, namespace, ports, conditionMap)
+
+	httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
+	if err != nil || httpRoute == nil {
+		t.Fatalf("Couldn't get the HTTPRoute, err: %+v", err)
+	}
+	akogatewayapitests.ValidateHTTPRouteStatus(t, &httpRoute.Status, &gatewayv1beta1.HTTPRouteStatus{RouteStatus: *expectedRouteStatus})
+
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}

--- a/ako-gateway-api/tests/utils.go
+++ b/ako-gateway-api/tests/utils.go
@@ -144,8 +144,9 @@ type Gateway struct {
 func (g *Gateway) GatewayV1Beta1(name, namespace, gatewayClass string, address []gatewayv1beta1.GatewayAddress, listeners []gatewayv1beta1.Listener) *gatewayv1beta1.Gateway {
 	gateway := &gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: time.Now().Local().String(),
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
 			GatewayClassName: gatewayv1beta1.ObjectName(gatewayClass),
@@ -264,8 +265,9 @@ type HTTPRoute struct {
 func (hr *HTTPRoute) HTTPRouteV1Beta1(name, namespace string, parentRefs []gatewayv1beta1.ParentReference, hostnames []gatewayv1beta1.Hostname, rules []gatewayv1beta1.HTTPRouteRule) *gatewayv1beta1.HTTPRoute {
 	httpRoute := &gatewayv1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: time.Now().Local().String(),
 		},
 		Spec: gatewayv1beta1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{


### PR DESCRIPTION
This PR contains the following:
  1. Validation of HTTPRoute objects.
  2. Status layer changes for HTTPRoute objects.
  3. UTs to test the HTTPRoute objects

TODO: FTs

UT results:
```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^(TestHTTPRouteWithValidConfig|TestHTTPRouteWithAtleastOneParentReferenceValid|TestHTTPRouteTransitionFromInvalidToValid|TestHTTPRouteTransitionFromValidToInvalid|TestHTTPRouteWithNoParentReference|TestHTTPRouteWithAllParentReferenceInvalid|TestHTTPRouteWithNonExistingGatewayReference|TestHTTPRouteWithNonExistingListenerReference|TestHTTPRouteWithNonAKOGatewayControllerReference|TestHTTPRouteWithNoHostnames)$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/status

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/status	1.324s
```
