### PR TITLE
AV-194491 : Setting local_as and remote_as fields type for bgp peer to uint32 to avoid parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,4 +296,4 @@ All notable changes to this project will be documented in this file. The format 
 ## AKO-1.7.6
 
 ### Fixed
- - AKO does not create static routes when a value greater than **2147483647** is specified for **LocalAs** (Local Autonomous System ID) field in Bgp profile. This scenario is applicable only when Bgp profile is specified for VRF Context.
+ - AKO does not create static routes when a value greater than **2147483647** is specified for the **LocalAs** (Local Autonomous System ID) field in Bgp profile or the **LocalAs** or **RemoteAs** field in Bgp peers. This scenario is applicable only when Bgp profile is specified for the VRF Context.

--- a/vendor/github.com/vmware/alb-sdk/go/models/bgp_peer.go
+++ b/vendor/github.com/vmware/alb-sdk/go/models/bgp_peer.go
@@ -39,7 +39,7 @@ type BgpPeer struct {
 	Label *string `json:"label,omitempty"`
 
 	// Local AS to use for this ebgp peer. If specified, this will override the local AS configured at the VRF level. Allowed values are 1-4294967295. Field introduced in 17.1.6,17.2.2.
-	LocalAs *int32 `json:"local_as,omitempty"`
+	LocalAs *uint32 `json:"local_as,omitempty"`
 
 	// Peer Autonomous System Md5 Digest Secret Key.
 	Md5Secret *string `json:"md5_secret,omitempty"`
@@ -54,7 +54,7 @@ type BgpPeer struct {
 	PeerIp6 *IPAddr `json:"peer_ip6,omitempty"`
 
 	// Peer Autonomous System ID. Allowed values are 1-4294967295.
-	RemoteAs *int32 `json:"remote_as,omitempty"`
+	RemoteAs *uint32 `json:"remote_as,omitempty"`
 
 	// Shutdown the BGP peer. Field introduced in 17.2.4.
 	Shutdown *bool `json:"shutdown,omitempty"`


### PR DESCRIPTION
This PR is an extension of https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1342.