### PR TITLE
AV-187521 : Adding retires for unauthorized error while getting routes with informer

### DIFF
--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -519,7 +519,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		ingClassList, err := utils.GetInformers().IngressClassInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the IngressClass object for UpdateStatus: %s", err)
-			// retry get if request timeout
+			// retry get if request timeout or Unauthorized
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
@@ -539,7 +539,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		ingressList, err := utils.GetInformers().IngressInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the ingress object for UpdateStatus: %v", err)
-			// retry get if request timeout
+			// retry get if request timeout or Unauthorized
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
@@ -572,7 +572,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		mIngress, err := utils.GetInformers().ClientSet.NetworkingV1().Ingresses(nsNameSplit[0]).Get(context.TODO(), nsNameSplit[1], metav1.GetOptions{})
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the ingress object for UpdateStatus: %v", err)
-			// retry get if request timeout
+			// retry get if request timeout or Unauthorized
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -520,7 +520,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the IngressClass object for UpdateStatus: %s", err)
 			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
 			return ingressMap
@@ -540,7 +540,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the ingress object for UpdateStatus: %v", err)
 			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
 		}
@@ -573,7 +573,7 @@ func getIngresses(ingressNSNames []string, bulk bool, retryNum ...int) map[strin
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the ingress object for UpdateStatus: %v", err)
 			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getIngresses(ingressNSNames, bulk, retry+1)
 			}
 			continue

--- a/internal/status/route_status.go
+++ b/internal/status/route_status.go
@@ -174,8 +174,8 @@ func getRoutes(routeNSNames []string, bulk bool, retryNum ...int) map[string]*ro
 		routeList, err := utils.GetInformers().RouteInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the route object for UpdateStatus: %s", err)
-			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			// retry get if request timeout or Unauthorized
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getRoutes(routeNSNames, bulk, retry+1)
 			}
 		}
@@ -199,8 +199,8 @@ func getRoutes(routeNSNames []string, bulk bool, retryNum ...int) map[string]*ro
 		route, err := utils.GetInformers().OshiftClient.RouteV1().Routes(nsNameSplit[0]).Get(context.TODO(), nsNameSplit[1], metav1.GetOptions{})
 		if err != nil {
 			utils.AviLog.Warnf("msg: Could not get the route object for UpdateStatus: %s", err)
-			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			// retry get if request timeout or Unauthorized
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getRoutes(routeNSNames, bulk, retry+1)
 			}
 			continue

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -222,7 +222,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 		serviceLBList, err := utils.GetInformers().ServiceInformer.Lister().List(labels.Set(nil).AsSelector())
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
-			// retry get if request timeout
+			// retry get if request timeout or Unauthorized
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getServices(serviceNSNames, bulk, retry+1)
 			}
@@ -251,7 +251,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 		serviceLB, err := utils.GetInformers().ServiceInformer.Lister().Services(nsNameSplit[0]).Get(nsNameSplit[1])
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
-			// retry get if request timeout
+			// retry get if request timeout or Unauthorized
 			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getServices(serviceNSNames, bulk, retry+1)
 			}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -223,7 +223,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
 			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getServices(serviceNSNames, bulk, retry+1)
 			}
 		}
@@ -252,7 +252,7 @@ func getServices(serviceNSNames []string, bulk bool, retryNum ...int) map[string
 		if err != nil {
 			utils.AviLog.Warnf("Could not get the service object for UpdateStatus: %s", err)
 			// retry get if request timeout
-			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) {
+			if strings.Contains(err.Error(), utils.K8S_ETIMEDOUT) || strings.Contains(err.Error(), utils.K8S_UNAUTHORIZED) {
 				return getServices(serviceNSNames, bulk, retry+1)
 			}
 			continue

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -84,6 +84,7 @@ const (
 	FULL_SYNC_INTERVAL            = "FULL_SYNC_INTERVAL"
 	DEFAULT_FILE_SUFFIX           = "avi.log"
 	K8S_ETIMEDOUT                 = "timed out"
+	K8S_UNAUTHORIZED              = "Unauthorized"
 	ADVANCED_L4                   = "ADVANCED_L4"
 	SERVICES_API                  = "SERVICES_API"
 	ENV_CTRL_USERNAME             = "CTRL_USERNAME"


### PR DESCRIPTION
This PR adds retries for **unauthorized** error while getting or listing routes with route informer. There were some random Unauthorized errors seen and adding retries may help in solving those.
```
2023-09-23T15:25:03.059Z	WARN	status/route_status.go:201	msg: Could not get the route object for UpdateStatus: an error on the server ("Internal Server Error: \"/apis/route.openshift.io/v1/namespaces/c6-002/routes/c6-002-rt-008-p1\": Unauthorized") has prevented the request from succeeding (get routes.route.openshift.io c6-002-rt-008-p1)
```