### PR TITLE
Allow LB to process even after aviinfrasetting is not valid.

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -5,7 +5,7 @@
     },
     "kubernetes": {
         "maxVersion": "1.29",
-        "minVersion": "1.22"
+        "minVersion": "1.26"
     },
     "version": "1.12.1"
 }

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -553,14 +553,9 @@ func (o *AviObjectGraph) ConstructSharedVipSvcLBNode(sharedVipKey, namespace, ke
 
 	// configures VS and VsVip nodes using infraSetting object (via CRD).
 	if serviceObject != nil {
-		infraSetting, err := getL4InfraSetting(key, namespace, serviceObject, nil)
-		if err != nil {
-			if !k8serrors.IsNotFound(err) {
-				utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting %s", key, err.Error())
-				return nil
-			}
+		if infraSetting, err := getL4InfraSetting(key, namespace, serviceObject, nil); err == nil {
+			buildWithInfraSetting(key, namespace, avi_vs_meta, vsVipNode, infraSetting)
 		}
-		buildWithInfraSetting(key, namespace, avi_vs_meta, vsVipNode, infraSetting)
 
 		// Copy the VS properties from L4Rule object
 		if l4Rule, err := getL4Rule(key, serviceObject); err == nil {
@@ -602,10 +597,7 @@ func (o *AviObjectGraph) ConstructSharedVipPolPoolNodes(vsNode *AviVsNode, share
 		if i == 0 {
 			infraSetting, err = getL4InfraSetting(key, namespace, svcObj, nil)
 			if err != nil {
-				if !k8serrors.IsNotFound(err) {
-					utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
-					return
-				}
+				utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
 			}
 
 			l4Rule, err = getL4Rule(key, svcObj)

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -34,7 +34,6 @@ import (
 	"github.com/vmware/alb-sdk/go/models"
 	avimodels "github.com/vmware/alb-sdk/go/models"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	k8net "k8s.io/utils/net"
@@ -74,10 +73,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 
 	infraSetting, err := getL4InfraSetting(key, svcObj.Namespace, svcObj, nil)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
-			return nil
-		}
+		utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
 	}
 
 	vrfcontext := lib.GetVrf()
@@ -194,10 +190,7 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 
 		infraSetting, err := getL4InfraSetting(key, svcObj.Namespace, svcObj, nil)
 		if err != nil {
-			if !k8serrors.IsNotFound(err) {
-				utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
-				return
-			}
+			utils.AviLog.Warnf("key: %s, msg: Error while fetching infrasetting for Service %s", key, err.Error())
 		}
 		t1lr := lib.GetT1LRPath()
 		if infraSetting != nil && infraSetting.Spec.NSXSettings.T1LR != nil {

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -658,11 +658,9 @@ func handleL4SharedVipService(namespacedVipKey, key string, fullsync bool) {
 		aviModelGraph := NewAviObjectGraph()
 		vipKey := strings.Split(namespacedVipKey, "/")[1]
 		aviModelGraph.BuildAdvancedL4Graph(namespace, vipKey, key, true)
-		if len(aviModelGraph.GetOrderedNodes()) > 0 {
-			ok := saveAviModel(modelName, aviModelGraph, key)
-			if ok && !fullsync {
-				PublishKeyToRestLayer(modelName, key, sharedQueue)
-			}
+		ok := saveAviModel(modelName, aviModelGraph, key)
+		if ok && len(aviModelGraph.GetOrderedNodes()) != 0 && !fullsync {
+			PublishKeyToRestLayer(modelName, key, sharedQueue)
 		}
 	}
 }

--- a/tests/integrationtest/l4_service_test.go
+++ b/tests/integrationtest/l4_service_test.go
@@ -1016,10 +1016,10 @@ func TestWithInfraSettingStatusUpdates(t *testing.T) {
 	g.Eventually(func() bool {
 		if found, aviModel := objects.SharedAviGraphLister().Get(SINGLEPORTMODEL); found && aviModel != nil {
 			if nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS(); len(nodes) > 0 {
-				return nodes[0].ServiceEngineGroup == "thisisaviref-seGroup" &&
+				return nodes[0].ServiceEngineGroup == lib.GetSEGName() &&
 					len(nodes[0].VSVIPRefs[0].VipNetworks) > 0 &&
-					nodes[0].VSVIPRefs[0].VipNetworks[0].NetworkName == "thisisaviref-networkName" &&
-					*nodes[0].EnableRhi
+					nodes[0].VSVIPRefs[0].VipNetworks[0].NetworkName == netList[0].NetworkName &&
+					!*nodes[0].EnableRhi
 			}
 		}
 		return false


### PR DESCRIPTION
We had introduced this changes to have uniform behaviour for L4 and Ingress. As L4 service has same naming convention with aviinfrasetting and without aviinfrasetting, L4 service was getting deleted due to this changes if infrasetting is not proper. This is causing issue in some scenarios.
So this PR is fixing that.