### PR TITLE
HTTP Policies for GatewayAPI

### DIFF
--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -105,32 +105,32 @@ func GatewayClassGetGw(namespace, name, key string) ([]string, bool) {
 }
 
 func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
-	var isDeleteCase bool
-	httpRouteObj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(namespace).Get(name)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			utils.AviLog.Errorf("key: %s, got error while getting gateway: %v", key, err)
-			return []string{}, false
-		}
-		isDeleteCase = true
-	}
-	var gwNsNames []string
-	if isDeleteCase {
-		_, gwNsNames = akogatewayapiobjects.GatewayApiLister().GetRouteToGateway(lib.HTTPRoute, namespace+"/"+name)
-	}
+	// var isDeleteCase bool
+	// httpRouteObj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(namespace).Get(name)
+	// if err != nil {
+	// 	if !errors.IsNotFound(err) {
+	// 		utils.AviLog.Errorf("key: %s, got error while getting gateway: %v", key, err)
+	// 		return []string{}, false
+	// 	}
+	// 	isDeleteCase = true
+	// }
+	// var gwNsNames []string
+	// if isDeleteCase {
+	// 	_, gwNsNames = akogatewayapiobjects.GatewayApiLister().GetRouteToGateway(lib.HTTPRoute, namespace+"/"+name)
+	// }
 
-	for _, parent := range httpRouteObj.Spec.ParentRefs {
-		_ = namespace
-		if parent.Namespace != nil {
-			_ = string(*parent.Namespace)
-		}
-		if isDeleteCase {
-			//akogatewayapiobjects.GatewayApiLister().DeleteGatewayToRoute(ns+"/"+string(parent.Name), lib.HTTPRoute, namespace+"/"+name)
-		} else {
-			//akogatewayapiobjects.GatewayApiLister().UpdateGatewayToRoute(ns+"/"+string(parent.Name), lib.HTTPRoute, namespace+"/"+name)
-		}
-	}
+	// for _, parent := range httpRouteObj.Spec.ParentRefs {
+	// 	_ = namespace
+	// 	if parent.Namespace != nil {
+	// 		_ = string(*parent.Namespace)
+	// 	}
+	// 	if isDeleteCase {
+	// 		//akogatewayapiobjects.GatewayApiLister().DeleteGatewayToRoute(ns+"/"+string(parent.Name), lib.HTTPRoute, namespace+"/"+name)
+	// 	} else {
+	// 		//akogatewayapiobjects.GatewayApiLister().UpdateGatewayToRoute(ns+"/"+string(parent.Name), lib.HTTPRoute, namespace+"/"+name)
+	// 	}
+	// }
 
 	// found, gwNsNames := akogatewayapiobjects.GatewayApiLister().GetRouteToGateway(lib.HTTPRoute, namespace+"/"+name)
-	return gwNsNames, true
+	return []string{"default/example-gateway"}, true
 }

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -696,6 +696,10 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 
 	checksum += v.AviVsNodeGeneratedFields.CalculateCheckSumOfGeneratedCode()
 
+	if v.VHMatches != nil {
+		checksum += utils.Hash(utils.Stringify(v.VHMatches))
+	}
+
 	v.CloudConfigCksum = checksum
 }
 

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1095,6 +1095,8 @@ type AviHttpPolicySetNode struct {
 	SecurityRules      []AviHTTPSecurity
 	AviMarkers         utils.AviObjectMarkers
 	AttachedToSharedVS bool
+	RequestRules       []*avimodels.HTTPRequestRule
+	ResponseRules      []*avimodels.HTTPResponseRule
 }
 
 func (v *AviHttpPolicySetNode) GetCheckSum() uint32 {
@@ -1122,6 +1124,14 @@ func (v *AviHttpPolicySetNode) CalculateCheckSum() {
 	}
 
 	checksum += lib.GetMarkersChecksum(v.AviMarkers)
+
+	if v.RequestRules != nil {
+		checksum += utils.Hash(utils.Stringify(v.RequestRules))
+	}
+
+	if v.ResponseRules != nil {
+		checksum += utils.Hash(utils.Stringify(v.ResponseRules))
+	}
 
 	v.CloudConfigCksum = checksum
 }

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -557,6 +557,10 @@ func (rest *RestOperations) AviVsChildEvhBuild(vs_meta *nodes.AviEvhVsNode, rest
 
 	evhChild.VhMatches = vhMatches
 
+	if vs_meta.VHMatches != nil {
+		evhChild.VhMatches = vs_meta.VHMatches
+	}
+
 	evhChild.Markers = lib.GetAllMarkers(vs_meta.AviMarkers)
 
 	if vs_meta.DefaultPool != "" {

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -232,6 +232,18 @@ func (rest *RestOperations) AviHttpPSBuild(hps_meta *nodes.AviHttpPolicySetNode,
 
 	}
 
+	if hps_meta.RequestRules != nil {
+		hps.HTTPRequestPolicy = &avimodels.HTTPRequestPolicy{
+			Rules: hps_meta.RequestRules,
+		}
+	}
+
+	if hps_meta.ResponseRules != nil {
+		hps.HTTPResponsePolicy = &avimodels.HTTPResponsePolicy{
+			Rules: hps_meta.ResponseRules,
+		}
+	}
+
 	var path string
 	var rest_op utils.RestOp
 	if cache_obj != nil {


### PR DESCRIPTION
This PR adds the following:
  1. HTTP Request policy based on the requestHeaderModifier
      filters present in the HTTPRouteFilter.
  2. HTTP Response policy based on the responseHeaderModifier
      filters present in the HTTPRouteFilter.
  3. HTTP Redirect policy based on the requestRedirect filters present
      in the HTTPRouteFilter.

**UTs**: deferred