### PR TITLE
AV-205437 Static Route fix

### DIFF
--- a/internal/nodes/avi_vrf_translator.go
+++ b/internal/nodes/avi_vrf_translator.go
@@ -77,7 +77,7 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 		}
 		if !ok {
 			//node not found, check overlapping and then add case
-			if !findRoutePrefix(nodeRoutes, aviVrfNode.StaticRoutes, key) {
+			if len(nodeRoutes) > 0 && !findRoutePrefix(nodeRoutes, aviVrfNode.StaticRoutes, key) {
 				// node is not present and no overlapping of cidr, append at last
 				aviVrfNode.StaticRoutes = append(aviVrfNode.StaticRoutes, nodeRoutes...)
 				nodeStaticRoute := StaticRouteDetails{}
@@ -87,6 +87,10 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 				nodeStaticRoute.routeID = routeid
 				aviVrfNode.NodeStaticRoutes[nodeName] = nodeStaticRoute
 				aviVrfNode.Nodes = append(aviVrfNode.Nodes, nodeName)
+			} else {
+				if len(nodeRoutes) == 0 {
+					delete(aviVrfNode.NodeIds, routeid)
+				}
 			}
 		} else {
 			// update case

--- a/tests/cnitests/static_route_test.go
+++ b/tests/cnitests/static_route_test.go
@@ -1338,10 +1338,13 @@ func TestStaticRoutesWithMultipleBlockAffinityDeletion(t *testing.T) {
 	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[0], metav1.DeleteOptions{})
-	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[1], metav1.DeleteOptions{})
-	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[2], metav1.DeleteOptions{})
-	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[3], metav1.DeleteOptions{})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity44", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity2", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity11", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
 	g.Eventually(func() bool {
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
@@ -1351,6 +1354,476 @@ func TestStaticRoutesWithMultipleBlockAffinityDeletion(t *testing.T) {
 		return found
 	}, 10*time.Second).Should(gomega.Equal(true))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[0], metav1.DeleteOptions{})
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[1], metav1.DeleteOptions{})
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[2], metav1.DeleteOptions{})
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[3], metav1.DeleteOptions{})
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(0))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(0))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(0))
+	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(0))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(0))
+}
+func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
+	if *cniPlugin != "calico" {
+		t.Skip("Skipping BlockAffinity test since CNI plugin is not Calico")
+	}
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/global"
+	nodesNameList := []string{"testNodeCalico1", "testNodeCalico2", "testNodeCalico3", "testNodeCalico4"}
+	nodeIPList := []string{"10.64.29.32", "10.64.29.33", "10.64.29.34", "10.64.29.35"}
+	objects.SharedAviGraphLister().Delete(modelName)
+	time.Sleep(10 * time.Second)
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData1 unstructured.Unstructured
+	testData1.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity1",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.255.236/30",
+			"deleted": "false",
+			"node":    nodesNameList[0],
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData1, v1.CreateOptions{})
+
+	nodeExample := (integrationtest.FakeNode{
+		Name:    nodesNameList[0],
+		Version: "1",
+		NodeIP:  nodeIPList[0],
+	}).NodeCalico()
+
+	_, err := KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelName, 5)
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	var banode1 unstructured.Unstructured
+	banode1.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity11",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.255.239/30",
+			"deleted": "false",
+			"node":    nodesNameList[0],
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &banode1, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 2 {
+			found = false
+		}
+		return found
+	}, 30*time.Second).Should(gomega.Equal(true))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData2 unstructured.Unstructured
+	testData2.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity2",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.255.72/30",
+			"deleted": "false",
+			"node":    nodesNameList[1],
+			"state":   "confirmed",
+		},
+	})
+
+	nodeExample2 := (integrationtest.FakeNode{
+		Name:    nodesNameList[1],
+		Version: "1",
+		NodeIP:  nodeIPList[1],
+	}).NodeCalico()
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(1))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(1))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData3 unstructured.Unstructured
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.115.128/25",
+			"deleted": "false",
+			"node":    nodesNameList[2],
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	nodeExample3 := (integrationtest.FakeNode{
+		Name:    nodesNameList[2],
+		Version: "1",
+		NodeIP:  nodeIPList[2],
+	}).NodeCalico()
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample3, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 3 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(2))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData4 unstructured.Unstructured
+	testData4.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity4",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.125.128/25",
+			"deleted": "false",
+			"node":    nodesNameList[3],
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData4, v1.CreateOptions{})
+
+	nodeExample4 := (integrationtest.FakeNode{
+		Name:    nodesNameList[3],
+		Version: "1",
+		NodeIP:  nodeIPList[3],
+	}).NodeCalico()
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample4, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(4))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(4))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+
+	var banode4 unstructured.Unstructured
+	banode4.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity44",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "10.244.127.128/25",
+			"deleted": "false",
+			"node":    nodesNameList[3],
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &banode4, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 5 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData2, v1.CreateOptions{})
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 6 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(6))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(6))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(4))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+	g.Expect(*nodes[0].StaticRoutes[5].RouteID).To(gomega.Equal("cluster-6"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity2", v1.DeleteOptions{})
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 5 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[1], metav1.DeleteOptions{})
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].NodeStaticRoutes) > 3 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity11", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 3 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[0], metav1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(2))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[1], metav1.DeleteOptions{})
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 3 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(2))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[2], metav1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].NodeStaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(2))
+	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(1))
+	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(2))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity44", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 0 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[3], metav1.DeleteOptions{})
 
 	g.Eventually(func() int {
 		num_routes := len(nodes[0].NodeStaticRoutes)


### PR DESCRIPTION
AV-205437 Static Route fix
This PR fixes following issue with Static routes:
If we have multiple nodes with multiple PODCidrs, if we delete all block affinities on any of intermediate node, the NodeId and NodeStaticRoute arrays and nodes gets deleted which results in a continuous route_ids(since we have handled it in delete and update case). However, if we delete all static routes from controller and reboot ako, the Node, NodeIds and NodeStaticRoute gets added even if number of block affinities are 0 for that node(Since we had not handled addition case earlier). As a part of the fix, if number of static route/PODCidrs attached to the Node are zero, we will not add Node, NodeIds and NodeStaticRoutes to the VRF node

