### PR TITLE
AV-212517: Rate limit logs to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash -o pipefail
 GOCMD=go
 GOBUILD=$(GOCMD) build -buildvcs=false
 GOCLEAN=$(GOCMD) clean
@@ -349,7 +350,7 @@ multitenancytests:
 	sudo docker run \
 	-w=/go/src/$(PACKAGE_PATH_AKO) \
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(GO_IMG_TEST) \
-	$(GOTEST) -mod=vendor $(PACKAGE_PATH_AKO)/tests/multitenancytests/... -failfast -timeout 0 -coverprofile cover-21.out -coverpkg=./...
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/multitenancytests/... -failfast -timeout 0 -coverprofile cover-21.out -coverpkg=./... | buffer -u 500
 
 .PHONY: int_test
 int_test:


### PR DESCRIPTION
Apply rate limiting of logs using buffer binary to only multitenancytests as of now. 