### PR TITLE
AV-200194 : Regression for user and name prefix in ako and ako-gateway

### DIFF
--- a/ako-gateway-api/k8s/ako_init.go
+++ b/ako-gateway-api/k8s/ako_init.go
@@ -489,7 +489,7 @@ func (c *GatewayController) HandleConfigMap(k8sinfo k8s.K8sinformers, ctrlCh cha
 
 			delModels := delConfigFromData(cm.Data)
 
-			validateUserInput, err := avicache.ValidateUserInput(aviclient)
+			validateUserInput, err := avicache.ValidateUserInput(aviclient, true)
 			if err != nil {
 				utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 				akogatewayapilib.AKOControlConfig().PodEventf(corev1.EventTypeWarning, lib.SyncDisabled, "Invalid user input %s", err.Error())
@@ -521,7 +521,7 @@ func (c *GatewayController) HandleConfigMap(k8sinfo k8s.K8sinformers, ctrlCh cha
 				return
 			}
 			// if DeleteConfig value has changed, then check if we need to enable/disable sync
-			isValidUserInput, err := avicache.ValidateUserInput(aviclient)
+			isValidUserInput, err := avicache.ValidateUserInput(aviclient, true)
 			if err != nil {
 				utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 			}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2564,7 +2564,7 @@ func GetControllerClusterUUID() string {
 	return controllerClusterUUID
 }
 
-func ValidateUserInput(client *clients.AviClient) (bool, error) {
+func ValidateUserInput(client *clients.AviClient, isGateway bool) (bool, error) {
 	// add other step0 validation logics here -> isValid := check1 && check2 && ...
 
 	var err error
@@ -2581,7 +2581,7 @@ func ValidateUserInput(client *clients.AviClient) (bool, error) {
 			return isVRFValid, err
 		}
 	}
-	isRequiredValuesValid := checkRequiredValuesYaml(client, &err)
+	isRequiredValuesValid := checkRequiredValuesYaml(client, isGateway, &err)
 	isSegroupValid := validateAndConfigureSeGroup(client, &err)
 	if lib.IsWCP() {
 		if isTenantValid &&
@@ -2860,15 +2860,18 @@ func PopulateVipNetworkwithUUID(segMgmtNetwork string, client *clients.AviClient
 	return ipNetworkList, retErr
 }
 
-func checkRequiredValuesYaml(client *clients.AviClient, returnErr *error) bool {
+func checkRequiredValuesYaml(client *clients.AviClient, isGateway bool, returnErr *error) bool {
 	if _, err := lib.IsClusterNameValid(); err != nil {
 		*returnErr = err
 		return false
 	}
 
-	lib.SetNamePrefix("")
+	// Set the ako user with prefix
 	// after clusterName validation, set AKO User to be used in created_by fields for Avi Objects
-	lib.SetAKOUser(lib.AKOPrefix)
+	if !isGateway {
+		lib.SetNamePrefix("")
+		lib.SetAKOUser(lib.AKOPrefix)
+	}
 	//Set clusterlabel checksum
 	lib.SetClusterLabelChecksum()
 

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -250,7 +250,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 	}
 	aviclient := aviClientPool.AviClient[0]
 
-	validateUserInput, err := avicache.ValidateUserInput(aviclient)
+	validateUserInput, err := avicache.ValidateUserInput(aviclient, false)
 	if err != nil {
 		utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 		lib.AKOControlConfig().PodEventf(v1.EventTypeWarning, lib.SyncDisabled, "Invalid user input %s", err.Error())
@@ -283,7 +283,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 
 			delModels := delConfigFromData(cm.Data)
 
-			validateUserInput, err := avicache.ValidateUserInput(aviclient)
+			validateUserInput, err := avicache.ValidateUserInput(aviclient, false)
 			if err != nil {
 				utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 				lib.AKOControlConfig().PodEventf(v1.EventTypeWarning, lib.SyncDisabled, "Invalid user input %s", err.Error())
@@ -315,7 +315,7 @@ func (c *AviController) HandleConfigMap(k8sinfo K8sinformers, ctrlCh chan struct
 				return
 			}
 			// if DeleteConfig value has changed, then check if we need to enable/disable sync
-			isValidUserInput, err := avicache.ValidateUserInput(aviclient)
+			isValidUserInput, err := avicache.ValidateUserInput(aviclient, false)
 			if err != nil {
 				utils.AviLog.Errorf("Error while validating input: %s", err.Error())
 			}


### PR DESCRIPTION
The issue is with the user name used by ako-gateway for created_by field in rest requests for Avi objects and for the name prefix used by ako-gateway to create the Avi objects. The issue is a regression added as part of changes for validating the values.yaml fields. The values set by ako-gateway for user name and name prefix are over-written by validator function. Hence, we are moving out the code for setting the user and name prefix out of the validator function.