### PR TITLE
AV-214324: Skip Default cert cleanup when cleaning up a VS

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -1764,7 +1764,13 @@ func (rest *RestOperations) KeyCertCU(sslkey_nodes []*nodes.AviTLSKeyCertNode, c
 func (rest *RestOperations) SSLKeyCertDelete(ssl_to_delete []avicache.NamespaceName, namespace string, rest_ops []*utils.RestOp, key string) []*utils.RestOp {
 	utils.AviLog.Debugf("key: %s, msg: about to delete ssl keycert %s", key, utils.Stringify(ssl_to_delete))
 	var noCARefRestOps []*utils.RestOp
+	defaultRouteCertName := lib.GetTLSKeyCertNodeName("", "", lib.GetDefaultSecretForRoutes())
+	defaultRouteAltCertName := lib.GetTLSKeyCertNodeName("", "", lib.GetDefaultSecretForRoutes()+"-alt")
 	for _, del_ssl := range ssl_to_delete {
+		// Skip SSL cert deletion if it maps to the Default Router Cert
+		if del_ssl.Name == defaultRouteCertName || del_ssl.Name == defaultRouteAltCertName {
+			continue
+		}
 		ssl_key := avicache.NamespaceName{Namespace: namespace, Name: del_ssl.Name}
 		ssl_cache, ok := rest.cache.SSLKeyCache.AviCacheGet(ssl_key)
 		if ok {


### PR DESCRIPTION
```
aviuser@avi-dev:~/load-balancer-and-ingress-services-for-kubernetes$ make int_test > out.txt
aviuser@avi-dev:~/load-balancer-and-ingress-services-for-kubernetes$ grep -w ok out.txt
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/k8stest	30.408s	coverage: 9.0% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest	484.065s	coverage: 26.9% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/ingresstests	975.908s	coverage: 39.3% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/evhtests	1328.222s	coverage: 38.8% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/evhtests	1233.708s	coverage: 38.1% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedevhtests	338.424s	coverage: 27.8% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedevhtests	434.402s	coverage: 28.2% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/oshiftroutetests	1268.025s	coverage: 33.1% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/bootuptests	20.141s	coverage: 3.8% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/multicloudtests	170.441s	coverage: 8.3% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/advl4tests	40.629s	coverage: 17.5% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/namespacesynctests	152.379s	coverage: 21.7% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/servicesapitests	79.030s	coverage: 22.9% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/npltests	116.789s	coverage: 24.2% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/dedicatedvstests	154.396s	coverage: 29.8% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/hatests	33.846s	coverage: 25.6% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/cnitests	103.554s	coverage: 13.5% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/cnitests	27.256s	coverage: 13.2% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer	244.753s	coverage: 17.6% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/ingestion	270.485s	coverage: 3.0% of statements in ./...
ok  	github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/status	310.686s	coverage: 12.2% of statements in ./...
```