### PR TITLE
Update ako-tenant.json: Allow user from this tenant to read tenants.

### DIFF
--- a/docs/roles/ako-tenant.json
+++ b/docs/roles/ako-tenant.json
@@ -226,7 +226,7 @@
         "resource": "PERMISSION_ROLE"
     },
     {
-        "type": "NO_ACCESS",
+        "type": "READ_ACCESS",
         "resource": "PERMISSION_TENANT"
     },
     {


### PR DESCRIPTION
When AKO is running with non-admin user, with customized role, it required `READ` permission to read tenant resources. Otherwise there will be failure in bootup.