### PR TITLE
AV-209807 : AKO does not honour readines probe for pods when Antrea with NPL is used

### DIFF
--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -263,7 +263,7 @@ func PopulateServersForNPL(poolNode *AviPoolNode, ns string, serviceName string,
 			return nil
 		}
 	}
-	pods, targetPort := lib.GetPodsFromService(ns, serviceName, poolNode.TargetPort)
+	pods, targetPort := lib.GetPodsFromService(ns, serviceName, poolNode.TargetPort, key)
 	if len(pods) == 0 {
 		utils.AviLog.Infof("key: %s, msg: got no Pod for Service %s", key, serviceName)
 		return make([]AviPoolMetaServer, 0)

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -54,7 +54,7 @@ const (
 	defaultHostIP   = "10.10.10.10"
 	defaultPodIP    = "192.168.32.10"
 	defaultPodPort  = 80
-	defaultNodePort = 40001
+	defaultNodePort = 61000
 	defaultLBModel  = "admin/cluster--default-testsvc"
 	defaultL7Model  = "admin/cluster--Shared-L7-0"
 )
@@ -66,7 +66,7 @@ func SetUpTestForIngress(t *testing.T, modelName string) {
 func createPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
@@ -74,7 +74,7 @@ func createPodWithNPLAnnotation(labels map[string]string) {
 func createNotReadyPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
@@ -83,9 +83,9 @@ func createNotReadyPodWithNPLAnnotation(labels map[string]string) {
 func updateNotReadyPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
-	testPod.ResourceVersion = "2"
+	testPod.ResourceVersion = "3"
 	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
 	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
 }
@@ -93,7 +93,7 @@ func updateNotReadyPodWithNPLAnnotation(labels map[string]string) {
 func createPodWithMultipleNPLAnnotations(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}, {\"podPort\":8081,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40002}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}, {\"podPort\":8081,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61001}]"
 	testPod.Annotations = ann
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
@@ -101,7 +101,7 @@ func createPodWithMultipleNPLAnnotations(labels map[string]string) {
 func updatePodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	testPod.ResourceVersion = "2"
 	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
@@ -1288,9 +1288,9 @@ func TestIngressAddPodWithMultiportSvc(t *testing.T) {
 	g.Expect(nodes[0].PoolRefs[0].Servers).To(gomega.HaveLen(1))
 	g.Expect(nodes[0].PoolRefs[1].Servers).To(gomega.HaveLen(1))
 	g.Expect(*nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
-	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(40001)))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(61000)))
 	g.Expect(*nodes[0].PoolRefs[1].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
-	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(40002)))
+	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(61001)))
 
 	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {
@@ -1348,6 +1348,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// updating the pod to ready state
 	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1357,6 +1359,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// updating the pod to not ready state again
 	updateNotReadyPodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1364,6 +1368,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// re-updating the pod to ready state
 	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1377,4 +1383,67 @@ func TestIngressPodReadiness(t *testing.T) {
 	}
 	verifyIngressDeletion(t, g, aviModel, 0)
 	TearDownTestForIngress(t, defaultL7Model)
+}
+
+// TestNPLLBSvcPodReadiness creates a Service type LB and a not ready Pod with matching label, then the model is verified.
+// It also updates the Pod to ready state and verifies the model.
+func TestNPLLBSvcPodReadiness(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	selectors := make(map[string]string)
+	selectors["app"] = "npl"
+	createNotReadyPodWithNPLAnnotation(selectors)
+	setUpTestForSvcLB(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(defaultLBModel)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(defaultLBModel)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", defaultNS, integrationtest.SINGLEPORTSVC)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(integrationtest.AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+
+	// verifying the number of pool servers to be zero
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	address := defaultHostIP
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(&address))
+
+	// updating the pod to not ready state again
+	updateNotReadyPodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// re-updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(&address))
+
+	tearDownTestForSvcLB(t, g)
 }

--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -71,6 +71,25 @@ func createPodWithNPLAnnotation(labels map[string]string) {
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
 
+func createNotReadyPodWithNPLAnnotation(labels map[string]string) {
+	testPod := getTestPod(labels)
+	ann := make(map[string]string)
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	testPod.Annotations = ann
+	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
+	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
+}
+
+func updateNotReadyPodWithNPLAnnotation(labels map[string]string) {
+	testPod := getTestPod(labels)
+	ann := make(map[string]string)
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	testPod.Annotations = ann
+	testPod.ResourceVersion = "2"
+	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
+	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
+}
+
 func createPodWithMultipleNPLAnnotations(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
@@ -1278,4 +1297,84 @@ func TestIngressAddPodWithMultiportSvc(t *testing.T) {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	verifyIngressDeletion(t, g, aviModel, 0)
+}
+
+// TestIngressPodReadiness creates a POD in not ready state with NPL annotation and corresponding Service and Ingress, then verifies the model.
+// It also updates the Pod to ready state and verifies the model.
+func TestIngressPodReadiness(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	SetUpTestForIngress(t, defaultL7Model)
+	selectors := make(map[string]string)
+	selectors["app"] = "npl"
+	integrationtest.CreateServiceWithSelectors(t, defaultNS, "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, selectors)
+	// creating pod in not ready state
+	createNotReadyPodWithNPLAnnotation(selectors)
+
+	integrationtest.PollForCompletion(t, defaultL7Model, 10)
+	found, _ := objects.SharedAviGraphLister().Get(defaultL7Model)
+	if found {
+		t.Fatalf("Model %v exists even after deletion", defaultL7Model)
+	}
+	ingrFake := (integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		ServiceName: "avisvc",
+	}).Ingress()
+
+	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, defaultL7Model, 10)
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(defaultL7Model)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(defaultL7Model)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+	g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+
+	// verifying the number of pool servers to be zero
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	g.Expect(*nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(defaultNodePort)))
+
+	// updating the pod to not ready state again
+	updateNotReadyPodWithNPLAnnotation(selectors)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// re-updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	g.Expect(*nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(defaultNodePort)))
+
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	verifyIngressDeletion(t, g, aviModel, 0)
+	TearDownTestForIngress(t, defaultL7Model)
 }


### PR DESCRIPTION
(#1455)

* AV-209807 : AKO does not honour readines probe for pods when Antrea with NPL is used

* AV-209807 : Adding UT to test that AKO now honours readines probe for pods when Antrea with NPL is used

* AV-209807 : Fix for review comments