### PR TITLE
Fix: AV-189167: remove improper conversion of error structure

### DIFF
--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -305,7 +305,6 @@ func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, 
 				key, op.Method, op.Path, op.Tenant, utils.Stringify(op.Obj), utils.Stringify(op.Err), utils.Stringify(op.Response))
 			// Wrap the error into a websync error.
 			err := &utils.WebSyncError{Err: op.Err, Operation: string(op.Method)}
-			op.Err = err
 			aviErr, ok := op.Err.(session.AviError)
 			if !ok {
 				utils.AviLog.Warnf("key: %s, msg: Error in rest operation is not of type AviError, err: %v, %T", key, op.Err, op.Err)


### PR DESCRIPTION
`err` from avi controller was getting typecasted wrong. This was causing issue in AKO retry mechanism.