### PR TITLE
AV-210932 Improve UT runtime (evhtests, vippernstests)

### DIFF
--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -46,14 +46,17 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
-var KubeClient *k8sfake.Clientset
-var CRDClient *crdfake.Clientset
-var v1alpha2CRDClient *v1alpha2crdfake.Clientset
-var v1beta1CRDClient *v1beta1crdfake.Clientset
-var ctrl *k8s.AviController
-var akoApiServer *api.FakeApiServer
-var keyChan chan string
-var endpointSliceEnabled bool
+var (
+	KubeClient           *k8sfake.Clientset
+	CRDClient            *crdfake.Clientset
+	v1alpha2CRDClient    *v1alpha2crdfake.Clientset
+	v1beta1CRDClient     *v1beta1crdfake.Clientset
+	ctrl                 *k8s.AviController
+	akoApiServer         *api.FakeApiServer
+	keyChan              chan string
+	endpointSliceEnabled bool
+	objNameMap           integrationtest.ObjectNameMap
+)
 
 var isVipPerNS = flag.String("isVipPerNS", "false", "is vip per namespace enabled")
 
@@ -168,7 +171,40 @@ func TestMain(m *testing.M) {
 	integrationtest.AddDefaultNamespace()
 	integrationtest.AddDefaultNamespace("red")
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
+	objNameMap.InitMap()
 	os.Exit(m.Run())
+}
+
+type IngressTestObject struct {
+	ingressName string
+	namespace   string
+	dnsNames    []string
+	ipAddrs     []string
+	hostnames   []string
+	paths       []string
+	isTLS       bool
+	withSecret  bool
+	secretName  string
+	serviceName string
+	modelNames  []string
+}
+
+func (ing *IngressTestObject) FillParams() {
+	if ing.namespace == "" {
+		ing.namespace = "default"
+	}
+	if len(ing.dnsNames) == 0 {
+		ing.dnsNames = append(ing.dnsNames, "foo.com")
+	}
+	if len(ing.ipAddrs) == 0 {
+		ing.ipAddrs = append(ing.ipAddrs, "8.8.8.8")
+	}
+	if len(ing.hostnames) == 0 {
+		ing.hostnames = append(ing.hostnames, "v1")
+	}
+	if len(ing.paths) == 0 {
+		ing.paths = append(ing.paths, "/foo")
+	}
 }
 
 func SetupDomain() {
@@ -195,31 +231,31 @@ func TearDownTestForIngress(t *testing.T, svcName string, modelNames ...string) 
 	integrationtest.DelEPorEPS(t, "default", svcName)
 }
 
-func SetUpIngressForCacheSyncCheck(t *testing.T, tlsIngress, withSecret bool, secretName, ingressName, svcName string, modelNames ...string) {
+func SetUpIngressForCacheSyncCheck(t *testing.T, ingTestObj IngressTestObject) {
 	SetupDomain()
-	SetUpTestForIngress(t, svcName, modelNames...)
+	SetUpTestForIngress(t, ingTestObj.serviceName, ingTestObj.modelNames...)
 	ingressObject := integrationtest.FakeIngress{
-		Name:        ingressName,
-		Namespace:   "default",
-		DnsNames:    []string{"foo.com"},
-		Ips:         []string{"8.8.8.8"},
-		HostNames:   []string{"v1"},
-		Paths:       []string{"/foo"},
-		ServiceName: svcName,
+		Name:        ingTestObj.ingressName,
+		Namespace:   ingTestObj.namespace,
+		DnsNames:    ingTestObj.dnsNames,
+		Ips:         ingTestObj.ipAddrs,
+		HostNames:   ingTestObj.hostnames,
+		Paths:       ingTestObj.paths,
+		ServiceName: ingTestObj.serviceName,
 	}
-	if withSecret {
-		integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	if ingTestObj.withSecret {
+		integrationtest.AddSecret(ingTestObj.secretName, ingTestObj.namespace, "tlsCert", "tlsKey")
 	}
-	if tlsIngress {
+	if ingTestObj.isTLS {
 		ingressObject.TlsSecretDNS = map[string][]string{
-			secretName: {"foo.com"},
+			ingTestObj.secretName: {"foo.com"},
 		}
 	}
 	ingrFake := ingressObject.Ingress()
-	if _, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
+	if _, err := KubeClient.NetworkingV1().Ingresses(ingTestObj.namespace).Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
-	integrationtest.PollForCompletion(t, modelNames[0], 5)
+	integrationtest.PollForCompletion(t, ingTestObj.modelNames[0], 5)
 }
 
 func TearDownIngressForCacheSyncCheck(t *testing.T, secretName, ingressName, svcName, modelName string) {
@@ -232,58 +268,34 @@ func TearDownIngressForCacheSyncCheck(t *testing.T, secretName, ingressName, svc
 	TearDownTestForIngress(t, svcName, modelName)
 }
 
-func SetUpIngressForCacheSyncCheckMultiPaths(t *testing.T, tlsIngress, withSecret bool, fqdns []string, paths []string, modelNames ...string) {
-	SetupDomain()
-	SetUpTestForIngress(t, modelNames...)
-	ingressObject := integrationtest.FakeIngress{
-		Name:        "app-root-test",
-		Namespace:   "default",
-		DnsNames:    fqdns,
-		Ips:         []string{"8.8.8.8"},
-		HostNames:   []string{"v1"},
-		Paths:       paths,
-		ServiceName: "avisvc",
-	}
-	if withSecret {
-		integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	}
-	if tlsIngress {
-		ingressObject.TlsSecretDNS = map[string][]string{
-			"my-secret": {"foo.com"},
-		}
-	}
-	ingrFake := ingressObject.Ingress()
-	if _, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("error in adding Ingress: %v", err)
-	}
-	integrationtest.PollForCompletion(t, modelNames[0], 5)
-}
-
-func TearDownIngressForCacheSyncCheckPath(t *testing.T, modelName string) {
-	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "app-root-test", metav1.DeleteOptions{}); err != nil {
-		t.Fatalf("Couldn't DELETE the Ingress %v", err)
-	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
-	TearDownTestForIngress(t, modelName)
-}
-
 func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-1"
-	secretName, ingressName, svcName := "my-secret-1", "foo-with-targets-1", "avisvc-1"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
@@ -315,7 +327,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 
 	//Update with another fqdn
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:              hrname,
+		Name:              hrName,
 		Namespace:         "default",
 		Fqdn:              "foo.com",
 		SslKeyCertificate: "thisisaviref-sslkey",
@@ -329,7 +341,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() []string {
@@ -354,7 +366,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 
 	//Delete/Disable
 	hrUpdate = integrationtest.FakeHostRule{
-		Name:              hrname,
+		Name:              hrName,
 		Namespace:         "default",
 		Fqdn:              "foo.com",
 		SslKeyCertificate: "thisisaviref-sslkey",
@@ -374,7 +386,7 @@ func TestCreateUpdateDeleteHostRuleForEvh(t *testing.T) {
 		return true
 	}, 25*time.Second).Should(gomega.Equal(false))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
@@ -393,16 +405,27 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-2"
-	secretName, ingressName, svcName := "my-secret-2", "foo-with-targets-2", "avisvc-2"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	fqdn := "cluster--Shared-L7-EVH-0.admin.com"
 	if lib.VIPPerNamespace() {
 		fqdn = "cluster--Shared-L7-EVH-NS-default.admin.com"
 	}
 	hostrule := integrationtest.FakeHostRule{
-		Name:                  hrname,
+		Name:                  hrName,
 		Namespace:             "default",
 		Fqdn:                  fqdn,
 		WafPolicy:             "thisisaviref-waf",
@@ -425,12 +448,12 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: strings.Split(modelName, "/")[1]}
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrName, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
@@ -460,7 +483,7 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 	g.Expect(ports[1]).To(gomega.Equal(8082))
 	g.Expect(ports[2]).To(gomega.Equal(8083))
 
-	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	integrationtest.TeardownHostRule(t, g, vsKey, hrName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].Enabled).To(gomega.BeNil())
@@ -492,16 +515,27 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-3"
-	secretName, ingressName, svcName := "my-secret-3", "foo-with-targets-3", "avisvc-3"
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -513,7 +547,7 @@ func TestCreateHostRuleBeforeIngressForEvh(t *testing.T) {
 	}, 10*time.Second).Should(gomega.ContainSubstring("thisisaviref-sslkey"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -531,17 +565,26 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-4"
-	ingressName, svcName := "foo-with-targets-4", "avisvc-4"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 
 	// update hostrule with bad ref
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:               hrname,
+		Name:               hrName,
 		Namespace:          "default",
 		Fqdn:               "voo.com",
 		WafPolicy:          "thisisBADaviref",
@@ -553,7 +596,7 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Rejected"))
 
@@ -572,7 +615,7 @@ func TestGoodToBadHostRuleForEvh(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].WafPolicyRef).To(gomega.ContainSubstring("thisisaviref-waf"))
 	g.Expect(*nodes[0].EvhNodes[0].ApplicationProfileRef).To(gomega.ContainSubstring("thisisaviref-appprof"))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
@@ -581,10 +624,19 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-5"
-	ingressName, svcName := "foo-with-targets-5", "avisvc-5"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", false)
 
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -592,7 +644,7 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 		return len(nodes[0].EvhNodes)
 	}, 10*time.Second).Should(gomega.Equal(1))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -605,7 +657,7 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 	//Update host rule with another fqdn
 	//Update with another fqdn
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -618,7 +670,7 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() int {
@@ -635,7 +687,7 @@ func TestInsecureHostAndHostruleForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(2))
 	g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.ContainElement("baz.com"))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
