### PR TITLE
AV-193761: Prometheus metrics publish for

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -66,7 +66,10 @@ func main() {
 }
 
 func InitializeAKOApi() {
-	akoApi := api.NewServer(lib.GetAkoApiServerPort(), []models.ApiModel{})
+	if lib.IsPrometheusEnabled() {
+		lib.SetPrometheusRegistry()
+	}
+	akoApi := api.NewServer(lib.GetAkoApiServerPort(), []models.ApiModel{}, lib.IsPrometheusEnabled(), lib.GetPrometheusRegistry())
 	akoApi.InitApi()
 	lib.SetApiServerInstance(akoApi)
 }
@@ -271,6 +274,9 @@ func InitializeAKC() {
 		utils.AviLog.Fatalf("Avi client not initialized")
 	}
 
+	if lib.IsPrometheusEnabled() {
+		lib.RegisterPromMetrics()
+	}
 	if aviRestClientPool != nil && !avicache.IsAviClusterActive(aviRestClientPool.AviClient[0]) {
 		akoControlConfig.PodEventf(corev1.EventTypeWarning, lib.AKOShutdown, "Avi Controller Cluster state is not Active")
 		utils.AviLog.Fatalf("Avi Controller Cluster state is not Active, shutting down AKO")

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -49,3 +49,4 @@ data:
   ipFamily: {{ .Values.AKOSettings.ipFamily | quote }}
   istioEnabled: {{ .Values.AKOSettings.istioEnabled | quote }}
   useDefaultSecretsOnly: {{ .Values.AKOSettings.useDefaultSecretsOnly | quote }}
+  enablePrometheus: {{ default "false" .Values.featureGates.EnablePrometheus | quote }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -19,8 +19,9 @@ spec:
       {{- include "ako.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{ if .Values.AKOSettings.istioEnabled }}
+      {{ if or (.Values.AKOSettings.istioEnabled) (.Values.featureGates.EnablePrometheus) }}
       annotations:
+        {{ if .Values.AKOSettings.istioEnabled }}
         sidecar.istio.io/inject: "true"
         traffic.sidecar.istio.io/includeInboundPorts: ""
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""
@@ -29,6 +30,12 @@ spec:
             OUTPUT_CERTS: /etc/istio-output-certs
         sidecar.istio.io/userVolume: '[{"name": "istio-certs", "emptyDir": {"medium":"Memory"}}]'
         sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
+        {{ end }}
+        {{ if .Values.featureGates.EnablePrometheus }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.AKOSettings.apiServerPort | quote}}
+        prometheus.io/path: "/metrics"
+        {{ end }}
       {{ end }}
       labels:
         {{- include "ako.selectorLabels" . | nindent 8 }}
@@ -61,6 +68,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{ if .Values.featureGates.EnablePrometheus }}
+          ports:
+          - containerPort:  {{ default "8080" .Values.AKOSettings.apiServerPort }}
+            name: prometheus-port
+          {{ end }}
           lifecycle:
             preStop:
               exec:
@@ -256,6 +268,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: useDefaultSecretsOnly
+          - name: PROMETHEUS_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: enablePrometheus
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -5,6 +5,7 @@
 ### FeatureGates is to enable or disable experimental features.
 featureGates:
   GatewayAPI: false # Enables/disables processing of Kubernetes Gateway API CRDs.
+  EnablePrometheus: false # Enable/Disable prometheus scraping for AKO container
 
 replicaCount: 1
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -823,6 +823,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 			// Publish vrfcontext model now, this has to be processed first
@@ -864,6 +865,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateHostRuleObj(key, hostRuleObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HostRule: %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -882,6 +884,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateHTTPRuleObj(key, httpRuleObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of HTTPRule: %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -900,6 +903,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateAviInfraSetting(key, aviInfraObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of AviInfraSetting: %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -918,6 +922,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateSSORuleObj(key, ssoRuleObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of SSORule : %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -936,6 +941,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateL4RuleObj(key, l4Rule); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of L4Rule: %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -970,6 +976,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				resVer := meta.GetResourceVersion()
 				objects.SharedResourceVerInstanceLister().Save(key, resVer)
 			}
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			nodes.DequeueIngestion(key, true)
 		}
 	}
@@ -996,6 +1003,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				resVer := meta.GetResourceVersion()
 				objects.SharedResourceVerInstanceLister().Save(key, resVer)
 			}
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			nodes.DequeueIngestion(key, true)
 		}
 	}
