### PR TITLE
AV-189284: Fix httprule issue overwriting other httprule setting applied to ingress with same fqdn with different path.

### DIFF
--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -782,7 +782,9 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 				}
 				utils.AviLog.Debugf("key: %s, msg: Computing for path %s in ingresses %v", key, path, ingresses)
 				for _, ing := range ingresses {
-					if !utils.HasElem(allIngresses, ing) {
+					ing_namespace, _, _ := lib.ExtractTypeNameNamespace(ing)
+					// httprule is namespace specific. So only add those ingresses which are in same namespace of rule.
+					if namespace == ing_namespace && !utils.HasElem(allIngresses, ing) {
 						allIngresses = append(allIngresses, ing)
 					}
 				}
@@ -802,7 +804,9 @@ func HTTPRuleToIng(rrname string, namespace string, key string) ([]string, bool)
 				}
 				utils.AviLog.Debugf("key: %s, msg: Computing for oldPath %s in oldIngresses %v", key, oldPath, oldIngresses)
 				for _, oldIng := range oldIngresses {
-					if !utils.HasElem(allIngresses, oldIng) {
+					ing_namespace, _, _ := lib.ExtractTypeNameNamespace(oldIng)
+					// httprule is namespace specific. So only add those ingresses which are in same namespace of rule.
+					if namespace == ing_namespace && !utils.HasElem(allIngresses, oldIng) {
 						allIngresses = append(allIngresses, oldIng)
 					}
 				}


### PR DESCRIPTION
In AKO, HTTPrule is namespace specific.  So if customer creates two ingresses say ingress1 and ingress2 with same fqdn.

ingress1 is in namespace default with path /path1 and ingress2 is namespace red with path /path2 . Then customer creates 2 httprule, rule1 and rule2.

rule1 is applied to ingress1/path1 and rule2 is applied to ingress2/path2 . So when rule2 is applied, configuration done by rule1 on pool is getting removed.