@@ -643,10 +695,19 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "ap-hr-foo"
-	ingressName, svcName := "foo-with-targets-6", "avisvc-6"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", false)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
@@ -663,7 +724,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 
 	// Update host rule with AnalyticsPolicy
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -682,7 +743,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -710,7 +771,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -727,7 +788,7 @@ func TestHostruleAnalyticsPolicyUpdateForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
 	g.Expect(nodes[0].EvhNodes[0].AnalyticsPolicy).Should(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
@@ -735,10 +796,21 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "fqdn-aliases-hr-foo"
-	secretName, ingressName, svcName := "my-secret-7", "foo-with-targets-7", "avisvc-7"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", false)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
@@ -775,7 +847,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 
 	// Update host rule with a valid FQDN Aliases
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -788,7 +860,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -813,7 +885,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -838,7 +910,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -854,7 +926,7 @@ func TestHostruleFQDNAliasesForEvh(t *testing.T) {
 	// Check whether the Alias reference is properly removed from Parent and Child VSes.
 	validateNode(nodes[0], aliases)
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
@@ -863,10 +935,12 @@ func TestHostruleFQDNAliasesForMultiPathIngressEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "fqdn-aliases-hr-multipath-foo"
+	hrName := objNameMap.GenerateName("samplehr-foo")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-8", "foo-with-targets-8", "avisvc-8"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -891,7 +965,7 @@ func TestHostruleFQDNAliasesForMultiPathIngressEvh(t *testing.T) {
 
 	// Create the hostrule with a valid FQDN Aliases
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -904,7 +978,7 @@ func TestHostruleFQDNAliasesForMultiPathIngressEvh(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -941,7 +1015,7 @@ func TestHostruleFQDNAliasesForMultiPathIngressEvh(t *testing.T) {
 	}
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
@@ -949,13 +1023,24 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "hr-cluster--Shared-L7-EVH-0"
+	hrName := objNameMap.GenerateName("samplehr-foo")
 
-	secretName, ingressName, svcName := "my-secret-9", "foo-with-targets-9", "avisvc-9"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:               hrname,
+		Name:               hrName,
 		Namespace:          "default",
 		WafPolicy:          "thisisaviref-waf",
 		ApplicationProfile: "thisisaviref-appprof",
@@ -973,7 +1058,7 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 30*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -997,7 +1082,7 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	g.Expect(nodes[0].VsDatascriptRefs[0]).To(gomega.ContainSubstring("thisisaviref-ds2"))
 	g.Expect(nodes[0].VsDatascriptRefs[1]).To(gomega.ContainSubstring("thisisaviref-ds1"))
 
-	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	integrationtest.TeardownHostRule(t, g, vsKey, hrName)
 	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--Shared-L7-EVH-0", false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
@@ -1018,12 +1103,23 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-10"
-	secretName, ingressName, svcName := "my-secret-10", "foo-with-targets-10", "avisvc-10"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}
@@ -1034,7 +1130,7 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1045,7 +1141,7 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].Enabled).To(gomega.Equal(true))
@@ -1063,7 +1159,7 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts).To(gomega.ContainElement("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].Host).To(gomega.ContainElement("foo.com"))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
@@ -1082,16 +1178,27 @@ func TestSharedVSHostRuleNoListenerForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-11"
-	secretName, ingressName, svcName := "my-secret-11", "foo-with-targets-11", "avisvc-11"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	fqdn := "cluster--Shared-L7-EVH-0.admin.com"
 	if lib.VIPPerNamespace() {
 		fqdn = "cluster--Shared-L7-EVH-NS-default.admin.com"
 	}
 	hostrule := integrationtest.FakeHostRule{
-		Name:               hrname,
+		Name:               hrName,
 		Namespace:          "default",
 		Fqdn:               fqdn,
 		WafPolicy:          "thisisaviref-waf",
@@ -1111,12 +1218,12 @@ func TestSharedVSHostRuleNoListenerForEvh(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: strings.Split(modelName, "/")[1]}
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrName, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
@@ -1133,7 +1240,7 @@ func TestSharedVSHostRuleNoListenerForEvh(t *testing.T) {
 	g.Expect(ports[1]).To(gomega.Equal(443))
 	g.Expect(nodes[0].VSVIPRefs[0].IPAddress).To(gomega.Equal("80.80.80.80"))
 
-	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	integrationtest.TeardownHostRule(t, g, vsKey, hrName)
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
@@ -1147,10 +1254,12 @@ func TestHTTPRuleCreateDeleteForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	rrname := "samplerr-foo-12"
+	rrName := objNameMap.GenerateName("samplerr-foo")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-12", "foo-with-targets-12", "avisvc-12"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1176,9 +1285,9 @@ func TestHTTPRuleCreateDeleteForEvh(t *testing.T) {
 	poolFooKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com_foo-"+ingressName+"-"+svcName, lib.Pool)}
 	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com_bar-"+ingressName+"-"+svcName, lib.Pool)}
 	httpRulePath := "/"
-	integrationtest.SetupHTTPRule(t, rrname, "foo.com", httpRulePath)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrname+"/"+httpRulePath, true)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrname+"/"+httpRulePath, true)
+	integrationtest.SetupHTTPRule(t, rrName, "foo.com", httpRulePath)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrName+"/"+httpRulePath, true)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrName+"/"+httpRulePath, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.Equal("LB_ALGORITHM_CONSISTENT_HASH"))
@@ -1190,9 +1299,9 @@ func TestHTTPRuleCreateDeleteForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].HealthMonitorRefs[1]).To(gomega.ContainSubstring("thisisaviref-hm1"))
 
 	// delete httprule deletes refs as well
-	integrationtest.TeardownHTTPRule(t, rrname)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrname+"/"+httpRulePath, false)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrname+"/"+httpRulePath, false)
+	integrationtest.TeardownHTTPRule(t, rrName)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrName+"/"+httpRulePath, false)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrName+"/"+httpRulePath, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.BeNil())
@@ -1207,10 +1316,12 @@ func TestHTTPRuleCreateDeleteWithPkiRefForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	rrname := "samplerr-foo-13"
+	rrName := objNameMap.GenerateName("samplerr-foo")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-13", "foo-with-targets-13", "avisvc-13"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1237,7 +1348,7 @@ func TestHTTPRuleCreateDeleteWithPkiRefForEvh(t *testing.T) {
 	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--default-foo.com_bar-"+ingressName+"-"+svcName, lib.Pool)}
 	httpRulePath := "/"
 	httprule := integrationtest.FakeHTTPRule{
-		Name:      rrname,
+		Name:      rrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		PathProperties: []integrationtest.FakeHTTPRulePath{{
@@ -1252,8 +1363,8 @@ func TestHTTPRuleCreateDeleteWithPkiRefForEvh(t *testing.T) {
 		t.Fatalf("error in adding HTTPRule: %v", err)
 	}
 
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrname+"/"+httpRulePath, true)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrname+"/"+httpRulePath, true)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrName+"/"+httpRulePath, true)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrName+"/"+httpRulePath, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(*nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.Equal("LB_ALGORITHM_CONSISTENT_HASH"))
@@ -1261,9 +1372,9 @@ func TestHTTPRuleCreateDeleteWithPkiRefForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].PkiProfile).To(gomega.BeNil())
 
 	// delete httprule deletes refs as well
-	integrationtest.TeardownHTTPRule(t, rrname)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrname+"/"+httpRulePath, false)
-	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrname+"/"+httpRulePath, false)
+	integrationtest.TeardownHTTPRule(t, rrName)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrName+"/"+httpRulePath, false)
+	integrationtest.VerifyMetadataHTTPRule(t, g, poolBarKey, "default/"+rrName+"/"+httpRulePath, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].LbAlgorithm).To(gomega.BeNil())
@@ -1277,10 +1388,12 @@ func TestHTTPRuleWithInvalidPath(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	rrname := "samplerr-foo-14"
+	rrName := objNameMap.GenerateName("samplerr-foo")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-14", "foo-with-targets-14", "avisvc-14"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1304,7 +1417,7 @@ func TestHTTPRuleWithInvalidPath(t *testing.T) {
 	integrationtest.PollForCompletion(t, modelName, 5)
 
 	// create a httprule with a non-existing path
-	integrationtest.SetupHTTPRule(t, rrname, "foo.com", "/invalidPath")
+	integrationtest.SetupHTTPRule(t, rrName, "foo.com", "/invalidPath")
 
 	time.Sleep(10 * time.Second)
 
@@ -1327,7 +1440,7 @@ func TestHTTPRuleWithInvalidPath(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].PoolRefs[1].HealthMonitorRefs).To(gomega.HaveLen(0))
 
 	// delete httprule must not change any configs
-	integrationtest.TeardownHTTPRule(t, rrname)
+	integrationtest.TeardownHTTPRule(t, rrName)
 
 	time.Sleep(10 * time.Second)
 
