### PR TITLE
AV-210421 StringGroup cache fix for Gateway

### DIFF
--- a/ako-gateway-api/lib/constants.go
+++ b/ako-gateway-api/lib/constants.go
@@ -41,7 +41,7 @@ const (
 // BackendRefFIlter data script is used to support Filters within backendRef in a HTTPRoute in Gateways
 const (
 	BackendRefFilterDatascript = `pool_name = avi.pool.name()
-  	add_header_strgrp = "ako-gw-AddHeaderStringGroup"
+  	add_header_strgrp = "NAMEPREFIX-AddHeaderStringGroup"
 	val, match_found = avi.stringgroup.contains(add_header_strgrp, pool_name)
 	if match_found then
    		for header_string in string.gmatch(val, '([^,]+)') do
@@ -51,7 +51,7 @@ const (
       		avi.http.add_header(headerkey, headerval)
    		end
 	end
-	update_header_strgrp = "ako-gw-UpdateHeaderStringGroup"
+	update_header_strgrp = "NAMEPREFIX-UpdateHeaderStringGroup"
 	val, match_found = avi.stringgroup.contains(update_header_strgrp, pool_name)
 	if match_found then
    		for header_string in string.gmatch(val, '([^,]+)') do
@@ -61,7 +61,7 @@ const (
       		avi.http.replace_header(headerkey, headerval)
    		end
 	end
-	delete_header_strgrp = "ako-gw-DeleteHeaderStringGroup"
+	delete_header_strgrp = "NAMEPREFIX-DeleteHeaderStringGroup"
 	val, match_found = avi.stringgroup.contains(delete_header_strgrp, pool_name)
 	if match_found then
    		for header_key in string.gmatch(val, '([^,]+)') do

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1931,12 +1931,12 @@ func (c *AviObjCache) PopulateL4PolicySetToCache(client *clients.AviClient, clou
 
 func (c *AviObjCache) AviPopulateAllStringGroups(client *clients.AviClient, cloud string, StringGroupData *[]AviStringGroupCache, nextPage ...NextPage) (*[]AviStringGroupCache, int, error) {
 	var uri string
-	akoUser := lib.AKOUser
 
 	if len(nextPage) == 1 {
 		uri = nextPage[0].NextURI
 	} else {
-		uri = "/api/stringgroup/?" + "&include_name=true&created_by=" + akoUser
+		//Fetching container specific StringGroups
+		uri = "/api/stringgroup?&include_name=true&label_key=created_by&label_value=" + lib.GetAKOUser()
 	}
 
 	result, err := lib.AviGetCollectionRaw(client, uri)

--- a/internal/rest/avi_obj_string_group.go
+++ b/internal/rest/avi_obj_string_group.go
@@ -27,6 +27,17 @@ import (
 	avimodels "github.com/vmware/alb-sdk/go/models"
 )
 
+func GetStringGroupMarkers() []*avimodels.RoleFilterMatchLabel {
+	stringGroupMarkers := lib.GetMarkers()
+	labelKey := "created_by"
+	rfml := &avimodels.RoleFilterMatchLabel{
+		Key:    &labelKey,
+		Values: []string{lib.GetAKOUser()},
+	}
+	stringGroupMarkers = append(stringGroupMarkers, rfml)
+	return stringGroupMarkers
+}
+
 func (rest *RestOperations) AviStringGroupBuild(sg_meta *nodes.AviStringGroupNode, cache_obj *avicache.AviStringGroupCache, key string) *utils.RestOp {
 
 	if lib.CheckObjectNameLength(*sg_meta.Name, lib.StringGroup) {
@@ -42,7 +53,7 @@ func (rest *RestOperations) AviStringGroupBuild(sg_meta *nodes.AviStringGroupNod
 		Description: sg_meta.Description,
 	}
 
-	stringgroup.Markers = lib.GetMarkers()
+	stringgroup.Markers = GetStringGroupMarkers()
 
 	var path string
 	var rest_op utils.RestOp


### PR DESCRIPTION
AV-210421 StringGroup cache fix for Gateway
**Issue:** SinceStringGroup object does not have a created_by field, the GET call on the controller was always giving an empty response when objects were fetched using created_by field resulting into failure in cache update.
**Changes:** AKO will now fetch StringGroup objects on the basis of name.contains "ako-gw"+ clustername prefix

Also as a part of this PR, StringGroup names will be prefixed with Clustername

**Testing Done:**
Manually tested CRUD and reboot scenarios. No error in cache updation is seen