### PR TITLE
AV-201231 : Allow AKO to use existing avi-secret in avi-system namespace

### DIFF
--- a/docs/values.md
+++ b/docs/values.md
@@ -281,6 +281,8 @@ authtoken = "<authtoken>"
 print(base64.b64encode(authtoken.encode("ascii")))
 ```
 
+**Note:** From release v1.12.1 onwards, AKO supports reading Avi controller credentials from existing `avi-secret` in `avi-system` namespace. If username and either of password or authtoken are not specified, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in avi-system namespace and will reference it.
+
 ### avicredentials.certificateAuthorityData
 
 This field allows setting the rootCA of the Avi controller, that AKO uses to verify the server certificate provided by the Avi Controller during the TLS handshake. This also enables AKO to connect securely over SSL with the Avi Controller, which is not possible in case the field is not provided.

--- a/docs/values.md
+++ b/docs/values.md
@@ -281,7 +281,7 @@ authtoken = "<authtoken>"
 print(base64.b64encode(authtoken.encode("ascii")))
 ```
 
-**Note:** From release v1.12.1 onwards, AKO supports reading Avi Controller credentials from existing `avi-secret` from the namespace in which AKO is installed. If username and either password or authtoken are not specified, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in the namespace in which the AKO Helm release is installed and will reference it.
+**Note:** From release v1.12.1 onwards, AKO supports reading Avi Controller credentials including `certificateAuthorityData` from existing `avi-secret` from the namespace in which AKO is installed. If `username` and either `password` or `authtoken` are not specified, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in the namespace in which the AKO Helm release is installed and will reference it. 
 
 ### avicredentials.certificateAuthorityData
 

--- a/docs/values.md
+++ b/docs/values.md
@@ -281,7 +281,7 @@ authtoken = "<authtoken>"
 print(base64.b64encode(authtoken.encode("ascii")))
 ```
 
-**Note:** From release v1.12.1 onwards, AKO supports reading Avi controller credentials from existing `avi-secret` in `avi-system` namespace. If username and either of password or authtoken are not specified, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in avi-system namespace and will reference it.
+**Note:** From release v1.12.1 onwards, AKO supports reading Avi Controller credentials from existing `avi-secret` from the namespace in which AKO is installed. If username and either password or authtoken are not specified, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in the namespace in which the AKO Helm release is installed and will reference it.
 
 ### avicredentials.certificateAuthorityData
 

--- a/helm/ako/templates/secret.yaml
+++ b/helm/ako/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.avicredentials.username (or .Values.avicredentials.password .Values.avicredentials.authtoken) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +16,4 @@ data:
   {{ if .Values.avicredentials.certificateAuthorityData  }}
   certificateAuthorityData: {{ .Values.avicredentials.certificateAuthorityData | b64enc }}
   {{ end }}
+{{- end -}}

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -127,7 +127,7 @@ rbac:
   # Creates the pod security policy if set to true
   pspEnable: false
 
-
+# If username and either of password or authtoken are not specified, avi-secret will not be created. AKO will assume that avi-secret already exists and will reference it.
 avicredentials:
   username:
   password:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -127,7 +127,7 @@ rbac:
   # Creates the pod security policy if set to true
   pspEnable: false
 
-# If username and either password or authtoken are not specified, avi-secret will not be created. AKO will assume that the avi-secret already exists and will reference it.
+# If username and either password or authtoken are not specified, avi-secret will not be created. AKO will assume that the avi-secret already exists and will reference it. The Avi Controller credentials, including certificateAuthorityData, will be read from the existing avi-secret.
 avicredentials:
   username:
   password:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -127,7 +127,7 @@ rbac:
   # Creates the pod security policy if set to true
   pspEnable: false
 
-# If username and either of password or authtoken are not specified, avi-secret will not be created. AKO will assume that avi-secret already exists and will reference it.
+# If username and either password or authtoken are not specified, avi-secret will not be created. AKO will assume that the avi-secret already exists and will reference it.
 avicredentials:
   username:
   password:

--- a/tests/helmtests/avi-secret_test.yaml
+++ b/tests/helmtests/avi-secret_test.yaml
@@ -1,0 +1,18 @@
+suite: Test avi-secret creation when avi controller credentials are specified or not specified in values.yaml
+templates:
+  - secret.yaml
+tests:
+  - it: avi-secret should not be present when avi controller credentials are not specified.
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: avi-secret should be present when avi controller credentials are specified.
+    set:
+      avicredentials:
+        username: 'admin'
+        password: 'avi123'
+    asserts:
+      - isKind:
+          of: Secret
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
This PR is to allow AKO to use existing avi-secret in avi-system namespace. If username and either of password or authtoken are not specified in Helm chart values.yaml, avi-secret will not be created as part of Helm installation. AKO will assume that avi-secret already exists in avi-system namespace and will reference it.