@@ -1354,9 +1467,20 @@ func TestCreateUpdateDeleteSSORuleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	srname := "samplesr-foo-15"
-	secretName, ingressName, svcName := "my-secret-15", "foo-with-targets-15", "avisvc-15"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	srName := objNameMap.GenerateName("samplesr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	err := integrationtest.SetUpOAuthSecret()
 	if err != nil {
@@ -1365,10 +1489,10 @@ func TestCreateUpdateDeleteSSORuleForEvh(t *testing.T) {
 	// Sleeping for 5s for secret to be updated in informer
 	time.Sleep(5 * time.Second)
 
-	integrationtest.SetupSSORule(t, srname, "foo.com", "OAuth")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "OAuth")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1405,7 +1529,7 @@ func TestCreateUpdateDeleteSSORuleForEvh(t *testing.T) {
 
 	//Update with Oidc parameters as false
 	srUpdate := integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "OAuth",
@@ -1422,7 +1546,7 @@ func TestCreateUpdateDeleteSSORuleForEvh(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1436,7 +1560,7 @@ func TestCreateUpdateDeleteSSORuleForEvh(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].OauthVsConfig.OauthSettings[0].AppSettings.OidcConfig.Profile).To(gomega.Equal(false))
 
 	// Delete/Disable
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -1455,11 +1579,20 @@ func TestCreateUpdateDeleteSSORuleForEvhInsecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	srname := "samplesr-foo-16"
+	srName := objNameMap.GenerateName("samplesr-foo")
 
 	// create insecure ingress, SSORule should be applied in case of EVH
-	ingressName, svcName := "foo-with-targets-16", "avisvc-16"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	err := integrationtest.SetUpOAuthSecret()
 	if err != nil {
@@ -1468,10 +1601,10 @@ func TestCreateUpdateDeleteSSORuleForEvhInsecure(t *testing.T) {
 	// Sleeping for 5s for secret to be updated in informer
 	time.Sleep(5 * time.Second)
 
-	integrationtest.SetupSSORule(t, srname, "foo.com", "SAML")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "SAML")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1497,7 +1630,7 @@ func TestCreateUpdateDeleteSSORuleForEvhInsecure(t *testing.T) {
 
 	//Update with oauth parameters instead of saml
 	srUpdate := integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "OAuth",
@@ -1508,7 +1641,7 @@ func TestCreateUpdateDeleteSSORuleForEvhInsecure(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1540,7 +1673,7 @@ func TestCreateUpdateDeleteSSORuleForEvhInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].OauthVsConfig.OauthSettings[0].ResourceServer.JwtParams).To(gomega.BeNil())
 
 	// Delete/Disable
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -1559,9 +1692,20 @@ func TestCreateUpdateDeleteSSORuleForEvhJwt(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	srname := "samplesr-foo-17"
-	secretName, ingressName, svcName := "my-secret-17", "foo-with-targets-17", "avisvc-17"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	srName := objNameMap.GenerateName("samplesr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	err := integrationtest.SetUpOAuthSecret()
 	if err != nil {
@@ -1570,10 +1714,10 @@ func TestCreateUpdateDeleteSSORuleForEvhJwt(t *testing.T) {
 		// Sleeping for 5s for secret to be updated in informer
 		time.Sleep(5 * time.Second)
 	}
-	integrationtest.SetupSSORule(t, srname, "foo.com", "OAuth")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "OAuth")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1610,7 +1754,7 @@ func TestCreateUpdateDeleteSSORuleForEvhJwt(t *testing.T) {
 
 	//Update with Opaque token parameters instead of jwt
 	srUpdate := integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "OAuth",
@@ -1627,7 +1771,7 @@ func TestCreateUpdateDeleteSSORuleForEvhJwt(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1658,7 +1802,7 @@ func TestCreateUpdateDeleteSSORuleForEvhJwt(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].SamlSpConfig).To(gomega.BeNil())
 
 	// Delete/Disable
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -1677,16 +1821,26 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	srname := "samplesr-foo-18"
+	srName := objNameMap.GenerateName("samplesr-foo")
 
 	// create insecure ingress, SSORule should be applied in case of EVH
-	secretName, ingressName, svcName := "my-secret-18", "foo-with-targets-18", "avisvc-18"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
-	integrationtest.SetupSSORule(t, srname, "foo.com", "SAML")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "SAML")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1712,7 +1866,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 
 	//Update saml parameters with acs type url
 	srUpdate := integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "SAML",
@@ -1728,7 +1882,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1750,7 +1904,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 
 	//Update saml parameters with acs type index
 	srUpdate = integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "SAML",
@@ -1766,7 +1920,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1787,7 +1941,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].SamlSpConfig.UseIdpSessionTimeout).To(gomega.Equal(false))
 
 	// Delete/Disable
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -1801,7 +1955,7 @@ func TestCreateUpdateDeleteSSORuleForEvhSamlACS(t *testing.T) {
 func TestCreateSSORuleBeforeIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	srname := "samplesr-foo-19"
+	srName := objNameMap.GenerateName("samplesr-foo")
 	err := integrationtest.SetUpOAuthSecret()
 	if err != nil {
 		t.Fatalf("error in creating my-oauth-secret: %v", err)
@@ -1810,16 +1964,27 @@ func TestCreateSSORuleBeforeIngressForEvh(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// creating SSORule before ingress
-	integrationtest.SetupSSORule(t, srname, "foo.com", "OAuth")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "OAuth")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-19", "foo-with-targets-19", "avisvc-19"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1853,7 +2018,7 @@ func TestCreateSSORuleBeforeIngressForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].SamlSpConfig).To(gomega.BeNil())
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	err = integrationtest.TearDownOAuthSecret()
 	if err != nil {
 		t.Fatalf("error in deleting my-oauth-secret: %v", err)
@@ -1865,16 +2030,25 @@ func TestGoodToBadSSORuleForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	srname := "samplesr-foo-20"
+	srName := objNameMap.GenerateName("samplesr-foo")
 
 	// create insecure ingress, SSORule should be applied in case of EVH
-	ingressName, svcName := "foo-with-targets-20", "avisvc-20"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
-	integrationtest.SetupSSORule(t, srname, "foo.com", "SAML")
+	integrationtest.SetupSSORule(t, srName, "foo.com", "SAML")
 
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -1900,7 +2074,7 @@ func TestGoodToBadSSORuleForEvh(t *testing.T) {
 
 	//Update with bad sso policy ref
 	srUpdate := integrationtest.FakeSSORule{
-		Name:      srname,
+		Name:      srName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 		SSOType:   "SAML",
@@ -1913,7 +2087,7 @@ func TestGoodToBadSSORuleForEvh(t *testing.T) {
 		t.Fatalf("error in updating SSORule: %v", err)
 	}
 	g.Eventually(func() string {
-		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srname, metav1.GetOptions{})
+		ssoRule, _ := v1alpha2CRDClient.AkoV1alpha2().SSORules("default").Get(context.TODO(), srName, metav1.GetOptions{})
 		return ssoRule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Rejected"))
 
@@ -1926,7 +2100,7 @@ func TestGoodToBadSSORuleForEvh(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].SsoPolicyRef).To(gomega.ContainSubstring("thisisaviref-ssopolicysaml"))
 
 	// Delete/Disable
-	integrationtest.TeardownSSORule(t, g, sniVSKey, srname)
+	integrationtest.TeardownSSORule(t, g, sniVSKey, srName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -1940,28 +2114,39 @@ func TestGoodToBadSSORuleForEvh(t *testing.T) {
 func TestCreateUpdateDeleteL7RuleInHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-21"
-	secretName, ingressName, svcName := "my-secret-21", "foo-with-targets-21", "avisvc-21"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	l7ruleName := "samplel7rule"
+	l7ruleName := objNameMap.GenerateName("samplel7rule")
 	integrationtest.SetupL7Rule(t, l7ruleName, g)
 
 	//Update hostrule with L7rule
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -1972,7 +2157,7 @@ func TestCreateUpdateDeleteL7RuleInHostRule(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() *bool {
@@ -1996,7 +2181,7 @@ func TestCreateUpdateDeleteL7RuleInHostRule(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
 	//remove L7rule from hostrule
 	hrUpdate = integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2024,7 +2209,7 @@ func TestCreateUpdateDeleteL7RuleInHostRule(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HostNameXlate).To(gomega.BeNil())
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 
@@ -2046,27 +2231,38 @@ func TestCreateUpdateDeleteL7RuleInHostRule(t *testing.T) {
 func TestDeleteL7RulePresentInHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-22"
-	secretName, ingressName, svcName := "my-secret-22", "foo-with-targets-22", "avisvc-22"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	l7ruleName := "samplel7rule"
+	l7ruleName := objNameMap.GenerateName("samplel7rule")
 	integrationtest.SetupL7Rule(t, l7ruleName, g)
 	//Update hostrule with L7rule
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2077,7 +2273,7 @@ func TestDeleteL7RulePresentInHostRule(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() *bool {
@@ -2121,7 +2317,7 @@ func TestDeleteL7RulePresentInHostRule(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HostNameXlate).To(gomega.BeNil())
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].EvhNodes[0].Enabled).To(gomega.BeNil())
@@ -2139,27 +2335,38 @@ func TestDeleteL7RulePresentInHostRule(t *testing.T) {
 func TestChangeL7RuleInHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-23"
-	secretName, ingressName, svcName := "my-secret-23", "foo-with-targets-23", "avisvc-23"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	l7ruleName := "samplel7rule"
+	l7ruleName := objNameMap.GenerateName("samplel7rule")
 	integrationtest.SetupL7Rule(t, l7ruleName, g)
 	//Update hostrule with L7rule
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2170,7 +2377,7 @@ func TestChangeL7RuleInHostRule(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() *bool {
@@ -2218,7 +2425,7 @@ func TestChangeL7RuleInHostRule(t *testing.T) {
 
 	//Update hostrule with L7rule2
 	hrUpdate = integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2230,7 +2437,7 @@ func TestChangeL7RuleInHostRule(t *testing.T) {
 	}
 
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() bool {
@@ -2252,7 +2459,7 @@ func TestChangeL7RuleInHostRule(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].MinPoolsUp).To(gomega.Equal(uint32(0)))
 	g.Expect(nodes[0].EvhNodes[0].HostNameXlate).To(gomega.BeNil())
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	if err := lib.AKOControlConfig().V1alpha2CRDClientset().AkoV1alpha2().L7Rules("default").Delete(context.TODO(), l7ruleName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("error in deleting l7Rule: %v", err)
 	}
@@ -2265,27 +2472,38 @@ func TestChangeL7RuleInHostRule(t *testing.T) {
 func TestValidToInvalidL7rule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-24"
-	secretName, ingressName, svcName := "my-secret-24", "foo-with-targets-24", "avisvc-24"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	l7ruleName := "samplel7rule"
+	l7ruleName := objNameMap.GenerateName("samplel7rule")
 	integrationtest.SetupL7Rule(t, l7ruleName, g)
 	//Update hostrule with L7rule
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2296,7 +2514,7 @@ func TestValidToInvalidL7rule(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() *bool {
@@ -2376,7 +2594,7 @@ func TestValidToInvalidL7rule(t *testing.T) {
 	g.Expect(*nodes[0].EvhNodes[0].MinPoolsUp).To(gomega.Equal(uint32(0)))
 	g.Expect(nodes[0].EvhNodes[0].HostNameXlate).To(gomega.BeNil())
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	if err := lib.AKOControlConfig().V1alpha2CRDClientset().AkoV1alpha2().L7Rules("default").Delete(context.TODO(), l7ruleName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("error in deleting l7Rule: %v", err)
 	}
@@ -2386,27 +2604,38 @@ func TestValidToInvalidL7rule(t *testing.T) {
 func TestDeleteHostRuleWithActiveL7Rule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo-25"
-	secretName, ingressName, svcName := "my-secret-25", "foo-with-targets-25", "avisvc-25"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
-	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+	integrationtest.SetupHostRule(t, hrName, "foo.com", true)
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrName, true)
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 25*time.Second).Should(gomega.Equal(true))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
-	l7ruleName := "samplel7rule"
+	l7ruleName := objNameMap.GenerateName("samplel7rule")
 	integrationtest.SetupL7Rule(t, l7ruleName, g)
 	//Update hostrule with L7rule
 	hrUpdate := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
@@ -2417,7 +2646,7 @@ func TestDeleteHostRuleWithActiveL7Rule(t *testing.T) {
 		t.Fatalf("error in updating HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 	g.Eventually(func() *bool {
@@ -2440,7 +2669,7 @@ func TestDeleteHostRuleWithActiveL7Rule(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HostNameXlate).To(gomega.BeNil())
 	g.Expect(nodes[0].EvhNodes[0].SecurityPolicyRef).To(gomega.BeNil())
 	//Delete Hostrule
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	g.Eventually(func() *bool {
 		if found, aviModel := objects.SharedAviGraphLister().Get(modelName); found {
 			nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
@@ -2481,14 +2710,26 @@ func TestHostRuleUseRegexSecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: namespace,
 		Fqdn:      fqdn,
 		UseRegex:  true,
@@ -2498,7 +2739,7 @@ func TestHostRuleUseRegexSecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2526,7 +2767,7 @@ func TestHostRuleUseRegexSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2543,22 +2784,35 @@ func TestHostRuleUseRegexSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestHostRuleAppRootSecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 	appRootPath := "/foo"
-
-	SetUpIngressForCacheSyncCheckMultiPaths(t, true, true, []string{fqdn}, []string{"/"}, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+		dnsNames:    []string{fqdn},
+		paths:       []string{"/"},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:                hrname,
+		Name:                hrName,
 		Namespace:           namespace,
 		Fqdn:                fqdn,
 		ApplicationRootPath: "/foo",
@@ -2568,7 +2822,7 @@ func TestHostRuleAppRootSecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2600,7 +2854,7 @@ func TestHostRuleAppRootSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2618,22 +2872,36 @@ func TestHostRuleAppRootSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestHostRuleRegexAppRootSecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 	appRootPath := "/foo"
 
-	SetUpIngressForCacheSyncCheckMultiPaths(t, true, true, []string{fqdn, fqdn}, []string{"/something(/|$)(.*)", "/"}, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+		dnsNames:    []string{fqdn, fqdn},
+		paths:       []string{"/something(/|$)(.*)", "/"},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:                hrname,
+		Name:                hrName,
 		Namespace:           namespace,
 		Fqdn:                fqdn,
 		UseRegex:            true,
@@ -2644,7 +2912,7 @@ func TestHostRuleRegexAppRootSecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2681,7 +2949,7 @@ func TestHostRuleRegexAppRootSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2702,21 +2970,31 @@ func TestHostRuleRegexAppRootSecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestHostRuleUseRegexInsecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:      hrname,
+		Name:      hrName,
 		Namespace: namespace,
 		Fqdn:      fqdn,
 		UseRegex:  true,
@@ -2726,7 +3004,7 @@ func TestHostRuleUseRegexInsecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2747,7 +3025,7 @@ func TestHostRuleUseRegexInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCase).Should(gomega.Equal("INSENSITIVE"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(1))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2757,22 +3035,34 @@ func TestHostRuleUseRegexInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
 func TestHostRuleAppRootInsecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 	appRootPath := "/foo"
 
-	SetUpIngressForCacheSyncCheckMultiPaths(t, false, false, []string{fqdn}, []string{"/"}, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+		dnsNames:    []string{fqdn},
+		paths:       []string{"/"},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:                hrname,
+		Name:                hrName,
 		Namespace:           namespace,
 		Fqdn:                fqdn,
 		ApplicationRootPath: "/foo",
@@ -2782,7 +3072,7 @@ func TestHostRuleAppRootInsecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2807,7 +3097,7 @@ func TestHostRuleAppRootInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].RedirectPorts[0].RedirectPath).To(gomega.Equal(strings.TrimPrefix(appRootPath, "/")))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].RedirectPorts[0].MatchCriteria).To(gomega.Equal("EQUALS"))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2818,22 +3108,34 @@ func TestHostRuleAppRootInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].Path[0]).To(gomega.Equal("/"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
 func TestHostRuleRegexAppRootInsecure(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	hrname := "samplehr-foo"
 	fqdn := "foo.com"
 	namespace := "default"
 	appRootPath := "/foo"
 
-	SetUpIngressForCacheSyncCheckMultiPaths(t, false, false, []string{fqdn, fqdn}, []string{"/something(/|$)(.*)", "/"}, modelName)
+	hrName := objNameMap.GenerateName("samplehr-foo")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+		dnsNames:    []string{fqdn, fqdn},
+		paths:       []string{"/something(/|$)(.*)", "/"},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
-		Name:                hrname,
+		Name:                hrName,
 		Namespace:           namespace,
 		Fqdn:                fqdn,
 		UseRegex:            true,
@@ -2844,7 +3146,7 @@ func TestHostRuleRegexAppRootInsecure(t *testing.T) {
 		t.Fatalf("error in adding HostRule: %v", err)
 	}
 	g.Eventually(func() string {
-		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrName, metav1.GetOptions{})
 		return hostrule.Status.Status
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
@@ -2874,7 +3176,7 @@ func TestHostRuleRegexAppRootInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].RedirectPorts[0].RedirectPath).To(gomega.Equal(strings.TrimPrefix(appRootPath, "/")))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].RedirectPorts[0].MatchCriteria).To(gomega.Equal("EQUALS"))
 
-	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrName)
 	time.Sleep(2 * time.Second)
 
 	g.Expect(nodes[0].EvhNodes).To(gomega.HaveLen(1))
@@ -2888,5 +3190,5 @@ func TestHostRuleRegexAppRootInsecure(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Path[0]).To(gomega.Equal("/"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -65,7 +65,8 @@ func TestL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-57", "avisvc-57"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -119,7 +120,9 @@ func TestShardObjectsForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-58", "foo-with-targets-58", "avisvc-58"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
@@ -199,7 +202,8 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-59", "avisvc-59"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 	objects.SharedAviGraphLister().Delete(modelName)
 
@@ -240,8 +244,9 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
-	svcName := "avisvc-60"
-	ingressName1, ingressName2 := "foo-with-targets-60", "foo-with-targets-61"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	svcExample := (integrationtest.FakeService{
 		Name:         svcName,
 		Namespace:    "default",
@@ -392,7 +397,8 @@ func TestMultiPathIngressForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "ingress-multipath-62", "avisvc-62"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -462,7 +468,8 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 
 	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
-	ingressName, svcName := "ingress-multipath-63", "avisvc-63"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	integrationtest.CreateSVC(t, "default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, true)
 	integrationtest.CreateEPorEPS(t, "default", svcName, true, true, "1.1.1")
 	ingrFake := (integrationtest.FakeIngress{
@@ -542,8 +549,9 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	svcName := "avisvc-64"
-	ingressName1, ingressName2 := "ingress-multipath-64", "ingress-multipath-65"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -637,8 +645,9 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	svcName := "avisvc-66"
-	ingressName1, ingressName2 := "ingress-multipath-66", "ingress-multipath-67"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -731,8 +740,9 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
 
-	ingressName := "ingress-multipath-68"
-	svcName1, svcName2 := "avisvc-68", "avisvc-69"
+	ingressName := objNameMap.GenerateName("ingress-multipath")
+	svcName1 := objNameMap.GenerateName("avisvc")
+	svcName2 := objNameMap.GenerateName("avisvc")
 
 	SetUpTestForIngress(t, svcName1, modelName)
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -803,7 +813,9 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName1, ingressName, svcName1 := "my-secret-70", "foo-with-targets-70", "avisvc-70"
+	secretName1 := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName1 := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName1, modelName)
 	integrationtest.AddSecret(secretName1, "default", "tlsCert", "tlsKey")
 	//create ingress with tls secret
@@ -917,7 +929,8 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-72", "avisvc-72"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -966,7 +979,8 @@ func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 func TestEditPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-73", "avisvc-73"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1056,7 +1070,8 @@ func TestEditPathIngressForEvh(t *testing.T) {
 func TestEditMultiPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-74", "avisvc-74"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
@@ -1184,8 +1199,9 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	svcName := "avisvc-75"
-	ingressName1, ingressName2 := "foo-with-targets-75", "foo-with-targets-76"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -1285,7 +1301,8 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 
 func TestNoHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	ingressName, svcName := "foo-with-targets-77", "avisvc-77"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	modelName, _ := GetModelName(ingressName+".default.com", "default")
 
 	SetUpTestForIngress(t, svcName, modelName)
@@ -1337,7 +1354,8 @@ func TestNoHostIngressForEvh(t *testing.T) {
 
 func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	ingressName, svcName := "foo-with-targets-78", "avisvc-78"
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	modelName, _ := GetModelName(ingressName+".default.com", "default")
 	SetUpTestForIngress(t, svcName, modelName)
 
@@ -1452,8 +1470,9 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	svcName := "avisvc-79"
-	ingressName1, ingressName2 := "foo-with-targets-79", "foo-with-targets-80"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
@@ -1554,7 +1573,9 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-80", "foo-with-targets-80", "avisvc-80"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1614,8 +1635,10 @@ func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, svcName := "my-secret-81", "avisvc-81"
-	ingressName1, ingressName2 := "foo-with-targets-81", "foo-with-targets-82"
+	secretName := objNameMap.GenerateName("my-secret")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingressName1 := objNameMap.GenerateName("foo-with-targets")
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -1712,7 +1735,9 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 
 func TestL7ModelMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	secretName, ingressName, svcName := "my-secret-83", "foo-with-targets-83", "avisvc-83"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	modelName, _ := GetModelName("foo.com", "default")
 	SetUpTestForIngress(t, svcName, modelName)
@@ -1767,7 +1792,9 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 	// This test covers creating multiple SNI nodes via multiple secrets.
 
 	g := gomega.NewGomegaWithT(t)
-	secretName, ingressName, svcName := "my-secret-84", "foo-with-targets-84", "avisvc-84"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
 	// Clean up any earlier models.
@@ -1877,7 +1904,9 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 
 func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	secretName, ingressName, svcName := "my-secret-85", "foo-with-targets-85", "avisvc-85"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
 	modelName, _ := GetModelName("foo.com", "default")
@@ -1951,8 +1980,19 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 func TestFQDNCountInL7Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-86", "foo-with-targets-86", "avisvc-86"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if aviModel == nil {
@@ -1980,7 +2020,9 @@ func TestFQDNCountInL7Model(t *testing.T) {
 func TestPortsForInsecureAndSecureEVH(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-87", "foo-with-targets-87", "avisvc-87"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, modelName)
 
 	// Insecure

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -65,7 +65,8 @@ func TestL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-57", "avisvc-57"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	// This check is moot since we were deleting the model earlier,
@@ -76,12 +77,12 @@ func TestL7ModelForEvh(t *testing.T) {
 	// 	t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
 	// }
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -101,14 +102,14 @@ func TestL7ModelForEvh(t *testing.T) {
 	g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 // This tests the different objects associated in the evh model for ingress
@@ -118,21 +119,22 @@ func TestShardObjectsForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	secretName, ingressName, svcName := "my-secret-58", "foo-with-targets-58", "avisvc-58"
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
 	// foo.com and noo.com compute the same hashed shard vs num
 	ingrFake := (integrationtest.FakeIngress{
-		Name:      "foo-with-targets",
+		Name:      ingressName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com", "noo.com"},
 		Ips:       []string{"8.8.8.8"},
 		Paths:     []string{"/foo/bar"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -141,7 +143,7 @@ func TestShardObjectsForEvh(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 
-	verifyIng, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	verifyIng, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 	for i, host := range []string{"foo.com", "noo.com"} {
 		if verifyIng.Spec.Rules[i].Host == host {
 			g.Expect(verifyIng.Spec.Rules[i].Host).To(gomega.Equal(host))
@@ -167,37 +169,38 @@ func TestShardObjectsForEvh(t *testing.T) {
 	// There will be 2 evh node one for each host
 	g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(2))
 	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--noo.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-foo-with-targets", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-foo-with-targets-avisvc", lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-"+ingressName+"-"+svcName, lib.Pool)))
 	// Shared VS in EVH will not have any certificates and httppolicy
 	g.Expect(nodes[0].EvhNodes[0].SSLKeyCertRefs).Should(gomega.HaveLen(0))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com", lib.HTTPPS)))
-	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-foo-with-targets", lib.HPPMAP)))
+	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal(lib.Encode("cluster--default-noo.com_foo_bar-"+ingressName, lib.HPPMAP)))
 
 	g.Expect(nodes[0].EvhNodes[1].Name).To(gomega.Equal(lib.Encode("cluster--foo.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[1].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-foo-with-targets", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[1].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-foo-with-targets-avisvc", lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[1].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[1].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-"+ingressName+"-"+svcName, lib.Pool)))
 	// since foo is bound with cert this node will have the cert bound to it
 	g.Expect(nodes[0].EvhNodes[1].SSLKeyCertRefs).Should(gomega.HaveLen(0))
 	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs).Should(gomega.HaveLen(2))
 	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com", lib.HTTPPS)))
-	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-foo-with-targets", lib.HPPMAP)))
+	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo_bar-"+ingressName, lib.HPPMAP)))
 	g.Expect(nodes[0].EvhNodes[1].HttpPolicyRefs[1].Name).To(gomega.Equal(lib.Encode("cluster--foo.com", lib.HTTPPS)))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestNoBackendL7ModelForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-59", "avisvc-59"
+	SetUpTestForIngress(t, svcName, modelName)
 	objects.SharedAviGraphLister().Delete(modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -207,7 +210,7 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 	// 	t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
 	// }
 	ingrFake := (integrationtest.FakeIngress{
-		Name:      "foo-with-targets",
+		Name:      ingressName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com"},
 		Paths:     []string{"/"},
@@ -225,20 +228,22 @@ func TestNoBackendL7ModelForEvh(t *testing.T) {
 		return found
 	}, 15*time.Second).Should(gomega.Equal(false))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
+	svcName := "avisvc-60"
+	ingressName1, ingressName2 := "foo-with-targets-60", "foo-with-targets-61"
 	svcExample := (integrationtest.FakeService{
-		Name:         "avisvc",
+		Name:         svcName,
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
 		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
@@ -248,14 +253,14 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -263,12 +268,12 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -293,8 +298,8 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	}
 	//====== VERIFICATION OF SERVICE DELETE
 	// Now we have cleared the layer 2 queue for both the models. Let's delete the service.
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
-	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	integrationtest.DelEPorEPS(t, "default", svcName)
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), svcName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Service %v", err)
 	}
@@ -313,10 +318,10 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	g.Expect(len(dsNodes)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 	//====== VERIFICATION OF ONE INGRESS DELETE
 	// Now let's delete one ingress and expect the update for that.
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -356,7 +361,7 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 		t.Fatalf("Could not find model on service ADD: %v", err)
 	}
 	//====== VERIFICATION OF ONE ENDPOINT DELETE
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	integrationtest.PollForCompletion(t, modelName, 5)
 	// Deletion should also give us the affected ingress objects
 	g.Eventually(func() bool {
@@ -371,11 +376,11 @@ func TestMultiIngressToSameSvcForEvh(t *testing.T) {
 	// Delete the model.
 	objects.SharedAviGraphLister().Delete(modelName)
 
-	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), svcName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Service %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -387,14 +392,15 @@ func TestMultiPathIngressForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "ingress-multipath-62", "avisvc-62"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-multipath",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -431,8 +437,8 @@ func TestMultiPathIngressForEvh(t *testing.T) {
 				nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Name}
 			sort.Strings(p)
 			return p
-		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-ingress-multipath", lib.HPPMAP),
-			lib.Encode("cluster--default-foo.com_foo-ingress-multipath", lib.HPPMAP)}))
+		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-"+ingressName, lib.HPPMAP),
+			lib.Encode("cluster--default-foo.com_foo-"+ingressName, lib.HPPMAP)}))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[1].Members)).To(gomega.Equal(1))
@@ -440,14 +446,14 @@ func TestMultiPathIngressForEvh(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multipath", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiPortServiceIngressForEvh(t *testing.T) {
@@ -456,14 +462,15 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 
 	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
-	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, true)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", true, true, "1.1.1")
+	ingressName, svcName := "ingress-multipath-63", "avisvc-63"
+	integrationtest.CreateSVC(t, "default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, true)
+	integrationtest.CreateEPorEPS(t, "default", svcName, true, true, "1.1.1")
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-multipath",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPort()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -479,12 +486,13 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 		g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 
+		g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolRefs)).To(gomega.Equal(2))
 		for _, pool := range nodes[0].EvhNodes[0].PoolRefs {
-			if pool.Name == lib.Encode("cluster--default-foo.com_foo-ingress-multipath-avisvc", lib.Pool) {
+			if pool.Name == lib.Encode("cluster--default-foo.com_foo-"+ingressName+"-"+svcName, lib.Pool) {
 				g.Expect(pool.Port).To(gomega.Equal(int32(8080)))
 				g.Expect(len(pool.Servers)).To(gomega.Equal(3))
-			} else if pool.Name == lib.Encode("cluster--default-foo.com_bar-ingress-multipath-avisvc", lib.Pool) {
+			} else if pool.Name == lib.Encode("cluster--default-foo.com_bar-"+ingressName+"-"+svcName, lib.Pool) {
 				g.Expect(pool.Port).To(gomega.Equal(int32(8081)))
 				g.Expect(len(pool.Servers)).To(gomega.Equal(2))
 			} else {
@@ -512,21 +520,21 @@ func TestMultiPortServiceIngressForEvh(t *testing.T) {
 				nodes[0].EvhNodes[0].HttpPolicyRefs[1].HppMap[0].Name}
 			sort.Strings(p)
 			return p
-		}, gomega.Equal([]string{"cluster--default-foo.com_bar-ingress-multipath",
-			"cluster--default-foo.com_foo-ingress-multipath"}))
+		}, gomega.Equal([]string{"cluster--default-foo.com_bar-" + ingressName,
+			"cluster--default-foo.com_foo-" + ingressName}))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multipath", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	time.Sleep(15 * time.Second)
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
 }
 
@@ -534,14 +542,16 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	svcName := "avisvc-64"
+	ingressName1, ingressName2 := "ingress-multipath-64", "ingress-multipath-65"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -550,11 +560,11 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 	}
 
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -595,13 +605,13 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 				nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Name}
 			sort.Strings(p)
 			return p
-		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-ingress-multi1", lib.HPPMAP),
-			lib.Encode("cluster--default-foo.com_foo-ingress-multi2", lib.HPPMAP)}))
+		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-"+ingressName1, lib.HPPMAP),
+			lib.Encode("cluster--default-foo.com_foo-"+ingressName2, lib.HPPMAP)}))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -613,28 +623,30 @@ func TestMultiIngressSameHostForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestDeleteBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	svcName := "avisvc-66"
+	ingressName1, ingressName2 := "ingress-multipath-66", "ingress-multipath-67"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -643,11 +655,11 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 	}
 
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -676,8 +688,8 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 	// Delete the service
-	integrationtest.DelSVC(t, "default", "avisvc")
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	g.Eventually(func() bool {
 		found, _ = objects.SharedAviGraphLister().Get(modelName)
 		return found
@@ -694,7 +706,7 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 		return len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)
 	}, 30*time.Second).Should(gomega.Equal(0))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -703,28 +715,32 @@ func TestDeleteBackendServiceForEvh(t *testing.T) {
 	VerifyEvhIngressDeletion(t, g, aviModel, 1)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-ingress-multi2-avisvc", lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-"+ingressName2+"-"+svcName, lib.Pool)))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestUpdateBackendServiceForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+
+	ingressName := "ingress-multipath-68"
+	svcName1, svcName2 := "avisvc-68", "avisvc-69"
+
+	SetUpTestForIngress(t, svcName1, modelName)
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "ingress-backend-svc",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName1,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -742,15 +758,15 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 	}, 15*time.Second).Should(gomega.Equal("1.1.1.1"))
 
 	// Update the service
-	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc2", false, false, "2.2.2")
+	integrationtest.CreateSVC(t, "default", svcName2, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEPorEPS(t, "default", svcName2, false, false, "2.2.2")
 
 	_, err = (integrationtest.FakeIngress{
-		Name:        "ingress-backend-svc",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc2",
+		ServiceName: svcName2,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -771,36 +787,37 @@ func TestUpdateBackendServiceForEvh(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-backend-svc", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc2")
-	integrationtest.DelEPorEPS(t, "default", "avisvc2")
+	integrationtest.DelSVC(t, "default", svcName2)
+	integrationtest.DelEPorEPS(t, "default", svcName2)
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName1, modelName)
 }
 
 func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	secretName1, ingressName, svcName1 := "my-secret-70", "foo-with-targets-70", "avisvc-70"
+	SetUpTestForIngress(t, svcName1, modelName)
+	integrationtest.AddSecret(secretName1, "default", "tlsCert", "tlsKey")
 	//create ingress with tls secret
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:      "ingress-chksum",
+		Name:      ingressName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com"},
 		Ips:       []string{"8.8.8.8"},
 		Paths:     []string{"/foo"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName1: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName1,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -832,12 +849,14 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 
 	g.Expect(len(nodes[0].HttpPolicyRefs)).To(gomega.Equal(0))
 
-	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc2", false, false, "2.2.2")
-	integrationtest.AddSecret("my-secret-new", "default", "tlsCert-new", "tlsKey")
+	secretName2, svcName2 := "my-secret-71", "avisvc-71"
+
+	integrationtest.CreateSVC(t, "default", svcName2, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEPorEPS(t, "default", svcName2, false, false, "2.2.2")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert-new", "tlsKey")
 
 	_, err = (integrationtest.FakeIngress{
-		Name:      "ingress-chksum",
+		Name:      ingressName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com"},
 		Ips:       []string{"8.8.8.8"},
@@ -846,10 +865,10 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
 			//to update tls secret checksum
-			"my-secret-new": {"foo.com"},
+			secretName2: {"foo.com"},
 		},
 		//to update poolref checksum
-		ServiceName: "avisvc2",
+		ServiceName: svcName2,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -882,30 +901,31 @@ func TestL2ChecksumsUpdateForEvh(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-chksum", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc2")
-	integrationtest.DelEPorEPS(t, "default", "avisvc2")
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret-new", metav1.DeleteOptions{})
+	integrationtest.DelSVC(t, "default", svcName2)
+	integrationtest.DelEPorEPS(t, "default", svcName2)
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName1, metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName2, metav1.DeleteOptions{})
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName1, modelName)
 }
 
 func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-72", "avisvc-72"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-multihost",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -933,27 +953,28 @@ func TestMultiHostSameHostNameIngressForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap)).To(gomega.Equal(2))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multihost", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-73", "avisvc-73"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-edit",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "1"
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -979,19 +1000,19 @@ func TestEditPathIngressForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 	g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(1))
 	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--foo.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-ingress-edit", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-ingress-edit-avisvc", lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-"+ingressName+"-"+svcName, lib.Pool)))
 	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "ingress-edit",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1011,8 +1032,8 @@ func TestEditPathIngressForEvh(t *testing.T) {
 		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 		g.Expect(nodes[0].EvhNodes).Should(gomega.HaveLen(1))
 		g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--foo.com", lib.EVHVS)))
-		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-ingress-edit", lib.PG)))
-		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-ingress-edit-avisvc", lib.Pool)))
+		g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-"+ingressName, lib.PG)))
+		g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_bar-"+ingressName+"-"+svcName, lib.Pool)))
 		g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
 		g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
@@ -1022,27 +1043,28 @@ func TestEditPathIngressForEvh(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-edit", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditMultiPathIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-74", "avisvc-74"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-multipath-edit",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "1"
 
@@ -1052,11 +1074,11 @@ func TestEditMultiPathIngressForEvh(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "ingress-multipath-edit",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1096,17 +1118,17 @@ func TestEditMultiPathIngressForEvh(t *testing.T) {
 			nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Name}
 		sort.Strings(p)
 		return p
-	}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-ingress-multipath-edit", lib.HPPMAP),
-		lib.Encode("cluster--default-foo.com_foo-ingress-multipath-edit", lib.HPPMAP)}))
+	}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_bar-"+ingressName, lib.HPPMAP),
+		lib.Encode("cluster--default-foo.com_foo-"+ingressName, lib.HPPMAP)}))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "ingress-multipath-edit",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/foobar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	ingrFake.ResourceVersion = "3"
 	objects.SharedAviGraphLister().Delete(modelName)
@@ -1140,36 +1162,38 @@ func TestEditMultiPathIngressForEvh(t *testing.T) {
 				nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Name}
 			sort.Strings(p)
 			return p
-		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_foo-ingress-multipath-edit", lib.HPPMAP),
-			lib.Encode("cluster--default-foo.com_foobar-ingress-multipath-edit", lib.HPPMAP)}))
+		}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_foo-"+ingressName, lib.HPPMAP),
+			lib.Encode("cluster--default-foo.com_foobar-"+ingressName, lib.HPPMAP)}))
 		g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 		g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multipath-edit", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	svcName := "avisvc-75"
+	ingressName1, ingressName2 := "foo-with-targets-75", "foo-with-targets-76"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := integrationtest.KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -1177,11 +1201,11 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -1189,11 +1213,11 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 	ingrFake2 = (integrationtest.FakeIngress{
-		Name:        "ingress-multi2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foobar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake2, metav1.UpdateOptions{})
@@ -1234,12 +1258,12 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 			nodes[0].EvhNodes[0].HttpPolicyRefs[0].HppMap[1].Name}
 		sort.Strings(p)
 		return p
-	}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_foo-ingress-multi1", lib.HPPMAP),
-		lib.Encode("cluster--default-foo.com_foobar-ingress-multi2", lib.HPPMAP)}))
+	}, gomega.Equal([]string{lib.Encode("cluster--default-foo.com_foo-"+ingressName1, lib.HPPMAP),
+		lib.Encode("cluster--default-foo.com_foobar-"+ingressName2, lib.HPPMAP)}))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].PoolGroupRefs)).To(gomega.Equal(0))
 
