### PR TITLE
AV-193232 : Fix for regression introduced in 1.11.1 for SNI Dedicated…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ helmtests:
 	-u root:root \
 	-v $(PWD)/helm/ako:/apps \
 	-v $(PWD)/tests/helmtests:/apps/tests \
-	helmunittest/helm-unittest:3.11.1-0.3.0 .
+	10.79.172.11:5000/avi-buildops/helmunittest/helm-unittest:3.11.1-0.3.0 .
 
 .PHONY: gatewayapitests
 gatewayapitests:

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -640,6 +640,7 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 	policies := v.HttpPolicySetRefs
 	scripts := v.VsDatascriptRefs
 	icaprefs := v.ICAPProfileRefs
+	sslKeyAndCertificateRefs := v.SslKeyAndCertificateRefs
 
 	var vsRefs string
 
@@ -671,6 +672,10 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 
 	if len(icaprefs) > 0 {
 		vsRefs += utils.Stringify(icaprefs)
+	}
+
+	if len(sslKeyAndCertificateRefs) > 0 {
+		vsRefs += utils.Stringify(sslKeyAndCertificateRefs)
 	}
 
 	sort.Strings(checksumStringSlice)

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -264,7 +264,7 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			vs.SslProfileRef = vs_meta.SslProfileRef
 		}
 
-		if len(vs_meta.SslKeyAndCertificateRefs) != 0 {
+		if len(vs_meta.SslKeyAndCertificateRefs) != 0 && !vs_meta.Dedicated {
 			vs.SslKeyAndCertificateRefs = append(vs.SslKeyAndCertificateRefs, vs_meta.SslKeyAndCertificateRefs...)
 		}
 


### PR DESCRIPTION
… L7 VS while adding SSL Key and Cert Ref using hostrule (#1328)

* AV-193232 : Fix for regression introduced in 1.11.1 for SNI Dedicated L7 VS while adding SSL Key and Cert Ref using hostrule

* AV-193232 : Adding UT for fixing issue for SNI Dedicated L7 VS while adding SSL Key and Cert Ref using hostrule

* AV-193232 : Adding SslKeyAndCertificateRefs to checksum calculation for EVH dedicated mode

* AV-193232 : Modified imgae registry for helm-unittest image to private registry