### PR TITLE
AV-200223 : AVIInfra Passthrough route is not getting created if aviinfrasetting is accepted later

### DIFF
--- a/internal/nodes/ingress_model_rel.go
+++ b/internal/nodes/ingress_model_rel.go
@@ -866,6 +866,8 @@ func AviSettingToRoute(infraSettingName, namespace, key string) ([]string, bool)
 	for _, route := range routes {
 		if routeObj, isRoute := route.(*routev1.Route); isRoute {
 			RouteChanges(routeObj.Name, routeObj.Namespace, key)
+			routeNSName := routeObj.Namespace + "/" + routeObj.Name
+			allRoutes = append(allRoutes, routeNSName)
 		}
 	}
 


### PR DESCRIPTION
The PR fixes the issue of attachment of aviinfrasetting to routes if aviinfrasetting is accepted after annotation addition to the route. The FT for the case can be found as part of this PR : https://github.com/avinetworks/avi-dev/pull/115457