### PR TITLE
AV-183158 : Add AKO image in relatedImages in CSV for AKO Operator 1.10.1 Release

### DIFF
--- a/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
+++ b/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
@@ -587,6 +587,8 @@ spec:
   relatedImages:
   - name: ako-operator
     image: projects.registry.vmware.com/ako/ako-operator@sha256:629c50ebe19c035d292ff5a3c45ccb4482f4b839234891f54087e6e4654b26ee
+  - name: ako
+    image: projects.registry.vmware.com/ako/ako@sha256:7c4f8c84eb5b1216f917ad1183c7e9ae19cd9b58d2a9669d7fb24b70156fc7e3
   keywords:
   - AKO
   - AKO Operator


### PR DESCRIPTION
The pipeline failed with the below error :
```
[digest-pinning : verify-related-images] + '[' true '!=' true ']'
[digest-pinning : verify-related-images] ++ realpath operators/ako-operator/1.10.1
[digest-pinning : verify-related-images] + BUNDLE_PATH=/workspace/source/operators/ako-operator/1.10.1
[digest-pinning : verify-related-images] + cat references.json
[digest-pinning : verify-related-images] ["projects.registry.vmware.com/ako/ako@sha256:7c4f8c84eb5b1216f917ad1183c7e9ae19cd9b58d2a9669d7fb24b70156fc7e3", "projects.registry.vmware.com/ako/ako-operator@sha256:629c50ebe19c035d292ff5a3c45ccb4482f4b839234891f54087e6e4654b26ee"]++ jq length references.json
[digest-pinning : verify-related-images] + REFERENCE_COUNT=2
[digest-pinning : verify-related-images] ++ find /workspace/source/operators/ako-operator/1.10.1 -name '*clusterserviceversion.yaml' -o -name '*clusterserviceversion.yml'
[digest-pinning : verify-related-images] + CSVFILE=/workspace/source/operators/ako-operator/1.10.1/manifests/ako-operator.clusterserviceversion.yaml
[digest-pinning : verify-related-images] ++ yq -e '.spec.relatedImages | length' /workspace/source/operators/ako-operator/1.10.1/manifests/ako-operator.clusterserviceversion.yaml
[digest-pinning : verify-related-images] + RELATED_IMAGE_COUNT=1
[digest-pinning : verify-related-images] + [[ 1 -ge 2 ]]
[digest-pinning : verify-related-images] + echo 'The relatedImages section does not exist or is missing images.'
[digest-pinning : verify-related-images] The relatedImages section does not exist or is missing images.
[digest-pinning : verify-related-images] + tee /tekton/results/related_images_flag
[digest-pinning : verify-related-images] false+ echo -n false
```
The ako image was previously not required to be added in the relatedImages section of the CSV. But now it should be required.