### PR TITLE
use first IP in case of multiple internal IPs for node (#1082)

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -2066,8 +2066,11 @@ func GetIPFromNode(node *v1.Node) (string, string) {
 		if addr.Type == corev1.NodeInternalIP {
 			nodeIP := addr.Address
 			if utils.IsV4(nodeIP) {
-				nodeV4 = nodeIP
-			} else {
+				//Use first IP in the list
+				if nodeV4 == "" {
+					nodeV4 = nodeIP
+				}
+			} else if nodeV6 == "" {
 				nodeV6 = nodeIP
 			}
 		}


### PR DESCRIPTION
cherry-pick from 1.9.2