### PR TITLE
[GatewayAPI] Pool removal on Service deletion and other minor fixes

### DIFF
--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -19,13 +19,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
 type AviObjectGraph struct {

--- a/tests/gatewayapitests/graphlayer/gateway_test.go
+++ b/tests/gatewayapitests/graphlayer/gateway_test.go
@@ -352,7 +352,7 @@ func TestGatewayTLSToNoTLS(t *testing.T) {
 }
 
 /*
-Positive Case
+Negative Case
 Delete Gateway 1 listener
 */
 


### PR DESCRIPTION
This PR contains the following changes:

  1. fixes the stale mappings present in the store.
  2. Pool removal when the service referred in the `backendRef` is removed.
  3. UTs to test the backendRef updates

**UT Results:**
```
Running tool: /usr/local/go/bin/go test -timeout 1000s -run ^(TestHTTPRouteCRUD|TestHTTPRouteRuleCRUD|TestHTTPRouteFilterCRUD|TestHTTPRouteFilterWithRequestHeaderModifier|TestHTTPRouteFilterWithResponseHeaderModifier|TestHTTPRouteFilterWithRequestRedirect|TestHTTPRouteWithValidConfig|TestHTTPRouteBackendRefCRUD|TestHTTPRouteBackendServiceCDC|TestHTTPRouteBackendServiceUpdate)$ github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer

ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer	123.101s
```