### PR TITLE
AV-184860 : VS and Pools not deleted when multiple ingress use same infrasetting for shard size

### DIFF
--- a/internal/objects/store.go
+++ b/internal/objects/store.go
@@ -142,3 +142,15 @@ func (o *ObjectMapStore) CopyAllObjects() map[string]interface{} {
 	}
 	return CopiedObjMap
 }
+
+func (o *ObjectMapStore) IsInfraSettingMapped(infrasetting string) bool {
+	o.ObjLock.RLock()
+	defer o.ObjLock.RUnlock()
+	for _, v := range o.ObjectMap {
+		vString := v.(string)
+		if infrasetting == vString {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -1558,3 +1558,199 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 	}, 50*time.Second).Should(gomega.Equal(true))
 	TearDownTestForIngress(t, modelName)
 }
+
+func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
+	// add ingress, ingressclass with valid infrasetting,
+	// add ingressclass in ingress, delete ingress
+	g := gomega.NewGomegaWithT(t)
+
+	ingClassName, ns, settingName := "avi-lb", "default", "my-infrasetting"
+	ingressName1, ingressName2 := "foo-with-class", "bar-with-class"
+	modelName := "admin/cluster--Shared-L7-1"
+
+	SetUpTestForIngress(t, modelName)
+
+	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
+	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
+	time.Sleep(5 * time.Second)
+	ingressCreate1 := (integrationtest.FakeIngress{
+		Name:        ingressName1,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"foo.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() int {
+		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
+			if settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS(); len(settingNodes) == 1 {
+				return len(settingNodes[0].PoolRefs)
+			}
+		}
+		return 0
+	}, 40*time.Second).Should(gomega.Equal(1))
+	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
+	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-foo.com_foo-default-foo-with-class"))
+
+	ingressCreate2 := (integrationtest.FakeIngress{
+		Name:        ingressName2,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err = KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() int {
+		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
+			if settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS(); len(settingNodes) == 1 {
+				return len(settingNodes[0].PoolRefs)
+			}
+		}
+		return 0
+	}, 40*time.Second).Should(gomega.Equal(2))
+	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName)
+	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs[1].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-bar-with-class"))
+
+	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(settingModelName)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() int {
+		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
+			if settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS(); len(settingNodes) == 1 {
+				return len(settingNodes[0].PoolRefs)
+			}
+		}
+		return 0
+	}, 40*time.Second).Should(gomega.Equal(1))
+	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName)
+	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-bar-with-class"))
+
+	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	VerifyPoolDeletionFromVsNode(g, settingModelName)
+
+	integrationtest.TeardownAviInfraSetting(t, settingName)
+	TearDownTestForIngress(t, modelName, settingModelName)
+	integrationtest.TeardownIngressClass(t, ingClassName)
+	VerifyPoolDeletionFromVsNode(g, settingModelName)
+}
+
+func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	modelName1 := "admin/cluster--my-infrasetting-foo.com-L7-dedicated"
+	modelName2 := "admin/cluster--my-infrasetting-bar.com-L7-dedicated"
+
+	ingClassName, ns, settingName := "avi-lb", "default", "my-infrasetting"
+	ingressName1, ingressName2 := "foo-with-class", "bar-with-class"
+
+	SetUpTestForIngress(t, modelName1, modelName2)
+	integrationtest.RemoveDefaultIngressClass()
+	defer integrationtest.AddDefaultIngressClass()
+
+	integrationtest.SetupAviInfraSetting(t, settingName, "DEDICATED")
+	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
+	time.Sleep(5 * time.Second)
+
+	ingressCreate1 := (integrationtest.FakeIngress{
+		Name:        ingressName1,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"foo.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate1, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName1)
+		if aviModel == nil {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+
+	ingressCreate2 := (integrationtest.FakeIngress{
+		Name:        ingressName2,
+		Namespace:   ns,
+		ClassName:   ingClassName,
+		DnsNames:    []string{"bar.com"},
+		ServiceName: "avisvc",
+	}).Ingress()
+	_, err = KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName2)
+		if aviModel == nil {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+
+	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+
+	mcache := cache.SharedAviObjCache()
+	vsKey1 := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-foo.com-L7-dedicated"}
+	vsKey2 := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-bar.com-L7-dedicated"}
+	// verify removal of VS.
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey1)
+		return found
+	}, 50*time.Second).Should(gomega.Equal(false))
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey2)
+		return found
+	}, 50*time.Second).Should(gomega.Equal(false))
+
+	integrationtest.TeardownAviInfraSetting(t, settingName)
+	integrationtest.TeardownIngressClass(t, ingClassName)
+	TearDownTestForIngress(t, modelName1, modelName2)
+}


### PR DESCRIPTION
This PR fixes the issue of VS and Pools not getting deleted when multiple ingress use same aviinfrasetting for shard size.
This issue is see when two ingress use the same ingress class and the ingress class refers to an aviinfrasetting object which sets the shard size. The vs and pool creation works fine. But on deleting the first ingress, the shard size to avinfrasetting mapping was also getting deleted even though it should still be in use with the second ingress. So, when the second ingress is deleted, the shard size from avinfrasetting object is not considered and hence wrong model name was calculated leading to failure in deletion.

Fix:
Check the ingress to aviinfasetting mapping in **IngRouteInfraSettingStore**. If no mapping exists, then only delete the shard size to aviinfrasetting mapping in **InfraSettingShardSizeStore**.