-	err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -1248,7 +1272,7 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
 
-	err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -1256,19 +1280,21 @@ func TestEditMultiIngressSameHostForEvh(t *testing.T) {
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestNoHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName, _ := GetModelName("ingress-nohost.default.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-77", "avisvc-77"
+	modelName, _ := GetModelName(ingressName+".default.com", "default")
+
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-nohost",
+		Name:        ingressName,
 		Namespace:   "default",
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1292,33 +1318,34 @@ func TestNoHostIngressForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 
-	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--ingress-nohost.default.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-ingress-nohost.default.com_foo-ingress-nohost", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-ingress-nohost.default.com_foo-ingress-nohost-avisvc", lib.Pool)))
-	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("ingress-nohost.default.com"))
+	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--"+ingressName+".default.com", lib.EVHVS)))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-"+ingressName+".default.com_foo-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-"+ingressName+".default.com_foo-"+ingressName+"-"+svcName, lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal(ingressName + ".default.com"))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-nohost", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName, _ := GetModelName("ingress-nohost.default.com", "default")
-	SetUpTestForIngress(t, modelName)
+	ingressName, svcName := "foo-with-targets-78", "avisvc-78"
+	modelName, _ := GetModelName(ingressName+".default.com", "default")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "ingress-nohost",
+		Name:        ingressName,
 		Namespace:   "default",
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1342,20 +1369,20 @@ func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 
-	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--ingress-nohost.default.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-ingress-nohost.default.com_foo-ingress-nohost", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-ingress-nohost.default.com_foo-ingress-nohost-avisvc", lib.Pool)))
-	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("ingress-nohost.default.com"))
+	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--"+ingressName+".default.com", lib.EVHVS)))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-"+ingressName+".default.com_foo-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-"+ingressName+".default.com_foo-"+ingressName+"-"+svcName, lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal(ingressName + ".default.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "ingress-nohost",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	ingrFake.ResourceVersion = "2"
@@ -1403,14 +1430,14 @@ func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].EvhNodes)).To(gomega.Equal(1))
 	g.Expect(nodes[0].EvhNodes[0].Name).To(gomega.Equal(lib.Encode("cluster--foo.com", lib.EVHVS)))
