### PR TITLE
AV-205285 : Shared VIP virtual service is not re-created if the LB service with incorrect configuration is deleted for NPL

### DIFF
--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -640,7 +640,9 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 		}
 	} else {
 		if lib.AutoAnnotateNPLSvc() {
-			if !status.CheckNPLSvcAnnotation(key, namespace, name) {
+			// TO DO : Modify CheckNPLSvcAnnotation method so that we do not try to update annotation in case svc is already deleted
+			_, err := utils.GetInformers().ServiceInformer.Lister().Services(namespace).Get(name)
+			if err == nil && !status.CheckNPLSvcAnnotation(key, namespace, name) {
 				statusOption := status.StatusOptions{
 					ObjType:   lib.NPLService,
 					Op:        lib.UpdateStatus,


### PR DESCRIPTION
Test results are given below for NPL. Only failures are for udp traffic as the client script was not updated correctly.
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| dev/test/avitest/functional/ako/test_lbsvc.py                                    |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_LBSvcSNI.test_create_namespace                                              |     PASSED     |       00:00:00      |   06:04:18  |   06:04:19  |
| Test_LBSvcSNI.test_app_creation                                                  |     PASSED     |       00:00:26      |   06:04:19  |   06:04:46  |
| Test_LBSvcSNI.test_lbsvc_avi_not_lbcontroller                                    |     PASSED     |       00:01:12      |   06:04:46  |   06:05:58  |
| Test_LBSvcSNI.test_lbsvc_avi_lbcontroller                                        |     PASSED     |       00:01:22      |   06:05:58  |   06:07:20  |
| Test_LBSvcSNI.test_create_multiple_services_shared_vip_lbclass                   |     PASSED     |       00:00:36      |   06:07:20  |   06:07:57  |
| Test_LBSvcSNI.test_aviinfrasetting_crd_with_invalid_lbclass_svc                  |     PASSED     |       00:00:21      |   06:07:57  |   06:08:19  |
| Test_LBSvcSNI.test_LBIP_annotation                                               |     PASSED     |       00:00:46      |   06:08:19  |   06:09:05  |
| Test_LBSvcSNI.test_update_service                                                |     PASSED     |       00:00:25      |   06:09:05  |   06:09:31  |
| Test_LBSvcSNI.test_update_deployment_replicas                                    |     PASSED     |       00:00:40      |   06:09:31  |   06:10:12  |
| Test_LBSvcSNI.test_create_multiple_services                                      |     PASSED     |       00:00:12      |   06:10:12  |   06:10:24  |
| Test_LBSvcSNI.test_delete_multiple_services                                      |     PASSED     |       00:00:00      |   06:10:24  |   06:10:24  |
| Test_LBSvcSNI.test_app_no_pod                                                    |     PASSED     |       00:00:15      |   06:10:24  |   06:10:40  |
| Test_LBSvcSNI.test_service_static_ip                                             |     PASSED     |       00:01:01      |   06:10:40  |   06:11:42  |
| Test_LBSvcSNI.test_ako_delete_pod_with_vs_deletion_static_ip                     |     PASSED     |       00:00:31      |   06:11:42  |   06:12:13  |
| Test_LBSvcSNI.test_ako_auto_fqdn                                                 |     PASSED     |       00:01:02      |   06:12:13  |   06:13:16  |
| Test_LBSvcSNI.test_ako_length_validation_for_auto_fqdn_flat                      |     PASSED     |       00:05:33      |   06:13:16  |   06:18:49  |
| Test_LBSvcSNI.test_ako_fqdn_annotation                                           |     PASSED     |       00:00:26      |   06:18:49  |   06:19:15  |
| Test_LBSvcSNI.test_extDNS_shared_vip_fqdn                                        |     PASSED     |       00:01:01      |   06:19:15  |   06:20:17  |
| Test_LBSvcSNI.test_svc_infrasetting_update_segroup                               |    SKIPPED     |       00:00:00      |   06:20:17  |   06:20:17  |
| Test_LBSvcSNI.test_svc_infrasetting_update_network                               |     PASSED     |       00:00:31      |   06:20:17  |   06:20:48  |
| Test_LBSvcSNI.test_public_ip_allocation                                          |    SKIPPED     |       00:00:00      |   06:20:48  |   06:20:48  |
| Test_LBSvcSNI.test_create_multiple_services_shared_vip                           |     PASSED     |       00:00:26      |   06:20:48  |   06:21:14  |
| Test_LBSvcSNI.test_create_multiple_services_shared_vip_static_ip                 |     PASSED     |       00:00:36      |   06:21:14  |   06:21:51  |
| Test_LBSvcSNI.test_app_creation_sctp                                             |    SKIPPED     |       00:00:00      |   06:21:51  |   06:21:51  |
| Test_LBSvcSNI.test_create_multiple_services_shared_vip_sctp                      |    SKIPPED     |       00:00:00      |   06:21:51  |   06:21:51  |
| Test_LBSvcSNI.test_multi_protocol_all                                            |    SKIPPED     |       00:00:00      |   06:21:51  |   06:21:51  |
| Test_LBSvcSNI.test_multi_protocol_tcp_udp                                        |     FAILED     |       00:00:56      |   06:21:51  |   06:22:47  |
| Test_LBSvcSNI.test_multi_protocol_tcp_sctp                                       |    SKIPPED     |       00:00:00      |   06:22:48  |   06:22:48  |
| Test_LBSvcSNI.test_multi_protocol_sctp_udp                                       |    SKIPPED     |       00:00:00      |   06:22:48  |   06:22:48  |
| Test_LBSvcSNI.test_multi_protocol_shared_vip                                     |    SKIPPED     |       00:00:00      |   06:22:48  |   06:22:48  |
| Test_LBSvcSNI.test_delete_apps                                                   |     PASSED     |       00:00:00      |   06:22:48  |   06:22:48  |
| Test_LBSvcSNI.test_delete_namespace                                              |     PASSED     |       00:00:50      |   06:22:48  |   06:23:39  |
| Test_LBSvcEVH.test_create_namespace                                              |     PASSED     |       00:00:00      |   06:23:39  |   06:23:40  |
| Test_LBSvcEVH.test_app_creation                                                  |     PASSED     |       00:00:41      |   06:23:40  |   06:24:21  |
| Test_LBSvcEVH.test_lbsvc_avi_not_lbcontroller                                    |     PASSED     |       00:01:12      |   06:24:21  |   06:25:33  |
| Test_LBSvcEVH.test_lbsvc_avi_lbcontroller                                        |     PASSED     |       00:03:08      |   06:25:33  |   06:28:41  |
| Test_LBSvcEVH.test_create_multiple_services_shared_vip_lbclass                   |     PASSED     |       00:00:36      |   06:28:41  |   06:29:18  |
| Test_LBSvcEVH.test_aviinfrasetting_crd_with_invalid_lbclass_svc                  |     PASSED     |       00:00:22      |   06:29:18  |   06:29:40  |
| Test_LBSvcEVH.test_LBIP_annotation                                               |     PASSED     |       00:00:46      |   06:29:40  |   06:30:26  |
| Test_LBSvcEVH.test_update_service                                                |     PASSED     |       00:00:25      |   06:30:26  |   06:30:52  |
| Test_LBSvcEVH.test_update_deployment_replicas                                    |     PASSED     |       00:00:40      |   06:30:52  |   06:31:33  |
| Test_LBSvcEVH.test_create_multiple_services                                      |     PASSED     |       00:00:22      |   06:31:33  |   06:31:55  |
| Test_LBSvcEVH.test_delete_multiple_services                                      |     PASSED     |       00:00:15      |   06:31:55  |   06:32:11  |
| Test_LBSvcEVH.test_app_no_pod                                                    |     PASSED     |       00:00:15      |   06:32:11  |   06:32:26  |
| Test_LBSvcEVH.test_service_static_ip                                             |     PASSED     |       00:01:01      |   06:32:26  |   06:33:28  |
| Test_LBSvcEVH.test_ako_delete_pod_with_vs_deletion_static_ip                     |     PASSED     |       00:00:46      |   06:33:28  |   06:34:14  |
| Test_LBSvcEVH.test_ako_auto_fqdn                                                 |     PASSED     |       00:01:02      |   06:34:14  |   06:35:17  |
| Test_LBSvcEVH.test_ako_length_validation_for_auto_fqdn_flat                      |     PASSED     |       00:05:33      |   06:35:17  |   06:40:51  |
| Test_LBSvcEVH.test_ako_fqdn_annotation                                           |     PASSED     |       00:00:26      |   06:40:51  |   06:41:17  |
| Test_LBSvcEVH.test_extDNS_shared_vip_fqdn                                        |     PASSED     |       00:01:01      |   06:41:17  |   06:42:18  |
| Test_LBSvcEVH.test_svc_infrasetting_update_segroup                               |    SKIPPED     |       00:00:00      |   06:42:18  |   06:42:18  |
| Test_LBSvcEVH.test_svc_infrasetting_update_network                               |     PASSED     |       00:00:31      |   06:42:18  |   06:42:50  |
| Test_LBSvcEVH.test_public_ip_allocation                                          |    SKIPPED     |       00:00:00      |   06:42:50  |   06:42:50  |
| Test_LBSvcEVH.test_create_multiple_services_shared_vip                           |     PASSED     |       00:00:26      |   06:42:50  |   06:43:16  |
| Test_LBSvcEVH.test_create_multiple_services_shared_vip_static_ip                 |     PASSED     |       00:00:36      |   06:43:16  |   06:43:52  |
| Test_LBSvcEVH.test_app_creation_sctp                                             |    SKIPPED     |       00:00:00      |   06:43:52  |   06:43:52  |
| Test_LBSvcEVH.test_create_multiple_services_shared_vip_sctp                      |    SKIPPED     |       00:00:00      |   06:43:52  |   06:43:52  |
| Test_LBSvcEVH.test_multi_protocol_all                                            |    SKIPPED     |       00:00:00      |   06:43:52  |   06:43:52  |
| Test_LBSvcEVH.test_multi_protocol_tcp_udp                                        |     FAILED     |       00:00:56      |   06:43:52  |   06:44:49  |
| Test_LBSvcEVH.test_multi_protocol_tcp_sctp                                       |    SKIPPED     |       00:00:00      |   06:44:49  |   06:44:49  |
| Test_LBSvcEVH.test_multi_protocol_sctp_udp                                       |    SKIPPED     |       00:00:00      |   06:44:49  |   06:44:49  |
| Test_LBSvcEVH.test_multi_protocol_shared_vip                                     |    SKIPPED     |       00:00:00      |   06:44:49  |   06:44:49  |
| Test_LBSvcEVH.test_delete_apps                                                   |     PASSED     |       00:00:00      |   06:44:49  |   06:44:50  |
| Test_LBSvcEVH.test_delete_namespace                                              |     PASSED     |       00:00:50      |   06:44:50  |   06:45:40  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 46   |                     |             |             |
|                                                                                  |    Failed:2    |                     |             |             |
|  Total test cases: 64                                                            |   Skipped:16   | Total Time:00:41:21 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```