### PR TITLE
AV-205715 : Increase timeout for avi client to two minutes

### DIFF
--- a/ako-infra/ingestion/vcf_k8s_controller.go
+++ b/ako-infra/ingestion/vcf_k8s_controller.go
@@ -371,6 +371,7 @@ func (c *VCFK8sController) ValidBootstrapSecretData(controllerIP, secretName, se
 		session.SetAuthToken(string(authToken)),
 		session.DisableControllerStatusCheckOnFailure(true),
 		session.SetTransport(transport),
+		session.SetTimeout(120 * time.Second),
 	}
 	if !isSecure {
 		options = append(options, session.SetInsecure)

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -373,6 +373,7 @@ func (c *AviController) ValidAviSecret() bool {
 		options := []func(*session.AviSession) error{
 			session.DisableControllerStatusCheckOnFailure(true),
 			session.SetTransport(transport),
+			session.SetTimeout(120 * time.Second),
 		}
 		if !isSecure {
 			options = append(options, session.SetInsecure)

--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -17,6 +17,7 @@ package lib
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/alb-sdk/go/session"
@@ -295,6 +296,7 @@ func NewAviRestClientWithToken(api_ep, username, authToken, cadata string) *clie
 		session.DisableControllerStatusCheckOnFailure(true),
 		session.SetTransport(transport),
 		session.SetAuthToken(authToken),
+		session.SetTimeout(120 * time.Second),
 	}
 	if !isSecure {
 		options = append(options, session.SetInsecure)

--- a/pkg/utils/avi_rest_utils.go
+++ b/pkg/utils/avi_rest_utils.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/alb-sdk/go/session"
@@ -45,6 +46,7 @@ func NewAviRestClientPool(num uint32, api_ep, username,
 	options := []func(*session.AviSession) error{
 		session.DisableControllerStatusCheckOnFailure(true),
 		session.SetTransport(transport),
+		session.SetTimeout(120 * time.Second),
 	}
 
 	if !isSecure {

--- a/tests/scaletest/lib/utils.go
+++ b/tests/scaletest/lib/utils.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/alb-sdk/go/models"
@@ -75,7 +76,7 @@ func NewAviRestClientPool(num uint32, api_ep string, username string,
 	var p AviRestClientPool
 	for i := uint32(0); i < num; i++ {
 		aviClient, err := clients.NewAviClient(api_ep, username,
-			session.SetPassword(password), session.SetControllerStatusCheckLimits(25, 15), session.SetInsecure)
+			session.SetPassword(password), session.SetControllerStatusCheckLimits(25, 15), session.SetInsecure, session.SetTimeout(120*time.Second))
 		if err != nil {
 			return &p, err
 		}


### PR DESCRIPTION
This PR increases the timeout for Avi client to 2 minutes as we are getting `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` error for **sslkeyandcertificate** PUT request in large setups.