### PR TITLE
AV-205976 : disabling status update for vs and pool from follower

### DIFF
--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -486,6 +486,10 @@ func AviVsHttpPSAdd(vs_meta interface{}, isEVH bool) []*avimodels.HTTPPolicies {
 }
 
 func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_cache_obj *avicache.AviVsCache, key string) {
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debugf("key: %s, AKO is not running as a leader, will not publish the status", key)
+		return
+	}
 	if restMethod == utils.RestPost || restMethod == utils.RestDelete || restMethod == utils.RestPut {
 		for _, poolkey := range vs_cache_obj.PoolKeyCollection {
 			// Fetch the pool object from cache and check the service metadata
@@ -546,6 +550,10 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 }
 
 func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCacheObj *avicache.AviVsCache, key string) {
+	if !lib.AKOControlConfig().IsLeader() {
+		utils.AviLog.Debugf("key: %s, AKO is not running as a leader, will not publish the status", key)
+		return
+	}
 	IPAddrs := rest.GetIPAddrsFromCache(vsCacheObj)
 	serviceMetadataObj := vsCacheObj.ServiceMetadataObj
 	switch serviceMetadataObj.ServiceMetadataMapping("VS") {


### PR DESCRIPTION
This PR addresses the issue of Follower AKO keeps on restarting after setup creation. The follower was getting OOMKilled due to status update in happening in bulk. The status update has been disabled for follower as it was only processing the status update operations but ultimately not doing anything.