### PR TITLE
AV-187995: GatewayClass status layer changes

### DIFF
--- a/ako-gateway-api/k8s/ako_init.go
+++ b/ako-gateway-api/k8s/ako_init.go
@@ -226,11 +226,9 @@ func (c *GatewayController) FullSyncK8s(sync bool) error {
 			resVer := meta.GetResourceVersion()
 			objects.SharedResourceVerInstanceLister().Save(key, resVer)
 		}
-		controllerName := string(gwClassObj.Spec.ControllerName)
-		if !akogatewayapilib.CheckGatewayClassController(controllerName) {
-			continue
+		if IsGatewayClassValid(key, gwClassObj) {
+			akogatewayapinodes.DequeueIngestion(key, true)
 		}
-		akogatewayapinodes.DequeueIngestion(key, true)
 	}
 
 	// Gateway Section

--- a/ako-gateway-api/k8s/gateway_controller.go
+++ b/ako-gateway-api/k8s/gateway_controller.go
@@ -180,7 +180,7 @@ func (c *GatewayController) SetupEventHandlers(k8sinfo k8s.K8sinformers) {
 			key := utils.Service + "/" + utils.ObjKey(svc)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == svc.ResourceVersion {
-				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
+				utils.AviLog.Debugf("key: %s, msg: same resource version returning", key)
 				return
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(svc))
@@ -449,7 +449,7 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 			key := lib.Gateway + "/" + utils.ObjKey(gw)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == gw.ResourceVersion {
-				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
+				utils.AviLog.Debugf("key: %s, msg: same resource version returning", key)
 				return
 			}
 			if !IsValidGateway(key, gw) {
@@ -511,14 +511,13 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 				return
 			}
 			gwClass := obj.(*gatewayv1beta1.GatewayClass)
-			controllerName := string(gwClass.Spec.ControllerName)
-			if !akogatewayapilib.CheckGatewayClassController(controllerName) {
-				return
-			}
 			key := lib.GatewayClass + "/" + utils.ObjKey(gwClass)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == gwClass.ResourceVersion {
-				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
+				utils.AviLog.Debugf("key: %s, msg: same resource version returning", key)
+				return
+			}
+			if !IsGatewayClassValid(key, gwClass) {
 				return
 			}
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gwClass))
@@ -561,14 +560,11 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 			}
 			oldGwClass := old.(*gatewayv1beta1.GatewayClass)
 			gwClass := obj.(*gatewayv1beta1.GatewayClass)
