### PR TITLE
Support reading credentials from env

### DIFF
--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -417,6 +417,7 @@ func PopulateControllerProperties(cs kubernetes.Interface) error {
 	if err != nil {
 		return err
 	}
+	ctrlProps = lib.OverrrideControllerCredsFromEnv(ctrlProps)
 	ctrlPropCache.PopulateCtrlProp(ctrlProps)
 	return nil
 }

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -256,6 +256,9 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: useDefaultSecretsOnly
+          {{- if .Values.ControllerSettings.extraEnv -}}
+          {{ toYaml .Values.ControllerSettings.extraEnv | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -102,6 +102,12 @@ ControllerSettings:
   cloudName: "Default-Cloud" # The configured cloud name on the Avi controller.
   controllerHost: "" # IP address or Hostname of Avi Controller
   tenantName: "admin" # Name of the tenant where all the AKO objects will be created in AVI.
+  extraEnv: {}
+  # - name: CTRL_USERNAME
+  #   valuesFrom:
+  #   secretKeyRef:
+  #     name: avi-external-secret
+  #     key: ctrl_user
 
 nodePortSelector: # Only applicable if serviceType is NodePort
   key: ""

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -145,6 +145,7 @@ func PopulateControllerProperties(cs kubernetes.Interface) error {
 	if err != nil {
 		return err
 	}
+	ctrlProps = lib.OverrrideControllerCredsFromEnv(ctrlProps)
 	ctrlPropCache.PopulateCtrlProp(ctrlProps)
 	return nil
 }

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1807,6 +1807,19 @@ func RefreshAuthToken(kc kubernetes.Interface) {
 	}
 }
 
+func OverrrideControllerCredsFromEnv(prop map[string]string) map[string]string {
+	u := os.Getenv("CTRL_USERNAME")
+	p := os.Getenv("CTRL_PASSWORD")
+	if u != "" {
+		prop[utils.ENV_CTRL_USERNAME] = u
+	}
+	if p != "" {
+		prop[utils.ENV_CTRL_PASSWORD] = p
+	}
+
+	return prop
+}
+
 func GetControllerPropertiesFromSecret(cs kubernetes.Interface) (map[string]string, error) {
 	ctrlProps := make(map[string]string)
 	aviSecret, err := cs.CoreV1().Secrets(utils.GetAKONamespace()).Get(context.TODO(), AviSecret, metav1.GetOptions{})


### PR DESCRIPTION
If GitOps setups secrets are not commited to the helm values, but rather delivered aside by for example ExternalSecrets. Hence we need an ability to inject CTRL_USERNAME and CTRL_PASSWORD from externally managed secret.

This commit adds CTLR_USERNAME and CTRL_PASSWORD override if environment variable is set.

Additionally helm chart has been extended to allow specifying extraEnv to perform mapping of secret name and key as environment variable