@@ -1015,6 +1023,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 						objects.SharedResourceVerInstanceLister().Save(key, resVer)
 					}
 					utils.AviLog.Debugf("Dequeue for ingressClass key: %v", key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					nodes.DequeueIngestion(key, true)
 				}
 			}
@@ -1034,6 +1043,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 							objects.SharedResourceVerInstanceLister().Save(key, resVer)
 						}
 						utils.AviLog.Debugf("Dequeue for ingress key: %v", key)
+						lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 						nodes.DequeueIngestion(key, true)
 					}
 				}
@@ -1056,6 +1066,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 						objects.SharedResourceVerInstanceLister().Save(key, resVer)
 					}
 					utils.AviLog.Debugf("Dequeue for route key: %v", key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					nodes.DequeueIngestion(key, true)
 				}
 			}
@@ -1077,6 +1088,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 						objects.SharedResourceVerInstanceLister().Save(key, resVer)
 					}
 					InformerStatusUpdatesForSvcApiGateway(key, gatewayObj)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					nodes.DequeueIngestion(key, true)
 				}
 			}
@@ -1093,6 +1105,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 					resVer := meta.GetResourceVersion()
 					objects.SharedResourceVerInstanceLister().Save(key, resVer)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -1112,6 +1125,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 						resVer := meta.GetResourceVersion()
 						objects.SharedResourceVerInstanceLister().Save(key, resVer)
 					}
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					nodes.DequeueIngestion(key, true)
 				}
 			}
@@ -1130,6 +1144,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 						resVer := meta.GetResourceVersion()
 						objects.SharedResourceVerInstanceLister().Save(key, resVer)
 					}
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					nodes.DequeueIngestion(key, true)
 				}
 			}
@@ -1149,6 +1164,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 				if err := c.GetValidator().ValidateAviInfraSetting(key, aviInfraObj); err != nil {
 					utils.AviLog.Warnf("key: %s, Error retrieved during validation of AviInfraSetting: %v", key, err)
 				}
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				nodes.DequeueIngestion(key, true)
 			}
 		}
@@ -1168,6 +1184,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 							objects.SharedResourceVerInstanceLister().Save(key, resVer)
 						}
 						utils.AviLog.Debugf("Dequeue for ingress key: %v", key)
+						lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 						nodes.DequeueIngestion(key, true)
 					}
 				}
@@ -1187,6 +1204,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 			}
 			key := lib.Gateway + "/" + utils.ObjKey(gatewayObj)
 			InformerStatusUpdatesForGateway(key, gatewayObj)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			nodes.DequeueIngestion(key, true)
 		}
 
@@ -1197,6 +1215,7 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 		}
 		for _, gwClassObj := range gwClassObjs {
 			key := lib.GatewayClass + "/" + utils.ObjKey(gwClassObj)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			nodes.DequeueIngestion(key, true)
 		}
 	}
@@ -1285,6 +1304,7 @@ func (c *AviController) DeleteModels() {
 		}
 		bkt := utils.Bkt(modelName, sharedQueue.NumWorkers)
 		utils.AviLog.Infof("Deleting objects for model: %s", modelName)
+		//graph queue prometheus
 		sharedQueue.Workqueue[bkt].AddRateLimited(modelName)
 	}
 
