### PR TITLE
AV-208387 add tenant annotation for AMKO consumption

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -953,13 +953,13 @@ func (c *AviController) SetupServiceImportEventHandlers(numWorkers uint32) {
 	c.informers.ServiceImportInformer.Informer().AddEventHandler(serviceImportEventHandler)
 }
 
-func checkRefsOnController(key string, refMap map[string]string) error {
+func checkRefsOnController(key string, refMap map[string]string, tenant string) error {
 	for k, value := range refMap {
 		if k == "" {
 			continue
 		}
 
-		if err := checkRefOnController(key, value, k); err != nil {
+		if err := checkRefOnController(key, value, k, tenant); err != nil {
 			return err
 		}
 	}
@@ -992,10 +992,10 @@ var refModelMap = map[string]string{
 }
 
 // checkRefOnController checks whether a provided ref on the controller
-func checkRefOnController(key, refKey, refValue string) error {
+func checkRefOnController(key, refKey, refValue, tenant string) error {
 	// assign the last avi client for ref checks
 	aviClientLen := lib.GetshardSize()
-	clients := avicache.SharedAVIClients(lib.GetTenant())
+	clients := avicache.SharedAVIClients(tenant)
 	uri := fmt.Sprintf("/api/%s?name=%s&fields=name,type,labels,created_by", refModelMap[refKey], refValue)
 
 	// For public clouds, check using network UUID in AWS, normal network API for GCP, skip altogether for Azure.

--- a/internal/k8s/validator.go
+++ b/internal/k8s/validator.go
@@ -203,8 +203,9 @@ func (l *leader) ValidateHostRuleObj(key string, hostrule *akov1beta1.HostRule) 
 	if hostrule.Spec.VirtualHost.NetworkSecurityPolicy != "" {
 		refData[hostrule.Spec.VirtualHost.NetworkSecurityPolicy] = "NetworkSecurityPolicy"
 	}
+	tenant := lib.GetTenantInNamespace(hostrule.Namespace)
 
-	if err := checkRefsOnController(key, refData); err != nil {
+	if err := checkRefsOnController(key, refData, tenant); err != nil {
 		status.UpdateHostRuleStatus(key, hostrule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
 		return err
 	}
@@ -281,8 +282,9 @@ func (l *leader) ValidateHTTPRuleObj(key string, httprule *akov1beta1.HTTPRule) 
 			refData[hm] = "HealthMonitor"
 		}
 	}
+	tenant := lib.GetTenantInNamespace(httprule.Namespace)
 
-	if err := checkRefsOnController(key, refData); err != nil {
+	if err := checkRefsOnController(key, refData, tenant); err != nil {
 		status.UpdateHTTPRuleStatus(key, httprule, status.UpdateCRDStatusOptions{
 			Status: lib.StatusRejected,
 			Error:  err.Error(),
@@ -376,7 +378,7 @@ func (l *leader) ValidateAviInfraSetting(key string, infraSetting *akov1beta1.Av
 			return err
 		}
 	}
-	if err := checkRefsOnController(key, refData); err != nil {
+	if err := checkRefsOnController(key, refData, lib.GetTenant()); err != nil {
 		status.UpdateAviInfraSettingStatus(key, infraSetting, status.UpdateCRDStatusOptions{
 			Status: lib.StatusRejected,
 			Error:  err.Error(),
@@ -561,8 +563,9 @@ func (l *leader) ValidateSSORuleObj(key string, ssoRule *akov1alpha2.SSORule) er
 			refData[*samlConfigObj.SigningSslKeyAndCertificateRef] = "SslKeyCert"
 		}
 	}
+	tenant := lib.GetTenantInNamespace(ssoRule.Namespace)
 
-	if err := checkRefsOnController(key, refData); err != nil {
+	if err := checkRefsOnController(key, refData, tenant); err != nil {
 		status.UpdateSSORuleStatus(key, ssoRule, status.UpdateCRDStatusOptions{Status: lib.StatusRejected, Error: err.Error()})
 		return err
 	}
@@ -715,8 +718,8 @@ func (l *leader) ValidateL4RuleObj(key string, l4Rule *akov1alpha2.L4Rule) error
 			return err
 		}
 	}
-
-	if err := checkRefsOnController(key, refData); err != nil {
+	tenant := lib.GetTenantInNamespace(l4Rule.Namespace)
+	if err := checkRefsOnController(key, refData, tenant); err != nil {
 		status.UpdateL4RuleStatus(key, l4Rule, status.UpdateCRDStatusOptions{
 			Status: lib.StatusRejected,
 			Error:  err.Error(),
@@ -753,7 +756,9 @@ func (l *leader) ValidateL7RuleObj(key string, l7Rule *akov1alpha2.L7Rule) error
 	if l7RuleSpec.TrafficCloneProfileRef != nil {
 		refData[*l7RuleSpec.TrafficCloneProfileRef] = "TrafficCloneProfile"
 	}
-	if err := checkRefsOnController(key, refData); err != nil {
+	tenant := lib.GetTenantInNamespace(l7Rule.Namespace)
+
+	if err := checkRefsOnController(key, refData, tenant); err != nil {
 		status.UpdateL7RuleStatus(key, l7Rule, status.UpdateCRDStatusOptions{
 			Status: lib.StatusRejected,
 			Error:  err.Error(),

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -248,7 +248,7 @@ func (o *AviObjectGraph) ConstructAviL4PolPoolNodes(svcObj *corev1.Service, vsNo
 	}
 
 	if !isSSLEnabled {
-		l4policyNode := &AviL4PolicyNode{Name: vsNode.Name, Tenant: lib.GetTenant(), PortPool: portPoolSet}
+		l4policyNode := &AviL4PolicyNode{Name: vsNode.Name, Tenant: vsNode.Tenant, PortPool: portPoolSet}
 		sort.Strings(protocolSet.List())
 		protocols := strings.Join(protocolSet.List(), ",")
 		l4policyNode.AviMarkers = lib.PopulateL4PolicysetMarkers(svcObj.ObjectMeta.Namespace, svcObj.ObjectMeta.Name, protocols)

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -55,6 +55,11 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 		} else if hostrule.Status.Status == lib.StatusRejected {
 			// do not apply a rejected hostrule, this way the VS would retain
 			return
+		} else {
+			if lib.GetTenantInNamespace(hostrule.Namespace) != vsNode.GetTenant() {
+				utils.AviLog.Warnf("key: %s, msg: Tenant annotation in hostrule namespace %s does not matches with the tenant of host %s ", key, hostrule.Namespace, host)
+				return
+			}
 		}
 	}
 
@@ -262,6 +267,11 @@ func BuildPoolHTTPRule(host, poolPath, ingName, namespace, infraSettingName, key
 			continue
 		} else if httpRuleObj.Status.Status == lib.StatusRejected {
 			continue
+		} else {
+			if lib.GetTenantInNamespace(httpRuleObj.Namespace) != vsNode.GetTenant() {
+				utils.AviLog.Warnf("key: %s, msg: Tenant annotation in httpRule namespace %s does not matches with the tenant of host %s ", key, httpRuleObj.Namespace, host)
+				continue
+			}
 		}
 		for _, path := range httpRuleObj.Spec.Paths {
 			httpruleNameObjMap[httprule+path.Target] = path
@@ -415,6 +425,11 @@ func BuildL7SSORule(host, key string, vsNode AviVsEvhSniModel) {
 		} else if ssoRule.Status.Status == lib.StatusRejected {
 			// do not apply a rejected SSORule, this way the VS would retain
 			return
+		} else {
+			if lib.GetTenantInNamespace(ssoRule.Namespace) != vsNode.GetTenant() {
+				utils.AviLog.Warnf("key: %s, msg: Tenant annotation in SSORule namespace %s does not matches with the tenant of host %s ", key, ssoRule.Namespace, host)
+				return
+			}
 		}
 	}
 	var crdStatus lib.CRDMetadata
@@ -498,6 +513,11 @@ func BuildL7Rule(host, key, l7RuleName, namespace string, vsNode AviVsEvhSniMode
 	} else if l7Rule.Status.Status == lib.StatusRejected {
 		// do not apply a rejected L7Rule, this way the VS would retain
 		return
+	} else {
+		if lib.GetTenantInNamespace(l7Rule.Namespace) != vsNode.GetTenant() {
+			utils.AviLog.Warnf("key: %s, msg: Tenant annotation in l7Rule namespace %s does not matches with the tenant of host %s ", key, l7Rule.Namespace, host)
+			return
+		}
 	}
 	generatedFields := vsNode.GetGeneratedFields()
 	if !deleteL7RuleCase {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -335,6 +335,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 							Key:                key,
 							VirtualServiceUUID: vs_cache_obj.Uuid,
 							VSName:             vs_cache_obj.Name,
+							Tenant:             vs_cache_obj.Tenant,
 						}
 						statusOption := status.StatusOptions{
 							ObjType: utils.L4LBService,
@@ -352,6 +353,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 								Key:                key,
 								VirtualServiceUUID: vs_cache_obj.Uuid,
 								VSName:             vs_cache_obj.Name,
+								Tenant:             vs_cache_obj.Tenant,
 							}
 							statusOption := status.StatusOptions{
 								ObjType: utils.Ingress,
@@ -418,6 +420,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
 					Key:             key,
 					VSName:          vsName,
+					Tenant:          pool_cache_obj.Tenant,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,
@@ -432,6 +435,7 @@ func (rest *RestOperations) DeletePoolIngressStatus(poolKey avicache.NamespaceNa
 					ServiceMetadata: pool_cache_obj.ServiceMetadataObj,
 					Key:             key,
 					VSName:          vsName,
+					Tenant:          pool_cache_obj.Tenant,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.Ingress,

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -511,6 +511,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 							Key:                key,
 							VirtualServiceUUID: vs_cache_obj.Uuid,
 							VSName:             vs_cache_obj.Name,
+							Tenant:             vs_cache_obj.Tenant,
 						}
 						statusOption := status.StatusOptions{
 							ObjType: utils.L4LBService,
@@ -527,6 +528,7 @@ func (rest *RestOperations) StatusUpdateForPool(restMethod utils.RestMethod, vs_
 							Key:                key,
 							VirtualServiceUUID: vs_cache_obj.Uuid,
 							VSName:             vs_cache_obj.Name,
+							Tenant:             vs_cache_obj.Tenant,
 						}
 						statusOption := status.StatusOptions{
 							ObjType: utils.Ingress,
@@ -563,6 +565,7 @@ func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCac
 			ServiceMetadata: serviceMetadataObj,
 			Key:             key,
 			VSName:          vsCacheObj.Name,
+			Tenant:          vsCacheObj.Tenant,
 		}
 		statusOption := status.StatusOptions{
 			ObjType: lib.Gateway,
@@ -582,6 +585,7 @@ func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCac
 			Key:                key,
 			VirtualServiceUUID: vsCacheObj.Uuid,
 			VSName:             vsCacheObj.Name,
+			Tenant:             vsCacheObj.Tenant,
 		}
 		statusOption := status.StatusOptions{
 			ObjType: utils.L4LBService,
@@ -790,6 +794,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
 					Key:             key,
 					VSName:          vs_cache_obj.Name,
+					Tenant:          vs_cache_obj.Tenant,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: lib.Gateway,
@@ -810,6 +815,7 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					Key:                key,
 					VirtualServiceUUID: vs_cache_obj.Uuid,
 					VSName:             vs_cache_obj.Name,
+					Tenant:             vs_cache_obj.Tenant,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,

--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -743,6 +743,7 @@ func updateGatewayStatusWithVsError(key string, rest_op *utils.RestOp) {
 						Key:             key,
 						VSName:          rest_op.ObjName,
 						Message:         rest_op.Err.Error(),
+						Tenant:          rest_op.Tenant,
 					}
 					statusOption := status.StatusOptions{
 						ObjType: lib.Gateway,

--- a/internal/rest/k8s_utils.go
+++ b/internal/rest/k8s_utils.go
@@ -65,6 +65,7 @@ func (l *leader) SyncObjectStatuses() {
 					Vip:             IPAddrs,
 					ServiceMetadata: vsSvcMetadataObj,
 					Key:             lib.SyncStatusKey,
+					Tenant:          vsCacheObj.Tenant,
 				})
 			for _, poolKey := range vsCacheObj.PoolKeyCollection {
 				poolCache, ok := l.restOp.cache.PoolCache.AviCacheGet(poolKey)
@@ -85,6 +86,7 @@ func (l *leader) SyncObjectStatuses() {
 							Key:                lib.SyncStatusKey,
 							VSName:             vsCacheObj.Name,
 							VirtualServiceUUID: vsCacheObj.Uuid,
+							Tenant:             vsCacheObj.Tenant,
 						})
 				}
 			}
@@ -114,6 +116,7 @@ func (l *leader) SyncObjectStatuses() {
 								ServiceMetadata:    poolCacheObj.ServiceMetadataObj,
 								Key:                lib.SyncStatusKey,
 								VirtualServiceUUID: vsCacheObj.Uuid,
+								Tenant:             vsCacheObj.Tenant,
 							})
 					}
 				}
@@ -139,6 +142,7 @@ func (l *leader) SyncObjectStatuses() {
 							ServiceMetadata:    poolCacheObj.ServiceMetadataObj,
 							Key:                lib.SyncStatusKey,
 							VirtualServiceUUID: vsCacheObj.Uuid,
+							Tenant:             vsCacheObj.Tenant,
 						})
 				} else if len(poolCacheObj.ServiceMetadataObj.NamespaceServiceName) > 0 {
 					allServiceLBUpdateOptions = append(allServiceLBUpdateOptions,
@@ -147,6 +151,7 @@ func (l *leader) SyncObjectStatuses() {
 							ServiceMetadata:    poolCacheObj.ServiceMetadataObj,
 							Key:                lib.SyncStatusKey,
 							VirtualServiceUUID: vsCacheObj.Uuid,
+							Tenant:             vsCacheObj.Tenant,
 						})
 				}
 			}
@@ -160,6 +165,7 @@ func (l *leader) SyncObjectStatuses() {
 					ServiceMetadata:    vsSvcMetadataObj,
 					Key:                lib.SyncStatusKey,
 					VirtualServiceUUID: vsCacheObj.Uuid,
+					Tenant:             vsCacheObj.Tenant,
 				})
 		}
 	}

--- a/internal/status/svc_status.go
+++ b/internal/status/svc_status.go
@@ -124,7 +124,7 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 		updateOption.ServiceMetadata.HostNames[0]: updateOption.VirtualServiceUUID,
 	}
 
-	if !isAnnotationsUpdateRequired(svc.Annotations, vsAnnotations) {
+	if !isAnnotationsUpdateRequired(svc.Annotations, vsAnnotations, updateOption.Tenant, false) {
 		utils.AviLog.Debugf("No annotations update required for service %s/%s", svc.Namespace, svc.Name)
 		return nil
 	}
@@ -140,6 +140,7 @@ func updateSvcAnnotations(svc *corev1.Service, updateOption UpdateOptions, oldSv
 	}
 	annotations[lib.VSAnnotation] = string(vsAnnotationsStr)
 	annotations[lib.ControllerAnnotation] = avicache.GetControllerClusterUUID()
+	annotations[lib.TenantAnnotation] = updateOption.Tenant
 
 	patchPayload := map[string]interface{}{
 		"metadata": map[string]map[string]string{
@@ -190,6 +191,7 @@ func deleteSvcAnnotation(svc *corev1.Service) error {
 			"annotations": {
 				lib.VSAnnotation:         nil,
 				lib.ControllerAnnotation: nil,
+				lib.TenantAnnotation:     nil,
 			},
 		},
 	}


### PR DESCRIPTION
This Pr add an annotation specifying the tenant name of vs in ingress,routes,lbsvc and mci

Testing done:
Update from default to tenant named "tt" on ingress and LBsvc
Update from  "tt" tenant to tenant named "tt2" on ingress and LBSVC
Hostrule re-validation on tenant update to "tt" and "t2" tenant