### PR TITLE
[GatewayAPI]code to process Service, Endpoint and Route objects

### DIFF
--- a/ako-gateway-api/k8s/ako_init.go
+++ b/ako-gateway-api/k8s/ako_init.go
@@ -226,7 +226,18 @@ func (c *GatewayController) FullSyncK8s(sync bool) error {
 		akogatewayapinodes.DequeueIngestion(key, true)
 	}
 
-	//Gateway Section
+	// GatewayClass Section
+	gwClassObjs, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Lister().List(labels.Set(nil).AsSelector())
+	if err != nil {
+		utils.AviLog.Errorf("Unable to retrieve the gatewayclasses during full sync: %s", err)
+		return err
+	}
+	for _, gwClassObj := range gwClassObjs {
+		key := lib.GatewayClass + "/" + utils.ObjKey(gwClassObj)
+		akogatewayapinodes.DequeueIngestion(key, true)
+	}
+
+	// Gateway Section
 	gatewayObjs, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayInformer.Lister().Gateways(metav1.NamespaceAll).List(labels.Set(nil).AsSelector())
 	if err != nil {
 		utils.AviLog.Errorf("Unable to retrieve the gateways during full sync: %s", err)
@@ -241,16 +252,6 @@ func (c *GatewayController) FullSyncK8s(sync bool) error {
 		key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
 		//TODO
 		//InformerStatusUpdatesForGateway(key, gatewayObj)
-		akogatewayapinodes.DequeueIngestion(key, true)
-	}
-
-	gwClassObjs, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Lister().List(labels.Set(nil).AsSelector())
-	if err != nil {
-		utils.AviLog.Errorf("Unable to retrieve the gatewayclasses during full sync: %s", err)
-		return err
-	}
-	for _, gwClassObj := range gwClassObjs {
-		key := lib.GatewayClass + "/" + utils.ObjKey(gwClassObj)
 		akogatewayapinodes.DequeueIngestion(key, true)
 	}
 

--- a/ako-gateway-api/k8s/gateway_controller.go
+++ b/ako-gateway-api/k8s/gateway_controller.go
@@ -619,8 +619,7 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 }
 
 func IsGatewayUpdated(oldGateway, newGateway *gatewayv1beta1.Gateway) bool {
-	if oldGateway.ResourceVersion != newGateway.ResourceVersion ||
-		newGateway.GetDeletionTimestamp() != nil {
+	if newGateway.GetDeletionTimestamp() != nil {
 		return true
 	}
 	oldHash := utils.Hash(utils.Stringify(oldGateway.Spec))
@@ -629,8 +628,7 @@ func IsGatewayUpdated(oldGateway, newGateway *gatewayv1beta1.Gateway) bool {
 }
 
 func IsHTTPRouteUpdated(oldHTTPRoute, newHTTPRoute *gatewayv1beta1.HTTPRoute) bool {
-	if oldHTTPRoute.ResourceVersion != newHTTPRoute.ResourceVersion ||
-		newHTTPRoute.GetDeletionTimestamp() != nil {
+	if newHTTPRoute.GetDeletionTimestamp() != nil {
 		return true
 	}
 	oldHash := utils.Hash(utils.Stringify(oldHTTPRoute.Spec))

--- a/ako-gateway-api/tests/graphlayer/gateway_test.go
+++ b/ako-gateway-api/tests/graphlayer/gateway_test.go
@@ -57,6 +57,8 @@ func TestMain(m *testing.M) {
 	os.Setenv("SEG_NAME", "Default-Group")
 	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
 	os.Setenv("FULL_SYNC_INTERVAL", utils.AKO_DEFAULT_NS)
+	os.Setenv("ENABLE_EVH", "true")
+	os.Setenv("TENANT", "admin")
 
 	// Set the user with prefix
 	_ = lib.AKOControlConfig()
@@ -94,7 +96,6 @@ func TestMain(m *testing.M) {
 	stopCh := utils.SetupSignalHandler()
 	ctrlCh := make(chan struct{})
 	quickSyncCh := make(chan struct{})
-	ctrl.Start(stopCh)
 
 	waitGroupMap := make(map[string]*sync.WaitGroup)
 	wgIngestion := &sync.WaitGroup{}

--- a/ako-gateway-api/tests/graphlayer/httproute_test.go
+++ b/ako-gateway-api/tests/graphlayer/httproute_test.go
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2023-2024 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package graphlayer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapitests "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests"
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+)
+
+/* Test cases
+ * - HTTPRoute CRUD
+ * - HTTPRouteRule CRUD
+ * - HTTPRouteFilter CRUD
+ * - HTTPRouteFilter with Request Header Modifier
+ * - HTTPRouteFilter with Response Header Modifier
+ * - HTTPRouteFilter with Request Redirect
+ * - HTTPRouteBackendRef CRUD (TODO)
+ */
+func TestHTTPRouteCRUD(t *testing.T) {
+
+	gatewayName := "gateway-hr-01"
+	gatewayClassName := "gateway-class-hr-01"
+	httpRouteName := "http-route-hr-01"
+	ports := []int32{8080}
+	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add", "remove", "replace"}})
+	rules := []gatewayv1beta1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+
+	childNode := nodes[0].EvhNodes[0]
+	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
+	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo-8080.com"))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/foo"))
+	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
+
+	rule = akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add"}})
+	rules = []gatewayv1beta1.HTTPRouteRule{rule}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	childNode = nodes[0].EvhNodes[0]
+	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
+	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo-8080.com"))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/foo"))
+	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+
+	// verifies the child deletion
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return -1
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(0))
+
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteRuleCRUD(t *testing.T) {
+
+	gatewayName := "gateway-hrr-01"
+	gatewayClassName := "gateway-class-hrr-01"
+	httpRouteName := "http-route-hrr-01"
+	ports := []int32{8080}
+	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	ruleWithoutCanary := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add", "remove", "replace"}})
+	ruleWithCanary := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/bar"}, []string{"canary"},
+		map[string][]string{"RequestHeaderModifier": {"add", "remove", "replace"}})
+	rules := []gatewayv1beta1.HTTPRouteRule{ruleWithCanary, ruleWithoutCanary}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(2))
+
+	// update httproute
+	rules = []gatewayv1beta1.HTTPRouteRule{ruleWithCanary}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	// update httproute
+	rules = []gatewayv1beta1.HTTPRouteRule{ruleWithCanary, ruleWithoutCanary}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(2))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteFilterCRUD(t *testing.T) {
+
+	gatewayName := "gateway-hrf-01"
+	gatewayClassName := "gateway-class-hrf-01"
+	httpRouteName := "http-route-hrf-01"
+	ports := []int32{8080}
+	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add"}})
+	rules := []gatewayv1beta1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if len(childVS.HttpPolicyRefs) != 1 {
+			return -1
+		}
+		return len(childVS.HttpPolicyRefs[0].RequestRules)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	childVS := nodes[0].EvhNodes[0]
+
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].Name).To(gomega.Equal(childVS.Name))
+	g.Expect(childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction).To(gomega.HaveLen(1))
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action).To(gomega.Equal("HTTP_ADD_HDR"))
+
+	// update httproute
+	rule = akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"replace"}})
+	rules = []gatewayv1beta1.HTTPRouteRule{rule}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() string {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action == nil {
+			return ""
+		}
+		return *childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action
+	}, 25*time.Second).Should(gomega.Equal("HTTP_REPLACE_HDR"))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteFilterWithRequestHeaderModifier(t *testing.T) {
+
+	gatewayName := "gateway-hrf-02"
+	gatewayClassName := "gateway-class-hrf-02"
+	httpRouteName := "http-route-hrf-02"
+	ports := []int32{8080}
+	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add", "replace", "remove"}})
+	rules := []gatewayv1beta1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if len(childVS.HttpPolicyRefs) != 1 {
+			return -1
+		}
+		return len(childVS.HttpPolicyRefs[0].RequestRules)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	childVS := nodes[0].EvhNodes[0]
+
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].Name).To(gomega.Equal(childVS.Name))
+	g.Expect(childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction).To(gomega.HaveLen(3))
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action).To(gomega.Equal("HTTP_ADD_HDR"))
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[1].Action).To(gomega.Equal("HTTP_REPLACE_HDR"))
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[2].Action).To(gomega.Equal("HTTP_REMOVE_HDR"))
+
+	// update httproute
+	rule = akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"replace", "remove"}})
+	rules = []gatewayv1beta1.HTTPRouteRule{rule}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action == nil ||
+			childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[1].Action == nil {
+			return false
+		}
+		return *childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[0].Action == "HTTP_REPLACE_HDR" &&
+			*childVS.HttpPolicyRefs[0].RequestRules[0].HdrAction[1].Action == "HTTP_REMOVE_HDR"
+	}, 25*time.Second).Should(gomega.BeTrue())
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteFilterWithResponseHeaderModifier(t *testing.T) {
+
+	gatewayName := "gateway-hrf-03"
+	gatewayClassName := "gateway-class-hrf-03"
+	httpRouteName := "http-route-hrf-03"
+	ports := []int32{8080}
+	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"ResponseHeaderModifier": {"add", "replace", "remove"}})
+	rules := []gatewayv1beta1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if len(childVS.HttpPolicyRefs) != 1 {
+			return -1
+		}
+		return len(childVS.HttpPolicyRefs[0].ResponseRules)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	childVS := nodes[0].EvhNodes[0]
+
+	g.Expect(*childVS.HttpPolicyRefs[0].ResponseRules[0].Name).To(gomega.Equal(childVS.Name))
+	g.Expect(childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction).To(gomega.HaveLen(3))
+	g.Expect(*childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[0].Action).To(gomega.Equal("HTTP_ADD_HDR"))
+	g.Expect(*childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[1].Action).To(gomega.Equal("HTTP_REPLACE_HDR"))
+	g.Expect(*childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[2].Action).To(gomega.Equal("HTTP_REMOVE_HDR"))
+
+	// update httproute
+	rule = akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"ResponseHeaderModifier": {"replace", "remove"}})
+	rules = []gatewayv1beta1.HTTPRouteRule{rule}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() bool {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[0].Action == nil ||
+			childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[1].Action == nil {
+			return false
+		}
+		return *childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[0].Action == "HTTP_REPLACE_HDR" &&
+			*childVS.HttpPolicyRefs[0].ResponseRules[0].HdrAction[1].Action == "HTTP_REMOVE_HDR"
+	}, 25*time.Second).Should(gomega.BeTrue())
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestHTTPRouteFilterWithRequestRedirect(t *testing.T) {
+
+	gatewayName := "gateway-hrf-04"
+	gatewayClassName := "gateway-class-hrf-04"
+	httpRouteName := "http-route-hrf-04"
+	ports := []int32{8080}
+	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1Beta1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestRedirect": {}})
+	rules := []gatewayv1beta1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		if len(childVS.HttpPolicyRefs) != 1 {
+			return -1
+		}
+		return len(childVS.HttpPolicyRefs[0].RequestRules)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+	childVS := nodes[0].EvhNodes[0]
+
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].Name).To(gomega.Equal(childVS.Name))
+	g.Expect(childVS.HttpPolicyRefs[0].RequestRules[0].RedirectAction).ShouldNot(gomega.BeNil())
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].RedirectAction.Host.Tokens[0].StrValue).To(gomega.Equal("redirect.com"))
+	g.Expect(*childVS.HttpPolicyRefs[0].RequestRules[0].RedirectAction.StatusCode).To(gomega.Equal("HTTP_REDIRECT_STATUS_CODE_302"))
+
+	// update httproute
+	rule = akogatewayapitests.GetHTTPRouteRuleV1Beta1([]string{"/foo"}, []string{},
+		map[string][]string{})
+	rules = []gatewayv1beta1.HTTPRouteRule{rule}
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		childVS := nodes[0].EvhNodes[0]
+		return len(childVS.HttpPolicyRefs)
+	}, 25*time.Second).Should(gomega.Equal(0))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}

