### PR TITLE
AV-195886: Fix for missing SSL port on adding HostRule with SSL cert to insecure Dedicated VS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ helmtests:
 	-u root:root \
 	-v $(PWD)/helm/ako:/apps \
 	-v $(PWD)/tests/helmtests:/apps/tests \
-	10.79.172.11:5000/avi-buildops/helmunittest/helm-unittest:3.11.1-0.3.0 .
+	avi-buildops-docker-registry-02.eng.vmware.com:5000/avi-buildops/helmunittest/helm-unittest:3.11.1-0.3.0 .
 
 .PHONY: gatewayapitests
 gatewayapitests:

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -261,7 +261,10 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 	if !validateUserInput {
 		return errors.New("sync is disabled because of configmap unavailability during bootup")
 	}
-	c.DisableSync, _ = DeleteConfigFromConfigmap(cs)
+	c.DisableSync, err = DeleteConfigFromConfigmap(cs)
+	if err != nil {
+		return err
+	}
 	lib.SetDisableSync(c.DisableSync)
 
 	configMapEventHandler := cache.ResourceEventHandlerFuncs{

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1132,6 +1132,7 @@ func (o *AviObjectGraph) BuildModelGraphForInsecureEVH(routeIgrObj RouteIngressM
 		evhNode = vsNode[0]
 		evhNode.DeletSSLRefInDedicatedNode(key)
 		evhNode.DeleteSSLPort(key)
+		evhNode.Secure = false
 		evhNode.DeleteSecureAppProfile(key)
 	} else {
 		vsNode[0].DeleteSSLRefInEVHNode(lib.GetTLSKeyCertNodeName(infraSettingName, host, ""), key)
@@ -1457,6 +1458,7 @@ func (o *AviObjectGraph) BuildModelGraphForSecureEVH(routeIgrObj RouteIngressMod
 		vsNode[0].ServiceMetadata.Namespace = namespace
 		vsNode[0].ServiceMetadata.HostNames = hosts
 		vsNode[0].AddSSLPort(key)
+		vsNode[0].Secure = true
 		vsNode[0].ApplicationProfile = utils.DEFAULT_L7_SECURE_APP_PROFILE
 		vsNode[0].AviMarkers = lib.PopulateVSNodeMarkers(namespace, host, infraSettingName)
 	}

--- a/internal/nodes/avi_model_l7_hostname_shard.go
+++ b/internal/nodes/avi_model_l7_hostname_shard.go
@@ -85,6 +85,7 @@ func (o *AviObjectGraph) BuildDedicatedL7VSGraphHostNameShard(vsName, hostname s
 	RemoveRedirectHTTPPolicyInModel(vsNode[0], pathFQDNs, key)
 	vsNode[0].DeletSSLRefInDedicatedNode(key)
 	vsNode[0].DeleteSSLPort(key)
+	vsNode[0].Secure = false
 	vsNode[0].DeleteSecureAppProfile(key)
 	objType := routeIgrObj.GetType()
 	isIngr := objType == utils.Ingress
@@ -638,6 +639,7 @@ func (o *AviObjectGraph) BuildModelGraphForSNI(routeIgrObj RouteIngressModel, in
 		vsNode[0].ServiceMetadata.Namespace = namespace
 		vsNode[0].ServiceMetadata.HostNames = sniHosts
 		vsNode[0].AddSSLPort(key)
+		vsNode[0].Secure = true
 		vsNode[0].ApplicationProfile = utils.DEFAULT_L7_SECURE_APP_PROFILE
 		vsNode[0].AviMarkers = lib.PopulateVSNodeMarkers(namespace, sniHost, infraSettingName)
 	}

--- a/tests/dedicatedvstests/l7_dedicated_crd_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_crd_test.go
@@ -342,6 +342,67 @@ func TestHostruleNoListenerDedicatedVS(t *testing.T) {
 
 }
 
+func TestApplySSLHostruleToInsecureDedicatedVS(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--foo.com-L7-dedicated"
+	hrname := "hr-cluster--foo.com-L7-dedicated"
+
+	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:               hrname,
+		Namespace:          "default",
+		WafPolicy:          "thisisaviref-waf",
+		ApplicationProfile: "thisisaviref-appprof",
+		AnalyticsProfile:   "thisisaviref-analyticsprof",
+		ErrorPageProfile:   "thisisaviref-errorprof",
+		Datascripts:        []string{"thisisaviref-ds2", "thisisaviref-ds1"},
+		HttpPolicySets:     []string{"thisisaviref-httpps2", "thisisaviref-httpps1"},
+	}
+	hostrule.SslKeyCertificate = "thisisaviref-sslkey"
+	hostrule.SslProfile = "thisisaviref-sslprof"
+	hrObj := hostrule.HostRule()
+	hrObj.Spec.VirtualHost.Fqdn = "foo.com"
+	hrObj.Spec.VirtualHost.FqdnType = v1beta1.Contains
+	hrObj.Spec.VirtualHost.TCPSettings = &v1beta1.HostRuleTCPSettings{
+		LoadBalancerIP: "80.80.80.80",
+	}
+
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules("default").Create(context.TODO(), hrObj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+
+	g.Eventually(func() string {
+		hostrule, _ := V1beta1Client.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 30*time.Second).Should(gomega.Equal("Accepted"))
+
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com-L7-dedicated"}
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--foo.com-L7-dedicated", true)
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
+	g.Expect(nodes[0].PortProto).To(gomega.HaveLen(2))
+	var portsWithHostRule []int
+	for _, port := range nodes[0].PortProto {
+		portsWithHostRule = append(portsWithHostRule, int(port.Port))
+		if port.EnableSSL {
+			g.Expect(int(port.Port)).To(gomega.Equal(443))
+		}
+	}
+	sort.Ints(portsWithHostRule)
+	g.Expect(portsWithHostRule[0]).To(gomega.Equal(80))
+	g.Expect(portsWithHostRule[1]).To(gomega.Equal(443))
+	g.Expect(nodes[0].VSVIPRefs[0].IPAddress).To(gomega.Equal("80.80.80.80"))
+
+	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--foo.com-L7-dedicated", false)
+
+	TearDownIngressForCacheSyncCheck(t, modelName)
+
+}
+
 // AviInfraSetting CRD
 
 func TestFQDNsCountForAviInfraSettingWithDedicatedShardSize(t *testing.T) {


### PR DESCRIPTION
UT Tests:

```
PASS
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedvstests      154.323s
```
```
PASS
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedevhtests     279.278s
```
```
PASS
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/evhtests      1042.875s
```
```
PASS
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/ingresstests  955.852s
```