### PR TITLE
AV-196436 & AV-196437 : Removing model saving after child deletion to allow model saving and publishing in DequeueIngestion for new child creation

### DIFF
--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -242,18 +242,11 @@ func (o *AviObjectGraph) DeleteStaleChildVSes(key string, routeModel RouteModel,
 
 	_, storedChildVSes := akogatewayapiobjects.GatewayApiLister().GetRouteToChildVS(routeModel.GetType() + "/" + routeModel.GetNamespace() + "/" + routeModel.GetName())
 
-	var childRemoved bool
 	for _, childVSName := range storedChildVSes {
 		if _, ok := childVSes[childVSName]; !ok {
-			childRemoved = true
 			utils.AviLog.Infof("key: %s, msg: child VS retrieved for deletion %v", key, childVSName)
 			nodes.RemoveEvhInModel(childVSName, parentNode, key)
 			akogatewayapiobjects.GatewayApiLister().DeleteRouteChildVSMappings(routeModel.GetType()+"/"+routeModel.GetNamespace()+"/"+routeModel.GetName(), childVSName)
 		}
-	}
-
-	if childRemoved {
-		modelName := lib.GetTenant() + "/" + parentNode[0].Name
-		_ = saveAviModel(modelName, o.AviObjectGraph, key)
 	}
 }


### PR DESCRIPTION
This PR is for removing model saving after each child deletion to allow model saving and publishing once in DequeueIngestion. This will delete the old child VS and create the new child VS. When the matches section is updated in HTTPRoute, a new child vs should be created.