### PR TITLE
Gateway UT fixes

### DIFF
--- a/tests/gatewayapitests/utils.go
+++ b/tests/gatewayapitests/utils.go
@@ -126,19 +126,21 @@ func UnsetListenerHostname(l *gatewayv1.Listener) {
 
 func GetListenersV1(ports []int32, samehost bool, secrets ...string) []gatewayv1.Listener {
 	listeners := make([]gatewayv1.Listener, 0, len(ports))
-	hostname := ""
+
 	for _, port := range ports {
-		if !samehost {
-			hostname = fmt.Sprintf("foo-%d.com", port)
-		} else {
-			hostname = "foo.com"
-		}
 		listener := gatewayv1.Listener{
 			Name:     gatewayv1.SectionName(fmt.Sprintf("listener-%d", port)),
 			Port:     gatewayv1.PortNumber(port),
 			Protocol: gatewayv1.ProtocolType("HTTPS"),
-			Hostname: (*gatewayv1.Hostname)(&hostname),
 		}
+		if !samehost {
+			hostname := fmt.Sprintf("foo-%d.com", port)
+			listener.Hostname = (*gatewayv1.Hostname)(&hostname)
+		} else {
+			hostname := "foo.com"
+			listener.Hostname = (*gatewayv1.Hostname)(&hostname)
+		}
+
 		if len(secrets) > 0 {
 			certRefs := make([]gatewayv1.SecretObjectReference, 0, len(secrets))
 			for _, secret := range secrets {


### PR DESCRIPTION
root@akshay-dev-box:/var/work/load-balancer-and-ingress-services-for-kubernetes# make gatewayapitests
sudo docker run \
-w=/go/src/github.com/vmware/load-balancer-and-ingress-services-for-kubernetes \
-v /var/work/load-balancer-and-ingress-services-for-kubernetes:/go/src/github.com/vmware/load-balancer-and-ingress-services-for-kubernetes golang:bullseye \
go test -mod=vendor github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests		coverage: 0.0% of statements
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer	244.725s	coverage: 17.5% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/ingestion	270.453s	coverage: 3.0% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/status	310.656s	coverage: 12.0% of statements in ./...