### PR TITLE
AV-210932 Improve UT runtime (dedicatedvstests)

### DIFF
--- a/tests/dedicatedvstests/l7_dedicated_rest_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_rest_test.go
@@ -48,7 +48,10 @@ func TestProfilesAttachedToDedicatedSecureVS(t *testing.T) {
 	})
 
 	modelName := "admin/cluster--foo.com-L7-dedicated"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName := "my-secret-9"
+	ingressName := "foo-with-targets-9"
+	svcName := "avisvc-9"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes, ok := aviModel.(*avinodes.AviObjectGraph)
@@ -58,7 +61,7 @@ func TestProfilesAttachedToDedicatedSecureVS(t *testing.T) {
 		return len(nodes.GetAviVS())
 	}, 30*time.Second).Should(gomega.Equal(1))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, modelName)
 
 	integrationtest.ResetMiddleware()
 


### PR DESCRIPTION
this PR isolates changes required for https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1339

file changes for dedicatedvstests

replaces names for following resources with suffixed variants

- secrets
- infrasettings

UT run for dedicatedvstests
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedvstests      155.556s