### PR TITLE
AV-199142 Validation for Multiple Gateways with Overlapping hostnames

### DIFF
--- a/tests/gatewayapitests/ingestion/httproute_test.go
+++ b/tests/gatewayapitests/ingestion/httproute_test.go
@@ -31,6 +31,7 @@ func TestHTTPRouteCUD(t *testing.T) {
 	namespace := "default"
 	ports := []int32{8080, 8081}
 	key := "HTTPRoute" + "/" + namespace + "/" + httpRouteName
+	gwkey := "Gateway/" + DEFAULT_NAMESPACE + "/" + gatewayName
 	akogatewayapiobjects.GatewayApiLister().UpdateGatewayClass(gatewayClassName, true)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
@@ -55,6 +56,8 @@ func TestHTTPRouteCUD(t *testing.T) {
 	// delete
 	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, namespace)
 	waitAndverify(t, key)
+	akogatewayapitests.TeardownGateway(t, gatewayName, namespace)
+	waitAndverify(t, gwkey)
 }
 
 func TestHTTPRouteInvalidHostname(t *testing.T) {


### PR DESCRIPTION
AV-199142 Validation for Multiple Gateways with Overlapping hostnames

This PR:

- Adds validation for rejecting multiple Gateways with Listener having same hostname.
- Adds validation for rejecting multiple Gateways with Listener having overlapping hostname
- Unit TestCases for both of these scenarios