### PR TITLE
AV-199140: Add default HTTP policy set for default-backend 404

### DIFF
--- a/ako-gateway-api/lib/constants.go
+++ b/ako-gateway-api/lib/constants.go
@@ -23,6 +23,7 @@ const (
 	AddHeaderStringGroup           = "AddHeaderStringGroup"
 	UpdateHeaderStringGroup        = "UpdateHeaderStringGroup"
 	DeleteHeaderStringGroup        = "DeleteHeaderStringGroup"
+	DefaultPSName                  = "default-backend"
 )
 
 const (

--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -31,12 +31,12 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
-func (o *AviObjectGraph) AddDefaultHTTPPS(key string) {
+func (o *AviObjectGraph) AddDefaultHTTPPolicySet(key string) {
 	parentVS := o.GetAviEvhVS()[0]
-	defaultPSName := "default-backend"
+
 	// find default backend, if found make sure it is at last index
 	for i, policyRef := range parentVS.HttpPolicyRefs {
-		if policyRef.Name == defaultPSName {
+		if policyRef.Name == akogatewayapilib.DefaultPSName {
 			if i != len(parentVS.HttpPolicyRefs)-1 {
 				utils.AviLog.Debugf("key: %s msg: Found default-backend httpref at non last position", key)
 				temp := parentVS.HttpPolicyRefs[i]
@@ -49,7 +49,7 @@ func (o *AviObjectGraph) AddDefaultHTTPPS(key string) {
 	// if not found add it to last index
 
 	utils.AviLog.Debugf("key: %s msg: default-backend httpref not found. Adding", key)
-	defaultPolicyRef := &nodes.AviHttpPolicySetNode{Name: defaultPSName, Tenant: lib.GetTenant()}
+	defaultPolicyRef := &nodes.AviHttpPolicySetNode{Name: akogatewayapilib.DefaultPSName, Tenant: lib.GetTenant()}
 	defaultPolicyRef.RequestRules = []*models.HTTPRequestRule{
 		{
 			Name:   proto.String("default-backend-rule"),

--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -31,6 +31,45 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
 
+func (o *AviObjectGraph) AddDefaultHTTPPS(key string) {
+	parentVS := o.GetAviEvhVS()[0]
+	defaultPSName := "default-backend"
+	// find default backend, if found make sure it is at last index
+	for i, policyRef := range parentVS.HttpPolicyRefs {
+		if policyRef.Name == defaultPSName {
+			if i != len(parentVS.HttpPolicyRefs)-1 {
+				utils.AviLog.Debugf("key: %s msg: Found default-backend httpref at non last position", key)
+				temp := parentVS.HttpPolicyRefs[i]
+				parentVS.HttpPolicyRefs = append(parentVS.HttpPolicyRefs[:i], parentVS.HttpPolicyRefs[i+1:]...)
+				parentVS.HttpPolicyRefs = append(parentVS.HttpPolicyRefs, temp)
+			}
+			return
+		}
+	}
+	// if not found add it to last index
+
+	utils.AviLog.Debugf("key: %s msg: default-backend httpref not found. Adding", key)
+	defaultPolicyRef := &nodes.AviHttpPolicySetNode{Name: defaultPSName, Tenant: lib.GetTenant()}
+	defaultPolicyRef.RequestRules = []*models.HTTPRequestRule{
+		{
+			Name:   proto.String("default-backend-rule"),
+			Enable: proto.Bool(true),
+			Index:  proto.Int32(0),
+			Match: &models.MatchTarget{
+				Path: &models.PathMatch{
+					MatchCriteria: proto.String("BEGINS_WITH"),
+					MatchStr:      []string{"/"},
+				},
+			},
+			SwitchingAction: &models.HttpswitchingAction{
+				Action:     proto.String("HTTP_SWITCHING_SELECT_LOCAL"),
+				StatusCode: proto.String("HTTP_LOCAL_RESPONSE_STATUS_CODE_404"),
+			},
+		},
+	}
+	parentVS.HttpPolicyRefs = append(parentVS.HttpPolicyRefs, defaultPolicyRef)
+}
+
 func (o *AviObjectGraph) ProcessL7Routes(key string, routeModel RouteModel, parentNsName string, childVSes map[string]struct{}, fullsync bool) {
 	httpRouteConfig := routeModel.ParseRouteConfig()
 	noHostsOnRoute := len(httpRouteConfig.Hosts) == 0

--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -94,7 +94,7 @@ func DequeueIngestion(key string, fullsync bool) {
 			}
 			model.DeleteStaleChildVSes(key, routeModel, childVSes, fullsync)
 		}
-		model.AddDefaultHTTPPS(key)
+		model.AddDefaultHTTPPolicySet(key)
 
 		// Only add this node to the list of models if the checksum has changed.
 		modelChanged := saveAviModel(modelName, model.AviObjectGraph, key)

--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -94,6 +94,7 @@ func DequeueIngestion(key string, fullsync bool) {
 			}
 			model.DeleteStaleChildVSes(key, routeModel, childVSes, fullsync)
 		}
+		model.AddDefaultHTTPPS(key)
 
 		// Only add this node to the list of models if the checksum has changed.
 		modelChanged := saveAviModel(modelName, model.AviObjectGraph, key)

--- a/tests/gatewayapitests/graphlayer/gateway_test.go
+++ b/tests/gatewayapitests/graphlayer/gateway_test.go
@@ -162,6 +162,9 @@ func TestGateway(t *testing.T) {
 	g.Expect(nodes[0].PortProto).To(gomega.HaveLen(1))
 	g.Expect(nodes[0].SSLKeyCertRefs).To(gomega.HaveLen(0))
 	g.Expect(nodes[0].VSVIPRefs).To(gomega.HaveLen(1))
+	// default backend response
+	g.Expect(nodes[0].HttpPolicyRefs[0].RequestRules[0].Match.Path.MatchStr[0]).To(gomega.Equal("/"))
+	g.Expect(*nodes[0].HttpPolicyRefs[0].RequestRules[0].SwitchingAction.StatusCode).To(gomega.Equal("HTTP_LOCAL_RESPONSE_STATUS_CODE_404"))
 
 	tests.TeardownGateway(t, gatewayName, DEFAULT_NAMESPACE)
 	tests.TeardownGatewayClass(t, gatewayClassName)

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -1173,7 +1173,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	rules := []gatewayv1.HTTPRouteRule{rule}
 	hostnames := []gatewayv1.Hostname{}
 	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
-
+	time.Sleep(2 * time.Second)
 	// no child vs
 	g.Eventually(func() int {
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1189,7 +1189,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Eventually(func() int {
 		return len(nodes[0].HttpPolicyRefs)
-	}, 20*time.Second).Should(gomega.Equal(1))
+	}, 20*time.Second).Should(gomega.Equal(2))
 	g.Expect(len(nodes[0].HttpPolicyRefs[0].RequestRules[0].Match.VsPort.Ports)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(1))
 
@@ -1200,7 +1200,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Eventually(func() int {
 		return len(nodes[0].HttpPolicyRefs)
-	}, 10*time.Second).Should(gomega.Equal(0))
+	}, 10*time.Second).Should(gomega.Equal(1))
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
 
 	integrationtest.DelSVC(t, DEFAULT_NAMESPACE, svcName)

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -1173,7 +1173,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	rules := []gatewayv1.HTTPRouteRule{rule}
 	hostnames := []gatewayv1.Hostname{}
 	akogatewayapitests.SetupHTTPRoute(t, httpRouteName, DEFAULT_NAMESPACE, parentRefs, hostnames, rules)
-	time.Sleep(2 * time.Second)
+
 	// no child vs
 	g.Eventually(func() int {
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)


### PR DESCRIPTION
Adding a default backend "/" http policy set which will return 404 if the path is not met. This will also return 404 if there is no hostname match.
Case 1: Success

![image](https://github.com/user-attachments/assets/1fd8915c-113e-4117-9b85-d7cc0d8ab0de)

Case 2: Wrong path

![image](https://github.com/user-attachments/assets/2e5046a0-13f4-4522-b84c-2ab3db86ed70)

Case 3: Wrong path but http route is "/" . This goes till the backend

![image](https://github.com/user-attachments/assets/283d9359-4e97-47bb-80ce-ab1cfe28c3d0)

Case 4: Wrong host

![image](https://github.com/user-attachments/assets/3e95dac1-1acf-458d-b8ab-151d91e1e4c7)

Case 5: Wildcard hostname

![image](https://github.com/user-attachments/assets/333aa4f9-7e0a-4471-b79c-bf49c1af52d8)

Pending Case:
Empty hostname
