### PR TITLE
AV-206828 Fix AKO-GW container crash when NPL enabled

### DIFF
--- a/ako-gateway-api/k8s/gateway_controller.go
+++ b/ako-gateway-api/k8s/gateway_controller.go
@@ -79,11 +79,6 @@ func (c *GatewayController) Start(stopCh <-chan struct{}) {
 		informersList = append(informersList, c.informers.SecretInformer.Informer().HasSynced)
 	}
 
-	if lib.GetServiceType() == lib.NodePortLocal {
-		go c.informers.PodInformer.Informer().Run(stopCh)
-		informersList = append(informersList, c.informers.PodInformer.Informer().HasSynced)
-	}
-
 	go akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Informer().Run(stopCh)
 	informersList = append(informersList, akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayClassInformer.Informer().HasSynced)
 	go akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayInformer.Informer().Run(stopCh)

--- a/cmd/gateway-api/main.go
+++ b/cmd/gateway-api/main.go
@@ -148,6 +148,11 @@ func Initialize() {
 		utils.AviLog.Errorf("Handle configmap error during reboot, shutting down AKO. Error is: %v", err)
 		return
 	}
+	if lib.GetServiceType() == lib.NodePortLocal {
+		akoControlConfig.PodEventf(corev1.EventTypeWarning, lib.AKOShutdown, "AKO Gateway API is not supported with NodePortLocal")
+		utils.AviLog.Errorf("AKO Gateway API is not supported with NodePortLocal, shutting down AKO Gateway API container")
+		select {}
+	}
 
 	waitGroupMap := make(map[string]*sync.WaitGroup)
 	wgIngestion := &sync.WaitGroup{}


### PR DESCRIPTION
This PR:

- removed pod informer being initialized incorrectly
- halts the gateway-api container when nodeportlocal is enabled