-	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-ingress-nohost", lib.PG)))
-	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-ingress-nohost-avisvc", lib.Pool)))
+	g.Expect(nodes[0].EvhNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-"+ingressName, lib.PG)))
+	g.Expect(nodes[0].EvhNodes[0].PoolRefs[0].Name).To(gomega.Equal(lib.Encode("cluster--default-foo.com_foo-"+ingressName+"-"+svcName, lib.Pool)))
 	g.Expect(nodes[0].EvhNodes[0].EvhHostName).To(gomega.Equal("foo.com"))
 	g.Expect(nodes[0].EvhNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[0].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-nohost", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -1418,21 +1445,23 @@ func TestEditNoHostToHostIngressForEvh(t *testing.T) {
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestScaleEndpointsForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	svcName := "avisvc-79"
+	ingressName1, ingressName2 := "foo-with-targets-79", "foo-with-targets-80"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -1441,11 +1470,11 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 	}
 
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "ingress-multi2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -1475,7 +1504,7 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[1].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[1].Servers)).To(gomega.Equal(1))
 
-	integrationtest.ScaleCreateEPorEPS(t, "default", "avisvc")
+	integrationtest.ScaleCreateEPorEPS(t, "default", svcName)
 	integrationtest.PollForCompletion(t, modelName, 5)
 	integrationtest.DetectModelChecksumChange(t, modelName, 5)
 
@@ -1501,7 +1530,7 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes[0].PoolGroupRefs[1].Members)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[1].Servers)).To(gomega.Equal(2))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -1510,14 +1539,14 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 // Additional EVH test cases follow:
@@ -1525,18 +1554,19 @@ func TestScaleEndpointsForEvh(t *testing.T) {
 func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	secretName, ingressName, svcName := "my-secret-80", "foo-with-targets-80", "avisvc-80"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-no-secret",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1558,7 +1588,7 @@ func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 	}
 
 	// Now create the secret and verify the models.
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		g.Eventually(func() int {
@@ -1570,32 +1600,34 @@ func TestL7ModelNoSecretToSecretForEvh(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-no-secret", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifyEvhPoolDeletion(t, g, aviModel, 0)
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	secretName, svcName := "my-secret-81", "avisvc-81"
+	ingressName1, ingressName2 := "foo-with-targets-81", "foo-with-targets-82"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "foo-no-secret1",
+		Name:        ingressName1,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -1604,15 +1636,15 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	}
 
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:      "foo-no-secret2",
+		Name:      ingressName2,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com"},
 		Ips:       []string{"8.8.8.8"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
 	if err != nil {
@@ -1632,7 +1664,7 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	}
 
 	// Now create the secret and verify the models.
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		// Check if the secret affected both the models.
@@ -1644,7 +1676,7 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 	time.Sleep(10 * time.Second)
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	integrationtest.DetectModelChecksumChange(t, modelName, 5)
@@ -1666,33 +1698,34 @@ func TestL7ModelOneSecretToMultiIngForEvh(t *testing.T) {
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 	g.Expect(nodes[0].SSLKeyCertRefs).Should(gomega.HaveLen(0))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-no-secret1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-no-secret2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	secretName, ingressName, svcName := "my-secret-83", "foo-with-targets-83", "avisvc-83"
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "noo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com", "noo.com"},
+			secretName: {"foo.com", "noo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1720,38 +1753,39 @@ func TestL7ModelMultiSNIForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes[0].PoolRefs[0].Servers)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 	// This test covers creating multiple SNI nodes via multiple secrets.
 
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	secretName, ingressName, svcName := "my-secret-84", "foo-with-targets-84", "avisvc-84"
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
 	// Clean up any earlier models.
 	modelName, _ := GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
 	modelName, _ = GetModelName("foo.com", "default")
 	objects.SharedAviGraphLister().Delete(modelName)
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "FOO.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.com"},
+			secretName:   {"foo.com"},
 			"my-secret2": {"FOO.com"},
 		},
 	}).Ingress()
@@ -1785,14 +1819,14 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 	g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(1))
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.com"},
+			secretName:   {"foo.com"},
 			"my-secret2": {"bar.com"},
 		},
 	}).Ingress()
