### PR TITLE
AV-197532 : HTTPRoute with multiple hostnames attaches invalid hostname to the child vs

### DIFF
--- a/ako-gateway-api/lib/lib.go
+++ b/ako-gateway-api/lib/lib.go
@@ -127,7 +127,6 @@ func VerifyHostnameSubdomainMatch(hostname string) bool {
 	// Check if a hostname is valid or not by verifying if it has a prefix that
 	// matches any of the sub-domains.
 	subDomains := nodes.GetDefaultSubDomain()
-	//subDomains := nodes.GetDefaultSubDomain()
 	if len(subDomains) == 0 {
 		// No IPAM DNS configured, we simply pass the hostname
 		return true

--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -87,7 +87,7 @@ func DequeueIngestion(key string, fullsync bool) {
 
 			switch objType {
 			case lib.HTTPRoute:
-				model.ProcessL7Routes(key, routeModel, gatewayNsName, childVSes)
+				model.ProcessL7Routes(key, routeModel, gatewayNsName, childVSes, fullsync)
 			default:
 				utils.AviLog.Warnf("key: %s, msg: route of type %s not supported", key, objType)
 				continue

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -236,7 +236,7 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 					}
 					hostnameMatched := false
 					for _, routeHostname := range hrObj.Spec.Hostnames {
-						if strings.HasSuffix(string(routeHostname), listenerHostname) {
+						if strings.HasSuffix(string(routeHostname), listenerHostname) && akogatewayapilib.VerifyHostnameSubdomainMatch(string(routeHostname)) {
 							hostnameIntersection = append(hostnameIntersection, string(routeHostname))
 							hostnameMatched = true
 						}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2269,6 +2269,19 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						}
 					}
 				}
+				if vs["pool_group_ref"] != nil {
+					pgRef, ok := vs["pool_group_ref"].(string)
+					if ok {
+						pgUuid := ExtractUuid(pgRef, "poolgroup-.*.#")
+						pgName, foundpg := c.PgCache.AviCacheGetNameByUuid(pgUuid)
+						if foundpg {
+							pgKey := NamespaceName{Namespace: lib.GetTenant(), Name: pgName.(string)}
+							poolgroupKeys = append(poolgroupKeys, pgKey)
+							pgpoolKeys := c.AviPGPoolCachePopulate(client, cloud, pgName.(string))
+							poolKeys = append(poolKeys, pgpoolKeys...)
+						}
+					}
+				}
 				// Populate the vscache meta object here.
 				vsMetaObj := AviVsCache{
 					Name:                 vs["name"].(string),

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -944,3 +944,91 @@ func TestHTTPRouteMultiportBackendSvc(t *testing.T) {
 	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
 	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
 }
+
+func TestHTTPRouteInvalidHostname(t *testing.T) {
+
+	gatewayName := "gateway-hr-01"
+	gatewayClassName := "gateway-class-hr-01"
+	httpRouteName := "http-route-hr-01"
+	ports := []int32{8080}
+	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	listeners := akogatewayapitests.GetListenersV1(ports)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+	svcExample := (integrationtest.FakeService{
+		Name:         "avisvc",
+		Namespace:    "default",
+		Type:         corev1.ServiceTypeClusterIP,
+		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
+	}).Service()
+
+	_, err := akogatewayapitests.KubeClient.CoreV1().Services("default").Create(context.TODO(), svcExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Service: %v", err)
+	}
+	epExample := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "avisvc",
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+			Ports:     []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+		}},
+	}
+	_, err = akogatewayapitests.KubeClient.CoreV1().Endpoints("default").Create(context.TODO(), epExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in creating Endpoint: %v", err)
+	}
+
+	parentRefs := akogatewayapitests.GetParentReferencesV1([]string{gatewayName}, DEFAULT_NAMESPACE, ports)
+	rule := akogatewayapitests.GetHTTPRouteRuleV1([]string{"/foo"}, []string{},
+		map[string][]string{"RequestHeaderModifier": {"add", "remove", "replace"}},
+		[][]string{{"avisvc", "default", "8080", "1"}})
+	rules := []gatewayv1.HTTPRouteRule{rule}
+	hostnames := []gatewayv1.Hostname{"foo-8080.com", "test-failure.com"}
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(1))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+
+	childNode := nodes[0].EvhNodes[0]
+	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
+	g.Expect(childNode.VHMatches).To(gomega.HaveLen(1))
+	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo-8080.com"))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/foo"))
+	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+
+	// verifies the child deletion
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return -1
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(0))
+
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}


### PR DESCRIPTION
This PR fixes issue which was discovered while running **test_httproute_multiple_hosts** test case in **test_http_route** test suite. The results are shared below.
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-dev/test/avitest/functional/ako/ako-gw-      |                |                     |             |             |
| api/test_http_route.py                                                           |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| TestHttpRoute.test_setup_configuration                                           |     PASSED     |       00:00:47      |   11:44:36  |   11:45:24  |
| TestHttpRoute.test_insecure_httproute                                            |     PASSED     |       00:01:18      |   11:45:24  |   11:46:43  |
| TestHttpRoute.test_secure_httproute                                              |     PASSED     |       00:01:01      |   11:46:43  |   11:47:44  |
| TestHttpRoute.test_httproute_match_crud                                          |     PASSED     |       00:01:47      |   11:47:44  |   11:49:32  |
| TestHttpRoute.test_httproute_match_append_header_crud                            |     PASSED     |       00:01:47      |   11:49:32  |   11:51:20  |
| TestHttpRoute.test_httproute_match_replace_header_crud                           |     PASSED     |       00:01:47      |   11:51:20  |   11:53:08  |
| TestHttpRoute.test_httproute_filter_crud                                         |     PASSED     |       00:01:31      |   11:53:08  |   11:54:39  |
| TestHttpRoute.test_httproute_backendref_crud                                     |     PASSED     |       00:01:31      |   11:54:39  |   11:56:11  |
| TestHttpRoute.test_httproute_multiple_rules                                      |     PASSED     |       00:01:32      |   11:56:11  |   11:57:44  |
| TestHttpRoute.test_multiple_http_routes_with_gateway                             |     PASSED     |       00:02:03      |   11:57:44  |   11:59:47  |
| TestHttpRoute.test_http_route_with_multiple_gateways                             |    SKIPPED     |       00:00:00      |   11:59:47  |   11:59:47  |
| TestHttpRoute.test_http_route_same_path_different_headers                        |     PASSED     |       00:01:32      |   11:59:47  |   12:01:20  |
| TestHttpRoute.test_httproute_multiple_hosts                                      |     PASSED     |       00:02:02      |   12:01:20  |   12:03:23  |
| TestHttpRoute.test_delete_configurations                                         |     PASSED     |       00:01:20      |   12:03:23  |   12:04:43  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 13   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 14                                                            |    Skipped:1   | Total Time:00:20:06 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```