### PR TITLE
AV-188019 : Adding ImagePullSecret support for AKO in Helm Chart

### DIFF
--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -182,7 +182,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `avicredentials.password` | Avi controller password | empty |
 | `avicredentials.authtoken` | Avi controller authentication token | empty |
 | `image.repository` | Specify docker-registry that has the AKO image | avinetworks/ako |
-| `image.pullSecrets` | Specify the pull secrets for the private container image registry that has the AKO image | `Empty List` |
+| `image.pullSecrets` | Specify the pull secrets for the secure private container image registry that has the AKO image | `Empty List` |
 
 > From AKO 1.5.1, fields `subnetIP` and `subnetPrefix` have been deprecated. See [Upgrade Notes](../upgrade/upgrade.md) for more details.
 

--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -182,6 +182,7 @@ The following table lists the configurable parameters of the AKO chart and their
 | `avicredentials.password` | Avi controller password | empty |
 | `avicredentials.authtoken` | Avi controller authentication token | empty |
 | `image.repository` | Specify docker-registry that has the AKO image | avinetworks/ako |
+| `image.pullSecrets` | Specify the pull secrets for the private container image registry that has the AKO image | `Empty List` |
 
 > From AKO 1.5.1, fields `subnetIP` and `subnetPrefix` have been deprecated. See [Upgrade Notes](../upgrade/upgrade.md) for more details.
 

--- a/docs/values.md
+++ b/docs/values.md
@@ -288,7 +288,7 @@ with the private registry name.
 
 ### image.pullSecrets
 
-If you are setting the [image.repository](#imagerepository) field to use a private container image registry for ako image, then you must specify the pull secrets in this field. The pull secrets are a list of Kubernetes Secret objects that are created from the login credentials of the image registry. The container runtime uses the pull secrets to authenticate with the registry in order to pull the ako image. The image pull secrets must be created in the `avi-system` namespace before deploying AKO.
+If you are setting the [image.repository](#imagerepository) field to use a secure private container image registry for ako image, then you must specify the pull secrets in this field. The pull secrets are a list of Kubernetes Secret objects that are created from the login credentials of the scure private image registry. The container runtime uses the pull secrets to authenticate with the registry in order to pull the ako image. The image pull secrets must be created in the `avi-system` namespace before deploying AKO.
 
     pullSecrets:
     - name: regcred

--- a/docs/values.md
+++ b/docs/values.md
@@ -286,6 +286,13 @@ One AKO runs in active mode, and the second in passive mode. The AKO, which is r
 If you are using a private container registry and you'd like to override the default dockerhub settings, then this field can be edited
 with the private registry name.
 
+### image.pullSecrets
+
+If you are setting the [image.repository](#imagerepository) field to use a private container image registry for ako image, then you must specify the pull secrets in this field. The pull secrets are a list of Kubernetes Secret objects that are created from the login credentials of the image registry. The container runtime uses the pull secrets to authenticate with the registry in order to pull the ako image. The image pull secrets must be created in the `avi-system` namespace before deploying AKO.
+
+    pullSecrets:
+    - name: regcred
+
 ### L7Settings.serviceType
 
 This option specifies whether the AKO functions in ClusterIP mode or NodePort mode. By default it is set to `ClusterIP`. Allowed values are `ClusterIP`, `NodePort`. If CNI type for the cluster is `antrea`, then another serviceType named `NodePortLocal` is allowed.

--- a/docs/values.md
+++ b/docs/values.md
@@ -288,7 +288,7 @@ with the private registry name.
 
 ### image.pullSecrets
 
-If you are setting the [image.repository](#imagerepository) field to use a secure private container image registry for ako image, then you must specify the pull secrets in this field. The pull secrets are a list of Kubernetes Secret objects that are created from the login credentials of the scure private image registry. The container runtime uses the pull secrets to authenticate with the registry in order to pull the ako image. The image pull secrets must be created in the `avi-system` namespace before deploying AKO.
+If you are setting the [image.repository](#imagerepository) field to use a secure private container image registry for ako image, then you must specify the pull secrets in this field. The pull secrets are a list of Kubernetes Secret objects that are created from the login credentials of a secure private image registry. The container runtime uses the pull secrets to authenticate with the registry in order to pull the ako image. The image pull secrets must be created in the `avi-system` namespace before deploying AKO.
 
     pullSecrets:
     - name: regcred

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -42,6 +42,12 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistentVolumeClaim }}
       {{ end }}
+      {{ if gt (len .Values.image.pullSecrets) 0 }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           {{ if or .Values.persistentVolumeClaim .Values.AKOSettings.istioEnabled }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -42,12 +42,8 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistentVolumeClaim }}
       {{ end }}
-      {{ if gt (len .Values.image.pullSecrets) 0 }}
-      {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{ end }}
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{ if or .Values.persistentVolumeClaim .Values.AKOSettings.istioEnabled }}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -7,6 +7,9 @@ replicaCount: 1
 image:
   repository: 10.79.172.11:5000/avi-buildops/ako
   pullPolicy: IfNotPresent
+  pullSecrets: [] # Setting this will add pull secrets to the statefulset for AKO
+  #pullSecrets:
+  # - name: regcred
 
 ### This section outlines the generic AKO settings
 AKOSettings:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: 10.79.172.11:5000/avi-buildops/ako
   pullPolicy: IfNotPresent
-  pullSecrets: [] # Setting this will add pull secrets to the statefulset for AKO
+  pullSecrets: [] # Setting this will add pull secrets to the statefulset for AKO. Required if using secure private container image registry for AKO image.
   #pullSecrets:
   # - name: regcred
 


### PR DESCRIPTION
This PR adds imagePullSecrets support for AKO in Helm chart. This will enable the user to store the AKO image in their own private registries and use the imagePullSecrets to pull the AKO image on their cluster from their own private registry.

TO DO : Documentation