### PR TITLE
AV-180357: Limit the Label length as per RFC1035 to 63 chars when AutoFQDN is set as flat 

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -171,6 +171,7 @@ const (
 	FQDN_SVCNAME_PREFIX                        = "s"
 	FQDN_SVCNAMESPACE_PREFIX                   = "n"
 	FQDN_SUBDOMAIN_PREFIX                      = "d"
+	DNS_LABEL_LENGTH                           = 63
 	VCF_NETWORK                                = "vcf-ako-net"
 	VIP_PER_NAMESPACE                          = "VIP_PER_NAMESPACE"
 	PRIMARY_AKO_FLAG                           = "PRIMARY_AKO_FLAG"

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -438,6 +438,7 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 			if err == nil {
 				if extDNS, ok := svcObj.Annotations[lib.ExternalDNSAnnotation]; ok {
 					fqdns = append(fqdns, extDNS)
+					continue
 				}
 			}
 

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -527,26 +527,8 @@ func getAutoFQDNForService(svcNamespace, svcName string) string {
 
 	} else if lib.GetL4FqdnFormat() == lib.AutoFQDNFlat {
 
-		// Limit the length of the label to 63 to follow RFC1035
-		if len(svcName)+len(svcNamespace)+1 > lib.DNS_LABEL_LENGTH {
-			availableSpaceForName := lib.DNS_LABEL_LENGTH - len(svcNamespace) - 1
-			if availableSpaceForName <= 0 {
-				// Length of the namespace is 63, Hence we need to recalculate the
-				// space available for name by shortening the namespace length
-				availableSpaceForNamespace := lib.DNS_LABEL_LENGTH - len(svcName) - 1
-				if availableSpaceForNamespace <= 0 {
-					// length of the name is also 63, Hence we will take
-					// 48 (75%) characters from namespace
-					svcNamespace = svcNamespace[:48]
-				} else {
-					svcNamespace = svcNamespace[:availableSpaceForNamespace]
-				}
-				availableSpaceForName = lib.DNS_LABEL_LENGTH - len(svcNamespace) - 1
-			}
-			if len(svcName) > availableSpaceForName {
-				svcName = svcName[:availableSpaceForName]
-			}
-		}
+		// check and shorten the length of name and namespace to follow RFC 1035.
+		svcName, svcNamespace := lib.CheckAndShortenLabelToFollowRFC1035(svcName, svcNamespace)
 
 		// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
 		fqdn = svcName + "-" + svcNamespace + "." + subdomain

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -70,7 +70,7 @@ func SetUpTestForSvcLBWithExtDNS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	CreateEP(t, NAMESPACE, SHAREDVIPSVC01, false, false, "1.1.1")
+	CreateEP(t, NAMESPACE, EXTDNSSVC, false, false, "1.1.1")
 	PollForCompletion(t, modelSvcDNS01, 5)
 }
 
@@ -1402,4 +1402,226 @@ func TestLBSvcCreationTCPUDP(t *testing.T) {
 	defer ResetMiddleware()
 
 	TearDownTestForSvcLB(t, g)
+}
+
+func TestLBSvcWithAutoFQDNAsFlat(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	svcName := "service-01"
+	svcNamespace := "red-ns"
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcObj := ConstructService(svcNamespace, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	_, err := KubeClient.CoreV1().Services(svcNamespace).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, svcNamespace, svcName, false, false, "1.1.1")
+	PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", svcNamespace, svcName)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(len(svcName) + 1 + len(svcNamespace) + len(".com")))
+
+	DelSVC(t, svcNamespace, svcName)
+	DelEP(t, svcNamespace, svcName)
+	os.Setenv("AUTO_L4_FQDN", "disable")
+}
+
+func TestLBSvcFQDNLengthValidation(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	svcName := "python-flask-consumer-api-poc"
+	svcNamespace := "service-ascend2-bookings-bi-int-dev"
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcObj := ConstructService(svcNamespace, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	_, err := KubeClient.CoreV1().Services(svcNamespace).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, svcNamespace, svcName, false, false, "1.1.1")
+	PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", svcNamespace, svcName)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(63 + len(".com")))
+
+	DelSVC(t, svcNamespace, svcName)
+	DelEP(t, svcNamespace, svcName)
+	os.Setenv("AUTO_L4_FQDN", "disable")
+}
+
+func TestLBSvcWithNameLen63(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	svcName := "service-0123456789012345678901234567890123456789012345678901234"
+	svcNamespace := "red-ns"
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcObj := ConstructService(svcNamespace, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	_, err := KubeClient.CoreV1().Services(svcNamespace).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, svcNamespace, svcName, false, false, "1.1.1")
+	PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", svcNamespace, svcName)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(63 + len(".com")))
+
+	DelSVC(t, svcNamespace, svcName)
+	DelEP(t, svcNamespace, svcName)
+	os.Setenv("AUTO_L4_FQDN", "disable")
+}
+
+func TestLBSvcWithNamespaceNameLen63(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	svcName := "service-01"
+	svcNamespace := "red-ns-01234567890123456789012345678901234567890123456789012345"
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcObj := ConstructService(svcNamespace, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	_, err := KubeClient.CoreV1().Services(svcNamespace).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, svcNamespace, svcName, false, false, "1.1.1")
+	PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", svcNamespace, svcName)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(63 + len(".com")))
+
+	DelSVC(t, svcNamespace, svcName)
+	DelEP(t, svcNamespace, svcName)
+	os.Setenv("AUTO_L4_FQDN", "disable")
+}
+
+func TestLBSvcWithNameLen63AndNamespaceNameLen63(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	svcName := "service-0123456789012345678901234567890123456789012345678901234"
+	svcNamespace := "red-ns-01234567890123456789012345678901234567890123456789012345"
+
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
+	objects.SharedAviGraphLister().Delete(modelName)
+	svcObj := ConstructService(svcNamespace, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	_, err := KubeClient.CoreV1().Services(svcNamespace).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, svcNamespace, svcName, false, false, "1.1.1")
+	PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", svcNamespace, svcName)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(63 + len(".com")))
+
+	DelSVC(t, svcNamespace, svcName)
+	DelEP(t, svcNamespace, svcName)
+	os.Setenv("AUTO_L4_FQDN", "disable")
+}
+
+func TestLBSvcWithExtDNSAndAutoFQDNAsFlat(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "flat")
+
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForSvcLBWithExtDNS(t)
+
+	modelName := "admin/cluster--red-ns-" + EXTDNSSVC
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].ServiceMetadata.HostNames[0]).To(gomega.Equal(EXTDNSANNOTATION))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.Equal(EXTDNSANNOTATION))
+
+	// remove the external-dns annotation and verfiy the auto-generated fqdn
+	svcExample := (FakeService{
+		Name:         EXTDNSSVC,
+		Namespace:    NAMESPACE,
+		Type:         corev1.ServiceTypeLoadBalancer,
+		ServicePorts: []Serviceport{{PortName: "foo1", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
+	}).Service()
+	svcExample.ResourceVersion = "2"
+	_, err := KubeClient.CoreV1().Services(NAMESPACE).Update(context.TODO(), svcExample, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return g.Expect(nodes).To(gomega.HaveLen(1)) &&
+			g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1)) &&
+			g.Expect(nodes[0].ServiceMetadata.HostNames[0]).NotTo(gomega.Equal(EXTDNSANNOTATION)) &&
+			g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).NotTo(gomega.Equal(EXTDNSANNOTATION)) &&
+			g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.Equal(EXTDNSSVC+"-"+NAMESPACE+".com"))
+	}, 30*time.Second).Should(gomega.BeTrue())
+
+	TearDownTestForSvcLBWithExtDNS(t, g)
+	os.Setenv("AUTO_L4_FQDN", "disable")
 }

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -1548,7 +1548,7 @@ func TestLBSvcWithNameLen63AndNamespaceNameLen63(t *testing.T) {
 	os.Setenv("AUTO_L4_FQDN", "flat")
 
 	svcName := "service-0123456789012345678901234567890123456789012345678901234"
-	svcNamespace := "red-ns-01234567890123456789012345678901234567890123456789012345"
+	svcNamespace := "red-ns-012345678901234567890123456789012345-----01234567890123"
 
 	g := gomega.NewGomegaWithT(t)
 	modelName := "admin/cluster--" + svcNamespace + "-" + svcName
@@ -1573,6 +1573,7 @@ func TestLBSvcWithNameLen63AndNamespaceNameLen63(t *testing.T) {
 	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
 	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
 	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveLen(63 + len(".com")))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.HaveSuffix("red-ns-012345678901234567890123456789012345.com"))
 
 	DelSVC(t, svcNamespace, svcName)
 	DelEP(t, svcNamespace, svcName)

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -69,7 +69,7 @@ const (
 	SHAREDVIPKEY        = "shared-vip-key"
 	SHAREDVIPSVC01      = "shared-vip-svc-01"
 	SHAREDVIPSVC02      = "shared-vip-svc-02"
-	EXTDNSANNOTATION    = "custom-fqdn"
+	EXTDNSANNOTATION    = "custom-fqdn.com"
 	EXTDNSSVC           = "custom-fqdn-svc"
 )
 


