### PR TITLE
AV-203833: Support for restricting FQDN re-use in AKO

### DIFF
--- a/cmd/ako-main/main.go
+++ b/cmd/ako-main/main.go
@@ -110,6 +110,7 @@ func InitializeAKC() {
 	akoControlConfig.SetAKOBlockedNSList(lib.GetGlobalBlockedNSList())
 	akoControlConfig.SetControllerVRFContext(lib.GetControllerVRFContext())
 	akoControlConfig.SetAKOPrometheusFlag(lib.IsPrometheusEnabled())
+	akoControlConfig.SetAKOFQDNReusePolicy(os.Getenv("FQDN_REUSE_POLICY"))
 
 	var crdClient *crd.Clientset
 	var advl4Client *advl4.Clientset

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -52,3 +52,4 @@ data:
   istioEnabled: {{ .Values.AKOSettings.istioEnabled | quote }}
   useDefaultSecretsOnly: {{ .Values.AKOSettings.useDefaultSecretsOnly | quote }}
   enablePrometheus: {{ default "false" .Values.featureGates.EnablePrometheus | quote }}
+  FQDNReusePolicy: {{ default "Strict" .Values.L7Settings.FQDNReusePolicy | quote}}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -108,6 +108,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: shardVSSize
+          - name: FQDN_REUSE_POLICY
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: FQDNReusePolicy
           - name: PASSTHROUGH_SHARD_SIZE
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -91,6 +91,7 @@ L7Settings:
   shardVSSize: "LARGE" # Use this to control the layer 7 VS numbers. This applies to both secure/insecure VSes but does not apply for passthrough. ENUMs: LARGE, MEDIUM, SMALL, DEDICATED
   passthroughShardSize: "SMALL" # Control the passthrough virtualservice numbers using this ENUM. ENUMs: LARGE, MEDIUM, SMALL
   enableMCI: "false" # Enabling this flag would tell AKO to start processing multi-cluster ingress objects.
+  FQDNReusePolicy: "Strict" # Use this to control whether AKO allows cross-namespace usage of FQDNs. enum Strict|InterNamespaceAllowed
 
 ### This section outlines all the knobs  used to control Layer 4 loadbalancing settings in AKO.
 L4Settings:

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -549,6 +549,11 @@ func (c *AviCache) AviGetAllFQDNKeys() []string {
 }
 
 func (c *AviCache) FQDNCacheRouteIngDelete(objName string) {
+	// this function deletes the given object from all cache entries
+	// check all FQDN cache entries for ingress association.
+	// if found
+	// 		if this ingress is the only object associated with this fqdn, delete the fqdn cache obj itself
+	//		else just delete this ingress entry from this fqdn's cache
 	parentKeys := c.AviGetAllFQDNKeys()
 	for i := range parentKeys {
 		value, _ := c.AviCacheGet(parentKeys[i])

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -550,7 +550,7 @@ func (c *AviCache) AviGetAllFQDNKeys() []string {
 
 func (c *AviCache) FQDNCacheRouteIngDelete(objName string) {
 	parentKeys := c.AviGetAllFQDNKeys()
-	for i, _ := range parentKeys {
+	for i := range parentKeys {
 		value, _ := c.AviCacheGet(parentKeys[i])
 		FQDNPolicyCacheObj := value.(FQDNPolicyCache)
 		if _, exists := FQDNPolicyCacheObj.IngressList[objName]; exists {

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -54,6 +54,7 @@ type AviObjCache struct {
 	VsCacheMeta        *AviCache
 	VsCacheLocal       *AviCache
 	ClusterStatusCache *AviCache
+	FQDNPolicyCache    *AviCache
 }
 
 func NewAviObjCache() *AviObjCache {
@@ -71,6 +72,7 @@ func NewAviObjCache() *AviObjCache {
 	c.VrfCache = NewAviCache()
 	c.PKIProfileCache = NewAviCache()
 	c.ClusterStatusCache = NewAviCache()
+	c.FQDNPolicyCache = NewAviCache()
 	return &c
 }
 
@@ -619,6 +621,24 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 			PkiProfileCollection: pkiKey,
 			ServiceMetadataObj:   svc_mdata_obj,
 			LastModified:         *pool.LastModified,
+		}
+		value, found := c.FQDNPolicyCache.AviCacheGet(poolCacheObj.ServiceMetadataObj.HostNames[0])
+		if !found {
+			// need to replace this with util function
+			FQDNPolicyCacheObj := FQDNPolicyCache{
+				Name:      poolCacheObj.ServiceMetadataObj.HostNames[0],
+				Namespace: poolCacheObj.ServiceMetadataObj.Namespace,
+				IngressList: map[string]struct{}{
+					poolCacheObj.ServiceMetadataObj.IngressName: {},
+				},
+				FQDNReusePolicy: poolCacheObj.ServiceMetadataObj.FQDNReusePolicy,
+			}
+			c.FQDNPolicyCache.AviCacheAdd(poolCacheObj.ServiceMetadataObj.HostNames[0], FQDNPolicyCacheObj)
+		} else {
+			FQDNPolicyCacheObj := value.(FQDNPolicyCache)
+			if _, ok := FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName]; !ok {
+				FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName] = struct{}{}
+			}
 		}
 		*poolData = append(*poolData, poolCacheObj)
 	}

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -622,22 +622,24 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 			ServiceMetadataObj:   svc_mdata_obj,
 			LastModified:         *pool.LastModified,
 		}
-		value, found := c.FQDNPolicyCache.AviCacheGet(poolCacheObj.ServiceMetadataObj.HostNames[0])
-		if !found {
-			// need to replace this with util function
-			FQDNPolicyCacheObj := FQDNPolicyCache{
-				Name:      poolCacheObj.ServiceMetadataObj.HostNames[0],
-				Namespace: poolCacheObj.ServiceMetadataObj.Namespace,
-				IngressList: map[string]struct{}{
-					poolCacheObj.ServiceMetadataObj.IngressName: {},
-				},
-				FQDNReusePolicy: poolCacheObj.ServiceMetadataObj.FQDNReusePolicy,
-			}
-			c.FQDNPolicyCache.AviCacheAdd(poolCacheObj.ServiceMetadataObj.HostNames[0], FQDNPolicyCacheObj)
-		} else {
-			FQDNPolicyCacheObj := value.(FQDNPolicyCache)
-			if _, ok := FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName]; !ok {
-				FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName] = struct{}{}
+		if len(poolCacheObj.ServiceMetadataObj.HostNames) != 0 {
+			value, found := c.FQDNPolicyCache.AviCacheGet(poolCacheObj.ServiceMetadataObj.HostNames[0])
+			if !found {
+				// need to replace this with util function
+				FQDNPolicyCacheObj := FQDNPolicyCache{
+					Name:      poolCacheObj.ServiceMetadataObj.HostNames[0],
+					Namespace: poolCacheObj.ServiceMetadataObj.Namespace,
+					IngressList: map[string]struct{}{
+						poolCacheObj.ServiceMetadataObj.IngressName: {},
+					},
+					FQDNReusePolicy: poolCacheObj.ServiceMetadataObj.FQDNReusePolicy,
+				}
+				c.FQDNPolicyCache.AviCacheAdd(poolCacheObj.ServiceMetadataObj.HostNames[0], FQDNPolicyCacheObj)
+			} else {
+				FQDNPolicyCacheObj := value.(FQDNPolicyCache)
+				if _, ok := FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName]; !ok {
+					FQDNPolicyCacheObj.IngressList[poolCacheObj.ServiceMetadataObj.IngressName] = struct{}{}
+				}
 			}
 		}
 		*poolData = append(*poolData, poolCacheObj)

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -222,8 +222,8 @@ const (
 	AKODeleteConfigDone      = "AKODeleteConfigDone"
 	AKODeleteConfigTimeout   = "AKODeleteConfigTimeout"
 	AKOGatewayEventComponent = "avi-kubernetes-operator-gateway-api"
-	FQDNReusePolicyStrict = "Strict"
-	FQDNReusePolicyOpen = "InterNamespaceAllowed"
+	FQDNReusePolicyStrict    = "Strict"
+	FQDNReusePolicyOpen      = "InterNamespaceAllowed"
 
 	DefaultIngressClassAnnotation    = "ingressclass.kubernetes.io/is-default-class"
 	ExternalDNSAnnotation            = "external-dns.alpha.kubernetes.io/hostname"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -222,6 +222,8 @@ const (
 	AKODeleteConfigDone      = "AKODeleteConfigDone"
 	AKODeleteConfigTimeout   = "AKODeleteConfigTimeout"
 	AKOGatewayEventComponent = "avi-kubernetes-operator-gateway-api"
+	FQDNReusePolicyStrict = "Strict"
+	FQDNReusePolicyOpen = "InterNamespaceAllowed"
 
 	DefaultIngressClassAnnotation    = "ingressclass.kubernetes.io/is-default-class"
 	ExternalDNSAnnotation            = "external-dns.alpha.kubernetes.io/hostname"

--- a/internal/lib/control_config.go
+++ b/internal/lib/control_config.go
@@ -161,6 +161,9 @@ type akoControlConfig struct {
 
 	//Prometheus enabled or not
 	isPrometheusEnabled bool
+
+	//FQDNReusePolicy is set to Strict/InterNamespaceAllowed according to whether AKO allows FQDN sharing across namespaces
+	FQDNReusePolicy string
 }
 
 var akoControlConfigInstance *akoControlConfig
@@ -182,6 +185,14 @@ func (c *akoControlConfig) SetIsLeaderFlag(flag bool) {
 
 func (c *akoControlConfig) SetDefaultLBController(flag bool) {
 	c.defaultLBController = flag
+}
+
+func (c *akoControlConfig) SetAKOFQDNReusePolicy(FQDNPolicy string) {
+	c.FQDNReusePolicy = FQDNPolicy
+}
+
+func (c *akoControlConfig) GetAKOFQDNReusePolicy() string {
+	return c.FQDNReusePolicy
 }
 
 func (c *akoControlConfig) IsLeader() bool {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -91,6 +91,7 @@ type ServiceMetadataObj struct {
 	Gateway               string      `json:"gateway"` // ns/name
 	InsecureEdgeTermAllow bool        `json:"insecureedgetermallow"`
 	IsMCIIngress          bool        `json:"is_mci_ingress"`
+	FQDNReusePolicy       string      `json:"fqdn_reuse_policy"`
 }
 
 type ServiceMetadataMappingObjType string
@@ -1747,6 +1748,10 @@ func ValidateSvcforClass(key string, svc *corev1.Service) bool {
 
 func isAviDefaultLBController() bool {
 	return AKOControlConfig().IsAviDefaultLBController()
+}
+
+func AKOFQDNReusePolicy() string {
+	return AKOControlConfig().GetAKOFQDNReusePolicy()
 }
 
 func ValidateIngressForClass(key string, ingress *networkingv1.Ingress) bool {

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1623,6 +1623,8 @@ func (v *AviPoolNode) CalculateCheckSum() {
 		checksumStringSlice = append(checksumStringSlice, utils.Stringify(v.ServiceMetadata.HostNames))
 	}
 
+	checksumStringSlice = append(checksumStringSlice, v.ServiceMetadata.FQDNReusePolicy)
+
 	chksumStr := fmt.Sprint(strings.Join(checksumStringSlice, delim))
 
 	checksum := utils.Hash(chksumStr)

--- a/internal/nodes/avi_model_routeingr_hostname_shard.go
+++ b/internal/nodes/avi_model_routeingr_hostname_shard.go
@@ -86,6 +86,7 @@ func HostNameShardAndPublish(objType, objname, namespace, key string, fullsync b
 			} else {
 				RouteIngrDeletePoolsByHostname(routeIgrObj, namespace, objname, key, fullsync, sharedQueue)
 			}
+			// if ingress is being deleted, delete all FQDN cache entries for it
 			FQDNCache.FQDNCacheRouteIngDelete(objname)
 		}
 		return

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1240,6 +1240,8 @@ func (rest *RestOperations) PoolCU(pool_nodes []*nodes.AviPoolNode, vs_cache_obj
 		utils.AviLog.Debugf("key: %s, msg: the cached pools are: %v", key, utils.Stringify(cache_pool_nodes))
 
 		for _, pool := range pool_nodes {
+			poolFQDNPolicy := &pool.ServiceMetadata.FQDNReusePolicy
+			*poolFQDNPolicy = lib.AKOFQDNReusePolicy()
 			// check in the pool cache to see if this pool exists in AVI
 			pool_key := avicache.NamespaceName{Namespace: namespace, Name: pool.Name}
 			found := utils.HasElem(cache_pool_nodes, pool_key)
@@ -1282,6 +1284,8 @@ func (rest *RestOperations) PoolCU(pool_nodes []*nodes.AviPoolNode, vs_cache_obj
 	} else {
 		// Everything is a POST call
 		for _, pool := range pool_nodes {
+			poolFQDNPolicy := &pool.ServiceMetadata.FQDNReusePolicy
+			*poolFQDNPolicy = lib.AKOFQDNReusePolicy()
 			_, rest_ops = rest.PkiProfileCU(pool.PkiProfile, nil, namespace, rest_ops, key)
 
 			utils.AviLog.Debugf("key: %s, msg: pool cache does not exist %s, operation: POST", key, pool.Name)


### PR DESCRIPTION
Known issue: Cache isn't updated correctly when ingress FQDN is updated in case of single ingress-multi FQDN case. 
I am working on above issue and UT's for this. Will merge in few days.

UT plan:

1. Create ingress with FQDN policy set to restrict/open and check if FQDN cache is being populated correctly
2. Set AKO to strict, create 2 ingresses with same FQDN in different namespaces, 2nd one's model should not be created (should not be processed by AKO)
3. Set AKO to strict, create 2 ingresses with same FQDN in same namespace, 2nd ingress should not be rejected.
4. Set AKO to internamespaceallowed, create 2 ingresses with same FQDN in different namespaces, 2nd ingress should not be rejected.
5. With pre-existing AVI objects, check if AKO correctly builds FQDN reuse policy cache