### PR TITLE
AV-199356 Added Validations for AllowedRoutes in Gateway Listener Validations

### DIFF
--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -50,6 +50,7 @@ const (
 	Service                       = "Service"
 	Secret                        = "Secret"
 	HTTP                          = "HTTP"
+	HTTPRoute                     = "HTTPRoute"
 	HeaderMethod                  = ":method"
 	HeaderAuthority               = ":authority"
 	HeaderScheme                  = ":scheme"


### PR DESCRIPTION
AV-199356 Added Validations for AllowedRoutes in Gateway Listener Validations.

- This PR adds validations to reject Gateways with Listeners having `Invalid Listener -> allowedRoutes -> kinds -> kind` and `Invalid Listener -> allowedRoutes -> kinds -> Group`.
- Unit TestCases for Ingestion and Graph Layer