@@ -1350,6 +1370,7 @@ func SyncFromIngestionLayer(key interface{}, wg *sync.WaitGroup) error {
 	keyStr, ok := key.(string)
 	if !ok {
 		utils.AviLog.Warnf("Unexpected object type: expected string, got %T", key)
+		lib.DecrementQueueCounter(utils.ObjectIngestionLayer)
 		return nil
 	}
 	nodes.DequeueIngestion(keyStr, false)
@@ -1358,6 +1379,7 @@ func SyncFromIngestionLayer(key interface{}, wg *sync.WaitGroup) error {
 
 func SyncFromFastRetryLayer(key interface{}, wg *sync.WaitGroup) error {
 	keyStr, ok := key.(string)
+	lib.DecrementQueueCounter(lib.FAST_RETRY_LAYER)
 	if !ok {
 		utils.AviLog.Warnf("Unexpected object type: expected string, got %T", key)
 		return nil
@@ -1368,6 +1390,7 @@ func SyncFromFastRetryLayer(key interface{}, wg *sync.WaitGroup) error {
 
 func SyncFromSlowRetryLayer(key interface{}, wg *sync.WaitGroup) error {
 	keyStr, ok := key.(string)
+	lib.DecrementQueueCounter(lib.SLOW_RETRY_LAYER)
 	if !ok {
 		utils.AviLog.Warnf("Unexpected object type: expected string, got %T", key)
 		return nil
@@ -1380,6 +1403,7 @@ func SyncFromNodesLayer(key interface{}, wg *sync.WaitGroup) error {
 	keyStr, ok := key.(string)
 	if !ok {
 		utils.AviLog.Warnf("Unexpected object type: expected string, got %T", key)
+		lib.DecrementQueueCounter(utils.GraphLayer)
 		return nil
 	}
 	cache := avicache.SharedAviObjCache()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -182,6 +182,7 @@ func AddIngressFromNSToIngestionQueue(numWorkers uint32, c *AviController, names
 		key := utils.Ingress + "/" + utils.ObjKey(ingObj)
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -196,6 +197,7 @@ func AddRoutesFromNSToIngestionQueue(numWorkers uint32, c *AviController, namesp
 		key := utils.OshiftRoute + "/" + utils.ObjKey(routeObj)
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -220,6 +222,7 @@ func AddServicesFromNSToIngestionQueue(numWorkers uint32, c *AviController, name
 		}
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -236,6 +239,7 @@ func AddGatewaysFromNSToIngestionQueue(numWorkers uint32, c *AviController, name
 		InformerStatusUpdatesForSvcApiGateway(key, gatewayObj)
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -250,6 +254,7 @@ func AddMultiClusterIngressFromNSToIngestionQueue(numWorkers uint32, c *AviContr
 		key := lib.MultiClusterIngress + "/" + utils.ObjKey(mciObj)
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -264,6 +269,7 @@ func AddServiceImportsFromNSToIngestionQueue(numWorkers uint32, c *AviController
 		key := lib.MultiClusterIngress + "/" + utils.ObjKey(siObj)
 		bkt := utils.Bkt(namespace, numWorkers)
 		c.workqueue[bkt].AddRateLimited(key)
+		lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		utils.AviLog.Debugf("key: %s, msg: %s for namespace: %s", key, msg, namespace)
 	}
 }
@@ -435,6 +441,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 				status.UpdateRouteStatusWithErrMsg(key, route.Name, namespace, lib.DuplicateBackends)
 			}
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -462,6 +469,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
@@ -483,6 +491,7 @@ func AddRouteEventHandler(numWorkers uint32, c *AviController) cache.ResourceEve
 					status.UpdateRouteStatusWithErrMsg(key, newRoute.Name, namespace, lib.DuplicateBackends)
 				}
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			}
 		},
@@ -514,6 +523,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -546,6 +556,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -567,6 +578,7 @@ func AddPodEventHandler(numWorkers uint32, c *AviController) cache.ResourceEvent
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			}
 		},
@@ -593,6 +605,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -621,6 +634,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -638,6 +652,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			}
 		},
@@ -683,6 +698,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -726,6 +742,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
@@ -776,9 +793,11 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					}
 				}
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				if oldKey != "" && key != oldKey {
 					c.workqueue[bkt].AddRateLimited(oldKey)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", oldKey)
 				}
 			}
