### PR TITLE
AV-180357: Add Hostname from external-dns annotation only when AutoFQDN is flat or default

### DIFF
--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -47,6 +47,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	}
 
 	if extDNS, ok := svcObj.Annotations[lib.ExternalDNSAnnotation]; ok && autoFQDN {
+		autoFQDN = false
 		fqdns = append(fqdns, extDNS)
 	}
 

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -61,6 +61,32 @@ func TearDownTestForSvcLB(t *testing.T, g *gomega.GomegaWithT) {
 	}, 5*time.Second).Should(gomega.Equal(false))
 }
 
+func SetUpTestForSvcLBWithExtDNS(t *testing.T) {
+	modelSvcDNS01 := "admin/cluster--red-ns-" + EXTDNSSVC
+	objects.SharedAviGraphLister().Delete(modelSvcDNS01)
+	svcObj := ConstructService(NAMESPACE, EXTDNSSVC, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, make(map[string]string))
+	svcObj.Annotations = map[string]string{lib.ExternalDNSAnnotation: EXTDNSANNOTATION}
+	_, err := KubeClient.CoreV1().Services(NAMESPACE).Create(context.TODO(), svcObj, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	CreateEP(t, NAMESPACE, SHAREDVIPSVC01, false, false, "1.1.1")
+	PollForCompletion(t, modelSvcDNS01, 5)
+}
+
+func TearDownTestForSvcLBWithExtDNS(t *testing.T, g *gomega.GomegaWithT) {
+	modelSvcDNS01 := "admin/cluster--red-ns-" + EXTDNSSVC
+	objects.SharedAviGraphLister().Delete(modelSvcDNS01)
+	DelSVC(t, NAMESPACE, EXTDNSSVC)
+	DelEP(t, NAMESPACE, EXTDNSSVC)
+	mcache := cache.SharedAviObjCache()
+	vsKey := cache.NamespaceName{Namespace: AVINAMESPACE, Name: fmt.Sprintf("cluster--%s-%s", NAMESPACE, EXTDNSSVC)}
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
+		return found
+	}, 5*time.Second).Should(gomega.Equal(false))
+}
+
 func SetUpTestForSvcLBMultiport(t *testing.T) {
 	objects.SharedAviGraphLister().Delete(MULTIPORTMODEL)
 	CreateSVC(t, NAMESPACE, MULTIPORTSVC, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, true)
@@ -1083,6 +1109,30 @@ func TestSharedVIPSvcWithUDPSCTProtocols(t *testing.T) {
 	g.Expect(nodes).To(gomega.HaveLen(1))
 	VerfiyL4Node(nodes[0], g, "SCTP", "UDP")
 	TearDownTestForSharedVIPSvcLB(t, g)
+}
+
+// this test checks if extDNS FQDN is being set properly
+func TestSvcExtDNSAddition(t *testing.T) {
+	os.Setenv("AUTO_L4_FQDN", "default")
+
+	g := gomega.NewGomegaWithT(t)
+	SetUpTestForSvcLBWithExtDNS(t)
+
+	modelSvcDNS01 := "admin/cluster--red-ns-" + EXTDNSSVC
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelSvcDNS01)
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelSvcDNS01)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].ServiceMetadata.HostNames[0]).To(gomega.Equal(EXTDNSANNOTATION))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].VSVIPRefs[0].FQDNs[0]).To(gomega.Equal(EXTDNSANNOTATION))
+	os.Setenv("AUTO_L4_FQDN", "disable")
+	TearDownTestForSvcLBWithExtDNS(t, g)
 }
 
 func TestLBSvcCreationMixedProtocol(t *testing.T) {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -69,6 +69,8 @@ const (
 	SHAREDVIPKEY        = "shared-vip-key"
 	SHAREDVIPSVC01      = "shared-vip-svc-01"
 	SHAREDVIPSVC02      = "shared-vip-svc-02"
+	EXTDNSANNOTATION    = "custom-fqdn.com"
+	EXTDNSSVC           = "custom-fqdn-svc"
 )
 
 var KubeClient *k8sfake.Clientset


### PR DESCRIPTION
This PR adds the following:
1. Add Hostname from `external-dns.alpha.kubernetes.io/hostname` only to the VSVIP and won't add any auto-generated FQDN.
2. UTs to check the number of FQDNs added to the VSVIP.

**Result:**
```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^TestSvcExtDNSAddition$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest
```