### PR TITLE
[GatewayAPI]Code to process objects during fullsync and bug fixes

### DIFF
--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -189,9 +189,11 @@ func (o *AviObjectGraph) BuildVHMatch(key string, vsNode *nodes.AviEvhVsNode, ro
 			// header match
 			rule.Matches.Hdrs = make([]*models.HdrMatch, 0, len(match.HeaderMatch))
 			for _, headerMatch := range match.HeaderMatch {
+				headerName := headerMatch.Name
 				hdrMatch := &models.HdrMatch{
 					MatchCase:     proto.String("SENSITIVE"),
 					MatchCriteria: proto.String("HDR_EQUALS"),
+					Hdr:           &headerName,
 					Value:         []string{headerMatch.Value},
 				}
 				rule.Matches.Hdrs = append(rule.Matches.Hdrs, hdrMatch)

--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -141,7 +141,7 @@ func BuildVsVipNodeForGateway(gateway *gatewayv1beta1.Gateway, vsName string) *n
 		Name:        lib.GetVsVipName(vsName),
 		Tenant:      lib.GetTenant(),
 		VrfContext:  lib.GetVrf(),
-		VipNetworks: lib.GetVipNetworkList(),
+		VipNetworks: utils.GetVipNetworkList(),
 	}
 
 	//Type is validated at ingestion

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -71,7 +71,7 @@ var (
 		GetRoutes:   ServiceToRoutes,
 	}
 	Endpoint = GraphSchema{
-		Type:        "Endpoint",
+		Type:        "Endpoints",
 		GetGateways: EndpointToGateways,
 		GetRoutes:   EndpointToRoutes,
 	}

--- a/ako-gateway-api/objects/gateway_store.go
+++ b/ako-gateway-api/objects/gateway_store.go
@@ -503,7 +503,7 @@ func (g *GWLister) DeleteRouteServiceMappings(routeTypeNsName string) {
 		if found, obj := g.serviceToRoute.Get(svcNsName); found {
 			routeTypeNsNameList := obj.([]string)
 			routeTypeNsNameList = utils.Remove(routeTypeNsNameList, routeTypeNsName)
-			g.gatewayToRoute.AddOrUpdate(svcNsName, routeTypeNsNameList)
+			g.serviceToRoute.AddOrUpdate(svcNsName, routeTypeNsNameList)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the following changes:

  1. Code to process HTTPRoute objects during bootup.
  2. Optimization to process the GatewayAPI objects once during bootup.
  3. Get the object from DeltaFIFO if the delete event is missed.
  4. Bug fixes.