@@ -1827,36 +1861,37 @@ func TestL7ModelMultiSNIMultiCreateEditSecretForEvh(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret2", metav1.DeleteOptions{})
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-1"})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-EVH-0"})
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
 }
 
 func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	secretName, ingressName, svcName := "my-secret-85", "foo-with-targets-85", "avisvc-85"
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.org"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.org"},
+			secretName: {"foo.org"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1865,14 +1900,14 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	}
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.org", "bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.org"},
+			secretName:   {"foo.org"},
 			"my-secret2": {"bar.com"},
 		},
 	}).Ingress()
@@ -1903,20 +1938,21 @@ func TestL7WrongSubDomainMultiSNIForEvh(t *testing.T) {
 	g.Expect(len(nodes[0].EvhNodes[0].SSLKeyCertRefs)).To(gomega.Equal(0))
 	g.Expect(nodes[0].EvhNodes[0].VHDomainNames).To(gomega.HaveLen(1))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifyEvhIngressDeletion(t, g, aviModel, 0)
 	VerifyEvhVsCacheChildDeletion(t, g, cache.NamespaceName{Namespace: "admin", Name: modelName})
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestFQDNCountInL7Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-86", "foo-with-targets-86", "avisvc-86"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if aviModel == nil {
@@ -1938,25 +1974,26 @@ func TestFQDNCountInL7Model(t *testing.T) {
 		g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7"))
 	}
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestPortsForInsecureAndSecureEVH(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpTestForIngress(t, modelName)
+	secretName, ingressName, svcName := "my-secret-87", "foo-with-targets-87", "avisvc-87"
+	SetUpTestForIngress(t, svcName, modelName)
 
 	// Insecure
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-no-secret",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1981,7 +2018,7 @@ func TestPortsForInsecureAndSecureEVH(t *testing.T) {
 	}
 
 	// Secure
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
@@ -2000,10 +2037,10 @@ func TestPortsForInsecureAndSecureEVH(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-no-secret", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
-	TearDownTestForIngress(t, modelName)
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+	TearDownTestForIngress(t, svcName, modelName)
 }

--- a/tests/evhtests/l7_evh_rest_test.go
+++ b/tests/evhtests/l7_evh_rest_test.go
@@ -43,31 +43,33 @@ func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
 		t.Skip()
 	}
 	SetupDomain()
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	secretName, ingressName, svcName := "my-secret-26", "foo-with-targets-26", "avisvc-26"
+	secretName2, ingressName2 := "my-secret-27", "foo-with-targets-27"
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 	modelName, _ := GetModelName("foo.com", "default")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	g := gomega.NewGomegaWithT(t)
 
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com", "xyz.com"},
 		Paths:       []string{"/foo", "/bar", "/xyz"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    {"foo.com"},
-			"my-secret-v2": {"bar.com"},
+			secretName:  {"foo.com"},
+			secretName2: {"bar.com"},
 		},
 	}
 
 	ingressObject2 := integrationtest.FakeIngress{
-		Name:        "foo-with-targets-2",
+		Name:        ingressName2,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/doo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 	ingrFake := ingressObject.Ingress()
@@ -80,18 +82,18 @@ func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 
-	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
 	// Shard scheme: cluster--Shared-L7-EVH-0 -> foo.com
 	// Shard scheme: cluster--Shared-L7-EVH-3 -> xyz.com
 	// Shard scheme: cluster--Shared-L7-EVH-1 -> bar.com
 
 	g.Eventually(func() int {
-		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 45*time.Second).Should(gomega.Equal(3))
-	ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 	// fake avi controller server returns IP in the form: 10.250.250.1<Shared-L7-NUM>
 	g.Expect(ingress.Status.LoadBalancer.Ingress[0].IP).To(gomega.MatchRegexp(`^(10.250.250.1(0|1|3))`))
 	g.Expect(ingress.Status.LoadBalancer.Ingress[0].Hostname).To(gomega.MatchRegexp(`^((foo|bar|xyz).com)$`))
@@ -100,15 +102,15 @@ func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
 	g.Expect(ingress.Status.LoadBalancer.Ingress[2].IP).To(gomega.MatchRegexp(`^(10.250.250.1(0|1|3))`))
 	g.Expect(ingress.Status.LoadBalancer.Ingress[2].Hostname).To(gomega.MatchRegexp(`^((foo|bar|xyz).com)$`))
 
-	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{}); err != nil {
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 
-	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets-2", metav1.DeleteOptions{}); err != nil {
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
@@ -120,7 +122,8 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 	modelName, vsName := GetModelName("foo"+pathSuffix, "default")
 
 	SetupDomain()
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	secretName, ingressName, svcName := "my-secret-28", "foo-with-targets-28", "avisvc-28"
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 	integrationtest.PollForCompletion(t, modelName, 5)
 
 	ingressObject := integrationtest.FakeIngress{
@@ -128,12 +131,12 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo" + pathSuffix, "xyz" + pathSuffix},
 		Paths:       []string{"/foo", "/xyz"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo" + pathSuffix},
+			secretName: {"foo" + pathSuffix},
 		},
 	}
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	ingrFake := ingressObject.Ingress()
 	if _, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
@@ -164,9 +167,9 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 		Paths:       []string{"/foo"},
 		Ips:         ingressStatusIPs,
 		HostNames:   ingressStatusNames,
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo" + pathSuffix},
+			secretName: {"foo" + pathSuffix},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
@@ -184,7 +187,7 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	g.Eventually(func() int {
 		mcache := cache.SharedAviObjCache()
 		vsKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -201,7 +204,8 @@ func TestCreateIngressCacheSyncForEvh(t *testing.T) {
 	var found bool
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	ingressName, svcName := "foo-with-targets-29", "avisvc-29"
+	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
 
 	g.Eventually(func() bool {
 		found, _ = objects.SharedAviGraphLister().Get(modelName)
@@ -242,19 +246,19 @@ func TestCreateIngressCacheSyncForEvh(t *testing.T) {
 	g.Expect(sniCacheObj.PGKeyCollection).To(gomega.HaveLen(1))
 	g.Expect(sniCacheObj.HTTPKeyCollection).To(gomega.HaveLen(1))
 
-	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{}); err != nil {
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestIngressStatusCheckForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	ingressName, svcName := "foo-with-targets-30", "avisvc-30"
+	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -264,13 +268,13 @@ func TestIngressStatusCheckForEvh(t *testing.T) {
 	}, 5*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() int {
-		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 5*time.Second).Should(gomega.Equal(1))
-	ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 	g.Expect(ingress.Status.LoadBalancer.Ingress).To(gomega.HaveLen(1))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
 func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
@@ -278,17 +282,18 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	ingressName, svcName := "foo-with-targets-31", "avisvc-31"
+	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
 
 	// Get hold of the pool checksum on CREATE
-	poolName := "cluster--default-foo.com_foo-foo-with-targets-avisvc"
+	poolName := "cluster--default-foo.com_foo-" + ingressName + "-" + svcName
 	mcache := cache.SharedAviObjCache()
 	poolKey := cache.NamespaceName{Namespace: integrationtest.AVINAMESPACE, Name: lib.Encode(poolName, lib.Pool)}
 	poolCacheBefore, _ := mcache.PoolCache.AviCacheGet(poolKey)
 	poolCacheBeforeObj, _ := poolCacheBefore.(*cache.AviPoolCache)
 	oldPoolCksum := poolCacheBeforeObj.CloudConfigCksum
 
-	integrationtest.ScaleCreateEPorEPS(t, "default", "avisvc")
+	integrationtest.ScaleCreateEPorEPS(t, "default", svcName)
 
 	g.Eventually(func() []avinodes.AviPoolMetaServer {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -306,7 +311,7 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 	}, 50*time.Second).Should(gomega.Not(gomega.Equal(oldPoolCksum)))
 	// If we transition the service from clusterIP to Loadbalancer - pools' servers should get deleted.
 	svcExample := (integrationtest.FakeService{
-		Name:         "avisvc",
+		Name:         svcName,
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeLoadBalancer,
 		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
@@ -323,7 +328,7 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 	}, 60*time.Second).Should(gomega.HaveLen(0))
 	// If we transition the service from Loadbalancer to clusterIP - pools' servers should get populated.
 	svcExample = (integrationtest.FakeService{
-		Name:         "avisvc",
+		Name:         svcName,
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
 		ServicePorts: []integrationtest.Serviceport{{PortName: "foo0", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
@@ -338,14 +343,15 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 		vs := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()
 		return vs[0].EvhNodes[0].PoolRefs[0].Servers
 	}, 15*time.Second).Should(gomega.HaveLen(2))
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, "", ingressName, svcName, modelName)
 }
 
 func TestCreateCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-32", "foo-with-targets-32", "avisvc-32"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -378,7 +384,7 @@ func TestCreateCacheSyncForEvh(t *testing.T) {
 	g.Expect(sniCacheObj.PGKeyCollection).To(gomega.HaveLen(1))
 	g.Expect(sniCacheObj.HTTPKeyCollection).To(gomega.HaveLen(2))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 
 }
 
@@ -387,7 +393,8 @@ func TestUpdateCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-33", "foo-with-targets-33", "avisvc-33"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
@@ -399,13 +406,13 @@ func TestUpdateCacheSyncForEvh(t *testing.T) {
 	oldSniCacheObj, _ := oldSniCache.(*cache.AviVsCache)
 
 	ingressUpdate := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar-updated"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
@@ -441,7 +448,7 @@ func TestUpdateCacheSyncForEvh(t *testing.T) {
 	g.Expect(sniVSCacheObj.HTTPKeyCollection).To(gomega.HaveLen(2))
 	g.Expect(sniVSCacheObj.SSLKeyCertCollection).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
@@ -452,22 +459,24 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-34", "foo-with-targets-34", "avisvc-34"
+	secretName2, ingressName2 := "my-secret-35", "foo-with-targets-35"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 	mcache := cache.SharedAviObjCache()
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	// update ingress
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    {"foo.com"},
-			"my-secret-v2": {"bar.com"},
+			secretName:  {"foo.com"},
+			secretName2: {"bar.com"},
 		},
 	}
-	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert", "tlsKey")
 	ingrFake := ingressObject.Ingress()
 	ingrFake.ResourceVersion = "2"
 	if _, err := KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{}); err != nil {
@@ -519,16 +528,16 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 
 	// create the ingress
 	ingressObject = integrationtest.FakeIngress{
-		Name:        "foo-with-targets-2",
+		Name:        ingressName2,
 		Namespace:   "red",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/doo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
-	integrationtest.AddSecret("my-secret", "red", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "red", "tlsCert", "tlsKey")
 	ingrFake = ingressObject.Ingress()
 	if _, err := KubeClient.NetworkingV1().Ingresses("red").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in updating Ingress: %v", err)
@@ -538,10 +547,10 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 		_, found1 := mcache.VsCacheMeta.AviCacheGet(sniVSKey3)
 		return found1
 	}, 20*time.Second).Should(gomega.Equal(true))
-	if err := KubeClient.NetworkingV1().Ingresses("red").Delete(context.TODO(), "foo-with-targets-2", metav1.DeleteOptions{}); err != nil {
+	if err := KubeClient.NetworkingV1().Ingresses("red").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
@@ -553,22 +562,24 @@ func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 	modelName, vsName := GetModelName("foo.com", "default")
 
 	SetupDomain()
-	SetUpTestForIngress(t, modelName, modelName)
+	secretName, ingressName, svcName := "my-secret-36", "foo-with-targets-36", "avisvc-36"
+	secretName2 := "my-secret-37"
+	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.PollForCompletion(t, modelName, 5)
 
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com", "xyz.com"},
 		Paths:       []string{"/foo", "/bar", "/xyz"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":    {"foo.com"},
-			"my-secret-v2": {"bar.com"},
+			secretName:  {"foo.com"},
+			secretName2: {"bar.com"},
 		},
 	}
-	integrationtest.AddSecret("my-secret-v2", "default", "tlsCert", "tlsKey")
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
 	ingrFake := ingressObject.Ingress()
 	if _, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
@@ -638,15 +649,15 @@ func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 	g.Expect(barCacheObj.SSLKeyCertCollection[0].Name).To(gomega.Equal(lib.Encode("cluster--bar.com", lib.SSLKeyCert)))
 
 	// delete one secret
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret-v2", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName2, metav1.DeleteOptions{})
 	ingressUpdateObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com", "xyz.com"},
 		Paths:       []string{"/foo", "/bar", "/xyz"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 
@@ -678,13 +689,13 @@ func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 	g.Expect(sniCacheObj.PoolKeyCollection).To(gomega.HaveLen(1))
 	g.Expect(sniCacheObj.SSLKeyCertCollection).To(gomega.HaveLen(0))
 
-	KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey1)
 		return found
 	}, 15*time.Second).Should(gomega.Equal(false))
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 // Secure ingress to insecure ingress transition
@@ -693,20 +704,21 @@ func TestDeleteCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-38", "foo-with-targets-38", "avisvc-38"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 
 	ingressUpdate := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingressName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{})
@@ -726,14 +738,15 @@ func TestDeleteCacheSyncForEvh(t *testing.T) {
 		return false
 	}, 20*time.Second).Should(gomega.Equal(true))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, false, modelName)
+	secretName, ingressName, svcName := "my-secret-39", "foo-with-targets-39", "avisvc-39"
+	SetUpIngressForCacheSyncCheck(t, true, false, secretName, ingressName, svcName, modelName)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -747,7 +760,7 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	}, 5*time.Second).Should(gomega.Equal(false))
 
 	// add Secret
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
 	// ssl key should be created now and must be attached to the sni vs cache
 	g.Eventually(func() bool {
@@ -762,7 +775,7 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	// update Secret
 	secretUpdate := (integrationtest.FakeSecret{
 		Namespace: "default",
-		Name:      "my-secret",
+		Name:      secretName,
 		Cert:      "tlsCert_Updated",
 		Key:       "tlsKey_Updated",
 	}).Secret()
@@ -773,14 +786,14 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	// but PUTs happen, everytime though
 
 	// delete Secret
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 
 	// ssl key must be deleted again and evh vs should  be deleted
 	g.Eventually(func() bool {
 		_, sslfound := mcache.SSLKeyCache.AviCacheGet(sslKey)
 		_, snifound := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 		return sslfound && snifound
-	}, 15*time.Second).Should(gomega.Equal(false))
+	}, 30*time.Second).Should(gomega.Equal(false))
 
 	g.Eventually(func() bool {
 		parentVSCache, found := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
@@ -791,28 +804,29 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 		return false
 	}, 30*time.Second).Should(gomega.Equal(true))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestDeleteSecretSecureIngressStatusCheckForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-40", "foo-with-targets-40", "avisvc-40"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 
 	g.Eventually(func() int {
-		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 30*time.Second).Should(gomega.Equal(1))
 
 	// post this EVH VS should get deleted, and ingress status must be updated accordingly
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 
 	g.Eventually(func() int {
-		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 30*time.Second).Should(gomega.Equal(1))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
 func TestProfilesAttachedToEvhVS(t *testing.T) {
@@ -843,7 +857,8 @@ func TestProfilesAttachedToEvhVS(t *testing.T) {
 	})
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	secretName, ingressName, svcName := "my-secret-41", "foo-with-targets-41", "avisvc-41"
+	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes, ok := aviModel.(*avinodes.AviObjectGraph)
@@ -867,7 +882,7 @@ func TestProfilesAttachedToEvhVS(t *testing.T) {
 		return found
 	}, 60*time.Second).Should(gomega.Equal(true))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 
 	integrationtest.ResetMiddleware()
 }

