### PR TITLE
AV-209065 Gateway container crash fix

### DIFF
--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -119,6 +119,10 @@ func (o *AviObjectGraph) BuildPGPool(key, parentNsName string, childVsNode *node
 			listeners = append(listeners, listener)
 		}
 	}
+	if len(listeners) == 0 {
+		utils.AviLog.Warnf("key: %s, msg: No matching listener available for the route : %s", key, routeTypeNsName)
+		return
+	}
 	//ListenerName/port/protocol/allowedRouteSpec
 	listenerProtocol := listeners[0].Protocol
 	PGName := akogatewayapilib.GetPoolGroupName(parentNs, parentName,


### PR DESCRIPTION
AV-209065 Gateway container crash fix

This PR fixes the regression introduced due to the length check removed as a part of this PR https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1382/files#diff-58c8f75b8707ea2e7bb3d1df4ed00cf35aa868544a55ed54876e6318ddafcef8 which causes gateway container crash when multiple gateways and multiple httproutes shares same backend app and httproute tries to connect to the the gateway listener which is not its parent.

**Testing status:**
Crash scenarios tested
Manual testing for gateway with and without the section name