--- a/ako-gateway-api/tests/status/httproute_test.go
+++ b/ako-gateway-api/tests/status/httproute_test.go
@@ -58,8 +58,8 @@ func TestHTTPRouteWithValidConfig(t *testing.T) {
 
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -126,8 +126,8 @@ func TestHTTPRouteWithAtleastOneParentReferenceValid(t *testing.T) {
 	// creates a httproute with parent which has listeners 8080, 8081
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -203,8 +203,8 @@ func TestHTTPRouteTransitionFromInvalidToValid(t *testing.T) {
 	// creates an invalid httproute with parent which has listeners 8081
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, []int32{8081})
 	hostnames := []gatewayv1beta1.Hostname{"foo-8081.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -239,7 +239,7 @@ func TestHTTPRouteTransitionFromInvalidToValid(t *testing.T) {
 	// update the httproute with valid configuration
 	parentRefs = akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames = []gatewayv1beta1.Hostname{"foo-8080.com"}
-	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -299,8 +299,8 @@ func TestHTTPRouteTransitionFromValidToInvalid(t *testing.T) {
 	// creates an invalid httproute with parent which has listeners 8080
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -334,7 +334,7 @@ func TestHTTPRouteTransitionFromValidToInvalid(t *testing.T) {
 
 	parentRefs = akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, []int32{8081})
 	hostnames = []gatewayv1beta1.Hostname{"foo-8080.com"}
-	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+	akogatewayapitests.UpdateHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -401,8 +401,8 @@ func TestHTTPRouteWithNoParentReference(t *testing.T) {
 
 	// creates a httproute with no parent reference which has listeners 8080
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, nil, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, nil, hostnames, nil)
 
 	time.Sleep(10 * time.Second)
 
@@ -446,8 +446,8 @@ func TestHTTPRouteWithAllParentReferenceInvalid(t *testing.T) {
 	// creates a httproute with parent which has listeners 8080, 8081
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -503,8 +503,8 @@ func TestHTTPRouteWithNonExistingGatewayReference(t *testing.T) {
 	// creates a httproute with no parent reference which has listeners 8080
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	time.Sleep(10 * time.Second)
 
@@ -547,8 +547,8 @@ func TestHTTPRouteWithNonExistingListenerReference(t *testing.T) {
 	// creates a httproute with parent which has listeners 8080, 8081
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
 	hostnames := []gatewayv1beta1.Hostname{"foo-8080.com", "foo-8081.com"}
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, hostnames, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})
@@ -618,8 +618,8 @@ func TestHTTPRouteWithNoHostnames(t *testing.T) {
 	}, 30*time.Second).Should(gomega.Equal(true))
 
 	parentRefs := akogatewayapitests.GetParentReferencesV1Beta1([]string{gatewayName}, namespace, ports)
-	rules := akogatewayapitests.GetHTTPRouteRulesV1Beta1()
-	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, nil, rules)
+
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, namespace, parentRefs, nil, nil)
 
 	g.Eventually(func() bool {
 		httpRoute, err := akogatewayapitests.GatewayClient.GatewayV1beta1().HTTPRoutes(namespace).Get(context.TODO(), httpRouteName, metav1.GetOptions{})


### PR DESCRIPTION
This PR contains the following:
  1. Logic to figure out the Parent and child model for all the
         objects pushed to the Graph layer.
  2. Child VS deletion logic
  3. Logic to delete stale child VSes
  4. UTs to test the HTTPRoute, HTTPRouteRule, HTTPRouteFilter CRUD.
  5. UTs to test HTTPRouteFilter of type RequestHeaderModifier,
         ResponseHeaderModifier and RequestRedirect

**UT Results**:

```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^(TestHTTPRouteCRUD|TestHTTPRouteRuleCRUD|TestHTTPRouteFilterCRUD|TestHTTPRouteFilterWithRequestHeaderModifier|TestHTTPRouteFilterWithResponseHeaderModifier|TestHTTPRouteFilterWithRequestRedirect)$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/graphlayer

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/graphlayer	60.834
```