### PR TITLE
AV-194491 : Setting local_as field type in bgp profile of vrf context to uint32 to avoid parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,3 +292,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
  - Annotation `external-dns.alpha.kubernetes.io/hostname` on the Service of type LoadBalancer overrides the `autoFQDN` feature for it.
+
+## AKO-1.7.6
+
+### Fixed
+ - AKO does not create static routes when a value greater than **2147483647** is specified for **LocalAs** (Local Autonomous System ID) field in Bgp profile. This scenario is applicable only when Bgp profile is specified for VRF Context.

--- a/buildsettings.json
+++ b/buildsettings.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.7.5",
+    "version": "1.7.6",
     "avi": {
         "maxVersion": "21.1.4",
         "minVersion": "20.1.5"

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ Please refer to this [page](objects.md) for details on how AKO interprets the Ku
 Please refer to this [page](cc_to_ako.md) for details on how to migrate workloads from cloud connector based Avi controller to AKO based Avi controller.
 
 ### AKO Compatibility Guide
-AKO version 1.7.5 support for Kubernetes, Openshift, Avi Controller is as below:
+AKO version 1.7.6 support for Kubernetes, Openshift, Avi Controller is as below:
 
 | **Orchestrator/ Controller** | **Versions Supported** |
 | --------- | ----------- |

--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -14,22 +14,22 @@ kubectl create ns avi-system
 Step 2: Search the available charts for AKO
 
 ```
-helm show chart oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5
+helm show chart oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6
 
-Pulled: projects.registry.vmware.com/ako/helm-charts/ako:1.7.5
+Pulled: projects.registry.vmware.com/ako/helm-charts/ako:1.7.6
 Digest: sha256:xyxyxxyxyx
 apiVersion: v2
-appVersion: 1.7.5
+appVersion: 1.7.6
 description: A helm chart for Avi Kubernetes Operator
 name: ako
 type: application
-version: 1.7.5
+version: 1.7.6
 ```
 
 Use the `values.yaml` from this chart to edit values related to Avi configuration. To get the values.yaml for a release, run the following command
 
 ```
-helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 > values.yaml
+helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 > values.yaml
 
 ```
 
@@ -44,12 +44,12 @@ Starting AKO-1.7.1, multiple AKO instances can be installed in a cluster.
 
 <b>Primary AKO installation</b>
 ```
-helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --set AKOSettings.primaryInstance=true --namespace=avi-system
+helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --set AKOSettings.primaryInstance=true --namespace=avi-system
 ```
 
 <b>Secondary AKO installation</b>
 ```
-helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --set AKOSettings.primaryInstance=false --namespace=avi-system
+helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --set AKOSettings.primaryInstance=false --namespace=avi-system
 
 ```
 
@@ -59,7 +59,7 @@ Step 4: Check the installation
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED     STATUS  	CHART    	APP VERSION
-ako-1691752136	avi-system	1       	2023-08-11	deployed	ako-1.7.5	1.7.5
+ako-1691752136	avi-system	1       	2023-08-11	deployed	ako-1.7.6	1.7.6
 ```
 
 ## Uninstall using *helm*
@@ -89,7 +89,7 @@ Follow these steps if you are upgrading from an older AKO release.
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, run the following command to download and upgrade the CRDs:
 
 ```
-helm template oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 --include-crds --output-dir <output_dir>
+helm template oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 --include-crds --output-dir <output_dir>
 ```
 
 This will save the helm files to an output directory which will contain the CRDs corresponding to the AKO version.
@@ -105,15 +105,15 @@ kubectl apply -f <output_dir>/ako/crds/
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED                             	    STATUS  	CHART    	APP VERSION
-ako-1593523840	avi-system	1       	2020-09-16 13:44:31.609195757 +0000 UTC	    deployed	ako-1.7.4	1.7.4
+ako-1593523840	avi-system	1       	2020-09-16 13:44:31.609195757 +0000 UTC	    deployed	ako-1.7.5	1.7.5
 ```
 
 *Step3*
 
-Get the values.yaml for the AKO version 1.7.5 and edit the values as per the requirement.
+Get the values.yaml for the AKO version 1.7.6 and edit the values as per the requirement.
 
 ```
-helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 > values.yaml
+helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 > values.yaml
 
 ```
 *Step4*
@@ -121,7 +121,7 @@ helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --versio
 Upgrade the helm chart
 
 ```
-helm upgrade ako-1593523840  oci://projects.registry.vmware.com/ako/helm-charts/ako -f /path/to/values.yaml --version 1.7.5 --set ControllerSettings.controllerHost=<IP or Hostname> --set avicredentials.password=<username> --set avicredentials.username=<username> --namespace=avi-system
+helm upgrade ako-1593523840  oci://projects.registry.vmware.com/ako/helm-charts/ako -f /path/to/values.yaml --version 1.7.6 --set ControllerSettings.controllerHost=<IP or Hostname> --set avicredentials.password=<username> --set avicredentials.username=<username> --namespace=avi-system
 
 ```
 

--- a/docs/openshift/openshift_helm.md
+++ b/docs/openshift/openshift_helm.md
@@ -17,16 +17,16 @@ oc new-project avi-system
 Search for available charts
 
 ```
-helm show chart oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5
+helm show chart oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6
 
-Pulled: projects.registry.vmware.com/ako/helm-charts/ako:1.7.5
+Pulled: projects.registry.vmware.com/ako/helm-charts/ako:1.7.6
 Digest: sha256:xyxyxxyxyx
 apiVersion: v2
-appVersion: 1.7.5
+appVersion: 1.7.6
 description: A helm chart for Avi Kubernetes Operator
 name: ako
 type: application
-version: 1.7.5
+version: 1.7.6
 ```
 
 *Step-3*
@@ -34,7 +34,7 @@ version: 1.7.5
 Edit the [values.yaml](../install/helm.md#parameters) file and update the details according to your environment.
 
 ```
-helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 > values.yaml
+helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 > values.yaml
 
 ```
 
@@ -43,7 +43,7 @@ helm show values oci://projects.registry.vmware.com/ako/helm-charts/ako --versio
 Install AKO.
 
 ```
-helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.5 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --namespace=avi-system
+helm install --generate-name oci://projects.registry.vmware.com/ako/helm-charts/ako --version 1.7.6 -f /path/to/values.yaml  --set ControllerSettings.controllerHost=<controller IP or Hostname> --set avicredentials.username=<avi-ctrl-username> --set avicredentials.password=<avi-ctrl-password> --namespace=avi-system
 ```
 
 
@@ -55,6 +55,6 @@ Verify the installation
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED     STATUS  	CHART    	APP VERSION
-ako-1691752136	avi-system	1       	2023-08-11	deployed	ako-1.7.5	1.7.5
+ako-1691752136	avi-system	1       	2023-08-11	deployed	ako-1.7.6	1.7.6
 ```
 

--- a/vendor/github.com/vmware/alb-sdk/go/models/bgp_profile.go
+++ b/vendor/github.com/vmware/alb-sdk/go/models/bgp_profile.go
@@ -26,7 +26,7 @@ type BgpProfile struct {
 
 	// Local Autonomous System ID. Allowed values are 1-4294967295.
 	// Required: true
-	LocalAs *int32 `json:"local_as"`
+	LocalAs *uint32 `json:"local_as"`
 
 	// LOCAL_PREF to be used for routes advertised. Applicable only over iBGP. Field introduced in 20.1.1.
 	LocalPreference *int32 `json:"local_preference,omitempty"`

--- a/version.yaml
+++ b/version.yaml
@@ -1,4 +1,4 @@
 major: 1
 minor: 7
-maintenance: 5
+maintenance: 6
 patch: null


### PR DESCRIPTION
This PR is to fix the issue of AKO not creating static routes when a value greater than **2147483647** is specified for **LocalAs** (Local Autonomous System ID) field in Bgp profile. This scenario is applicable only when Bgp profile is specified for VRF Context. The type for **LocalAs** field was **int32** and hence a value greater than **2147483647** was not accepted. Now, the type has been changed to **unit32**.