### PR DESCRIPTION
This PR adds the following:
1. logic to reduce the length of the label created by the AKO when the AutoFQDN is set as flat for service of Type LB.
2. Consider only the fqdn in the `external-dns.alpha.kubernetes.io/hostname` when configured with AutoFQDN as flat or default for Service of type LB and shared VIP LB service.
3. UTs to test various scenarios.

**Logic:** https://confluence.eng.vmware.com/display/~swathins/Bug%3A+AV-180357

**Relevant part of RFC 1035:**
```
The labels must follow the rules for ARPANET host names.  They must
start with a letter, end with a letter or digit, and have as interior
characters only letters, digits, and hyphen.  There are also some
restrictions on the length.  Labels must be 63 characters or less.
```

**UT:**
```
go test -timeout 1000s -run ^(TestAviSvcCreationSinglePort|TestAviSvcCreationSinglePortMultiTenantEnabled|TestAviSvcCreationMultiPort|TestL4NamingConvention|TestAviSvcMultiPortApplicationProf|TestAviSvcUpdateEndpoint|TestCreateServiceLBCacheSync|TestCreateServiceLBWithFaultCacheSync|TestCreateMultiportServiceLBCacheSync|TestUpdateAndDeleteServiceLBCacheSync|TestScaleUpAndDownServiceLBCacheSync|TestAviSvcCreationWithStaticIP|TestWithInfraSettingStatusUpdates|TestInfraSettingDelete|TestInfraSettingChangeMapping|TestSharedVIPSvcWithTCPUDPProtocols|TestSharedVIPSvcWithTCPSCTProtocols|TestSharedVIPSvcWithUDPSCTProtocols|TestSvcExternalDNSWithSharedVIP|TestSvcExtDNSAddition|TestLBSvcCreationMixedProtocol|TestLBSvcCreationSCTPTCP|TestLBSvcCreationSCTPUDP|TestLBSvcCreationTCPUDP|TestLBSvcWithAutoFQDNAsFlat|TestLBSvcFQDNLengthValidation|TestLBSvcWithNameLen63|TestLBSvcWithNamespaceNameLen63|TestLBSvcWithNameLen63AndNamespaceNameLen63|TestLBSvcWithExtDNSAndAutoFQDNAsFlat)$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest
```

**FTs:** in-progress