### PR TITLE
AV-209807 : Adding UT to test AKO now honours readines probe for pods when Antrea with NPL is used

### DIFF
--- a/tests/npltests/npl_pod_test.go
+++ b/tests/npltests/npl_pod_test.go
@@ -54,7 +54,7 @@ const (
 	defaultHostIP   = "10.10.10.10"
 	defaultPodIP    = "192.168.32.10"
 	defaultPodPort  = 80
-	defaultNodePort = 40001
+	defaultNodePort = 61000
 	defaultLBModel  = "admin/cluster--default-testsvc"
 	defaultL7Model  = "admin/cluster--Shared-L7-0"
 )
@@ -66,7 +66,7 @@ func SetUpTestForIngress(t *testing.T, modelName string) {
 func createPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
@@ -74,7 +74,7 @@ func createPodWithNPLAnnotation(labels map[string]string) {
 func createNotReadyPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
@@ -83,9 +83,9 @@ func createNotReadyPodWithNPLAnnotation(labels map[string]string) {
 func updateNotReadyPodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
-	testPod.ResourceVersion = "2"
+	testPod.ResourceVersion = "3"
 	testPod.Status.Conditions = append(testPod.Status.Conditions, corev1.PodCondition{Type: "Ready", Status: "False"})
 	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
 }
@@ -93,7 +93,7 @@ func updateNotReadyPodWithNPLAnnotation(labels map[string]string) {
 func createPodWithMultipleNPLAnnotations(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}, {\"podPort\":8081,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40002}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}, {\"podPort\":8081,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61001}]"
 	testPod.Annotations = ann
 	KubeClient.CoreV1().Pods(defaultNS).Create(context.TODO(), &testPod, metav1.CreateOptions{})
 }
@@ -101,7 +101,7 @@ func createPodWithMultipleNPLAnnotations(labels map[string]string) {
 func updatePodWithNPLAnnotation(labels map[string]string) {
 	testPod := getTestPod(labels)
 	ann := make(map[string]string)
-	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":40001}]"
+	ann[lib.NPLPodAnnotation] = "[{\"podPort\":8080,\"nodeIP\":\"10.10.10.10\",\"nodePort\":61000}]"
 	testPod.Annotations = ann
 	testPod.ResourceVersion = "2"
 	KubeClient.CoreV1().Pods(defaultNS).Update(context.TODO(), &testPod, metav1.UpdateOptions{})
@@ -1288,9 +1288,9 @@ func TestIngressAddPodWithMultiportSvc(t *testing.T) {
 	g.Expect(nodes[0].PoolRefs[0].Servers).To(gomega.HaveLen(1))
 	g.Expect(nodes[0].PoolRefs[1].Servers).To(gomega.HaveLen(1))
 	g.Expect(*nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
-	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(40001)))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Port).To(gomega.Equal(int32(61000)))
 	g.Expect(*nodes[0].PoolRefs[1].Servers[0].Ip.Addr).To(gomega.Equal(defaultHostIP))
-	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(40002)))
+	g.Expect(nodes[0].PoolRefs[1].Servers[0].Port).To(gomega.Equal(int32(61001)))
 
 	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
 	if err != nil {
@@ -1348,6 +1348,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// updating the pod to ready state
 	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1357,6 +1359,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// updating the pod to not ready state again
 	updateNotReadyPodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1364,6 +1368,8 @@ func TestIngressPodReadiness(t *testing.T) {
 
 	// re-updating the pod to ready state
 	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultL7Model)
 	g.Eventually(func() int {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes[0].PoolRefs[0].Servers)
@@ -1377,4 +1383,67 @@ func TestIngressPodReadiness(t *testing.T) {
 	}
 	verifyIngressDeletion(t, g, aviModel, 0)
 	TearDownTestForIngress(t, defaultL7Model)
+}
+
+// TestNPLLBSvcPodReadiness creates a Service type LB and a not ready Pod with matching label, then the model is verified.
+// It also updates the Pod to ready state and verifies the model.
+func TestNPLLBSvcPodReadiness(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	selectors := make(map[string]string)
+	selectors["app"] = "npl"
+	createNotReadyPodWithNPLAnnotation(selectors)
+	setUpTestForSvcLB(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(defaultLBModel)
+		return found
+	}, 40*time.Second).Should(gomega.Equal(true))
+	_, aviModel := objects.SharedAviGraphLister().Get(defaultLBModel)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].Name).To(gomega.Equal(fmt.Sprintf("cluster--%s-%s", defaultNS, integrationtest.SINGLEPORTSVC)))
+	g.Expect(nodes[0].Tenant).To(gomega.Equal(integrationtest.AVINAMESPACE))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8080)))
+
+	// verifying the number of pool servers to be zero
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	address := defaultHostIP
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(&address))
+
+	// updating the pod to not ready state again
+	updateNotReadyPodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	// re-updating the pod to ready state
+	updatePodWithNPLAnnotation(selectors)
+	time.Sleep(5 * time.Second)
+	_, aviModel = objects.SharedAviGraphLister().Get(defaultLBModel)
+	g.Eventually(func() int {
+		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		g.Expect(nodes[0].PoolRefs).To(gomega.HaveLen(1))
+		return len(nodes[0].PoolRefs[0].Servers)
+	}, 40*time.Second).Should(gomega.Equal(1))
+	g.Expect(nodes[0].PoolRefs[0].Servers[0].Ip.Addr).To(gomega.Equal(&address))
+
+	tearDownTestForSvcLB(t, g)
 }


### PR DESCRIPTION
Thsi PR adds a UT to test that AKO now honours readines probe for pods when Antrea with NPL is used for LoadBalancer service. Previously UT was only added for ingress. Also, small changes have been made in the previously added UT to fix some issues.