### PR TITLE
AV-187992: NodePort Implementation for GatewayAPI

### DIFF
--- a/cmd/gateway-api/main.go
+++ b/cmd/gateway-api/main.go
@@ -151,6 +151,8 @@ func Initialize() {
 	wgStatus := &sync.WaitGroup{}
 	waitGroupMap["status"] = wgStatus
 
+	k8s.PopulateNodeCache(kubeClient)
+
 	go c.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
 
 	<-stopCh


### PR DESCRIPTION
This PR adds the logic to populate the pool servers in NodePort deployments.

**Test scenario:**
Manually updated the `serviceType` to `NodePort` and verified the pool servers populated from the controller GUI. 