### PR TITLE
AV-216010: Fix http policyset creation fails with error no port specified for httproute and Gateway without hostname

### DIFF
--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -369,7 +369,6 @@ func (o *AviObjectGraph) BuildDefaultPGPoolForParentVS(key, parentNsName, matchN
 			httpPSPGPool.Pool = uniquePools.List()
 		}
 		pool_ref := fmt.Sprintf("/api/pool?name=%s", poolNode.Name)
-		o.BuildBackendFiltersModel(key, poolName, backend, parentVsNode)
 		ratio := uint32(backend.Backend.Weight)
 		PG.Members = append(PG.Members, &models.PoolGroupMember{PoolRef: &pool_ref, Ratio: &ratio})
 	}
@@ -496,7 +495,7 @@ func (o *AviObjectGraph) BuildParentHTTPPS(key, parentNsName string, vsNode *nod
 	parentNs, _, parentName := lib.ExtractTypeNameNamespace(parentNsName)
 
 	// Code to retrieve ports associated with given httproute name
-	routeTypeNsName := fmt.Sprintf("%s/%s", httpRouteNamespace, httpRouteName)
+	routeTypeNsName := fmt.Sprintf("%s/%s/%s", lib.HTTPRoute, httpRouteNamespace, httpRouteName)
 	allListeners := objects.GatewayApiLister().GetRouteToGatewayListener(routeTypeNsName)
 	listeners := []akogatewayapiobjects.GatewayListenerStore{}
 	for _, listener := range allListeners {

--- a/tests/gatewayapitests/graphlayer/httproute_test.go
+++ b/tests/gatewayapitests/graphlayer/httproute_test.go
@@ -1155,7 +1155,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	integrationtest.CreateSVC(t, DEFAULT_NAMESPACE, svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
 	integrationtest.CreateEP(t, DEFAULT_NAMESPACE, svcName, false, false, "1.2.3")
 	akogatewayapitests.SetupGatewayClass(t, gatewayClassName, akogatewayapilib.GatewayController)
-	listeners := akogatewayapitests.GetListenersV1(ports, false)
+	listeners := akogatewayapitests.GetListenersV1(ports, true)
 	akogatewayapitests.SetupGateway(t, gatewayName, DEFAULT_NAMESPACE, gatewayClassName, nil, listeners)
 
 	g := gomega.NewGomegaWithT(t)
@@ -1188,6 +1188,7 @@ func TestHTTPRouteGatewayWithEmptyHostnameInGatewayHTTPRoute(t *testing.T) {
 	g.Eventually(func() int {
 		return len(nodes[0].HttpPolicyRefs)
 	}, 20*time.Second).Should(gomega.Equal(1))
+	g.Expect(len(nodes[0].HttpPolicyRefs[0].RequestRules[0].Match.VsPort.Ports)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(1))
 
 	// delete httproute


### PR DESCRIPTION
There is a change in this PR: https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1468
which addresses part of the issue AV-216010 so both PR has to be merged to address the issue AV-216010