-			controllerName := string(gwClass.Spec.ControllerName)
-			oldControllerName := string(oldGwClass.Spec.ControllerName)
-
-			if !(akogatewayapilib.CheckGatewayClassController(controllerName) || akogatewayapilib.CheckGatewayClassController(oldControllerName)) {
-				return
-			}
 			if !reflect.DeepEqual(oldGwClass.Spec, gwClass.Spec) || gwClass.GetDeletionTimestamp() != nil {
 				key := lib.GatewayClass + "/" + utils.ObjKey(gwClass)
+				if !IsGatewayClassValid(key, gwClass) {
+					return
+				}
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gwClass))
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
@@ -587,7 +583,7 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 			key := lib.HTTPRoute + "/" + utils.ObjKey(httpRoute)
 			ok, resVer := objects.SharedResourceVerInstanceLister().Get(key)
 			if ok && resVer.(string) == httpRoute.ResourceVersion {
-				utils.AviLog.Debugf("key : %s, msg: same resource version returning", key)
+				utils.AviLog.Debugf("key: %s, msg: same resource version returning", key)
 				return
 			}
 			if !IsHTTPRouteValid(key, httpRoute) {

--- a/ako-gateway-api/status/gateway_status.go
+++ b/ako-gateway-api/status/gateway_status.go
@@ -163,6 +163,7 @@ func (o *gateway) Update(key string, option status.StatusOptions) {
 			Status(metav1.ConditionTrue).
 			Reason(string(gatewayv1beta1.GatewayReasonProgrammed)).
 			ObservedGeneration(gw.ObjectMeta.Generation).
+			Message("Virtual service configured/updated").
 			SetIn(&status.Listeners[i].Conditions)
 	}
 
@@ -213,7 +214,7 @@ func (o *gateway) Patch(key string, obj runtime.Object, status *Status, retryNum
 	}
 
 	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": status,
+		"status": status.GatewayStatus,
 	})
 	_, err := akogatewayapilib.AKOControlConfig().GatewayAPIClientset().GatewayV1beta1().Gateways(gw.Namespace).Patch(context.TODO(), gw.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 	if err != nil {
@@ -224,6 +225,7 @@ func (o *gateway) Patch(key string, obj runtime.Object, status *Status, retryNum
 			return
 		}
 		o.Patch(key, updatedGW, status, retry+1)
+		return
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Successfully updated the gateway %s/%s status %+v", key, gw.Namespace, gw.Name, utils.Stringify(status))

--- a/ako-gateway-api/status/gatewayclass_status.go
+++ b/ako-gateway-api/status/gatewayclass_status.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023-2024 VMware, Inc.
+ * All Rights Reserved.
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*   http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+)
+
+type gatewayClass struct{}
+
+func (o *gatewayClass) Get(key string, name string) *gatewayv1beta1.GatewayClass {
+
+	obj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Lister().Get(name)
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: unable to get the GatewayClass object. err: %s", key, err)
+		return nil
+	}
+	utils.AviLog.Debugf("key: %s, msg: Successfully retrieved the GatewayClass object %s", key, name)
+	return obj.DeepCopy()
+}
+
+func (o *gatewayClass) GetAll(key string) map[string]*gatewayv1beta1.GatewayClass {
+
+	objs, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Lister().List(labels.Everything())
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: unable to get the GatewayClass objects. err: %s", key, err)
+		return nil
+	}
+
+	gatewayClassMap := make(map[string]*gatewayv1beta1.GatewayClass)
+	for _, obj := range objs {
+		gatewayClassMap[obj.Name] = obj.DeepCopy()
+	}
+
+	utils.AviLog.Debugf("key: %s, msg: Successfully retrieved the GatewayClass objects", key)
+	return gatewayClassMap
+}
+
+func (o *gatewayClass) Delete(key string, option status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *gatewayClass) Update(key string, option status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *gatewayClass) BulkUpdate(key string, options []status.StatusOptions) {
+	// TODO: Add this code when we publish the status from the rest layer
+}
+
+func (o *gatewayClass) Patch(key string, obj runtime.Object, status *Status, retryNum ...int) {
+	retry := 0
+	if len(retryNum) > 0 {
+		retry = retryNum[0]
+		if retry >= 5 {
+			utils.AviLog.Errorf("key: %s, msg: Patch retried 5 times, aborting", key)
+			return
+		}
+	}
+
+	gatewayClass := obj.(*gatewayv1beta1.GatewayClass)
+	if o.isStatusEqual(&gatewayClass.Status, &status.GatewayClassStatus) {
+		return
+	}
+
+	patchPayload, _ := json.Marshal(map[string]interface{}{
+		"status": status.GatewayClassStatus,
+	})
+	_, err := akogatewayapilib.AKOControlConfig().GatewayAPIClientset().GatewayV1beta1().GatewayClasses().Patch(context.TODO(), gatewayClass.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
+	if err != nil {
+		utils.AviLog.Warnf("key: %s, msg: there was an error in updating the GatewayClass status. err: %+v, retry: %d", key, err, retry)
+		updatedObj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Lister().Get(gatewayClass.Name)
+		if err != nil {
+			utils.AviLog.Warnf("GatewayClass not found %v", err)
+			return
+		}
+		o.Patch(key, updatedObj, status, retry+1)
+		return
+	}
+
+	utils.AviLog.Infof("key: %s, msg: Successfully updated the GatewayClass %s status %+v %v", key, gatewayClass.Name, utils.Stringify(status), err)
+}
+
+func (o *gatewayClass) isStatusEqual(old, new *gatewayv1beta1.GatewayClassStatus) bool {
+	oldStatus, newStatus := old.DeepCopy(), new.DeepCopy()
+	currentTime := metav1.Now()
+	for i := range oldStatus.Conditions {
+		oldStatus.Conditions[i].LastTransitionTime = currentTime
+	}
+	for i := range newStatus.Conditions {
+		newStatus.Conditions[i].LastTransitionTime = currentTime
+	}
+	return reflect.DeepEqual(oldStatus, newStatus)
+}

--- a/ako-gateway-api/status/httproute_status.go
+++ b/ako-gateway-api/status/httproute_status.go
@@ -88,17 +88,18 @@ func (o *httproute) Patch(key string, obj runtime.Object, status *Status, retryN
 	}
 
 	patchPayload, _ := json.Marshal(map[string]interface{}{
-		"status": status,
+		"status": status.HTTPRouteStatus,
 	})
 	_, err := akogatewayapilib.AKOControlConfig().GatewayAPIClientset().GatewayV1beta1().HTTPRoutes(httpRoute.Namespace).Patch(context.TODO(), httpRoute.Name, types.MergePatchType, patchPayload, metav1.PatchOptions{}, "status")
 	if err != nil {
-		utils.AviLog.Warnf("key: %s, msg: there was an error in updating the gateway status. err: %+v, retry: %d", key, err, retry)
-		updatedGW, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(httpRoute.Namespace).Get(httpRoute.Name)
+		utils.AviLog.Warnf("key: %s, msg: there was an error in updating the HTTPRoute status. err: %+v, retry: %d", key, err, retry)
+		updatedObj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().HTTPRouteInformer.Lister().HTTPRoutes(httpRoute.Namespace).Get(httpRoute.Name)
 		if err != nil {
-			utils.AviLog.Warnf("gateway not found %v", err)
+			utils.AviLog.Warnf("HTTPRoute not found %v", err)
 			return
 		}
-		o.Patch(key, updatedGW, status, retry+1)
+		o.Patch(key, updatedObj, status, retry+1)
+		return
 	}
 
 	utils.AviLog.Infof("key: %s, msg: Successfully updated the HTTPRoute %s/%s status %+v", key, httpRoute.Namespace, httpRoute.Name, utils.Stringify(status))

--- a/ako-gateway-api/status/status.go
+++ b/ako-gateway-api/status/status.go
@@ -31,12 +31,15 @@ type StatusUpdater interface {
 }
 
 type Status struct {
+	gatewayv1beta1.GatewayClassStatus
 	gatewayv1beta1.GatewayStatus
 	gatewayv1beta1.HTTPRouteStatus
 }
 
 func New(ObjectType string) StatusUpdater {
 	switch ObjectType {
+	case lib.GatewayClass:
+		return &gatewayClass{}
 	case lib.Gateway:
 		return &gateway{}
 	case lib.HTTPRoute:
@@ -76,6 +79,8 @@ func BulkUpdate(key string, objectType string, options []status.StatusOptions) e
 func Record(key string, obj runtime.Object, status *Status) {
 	var objectType string
 	switch obj.(type) {
+	case *gatewayv1beta1.GatewayClass:
+		objectType = lib.GatewayClass
 	case *gatewayv1beta1.Gateway:
 		objectType = lib.Gateway
 	case *gatewayv1beta1.HTTPRoute:

--- a/ako-gateway-api/tests/status/gatewayclass_test.go
+++ b/ako-gateway-api/tests/status/gatewayclass_test.go
@@ -13,3 +13,71 @@
 */
 
 package status
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapitests "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests"
+)
+
+func TestGatewayClassValidation(t *testing.T) {
+
+	gatewayClassName := "gateway-class-01"
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gatewayClass, err := akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Get(context.TODO(), gatewayClassName, metav1.GetOptions{})
+		if err != nil || gatewayClass == nil {
+			t.Logf("Couldn't get the GatewayClass, err: %+v", err)
+			return false
+		}
+		return apimeta.IsStatusConditionTrue(gatewayClass.Status.Conditions, string(gatewayv1beta1.GatewayClassConditionStatusAccepted))
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	expectedStatus := &gatewayv1beta1.GatewayClassStatus{
+		Conditions: []metav1.Condition{
+			{
+				Type:               string(gatewayv1beta1.GatewayClassConditionStatusAccepted),
+				Status:             metav1.ConditionTrue,
+				Message:            "GatewayClass is valid",
+				ObservedGeneration: 1,
+				Reason:             string(gatewayv1beta1.GatewayClassReasonAccepted),
+			},
+		},
+	}
+
+	gatewayClass, err := akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Get(context.TODO(), gatewayClassName, metav1.GetOptions{})
+	if err != nil || gatewayClass == nil {
+		t.Fatalf("Couldn't get the GatewayClass, err: %+v", err)
+	}
+
+	akogatewayapitests.ValidateConditions(t, gatewayClass.Status.Conditions, expectedStatus.Conditions)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}
+
+func TestGatewayClassWithNonAKOController(t *testing.T) {
+
+	gatewayClassName := "gateway-class-01"
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, "other.com/non-ako-controller")
+
+	g := gomega.NewGomegaWithT(t)
+	g.Eventually(func() bool {
+		gatewayClass, err := akogatewayapitests.GatewayClient.GatewayV1beta1().GatewayClasses().Get(context.TODO(), gatewayClassName, metav1.GetOptions{})
+		if err != nil || gatewayClass == nil {
+			t.Logf("Couldn't get the GatewayClass, err: %+v", err)
+			return false
+		}
+		return apimeta.FindStatusCondition(gatewayClass.Status.Conditions, string(gatewayv1beta1.GatewayClassConditionStatusAccepted)) == nil
+	}, 30*time.Second).Should(gomega.Equal(true))
+
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}


### PR DESCRIPTION
This commit adds the following:
  1. Status update of GatewayClass during ingestion
  2. Status layer changes for GatewayClass
  3. minor fixes
  4. Adds UTs to test the status layer changes for GatewayClass 


**UTs**:
```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^(TestGatewayClassValidation|TestGatewayClassWithNonAKOController)$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/status

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/tests/status	20.620s
```