### PR TITLE
AV-121758: AKO Pod restarted due to panic due to indexing issue.

### DIFF
--- a/internal/objects/store.go
+++ b/internal/objects/store.go
@@ -116,8 +116,8 @@ func (o *ObjectMapStore) Get(objName string) (bool, interface{}) {
 }
 
 func (o *ObjectMapStore) GetAllObjectNames() map[string]interface{} {
-	o.ObjLock.RLock()
-	defer o.ObjLock.RUnlock()
+	o.ObjLock.Lock()
+	defer o.ObjLock.Unlock()
 	// TODO (sudswas): Pass a copy instead of the reference
 	return o.ObjectMap
 


### PR DESCRIPTION
Issue is happening due to `concurrent map iteration and map write`. 

So lock is added to avoid this condition.
Another thing we can try out is to send copy of object instead of sending reference .