@@ -805,6 +824,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + specJSON["node"]
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			DeleteFunc: func(obj interface{}) {
 				utils.AviLog.Debugf("calico blockaffinity DELETE Event")
@@ -820,6 +840,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + specJSON["node"]
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -843,6 +864,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + host
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			DeleteFunc: func(obj interface{}) {
 				utils.AviLog.Debugf("hostsubnets DELETE Event")
@@ -858,6 +880,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + host
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -876,6 +899,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + nodename
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
 				utils.AviLog.Debugf("ciliumnode UPDATE Event")
@@ -887,6 +911,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + nodename
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			DeleteFunc: func(obj interface{}) {
 				utils.AviLog.Debugf("ciliumnode DELETE Event")
@@ -898,6 +923,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				key := utils.NodeObj + "/" + nodename
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -912,6 +938,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key := utils.Secret + "/" + utils.GetAKONamespace() + "/" + lib.IstioSecret
 					bkt := utils.Bkt(utils.GetAKONamespace(), numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				}
 			}
@@ -927,6 +954,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -961,6 +989,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 			}
 		},
@@ -971,6 +1000,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key := utils.Secret + "/" + utils.GetAKONamespace() + "/" + lib.IstioSecret
 					bkt := utils.Bkt(utils.GetAKONamespace(), numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				}
 			}
@@ -990,6 +1020,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					}
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				}
 			}
@@ -1045,6 +1076,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -1079,6 +1111,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -1096,6 +1129,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			}
 		},
