### PR TITLE
AV-208589 RouteToChildVs mapping fixes

### DIFF
--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -215,16 +215,22 @@ func saveAviModel(modelName string, aviGraph *nodes.AviObjectGraph, key string) 
 func (o *AviObjectGraph) ProcessRouteDeletion(key, parentNsName string, routeModel RouteModel, fullsync bool) {
 
 	parentNode := o.GetAviEvhVS()
+	routeTypeNsName := routeModel.GetType() + "/" + routeModel.GetNamespace() + "/" + routeModel.GetName()
 
-	found, childVSNames := akogatewayapiobjects.GatewayApiLister().GetRouteToChildVS(routeModel.GetType() + "/" + routeModel.GetNamespace() + "/" + routeModel.GetName())
+	found, childVSNamesTemp := akogatewayapiobjects.GatewayApiLister().GetRouteToChildVS(routeTypeNsName)
+	childVSNames := make([]string, len(childVSNamesTemp))
+
+	copy(childVSNames, childVSNamesTemp)
 	if found {
 		utils.AviLog.Infof("key: %s, msg: child VSes retrieved for deletion %v", key, childVSNames)
 
 		for _, childVSName := range childVSNames {
 			o.RemovePoolNameFromStringGroups(childVSName, parentNode, key)
-			nodes.RemoveEvhInModel(childVSName, parentNode, key)
+			removed := nodes.RemoveEvhInModel(childVSName, parentNode, key)
+			if removed {
+				akogatewayapiobjects.GatewayApiLister().DeleteRouteChildVSMappings(routeTypeNsName, childVSName)
+			}
 		}
-		akogatewayapiobjects.GatewayApiLister().DeleteRouteToChildVS(routeModel.GetType() + "/" + routeModel.GetNamespace() + "/" + routeModel.GetName())
 
 		modelName := lib.GetTenant() + "/" + parentNode[0].Name
 		ok := saveAviModel(modelName, o.AviObjectGraph, key)
@@ -290,8 +296,10 @@ func (o *AviObjectGraph) DeleteStaleChildVSes(key string, routeModel RouteModel,
 	for _, childVSName := range storedChildVSes {
 		if _, ok := childVSes[childVSName]; !ok {
 			utils.AviLog.Infof("key: %s, msg: child VS retrieved for deletion %v", key, childVSName)
-			nodes.RemoveEvhInModel(childVSName, parentNode, key)
-			akogatewayapiobjects.GatewayApiLister().DeleteRouteChildVSMappings(routeModel.GetType()+"/"+routeModel.GetNamespace()+"/"+routeModel.GetName(), childVSName)
+			removed := nodes.RemoveEvhInModel(childVSName, parentNode, key)
+			if removed {
+				akogatewayapiobjects.GatewayApiLister().DeleteRouteChildVSMappings(routeModel.GetType()+"/"+routeModel.GetNamespace()+"/"+routeModel.GetName(), childVSName)
+			}
 		}
 	}
 }

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -247,9 +247,10 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 	}
 	var listenerList []objects.GatewayListenerStore
 	var gatewayList []string
-	var hostnameIntersection []string
 	var gwNsNameList []string
+	parentNameToHostnameMap := make(map[string][]string)
 	for _, parentRef := range hrObj.Spec.ParentRefs {
+		hostnameIntersection, _ := parentNameToHostnameMap[string(parentRef.Name)]
 		ns := namespace
 		if parentRef.Namespace != nil {
 			ns = string(*parentRef.Namespace)
@@ -308,6 +309,7 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 		if !utils.HasElem(gwNsNameList, gwNsName) {
 			gwNsNameList = append(gwNsNameList, gwNsName)
 		}
+		parentNameToHostnameMap[string(parentRef.Name)] = hostnameIntersection
 	}
 
 	utils.AviLog.Debugf("key: %s, msg: Gateways retrieved %s", key, gwNsNameList)

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -1632,16 +1632,17 @@ func FindAndReplaceEvhInModel(currentEvhNode *AviEvhVsNode, modelEvhNodes []*Avi
 	return false
 }
 
-func RemoveEvhInModel(currentEvhNodeName string, modelEvhNodes []*AviEvhVsNode, key string) {
+func RemoveEvhInModel(currentEvhNodeName string, modelEvhNodes []*AviEvhVsNode, key string) bool {
 	if len(modelEvhNodes[0].EvhNodes) > 0 {
 		for i, modelEvhNode := range modelEvhNodes[0].EvhNodes {
 			if currentEvhNodeName == modelEvhNode.Name {
 				modelEvhNodes[0].EvhNodes = append(modelEvhNodes[0].EvhNodes[:i], modelEvhNodes[0].EvhNodes[i+1:]...)
 				utils.AviLog.Infof("key: %s, msg: deleted evh node in model: %s", key, currentEvhNodeName)
-				return
+				return true
 			}
 		}
 	}
+	return false
 }
 
 // As either HttpSecurityPolicy or HttpRedirect policy exists, using same function for both.


### PR DESCRIPTION
AV-208589 RouteToChildVs mapping fixes.

This PR fixes following issues with one HTTPRoute getting connected to 2 Gateways:
- Hostname of first parentVS/Gateway listener being appended to the second parentVS' DNS fqdn
- RouteToChildVS mapping resulting into child VSes not getting deleted

Testing Status:

Unit Test Cases added.
Manual Testing Done.
Unit Test run attached
FT run attached