### PR TITLE
AV-198407 Fixing parent vs creation for gateways created before bootup

### DIFF
--- a/ako-gateway-api/k8s/ako_init.go
+++ b/ako-gateway-api/k8s/ako_init.go
@@ -289,9 +289,8 @@ func (c *GatewayController) FullSyncK8s(sync bool) error {
 		// not required since we don't create a model out of service
 	}
 
-	if sync {
-		c.publishAllParentVSKeysToRestLayer()
-	}
+	c.publishAllParentVSKeysToRestLayer()
+
 	return nil
 }
 


### PR DESCRIPTION
AV-198407 Fixing parent vs creation for gateways created before bootup

This PR fixes creation of parent vs when gateway is created first and then AKO is started.

Since the gateway code s similar to AKO's code, PublishToRestLayer is called only by the leader in HA mode in AKO
However in Gateways, since we are yet to model Gateways behaviour in HA mode, I am temporarily disabling check for sync==True, to enable publishing all parent VSes to RestLayer