### PR TITLE
Fix Istio failure due to panic

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -141,9 +141,9 @@ func (rest *RestOperations) IstioCU(key string, avimodel *nodes.AviObjectGraph) 
 		restOps = []*utils.RestOp{restOp}
 		pkiSuccess, _ = rest.ExecuteRestAndPopulateCache(restOps, pkiKey, avimodel, key, false)
 	} else {
-		pkiCache := pkiCacheObj.(avicache.AviPkiProfileCache)
+		pkiCache := pkiCacheObj.(*avicache.AviPkiProfileCache)
 		if pkiCache.CloudConfigCksum != pkiNode.GetCheckSum() {
-			restOp := rest.AviPkiProfileBuild(pkiNode, &pkiCache)
+			restOp := rest.AviPkiProfileBuild(pkiNode, pkiCache)
 			restOps = []*utils.RestOp{restOp}
 			pkiSuccess, _ = rest.ExecuteRestAndPopulateCache(restOps, pkiKey, avimodel, key, false)
 		}


### PR DESCRIPTION
AKO was throwing follwowing panic error

panic: interface conversion: interface {} is *cache.AviPkiProfileCache, not cache.AviPkiProfileCache