### PR TITLE
AV-211111 Honoring deleteConfig for backendRefFilters

### DIFF
--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -481,8 +481,8 @@ func (o *AviObjectGraph) RemovePoolNameFromStringGroups(currentEvhNodeName strin
 		for _, modelEvhNode := range modelEvhNodes[0].EvhNodes {
 			if currentEvhNodeName == modelEvhNode.Name {
 				utils.AviLog.Infof("key: %s, msg: Updating stringgroups for model: %s", key, currentEvhNodeName)
-				if len(modelEvhNode.PoolRefs) > 0 {
-					poolname := modelEvhNode.PoolRefs[0].Name
+				for _, poolRef := range modelEvhNode.PoolRefs {
+					poolname := poolRef.Name
 					o.UpdateStringGroupsOnRouteDeletion(key, poolname)
 				}
 				return

--- a/internal/cache/cache_utils.go
+++ b/internal/cache/cache_utils.go
@@ -380,7 +380,7 @@ func (v *AviVsCache) GetVSCopy() (*AviVsCache, bool) {
 /*
  * AviCache provides a one to one cache
  * AviCache for storing objects such as:
- * VirtualServices, PoolGroups, Pools, etc.
+ * VirtualServices, PoolGroups, Pools, StringGroups etc.
  */
 
 type AviCache struct {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -205,6 +205,7 @@ const (
 	HTTPMethodGet                              = "GET"
 	HTTPMethodPut                              = "PUT"
 	VrfContextObjectNotFoundError              = "VrfContext object not found"
+	StringGroupCannotDeleteObjectError         = "Cannot delete, object is referred by"
 	NetworkNotFoundError                       = "Network object not found"
 	CtrlVersion_22_1_6                         = "22.1.6"
 

--- a/internal/rest/rest_operation.go
+++ b/internal/rest/rest_operation.go
@@ -233,7 +233,7 @@ func isErrorRetryable(statusCode int, errMsg string) bool {
 	if statusCode == 400 && (strings.Contains(errMsg, lib.VrfContextNotFoundError) || strings.Contains(errMsg, lib.VrfContextObjectNotFoundError)) {
 		return true
 	}
-	if statusCode == 403 && strings.Contains(errMsg, lib.ConfigDisallowedDuringUpgradeError) {
+	if statusCode == 403 && (strings.Contains(errMsg, lib.ConfigDisallowedDuringUpgradeError) || strings.Contains(errMsg, lib.StringGroupCannotDeleteObjectError)) {
 		return true
 	}
 	return false


### PR DESCRIPTION
AV-211111 Honoring deleteConfig for backendRefFilters.
Currently, Ako gateway container is not deleting the StringGroup objects from the controller, when deleteConfig flag is set to True. This PR fixes this issue.