### PR TITLE
AV-210402: Fix: AKO-Gw: Child VS creation fails with duplicate FQDN in VHMatch creation

### DIFF
--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -284,8 +284,8 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 							}
 						}
 					}
-					if (hostnameMatched && !utils.HasElem(listenerList, listener)) || len(hrObj.Spec.Hostnames) == 0 {
-						gatewayListenerList = append(listenerList, listener)
+					if (hostnameMatched && !utils.HasElem(gatewayListenerList, listener)) || len(hrObj.Spec.Hostnames) == 0 {
+						gatewayListenerList = append(gatewayListenerList, listener)
 					}
 				}
 			}

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -301,7 +301,9 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 				}
 			}
 		}
-		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteToHostname(gwNsName, hostnameIntersection)
+		uniqueHosts := sets.NewString(hostnameIntersection...)
+
+		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteToHostname(gwNsName, uniqueHosts.List())
 		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteMappings(gwNsName, listenerList, routeTypeNsName)
 		if !utils.HasElem(gwNsNameList, gwNsName) {
 			gwNsNameList = append(gwNsNameList, gwNsName)

--- a/tests/gatewayapitests/graphlayer/gateway_test.go
+++ b/tests/gatewayapitests/graphlayer/gateway_test.go
@@ -135,7 +135,7 @@ func TestGateway(t *testing.T) {
 	ports := []int32{8080}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -179,7 +179,7 @@ func TestGatewayWithTLS(t *testing.T) {
 	}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false, secrets...)
+	listeners := tests.GetListenersV1(ports, false, false, secrets...)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -226,7 +226,7 @@ func TestGatewayNoTLSToTLS(t *testing.T) {
 	ports := []int32{8080}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -305,7 +305,7 @@ func TestGatewayTLSToNoTLS(t *testing.T) {
 	}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false, secrets...)
+	listeners := tests.GetListenersV1(ports, false, false, secrets...)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -373,7 +373,7 @@ func TestGatewayDelete(t *testing.T) {
 	ports := []int32{8080}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -415,7 +415,7 @@ func TestSecretCreateDelete(t *testing.T) {
 	secrets := []string{"secret-06"}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false, secrets...)
+	listeners := tests.GetListenersV1(ports, false, false, secrets...)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)

--- a/tests/gatewayapitests/graphlayer/gatewayclass_test.go
+++ b/tests/gatewayapitests/graphlayer/gatewayclass_test.go
@@ -38,7 +38,7 @@ func TestGatewayClassCDC(t *testing.T) {
 	ports := []int32{8080}
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -52,7 +52,7 @@ func TestHTTPRouteCRUD(t *testing.T) {
 	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -148,7 +148,7 @@ func TestHTTPRouteRuleCRUD(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -216,7 +216,7 @@ func TestHTTPRouteFilterCRUD(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -292,7 +292,7 @@ func TestHTTPRouteFilterWithRequestHeaderModifier(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -372,7 +372,7 @@ func TestHTTPRouteFilterWithResponseHeaderModifier(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -452,7 +452,7 @@ func TestHTTPRouteFilterWithRequestRedirect(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -526,7 +526,7 @@ func TestHTTPRouteWithValidConfig(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -598,7 +598,7 @@ func TestHTTPRouteBackendRefCRUD(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -697,7 +697,7 @@ func TestHTTPRouteBackendServiceCDC(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -784,7 +784,7 @@ func TestHTTPRouteBackendServiceUpdate(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -883,7 +883,7 @@ func TestHTTPRouteMultiportBackendSvc(t *testing.T) {
 	modelName, _ := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -942,7 +942,7 @@ func TestHTTPRouteInvalidHostname(t *testing.T) {
 	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -1010,7 +1010,7 @@ func TestHTTPRouteWithBackendRefFilters(t *testing.T) {
 	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -1155,7 +1155,9 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	integrationtest.CreateSVC(t, DEFAULT_NAMESPACE, svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, DEFAULT_NAMESPACE, svcName, false, false, "1.2.3")
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, true)
+
+	listeners := akogatewayapitests.GetListenersV1(ports, true, false)
+
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -1208,16 +1210,16 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 }
 
 func TestHTTPRouteWithMultipleListenerGateway(t *testing.T) {
-	gatewayName := "gateway-hr-08"
-	gatewayClassName := "gateway-class-hr-08"
-	httpRouteName := "http-route-hr-08"
-	svcName := "avisvc-hr-077"
+	gatewayName := "gateway-hr-09"
+	gatewayClassName := "gateway-class-hr-09"
+	httpRouteName := "http-route-hr-09"
+	svcName := "avisvc-hr-078"
 	ports := []int32{8080, 8082}
 	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 	// create a gateway with listener with same hostname and different port
-	listeners := akogatewayapitests.GetListenersV1(ports, true)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, true)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -1206,3 +1206,84 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
 	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
 }
+
+func TestHTTPRouteWithMultipleListenerGateway(t *testing.T) {
+	gatewayName := "gateway-hr-08"
+	gatewayClassName := "gateway-class-hr-08"
+	httpRouteName := "http-route-hr-08"
+	svcName := "avisvc-hr-077"
+	ports := []int32{8080, 8082}
+	modelName, parentVSName := akogatewayapitests.GetModelName(DEFAULT_NAMESPACE, gatewayName)
+
+	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
+	// create a gateway with listener with same hostname and different port
+	listeners := akogatewayapitests.GetListenersV1(ports, true)
+	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
+
+	g := gomega.NewGomegaWithT(t)
+
+	g.Eventually(func() bool {
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
+		return found
+	}, 25*time.Second).Should(gomega.Equal(true))
+
+	integrationtest.CreateSVC(t, DEFAULT_NAMESPACE, svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, DEFAULT_NAMESPACE, svcName, false, false, "1.2.3")
+
+	// httproute parent ref
+	parentRefs := akogatewayapitests.GetParentReferencesV1WithGatewayNameOnly([]string{gatewayName}, DEFAULT_NAMESPACE)
+
+	// httproute rule 1
+	rule1 := akogatewayapitests.GetHTTPRouteRuleV1([]string{"/foo"}, []string{}, nil,
+		[][]string{{svcName, DEFAULT_NAMESPACE, "8080", "1"}}, nil)
+	rules := []gatewayv1.HTTPRouteRule{rule1}
+
+	// httproute rule2
+	rule2 := akogatewayapitests.GetHTTPRouteRuleV1([]string{"/bar"}, []string{}, nil,
+		[][]string{{svcName, DEFAULT_NAMESPACE, "8082", "1"}}, nil)
+	rules = append(rules, rule2)
+
+	hostnames := []gatewayv1.Hostname{"foo.com"}
+
+	//create httproute
+	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
+
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return 0
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 25*time.Second).Should(gomega.Equal(2))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+
+	childNode := nodes[0].EvhNodes[0]
+	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
+	g.Expect(childNode.VHMatches).To(gomega.HaveLen(1))
+	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo.com"))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/foo"))
+	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
+	g.Expect(len(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports)).To(gomega.Equal(2))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports).Should(gomega.ConsistOf([]int64{8080, 8082}))
+
+	// delete httproute
+	akogatewayapitests.TeardownHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE)
+
+	// verifies the child deletion
+	g.Eventually(func() int {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		if !found {
+			return -1
+		}
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
+		return len(nodes[0].EvhNodes)
+	}, 30*time.Second).Should(gomega.Equal(0))
+
+	integrationtest.DelSVC(t, DEFAULT_NAMESPACE, svcName)
+	integrationtest.DelEP(t, DEFAULT_NAMESPACE, svcName)
+	akogatewayapitests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
+	akogatewayapitests.TeardownGatewayClass(t, gatewayClassName)
+}

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -1260,11 +1260,24 @@ func TestHTTPRouteWithMultipleListenerGateway(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
+	// childe node 1
 	childNode := nodes[0].EvhNodes[0]
 	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
 	g.Expect(childNode.VHMatches).To(gomega.HaveLen(1))
 	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo.com"))
+	// path foo
 	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/foo"))
+	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
+	g.Expect(len(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports)).To(gomega.Equal(2))
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports).Should(gomega.ConsistOf([]int64{8080, 8082}))
+
+	// child node 2
+	childNode = nodes[0].EvhNodes[1]
+	g.Expect(childNode.VHParentName).To(gomega.Equal(parentVSName))
+	g.Expect(childNode.VHMatches).To(gomega.HaveLen(1))
+	g.Expect(*childNode.VHMatches[0].Host).To(gomega.Equal("foo.com"))
+	// Path bar
+	g.Expect(childNode.VHMatches[0].Rules[0].Matches.Path.MatchStr).To(gomega.ContainElement("/bar"))
 	g.Expect(*childNode.VHMatches[0].Rules[0].Matches.Path.MatchCriteria).To(gomega.Equal("BEGINS_WITH"))
 	g.Expect(len(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports)).To(gomega.Equal(2))
 	g.Expect(childNode.VHMatches[0].Rules[0].Matches.VsPort.Ports).Should(gomega.ConsistOf([]int64{8080, 8082}))

--- a/tests/gatewayapitests/ingestion/gateway_test.go
+++ b/tests/gatewayapitests/ingestion/gateway_test.go
@@ -395,7 +395,7 @@ func TestGatewayInvalidListenerTLS(t *testing.T) {
 		waitAndverify(t, "Secret/"+DEFAULT_NAMESPACE+"/"+secret)
 	}
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false, secrets...)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false, secrets...)
 	tlsModePassthrough := gatewayv1.TLSModePassthrough
 	listeners[0].TLS.Mode = &tlsModePassthrough
 	//create

--- a/tests/gatewayapitests/ingestion/httproute_test.go
+++ b/tests/gatewayapitests/ingestion/httproute_test.go
@@ -38,7 +38,7 @@ func TestHTTPRouteCUD(t *testing.T) {
 	t.Logf("Created GatewayClass %s", gatewayClassName)
 	waitAndverify(t, "GatewayClass/gateway-class-01")
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, "Gateway/default/gateway-01")
@@ -75,7 +75,7 @@ func TestHTTPRouteHostnameInvalid(t *testing.T) {
 	t.Logf("Created GatewayClass %s", gatewayClassName)
 	waitAndverify(t, gwClassKey)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, gwKey)
@@ -120,7 +120,7 @@ func TestHTTPRouteGatewayNotPresent(t *testing.T) {
 	waitAndverify(t, "")
 
 	// update
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, gwKey)
@@ -153,7 +153,7 @@ func TestHTTPRouteWithBackendRefFilters(t *testing.T) {
 	t.Logf("Created GatewayClass %s", gatewayClassName)
 	waitAndverify(t, gwClassKey)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, gwKey)
@@ -191,7 +191,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGateway(t *testing.T) {
 	waitAndverify(t, gwClassKey)
 
 	// Gateway with empty hostname
-	listeners := akogatewayapitests.GetListenersV1(ports, true)
+	listeners := akogatewayapitests.GetListenersV1(ports, true, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s without hostname", gatewayName)
 	waitAndverify(t, gwKey)
@@ -228,7 +228,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInHTTPRoute(t *testing.T) {
 	waitAndverify(t, gwClassKey)
 
 	// Gateway
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, gwKey)
@@ -266,7 +266,7 @@ func TestHTTPRouteGatewayWithEmptyHostname(t *testing.T) {
 	waitAndverify(t, gwClassKey)
 
 	// Gateway without hostname
-	listeners := akogatewayapitests.GetListenersV1(ports, true)
+	listeners := akogatewayapitests.GetListenersV1(ports, true, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 	t.Logf("Created Gateway %s", gatewayName)
 	waitAndverify(t, gwKey)

--- a/tests/gatewayapitests/status/gateway_test.go
+++ b/tests/gatewayapitests/status/gateway_test.go
@@ -134,7 +134,7 @@ func TestGatewayWithValidListenersAndGatewayClass(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -187,7 +187,7 @@ func TestGatewayWithTLSListeners(t *testing.T) {
 		integrationtest.AddSecret(secret, DEFAULT_NAMESPACE, "cert", "key")
 	}
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false, secrets...)
+	listeners := tests.GetListenersV1(ports, false, false, secrets...)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -233,7 +233,7 @@ func TestGatewayListenerUpdate(t *testing.T) {
 	ports := []int32{8080, 8081, 8082}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -268,7 +268,7 @@ func TestGatewayListenerUpdate(t *testing.T) {
 
 	// Update the Gateway with new listeners
 	ports = []int32{8080, 8082}
-	listeners = tests.GetListenersV1(ports, false)
+	listeners = tests.GetListenersV1(ports, false, false)
 	tests.UpdateGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g.Eventually(func() bool {
@@ -307,7 +307,7 @@ func TestGatewayTransitionFromValidToInvalid(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -409,7 +409,7 @@ func TestGatewayTransitionFromInvalidToValid(t *testing.T) {
 	tests.ValidateGatewayStatus(t, &gateway.Status, expectedStatus)
 
 	// Update the gateway with a valid configuration
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.UpdateGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g.Eventually(func() bool {
@@ -443,7 +443,7 @@ func TestGatewayTransitionFromNonAKOControllerToAKOController(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassNameWithNonAkoController, "foo.company.com/foo-gateway-controller")
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassNameWithNonAkoController, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -499,7 +499,7 @@ func TestGatewayTransitionFromAKOControllerToNonAKOController(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -604,7 +604,7 @@ func TestGatewayWithMoreThanOneAddress(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	fakeGateway := tests.Gateway{}
 	addresses := []gatewayv1.GatewayAddress{{Value: "10.10.10.1"}, {Value: "10.10.10.2"}}
 	fakeGateway.Gateway = fakeGateway.GatewayV1(gatewayName, DEFAULT_NAMESPACE, gatewayClassName, addresses, listeners)
@@ -649,7 +649,7 @@ func TestGatewayWithUnsupportedProtocolInListeners(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	listeners[0].Protocol = "GRPC"
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
@@ -696,7 +696,7 @@ func TestGatewayWithInvalidHostnameInListeners(t *testing.T) {
 	ports := []int32{8080, 8081}
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	invalidHostname := "*"
 	listeners[0].Hostname = (*gatewayv1.Hostname)(&invalidHostname)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
@@ -747,7 +747,7 @@ func TestGatewayWithInvalidTLSConfigInListeners(t *testing.T) {
 		integrationtest.AddSecret(secret, DEFAULT_NAMESPACE, "cert", "key")
 	}
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false, secrets...)
+	listeners := tests.GetListenersV1(ports, false, false, secrets...)
 	invalidTLSMode := "invalid-mode"
 	listeners[0].TLS.Mode = (*gatewayv1.TLSModeType)(&invalidTLSMode)
 	tests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
@@ -799,7 +799,7 @@ func TestGatewayWithInvalidAllowedRoute(t *testing.T) {
 
 	// Checking for Invalid RouteKind -> Kind
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	allowedRoutes := gatewayv1.AllowedRoutes{
 		Kinds: []gatewayv1.RouteGroupKind{{
 			Kind: "Services",
@@ -897,7 +897,7 @@ func TestGatewayWithValidAllowedRoute(t *testing.T) {
 
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 	// Checking for Valid RouteKind -> Kind and Group as nil
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	allowedRoutes := gatewayv1.AllowedRoutes{
 		Kinds: []gatewayv1.RouteGroupKind{{
 			Kind: "HTTPRoute",
@@ -1070,7 +1070,7 @@ func TestMultipleGatewaySameHostname(t *testing.T) {
 	gatewayClassName := "gateway-class-neg-08"
 	ports := []int32{8080}
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	hostname := "products.example.com"
 	listeners[0].Hostname = (*gatewayv1.Hostname)(&hostname)
 	tests.SetupGateway(t, gatewayName1, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
@@ -1153,7 +1153,7 @@ func TestMultipleGatewayOverlappingHostname(t *testing.T) {
 	gatewayClassName := "gateway-class-neg-10"
 	ports := []int32{8080}
 	tests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := tests.GetListenersV1(ports, false)
+	listeners := tests.GetListenersV1(ports, false, false)
 	hostname := "products.example.com"
 	listeners[0].Hostname = (*gatewayv1.Hostname)(&hostname)
 	tests.SetupGateway(t, gatewayName1, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)

--- a/tests/gatewayapitests/status/httproute_test.go
+++ b/tests/gatewayapitests/status/httproute_test.go
@@ -45,7 +45,7 @@ func TestHTTPRouteWithValidConfig(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -112,7 +112,7 @@ func TestHTTPRouteWithAtleastOneParentReferenceValid(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8080 and 8082
-	listeners := akogatewayapitests.GetListenersV1([]int32{8080, 8082}, false)
+	listeners := akogatewayapitests.GetListenersV1([]int32{8080, 8082}, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -189,7 +189,7 @@ func TestHTTPRouteTransitionFromInvalidToValid(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8080
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -285,7 +285,7 @@ func TestHTTPRouteTransitionFromValidToInvalid(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8080
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -388,7 +388,7 @@ func TestHTTPRouteWithNoParentReference(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8080
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -432,7 +432,7 @@ func TestHTTPRouteWithAllParentReferenceInvalid(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8082 and 8083
-	listeners := akogatewayapitests.GetListenersV1([]int32{8082, 8083}, false)
+	listeners := akogatewayapitests.GetListenersV1([]int32{8082, 8083}, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -533,7 +533,7 @@ func TestHTTPRouteWithNonExistingListenerReference(t *testing.T) {
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
 	// creates a gateway with listeners 8082 and 8083
-	listeners := akogatewayapitests.GetListenersV1([]int32{8082}, false)
+	listeners := akogatewayapitests.GetListenersV1([]int32{8082}, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -606,7 +606,7 @@ func TestHTTPRouteWithNoHostnames(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	akogatewayapitests.SetupGateway(t, gatewayName, namespace, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -677,7 +677,7 @@ func TestHTTPRouteUnprocessedGateway(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 
 	g := gomega.NewGomegaWithT(t)
 
@@ -734,7 +734,7 @@ func TestHTTPRouteWithInvalidGatewayListener(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 	listeners[0].Hostname = nil
 
 	g := gomega.NewGomegaWithT(t)
@@ -799,7 +799,7 @@ func TestHTTPRouteWithOneExistingAndOneNonExistingGateway(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 
 	g := gomega.NewGomegaWithT(t)
 	akogatewayapitests.SetupGateway(t, gatewayName2, namespace, gatewayClassName, nil, listeners)
@@ -864,7 +864,7 @@ func TestHTTPRouteWithBackendRefFilters(t *testing.T) {
 
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
 
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, false, false)
 
 	g := gomega.NewGomegaWithT(t)
 

--- a/tests/gatewayapitests/utils.go
+++ b/tests/gatewayapitests/utils.go
@@ -130,18 +130,19 @@ func UnsetListenerHostname(l *gatewayv1.Listener) {
 func GetListenersV1(ports []int32, emptyHostName, samehost bool, secrets ...string) []gatewayv1.Listener {
 	listeners := make([]gatewayv1.Listener, 0, len(ports))
 	for _, port := range ports {
-		hostname := ""
-		if !emptyHostName && !samehost {
-			hostname = fmt.Sprintf("foo-%d.com", port)
-		} else if samehost {
-			hostname = "foo.com"
-		}
 		listener := gatewayv1.Listener{
 			Name:     gatewayv1.SectionName(fmt.Sprintf("listener-%d", port)),
 			Port:     gatewayv1.PortNumber(port),
 			Protocol: gatewayv1.ProtocolType("HTTPS"),
-			Hostname: (*gatewayv1.Hostname)(&hostname),
 		}
+		if !samehost && !emptyHostName {
+			hostname := fmt.Sprintf("foo-%d.com", port)
+			listener.Hostname = (*gatewayv1.Hostname)(&hostname)
+		} else if samehost {
+			hostname := "foo.com"
+			listener.Hostname = (*gatewayv1.Hostname)(&hostname)
+		}
+
 		if len(secrets) > 0 {
 			certRefs := make([]gatewayv1.SecretObjectReference, 0, len(secrets))
 			for _, secret := range secrets {

--- a/tests/gatewayapitests/utils.go
+++ b/tests/gatewayapitests/utils.go
@@ -127,12 +127,14 @@ func UnsetListenerHostname(l *gatewayv1.Listener) {
 	l.Hostname = &hname
 }
 
-func GetListenersV1(ports []int32, emptyHostName bool, secrets ...string) []gatewayv1.Listener {
+func GetListenersV1(ports []int32, emptyHostName, samehost bool, secrets ...string) []gatewayv1.Listener {
 	listeners := make([]gatewayv1.Listener, 0, len(ports))
 	for _, port := range ports {
 		hostname := ""
-		if !emptyHostName {
+		if !emptyHostName && !samehost {
 			hostname = fmt.Sprintf("foo-%d.com", port)
+		} else if samehost {
+			hostname = "foo.com"
 		}
 		listener := gatewayv1.Listener{
 			Name:     gatewayv1.SectionName(fmt.Sprintf("listener-%d", port)),
@@ -336,6 +338,21 @@ func GetParentReferencesV1(gatewayNames []string, namespace string, ports []int3
 			}
 			parentRefs = append(parentRefs, parentRef)
 		}
+	}
+	return parentRefs
+}
+
+// created new function to avoid confusion
+func GetParentReferencesV1WithGatewayNameOnly(gatewayNames []string, namespace string) []gatewayv1.ParentReference {
+	parentRefs := make([]gatewayv1.ParentReference, 0)
+	for _, gwName := range gatewayNames {
+
+		parentRef := gatewayv1.ParentReference{
+			Name:      gatewayv1.ObjectName(gwName),
+			Namespace: (*gatewayv1.Namespace)(&namespace),
+		}
+		parentRefs = append(parentRefs, parentRef)
+
 	}
 	return parentRefs
 }

--- a/tests/integrationtest/l4_crd_test.go
+++ b/tests/integrationtest/l4_crd_test.go
@@ -171,6 +171,7 @@ func TestCreateDeleteL4RuleInvalidLBClass(t *testing.T) {
 	}, 30*time.Second).Should(gomega.Equal(false))
 
 	SetupL4Rule(t, L4RuleName, NAMESPACE, ports)
+	PollForCompletion(t, SINGLEPORTMODEL, 15)
 	g.Eventually(func() string {
 		l4Rule, _ := lib.AKOControlConfig().V1alpha2CRDClientset().AkoV1alpha2().L4Rules(NAMESPACE).Get(context.TODO(), L4RuleName, metav1.GetOptions{})
 		return l4Rule.Status.Status


### PR DESCRIPTION
****PR is addressing issue ***
AKO gateway was failing to create child VS when HTTPRoute with multiple/single matches and single hostname is attaching to a Gateway with multiple listeners. Each listener will have same Host with different port. In HttpRoute, there is only name of  gateway mentioned in parent ref.

