### PR TITLE
AV-216384:T1LR support for AKO gateway api

### DIFF
--- a/ako-gateway-api/lib/lib.go
+++ b/ako-gateway-api/lib/lib.go
@@ -16,6 +16,8 @@ package lib
 
 import (
 	"fmt"
+
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -125,6 +127,9 @@ func FindPortName(serviceName, ns string, servicePort int32, key string) string 
 	}
 	utils.AviLog.Warnf("key: %s, msg: Port name not found in service obj: %v", key, svcObj)
 	return ""
+}
+func GetT1LRPath() string {
+	return os.Getenv("NSXT_T1_LR")
 }
 
 func FindTargetPort(serviceName, ns string, svcPort int32, key string) intstr.IntOrString {

--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -201,7 +201,14 @@ func (o *AviObjectGraph) BuildPGPool(key, parentNsName string, childVsNode *node
 			ServiceMetadata: lib.ServiceMetadataObj{
 				NamespaceServiceName: []string{httpbackend.Backend.Namespace + "/" + httpbackend.Backend.Name},
 			},
-			VrfContext: lib.GetVrf(),
+		}
+		t1LR := lib.GetT1LRPath()
+		if t1LR == "" {
+			poolNode.VrfContext = lib.GetVrf()
+		} else {
+			poolNode.T1Lr = t1LR
+			poolNode.VrfContext = ""
+			utils.AviLog.Infof("key: %s, msg: setting t1LR: %s for pool node.", key, t1LR)
 		}
 		poolNode.NetworkPlacementSettings = lib.GetNodeNetworkMap()
 		serviceType := lib.GetServiceType()

--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -61,7 +61,11 @@ func (o *AviObjectGraph) BuildGatewayParent(gateway *gatewayv1.Gateway, key stri
 		},
 		Caller: utils.GATEWAY_API, // Always Populate this field to recognise caller at rest layer
 	}
-
+	t1LR := lib.GetT1LRPath()
+	if t1LR != "" {
+		utils.AviLog.Infof("key: %s, msg: T1LR is %s.", key, t1LR)
+		parentVsNode.VrfContext = ""
+	}
 	parentVsNode.PortProto = BuildPortProtocols(gateway, key)
 
 	tlsNodes := BuildTLSNodesForGateway(gateway, key)
@@ -146,7 +150,12 @@ func BuildVsVipNodeForGateway(gateway *gatewayv1.Gateway, vsName string) *nodes.
 		VrfContext:  lib.GetVrf(),
 		VipNetworks: utils.GetVipNetworkList(),
 	}
-
+	t1LR := lib.GetT1LRPath()
+	if t1LR != "" {
+		utils.AviLog.Infof("key: %s, msg: T1LR for vsvip node is: %s.", vsName, t1LR)
+		vsvipNode.VrfContext = ""
+		vsvipNode.T1Lr = t1LR
+	}
 	//Type is validated at ingestion
 	if len(gateway.Spec.Addresses) == 1 {
 		ipAddr := gateway.Spec.Addresses[0].Value

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -390,6 +390,13 @@ spec:
                 name: avi-k8s-config
                 key: nodeValue
           {{ end }}
+          {{ if .Values.NetworkSettings.nsxtT1LR }}
+          - name: NSXT_T1_LR
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: nsxtT1LR
+          {{ end }}
           {{ if .Values.persistentVolumeClaim }}
           - name: USE_PVC
             value: "true"


### PR DESCRIPTION
AKO 1.13.1 supports Avi controller version 22.1.3 and above. This PR introduces NSX-T support in AKO gateway API.