--- a/tests/evhtests/l7_evh_rest_test.go
+++ b/tests/evhtests/l7_evh_rest_test.go
@@ -43,7 +43,9 @@ func TestMultiHostIngressStatusCheckForEvh(t *testing.T) {
 		t.Skip()
 	}
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-26", "foo-with-targets-26", "avisvc-26"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	secretName2, ingressName2 := "my-secret-27", "foo-with-targets-27"
 	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 	modelName, _ := GetModelName("foo.com", "default")
@@ -122,7 +124,8 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 	modelName, vsName := GetModelName("foo"+pathSuffix, "default")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-28", "foo-with-targets-28", "avisvc-28"
+	secretName := objNameMap.GenerateName("my-secret")
+	svcName := objNameMap.GenerateName("avisvc")
 	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 	integrationtest.PollForCompletion(t, modelName, 5)
 
@@ -150,6 +153,7 @@ func TestMultiHostUpdateIngressStatusCheckForEvh(t *testing.T) {
 		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 		return len(ingress.Status.LoadBalancer.Ingress)
 	}, 60*time.Second).Should(gomega.Equal(2))
+
 	ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
 
 	// donot update status
@@ -204,8 +208,17 @@ func TestCreateIngressCacheSyncForEvh(t *testing.T) {
 	var found bool
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-29", "avisvc-29"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	g.Eventually(func() bool {
 		found, _ = objects.SharedAviGraphLister().Get(modelName)
@@ -257,8 +270,17 @@ func TestIngressStatusCheckForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-30", "avisvc-30"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -282,8 +304,17 @@ func TestUpdatePoolCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	ingressName, svcName := "foo-with-targets-31", "avisvc-31"
-	SetUpIngressForCacheSyncCheck(t, false, false, "", ingressName, svcName, modelName)
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	// Get hold of the pool checksum on CREATE
 	poolName := "cluster--default-foo.com_foo-" + ingressName + "-" + svcName
@@ -350,8 +381,19 @@ func TestCreateCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-32", "foo-with-targets-32", "avisvc-32"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -393,8 +435,19 @@ func TestUpdateCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-33", "foo-with-targets-33", "avisvc-33"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
@@ -459,9 +512,20 @@ func TestMultiHostMultiSecretCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-34", "foo-with-targets-34", "avisvc-34"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	secretName2, ingressName2 := "my-secret-35", "foo-with-targets-35"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	mcache := cache.SharedAviObjCache()
 	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	// update ingress
@@ -562,7 +626,9 @@ func TestMultiHostMultiSecretUpdateCacheSyncForEvh(t *testing.T) {
 	modelName, vsName := GetModelName("foo.com", "default")
 
 	SetupDomain()
-	secretName, ingressName, svcName := "my-secret-36", "foo-with-targets-36", "avisvc-36"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
 	secretName2 := "my-secret-37"
 	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -704,8 +770,19 @@ func TestDeleteCacheSyncForEvh(t *testing.T) {
 	var err error
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-38", "foo-with-targets-38", "avisvc-38"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -745,8 +822,19 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-39", "foo-with-targets-39", "avisvc-39"
-	SetUpIngressForCacheSyncCheck(t, true, false, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  false,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: vsName}
@@ -810,8 +898,19 @@ func TestCUDSecretCacheSyncForEvh(t *testing.T) {
 func TestDeleteSecretSecureIngressStatusCheckForEvh(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	modelName, _ := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-40", "foo-with-targets-40", "avisvc-40"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	g.Eventually(func() int {
 		ingress, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingressName, metav1.GetOptions{})
@@ -857,8 +956,19 @@ func TestProfilesAttachedToEvhVS(t *testing.T) {
 	})
 
 	modelName, vsName := GetModelName("foo.com", "default")
-	secretName, ingressName, svcName := "my-secret-41", "foo-with-targets-41", "avisvc-41"
-	SetUpIngressForCacheSyncCheck(t, true, true, secretName, ingressName, svcName, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		nodes, ok := aviModel.(*avinodes.AviObjectGraph)


### PR DESCRIPTION
this PR isolates changes required for https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1339

file changes for evhtests and vippernstests

UT results

vippernstests
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/evhtests      1483.889s

evhtests
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/evhtests      1573.992s