@@ -1122,6 +1156,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				return
 			}
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -1151,6 +1186,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, cur interface{}) {
@@ -1169,6 +1205,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 			if isNodeUpdated(oldobj, node) {
 				bkt := utils.Bkt(lib.GetTenant(), numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 			} else {
 				utils.AviLog.Debugf("key: %s, msg: node object did not change", key)
@@ -1196,6 +1233,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				}
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -1220,6 +1258,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 				bkt := utils.Bkt(namespace, numWorkers)
 				objects.SharedResourceVerInstanceLister().Delete(key)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 			},
 			UpdateFunc: func(old, cur interface{}) {
@@ -1234,6 +1273,7 @@ func (c *AviController) SetupEventHandlers(k8sinfo K8sinformers) {
 					key := utils.IngressClass + "/" + utils.ObjKey(ingClass)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				}
 			},

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -167,6 +167,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				if c.DisableSync {
@@ -183,6 +184,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -208,6 +210,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				objects.SharedResourceVerInstanceLister().Delete(key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -229,6 +232,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				if c.DisableSync {
@@ -247,6 +251,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -273,6 +278,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				bkt := utils.Bkt(namespace, numWorkers)
 				objects.SharedResourceVerInstanceLister().Delete(key)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -294,6 +300,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				if c.DisableSync {
@@ -310,6 +317,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -336,6 +344,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				// no need to validate for delete handler
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 
@@ -373,6 +382,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -398,6 +408,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				objects.SharedResourceVerInstanceLister().Delete(key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 		informer.SSORuleInformer.Informer().AddEventHandler(ssoRuleEventHandler)
@@ -418,6 +429,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: ADD", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 			UpdateFunc: func(old, new interface{}) {
 				if c.DisableSync {
@@ -434,6 +446,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 					utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 					bkt := utils.Bkt(namespace, numWorkers)
 					c.workqueue[bkt].AddRateLimited(key)
+					lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
@@ -459,6 +472,7 @@ func (c *AviController) SetupAKOCRDEventHandlers(numWorkers uint32) {
 				bkt := utils.Bkt(namespace, numWorkers)
 				objects.SharedResourceVerInstanceLister().Delete(key)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			},
 		}
 		informer.L4RuleInformer.Informer().AddEventHandler(l4RuleEventHandler)
@@ -487,6 +501,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if c.DisableSync {
@@ -500,6 +515,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -525,6 +541,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 	}
 
@@ -546,6 +563,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 				return
 			}
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if c.DisableSync {
@@ -559,6 +577,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -584,6 +603,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 	}
 
@@ -605,6 +625,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 			}
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if c.DisableSync {
@@ -618,6 +639,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -643,6 +665,7 @@ func (c *AviController) SetupIstioCRDEventHandlers(numWorkers uint32) {
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 	}
 
@@ -673,6 +696,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if c.DisableSync {
@@ -694,6 +718,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -723,6 +748,7 @@ func (c *AviController) SetupMultiClusterIngressEventHandlers(numWorkers uint32)
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 	}
 	c.informers.MultiClusterIngressInformer.Informer().AddEventHandler(multiClusterIngressEventHandler)
@@ -751,6 +777,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			utils.AviLog.Debugf("key: %s, msg: ADD", key)
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if c.DisableSync {
@@ -772,6 +799,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 				utils.AviLog.Debugf("key: %s, msg: UPDATE", key)
 				bkt := utils.Bkt(namespace, numWorkers)
 				c.workqueue[bkt].AddRateLimited(key)
+				lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -801,6 +829,7 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 			bkt := utils.Bkt(namespace, numWorkers)
 			objects.SharedResourceVerInstanceLister().Delete(key)
 			c.workqueue[bkt].AddRateLimited(key)
+			lib.IncrementQueueCounter(utils.ObjectIngestionLayer)
 		},
 	}
 	c.informers.ServiceImportInformer.Informer().AddEventHandler(serviceImportEventHandler)

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -37,6 +37,7 @@ func AviGetCollectionRaw(client *clients.AviClient, uri string, retryNum ...int)
 	}
 
 	result, err := client.AviSession.GetCollectionRaw(uri)
+	IncrementRestOpCouter(HTTPMethodGet, uri)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to fetch collection data from uri %s %v", uri, err)
 		CheckForInvalidCredentials(uri, err)
@@ -61,6 +62,7 @@ func AviGet(client *clients.AviClient, uri string, response interface{}, retryNu
 	}
 
 	err := client.AviSession.Get(uri, &response)
+	IncrementRestOpCouter(HTTPMethodGet, uri)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {
@@ -100,6 +102,7 @@ func AviGetRaw(client *clients.AviClient, uri string, retryNum ...int) ([]byte, 
 	}
 
 	rawData, err := client.AviSession.GetRaw(uri)
+	IncrementRestOpCouter(HTTPMethodGet, uri)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to fetch data from uri %s %v", uri, err)
 		CheckForInvalidCredentials(uri, err)
@@ -128,6 +131,7 @@ func AviPut(client *clients.AviClient, uri string, payload interface{}, response
 	}
 
 	err := client.AviSession.Put(uri, payload, &response)
+	IncrementRestOpCouter(HTTPMethodPut, uri)
 	if err != nil {
 		utils.AviLog.Warnf("msg: Unable to execute Put on uri %s %v", uri, err)
 		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 403 {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -196,6 +196,8 @@ const (
 	Namespace                                  = "Namespace"
 	VrfContextNotFoundError                    = "VrfContext not found"
 	K8s_1_28                                   = "1.28"
+	HTTPMethodGet                              = "GET"
+	HTTPMethodPut                              = "PUT"
 
 	// AKO Event constants
 	AKOEventComponent        = "avi-kubernetes-operator"

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -36,6 +36,7 @@ func DequeueIngestion(key string, fullsync bool) {
 	var ingressFound, routeFound, mciFound bool
 	var ingressNames, routeNames, mciNames []string
 	utils.AviLog.Infof("key: %s, msg: starting graph Sync", key)
+	lib.DecrementQueueCounter(utils.ObjectIngestionLayer)
 	sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
 
 	objType, namespace, name := lib.ExtractTypeNameNamespace(key)
@@ -825,6 +826,7 @@ func processNodeObj(key, nodename string, sharedQueue *utils.WorkerQueue, fullsy
 func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.WorkerQueue) {
 	bkt := utils.Bkt(modelName, sharedQueue.NumWorkers)
 	sharedQueue.Workqueue[bkt].AddRateLimited(modelName)
+	lib.IncrementQueueCounter(utils.GraphLayer)
 	utils.AviLog.Infof("key: %s, msg: Published key with modelName: %s", key, modelName)
 }
 

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -58,7 +58,7 @@ func (rest *RestOperations) CleanupVS(key string, skipVS bool) {
 
 func (rest *RestOperations) DequeueNodes(key string) {
 	utils.AviLog.Infof("key: %s, msg: start rest layer sync.", key)
-
+	lib.DecrementQueueCounter(utils.GraphLayer)
 	// Got the key from the Graph Layer - let's fetch the model
 	ok, avimodelIntf := objects.SharedAviGraphLister().Get(key)
 	if !ok {
@@ -781,12 +781,14 @@ func (rest *RestOperations) DataScriptDelete(dsToDelete []avicache.NamespaceName
 func (rest *RestOperations) PublishKeyToRetryLayer(parentVsKey string, key string) {
 	fastRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.FAST_RETRY_LAYER)
 	fastRetryQueue.Workqueue[0].AddRateLimited(parentVsKey)
+	lib.IncrementQueueCounter(lib.FAST_RETRY_LAYER)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to fast path retry queue: %s", key, parentVsKey)
 }
 
 func (rest *RestOperations) PublishKeyToSlowRetryLayer(parentVsKey string, key string) {
 	slowRetryQueue := utils.SharedWorkQueue().GetQueueByName(lib.SLOW_RETRY_LAYER)
 	slowRetryQueue.Workqueue[0].AddRateLimited(parentVsKey)
+	lib.IncrementQueueCounter(lib.SLOW_RETRY_LAYER)
 	utils.AviLog.Infof("key: %s, msg: Published key with vs_key to slow path retry queue: %s", key, parentVsKey)
 }
 

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -278,6 +278,7 @@ func (l *leader) AviRestOperate(c *clients.AviClient, rest_ops []*utils.RestOp, 
 			utils.AviLog.Warnf("key: %s, msg: Sync is disabled, Only DELETE operation is allowed for models other than VRF model", key)
 			continue
 		}
+		lib.IncrementRestOpCouter(utils.Stringify(op.Method), op.ObjName)
 		SetTenant := session.SetTenant(op.Tenant)
 		SetTenant(c.AviSession)
 		if op.Version != "" {

--- a/internal/status/status_toiler.go
+++ b/internal/status/status_toiler.go
@@ -32,11 +32,13 @@ type StatusOptions struct {
 func PublishToStatusQueue(key string, statusOption StatusOptions) {
 	statusQueue := utils.SharedWorkQueue().GetQueueByName(utils.StatusQueue)
 	bkt := utils.Bkt(key, statusQueue.NumWorkers)
+	lib.IncrementQueueCounter(utils.StatusQueue)
 	statusQueue.Workqueue[bkt].AddRateLimited(statusOption)
 }
 
 func (l *leader) DequeueStatus(objIntf interface{}) error {
 	obj, ok := objIntf.(StatusOptions)
+	lib.DecrementQueueCounter(utils.StatusQueue)
 	if !ok {
 		utils.AviLog.Warnf("Object is not of type StatusOptions, %T", objIntf)
 		return nil

--- a/pkg/api/api_fake.go
+++ b/pkg/api/api_fake.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api/models"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -46,7 +47,7 @@ func (a *FakeApiServer) InitApi() {
 	return
 }
 
-func (a *FakeApiServer) SetRouter() *mux.Router {
+func (a *FakeApiServer) SetRouter(prometheusEnavbled bool, reg *prometheus.Registry) *mux.Router {
 	return nil
 }
 

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -14,7 +14,11 @@
 
 package models
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type OperationMap struct {
 	Route   string
@@ -24,5 +28,5 @@ type OperationMap struct {
 
 type ApiModel interface {
 	InitModel()
-	ApiOperationMap() []OperationMap
+	ApiOperationMap(prometheusEnavbled bool, reg *prometheus.Registry) []OperationMap
 }


### PR DESCRIPTION
1. Number of objects in Ingestion, Graph, Status, retry(slow,fast) queues
2. Number of API calls made by AKO to Avi Controller
3. Number of API calls per Object per type made by AKO to Avi Controller

TODO:
This PR doesn't take care of fetching `conntectivity status of AKO with Avi Controller`, `number of nodes in K8` 