### PR TITLE
AV-195118: Fixing race condition in status layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ helmtests:
 	-u root:root \
 	-v $(PWD)/helm/ako:/apps \
 	-v $(PWD)/tests/helmtests:/apps/tests \
-	10.79.172.11:5000/avi-buildops/helmunittest/helm-unittest:3.11.1-0.3.0 .
+	avi-buildops-docker-registry-02.eng.vmware.com:5000/avi-buildops/helmunittest/helm-unittest:3.11.1-0.3.0 .
 
 .PHONY: gatewayapitests
 gatewayapitests:

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -363,7 +363,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 							if pool_cache_obj.ServiceMetadataObj.IsMCIIngress {
 								statusOption.ObjType = lib.MultiClusterIngress
 							}
-							utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+							utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.HostNames[0], utils.Stringify(statusOption))
 							status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 						}
 					}
@@ -445,7 +445,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 				if pool_cache_obj.ServiceMetadataObj.IsMCIIngress {
 					statusOption.ObjType = lib.MultiClusterIngress
 				}
-				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.HostNames[0], utils.Stringify(statusOption))
 				status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 			}
 		}

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -364,7 +364,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 								statusOption.ObjType = lib.MultiClusterIngress
 							}
 							utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
-							status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
+							status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 						}
 					}
 				}
@@ -446,7 +446,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					statusOption.ObjType = lib.MultiClusterIngress
 				}
 				utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
-				status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
+				status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 			}
 		}
 	}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -537,7 +537,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 							statusOption.ObjType = lib.MultiClusterIngress
 						}
 						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
-						status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
+						status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 					}
 				}
 			}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -536,7 +536,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 						if pool_cache_obj.ServiceMetadataObj.IsMCIIngress {
 							statusOption.ObjType = lib.MultiClusterIngress
 						}
-						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.IngressName, utils.Stringify(statusOption))
+						utils.AviLog.Debugf("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.HostNames[0], utils.Stringify(statusOption))
 						status.PublishToStatusQueue(updateOptions.ServiceMetadata.HostNames[0], statusOption)
 					}
 				}


### PR DESCRIPTION
This commit makes the following change:
- To ensure that race condition does not happen in case of status update/delete of ingresses, key on which sharding was done to status queue is now changed from ingressname to hostname, to ensure that status changes of particular hostname will always get enqueued in same queue and sequential flow will be present