### PR TITLE
AV-199357 register gatewayapi for event recording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ gatewayapitests:
 	sudo docker run \
 	-w=/go/src/$(PACKAGE_PATH_AKO) \
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(GO_IMG_TEST) \
-	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
+	$(GOTEST) -mod=vendor $(PACKAGE_PATH_AKO)/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
 
 .PHONY: int_test
 int_test:

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ gatewayapitests:
 	sudo docker run \
 	-w=/go/src/$(PACKAGE_PATH_AKO) \
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(GO_IMG_TEST) \
-	$(GOTEST) -mod=vendor $(PACKAGE_PATH_AKO)/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
 
 .PHONY: int_test
 int_test:

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	networkingv1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 
 	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
@@ -53,6 +54,7 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 	corev1.AddToScheme,
 	networkingv1.AddToScheme,
 	networkingv1beta1.AddToScheme,
+	gatewayv1.Install,
 }
 
 var AddToScheme = localSchemeBuilder.AddToScheme


### PR DESCRIPTION
Tested by running Ut with invalid HTTP route and enabling eventrecording . 

`no kind is registered for the type v1.HTTPRoute in scheme "pkg/utils/events.go:40"
`
was replaced in logs by
`
2024-02-21T13:22:35.758+0530    ERROR   k8s/validator.go:227    key: HTTPRoute/default/httproute-06, msg: HTTPRoute object httproute-06 is not valid
2024-02-21T13:22:35.758+0530    INFO    record/event.go:299     Event(v1.ObjectReference{Kind:"HTTPRoute", Namespace:"default", Name:"httproute-06", UID:"", APIVersion:"gateway.networking.k8s.io/v1", ResourceVersion:"2024-02-21 13:22:35.757036 +0530 IST", FieldPath:""}): type: 'Warning' reason: 'Detached' HTTPRoute object httproute-06 is not valid`