### PR TITLE
AV-210932 Improve UT runtime (ingresstests)

### DIFF
--- a/tests/ingresstests/crd_test.go
+++ b/tests/ingresstests/crd_test.go
@@ -36,9 +36,21 @@ import (
 func TestCreateDeleteHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
@@ -48,7 +60,7 @@ func TestCreateDeleteHostRule(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(*nodes[0].SniNodes[0].Enabled).To(gomega.Equal(true))
@@ -93,7 +105,7 @@ func TestCreateDeleteHostRule(t *testing.T) {
 	}, 25*time.Second).Should(gomega.Equal(false))
 	g.Expect(nodes[0].SniNodes[0].VHDomainNames).To(gomega.ContainElement("baz.com"))
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", false)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].Enabled).To(gomega.BeNil())
@@ -108,15 +120,27 @@ func TestCreateDeleteHostRule(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].SslProfileRef).To(gomega.BeNil())
 	g.Expect(nodes[0].SniNodes[0].VHDomainNames).To(gomega.Not(gomega.ContainElement("baz.com")))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestCreateDeleteSharedVSHostRule(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:                  hrname,
@@ -146,7 +170,7 @@ func TestCreateDeleteSharedVSHostRule(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
@@ -175,7 +199,7 @@ func TestCreateDeleteSharedVSHostRule(t *testing.T) {
 	g.Expect(ports[2]).To(gomega.Equal(8083))
 
 	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", false)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Enabled).To(gomega.BeNil())
@@ -199,14 +223,17 @@ func TestCreateDeleteSharedVSHostRule(t *testing.T) {
 	g.Expect(ports[0]).To(gomega.Equal(80))
 	g.Expect(ports[1]).To(gomega.Equal(443))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestCreateHostRuleBeforeIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	g.Eventually(func() string {
@@ -214,7 +241,17 @@ func TestCreateHostRuleBeforeIngress(t *testing.T) {
 		return hostrule.Status.Status
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	g.Eventually(func() string {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -236,16 +273,27 @@ func TestCreateHostRuleBeforeIngress(t *testing.T) {
 		}
 		return ""
 	}, 10*time.Second).Should(gomega.Equal(""))
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestInsecureToSecureHostRule(t *testing.T) {
 	// insecure ingress to secure VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
@@ -264,7 +312,7 @@ func TestInsecureToSecureHostRule(t *testing.T) {
 	}, 15*time.Second).Should(gomega.Equal(1))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -274,16 +322,27 @@ func TestInsecureToSecureHostRule(t *testing.T) {
 	g.Expect(nodes[0].HttpPolicyRefs[0].RedirectPorts[0].StatusCode).To(gomega.Equal("HTTP_REDIRECT_STATUS_CODE_302"))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestGSLBHostRewriteRule(t *testing.T) {
 	// insecure ingress to secure VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	mcache := cache.SharedAviObjCache()
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
@@ -322,26 +381,39 @@ func TestGSLBHostRewriteRule(t *testing.T) {
 		return len(vsCacheObj.HTTPKeyCollection)
 	}, 30*time.Second).Should(gomega.Equal(0))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestMultiIngressToSecureHostRule(t *testing.T) {
 	// 1 insecure ingress, 1 secure ingress -> secure VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingName2 := objNameMap.GenerateName("foo-with-targets")
 
 	// creating secure default/foo.com/foo
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	// creating insecure red/foo.com/bar
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets-2",
+		Name:        ingName2,
 		Namespace:   "red",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}
 	ingrFake := ingressObject.Ingress()
 	if _, err := KubeClient.NetworkingV1().Ingresses("red").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
@@ -371,24 +443,34 @@ func TestMultiIngressToSecureHostRule(t *testing.T) {
 	}
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
-	if err := KubeClient.NetworkingV1().Ingresses("red").Delete(context.TODO(), "foo-with-targets-2", metav1.DeleteOptions{}); err != nil {
+	if err := KubeClient.NetworkingV1().Ingresses("red").Delete(context.TODO(), ingName2, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	// 2 insecure ingresses -> VS via Hostrule
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	// creating insecure default/foo.com/foo
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	// creating insecure red/voo.com/voo
 	ingressObject := integrationtest.FakeIngress{
@@ -396,7 +478,7 @@ func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 		Namespace:   "red",
 		DnsNames:    []string{"voo.com"},
 		Paths:       []string{"/voo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}
 	ingrFake := ingressObject.Ingress()
 	if _, err := KubeClient.NetworkingV1().Ingresses("red").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
@@ -421,7 +503,7 @@ func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].Name).To(gomega.Equal("cluster--foo.com"))
-	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-" + ingName))
 
 	// change hostrule for foo.com to voo.com
 	hrUpdate := integrationtest.FakeHostRule{
@@ -448,7 +530,7 @@ func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	}, 30*time.Second).Should(gomega.Equal(true))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--foo.com_foo-default-foo-with-targets"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--foo.com_foo-default-" + ingName))
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--red-voo.com_voo-voo-with-targets"))
 
 	if err := KubeClient.NetworkingV1().Ingresses("red").Delete(context.TODO(), "voo-with-targets", metav1.DeleteOptions{}); err != nil {
@@ -456,20 +538,30 @@ func TestMultiIngressSwitchHostRuleFqdn(t *testing.T) {
 	}
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--voo.com"}
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestGoodToBadHostRule(t *testing.T) {
 	// create insecure ingress, apply good secure hostrule, transition to bad
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	// update hostrule with bad ref
 	hrUpdate := integrationtest.FakeHostRule{
@@ -504,16 +596,26 @@ func TestGoodToBadHostRule(t *testing.T) {
 	g.Expect(*nodes[0].SniNodes[0].ApplicationProfileRef).To(gomega.ContainSubstring("thisisaviref-appprof"))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestInsecureHostAndHostrule(t *testing.T) {
 	// create insecure ingress, insecure hostrule, nothing should be applied
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 
 	g.Eventually(func() int {
@@ -529,7 +631,7 @@ func TestInsecureHostAndHostrule(t *testing.T) {
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestValidToInvalidHostSwitch(t *testing.T) {
@@ -538,13 +640,23 @@ func TestValidToInvalidHostSwitch(t *testing.T) {
 	// change hostrule back to foo.com and it should become secure again
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	hrUpdate := integrationtest.FakeHostRule{
 		Name:              hrname,
@@ -567,7 +679,7 @@ func TestValidToInvalidHostSwitch(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(1))
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--foo.com_foo-default-foo-with-targets"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--foo.com_foo-default-" + ingName))
 
 	// change back to good host
 	hrUpdate = integrationtest.FakeHostRule{
@@ -584,17 +696,17 @@ func TestValidToInvalidHostSwitch(t *testing.T) {
 	VerifyPoolDeletionFromVsNode(g, modelName)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo-" + ingName))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 // This tc tests hostrule state if GSLB FQDN is same as that of Local FQDN/ Host.
 func TestCreateHostRuleWithGSLBFqdn(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	hrname := "samplehr-foo-1"
+	hrname := objNameMap.GenerateName("samplehr-foo")
 	integrationtest.SetupHostRule(t, hrname, "zoo.com", true)
 
 	g.Eventually(func() string {
@@ -613,9 +725,21 @@ func TestCreateHostRuleWithGSLBFqdn(t *testing.T) {
 func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "ap-hr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	integrationtest.SetupHostRule(t, hrname, "foo.com", true)
 
@@ -625,7 +749,7 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/ap-hr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 
@@ -700,15 +824,27 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].AnalyticsPolicy).Should(gomega.BeNil())
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostruleFQDNAliases(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "fqdn-aliases-hr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -716,7 +852,7 @@ func TestHostruleFQDNAliases(t *testing.T) {
 		return len(nodes[0].SniNodes)
 	}, 10*time.Second).Should(gomega.Equal(1))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/fqdn-aliases-hr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 
@@ -821,15 +957,27 @@ func TestHostruleFQDNAliases(t *testing.T) {
 	validateNode(nodes[0], aliases)
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "fqdn-aliases-hr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	integrationtest.SetupHostRule(t, hrname, "foo.com", false)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -837,7 +985,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 		return len(nodes[0].SniNodes)
 	}, 10*time.Second).Should(gomega.Equal(1))
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/fqdn-aliases-hr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 
@@ -917,7 +1065,7 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 
 	// Create another host rule with same Aliases
 	newHostRule := integrationtest.FakeHostRule{
-		Name:      "new-fqdn-aliases-hr-foo",
+		Name:      "new-" + hrname,
 		Namespace: "default",
 		Fqdn:      "baz.com",
 	}.HostRule()
@@ -937,30 +1085,33 @@ func TestValidationsOfHostruleFQDNAliases(t *testing.T) {
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, newHostRule.Name)
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostruleFQDNAliasesForMultiPathIngress(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "fqdn-aliases-hr-multipath-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	SetupDomain()
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"10.0.0.1"},
 		HostNames:   []string{"v1"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 
@@ -1023,16 +1174,27 @@ func TestHostruleFQDNAliasesForMultiPathIngress(t *testing.T) {
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: lib.Encode("cluster--foo.com", lib.EVHVS)}
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestApplyHostruleToParentVS(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "hr-cluster--Shared-L7-0"
-
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:               hrname,
@@ -1058,7 +1220,7 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	}, 30*time.Second).Should(gomega.Equal("Accepted"))
 
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--Shared-L7-0", true)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
@@ -1074,7 +1236,7 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	g.Expect(nodes[0].VsDatascriptRefs[1]).To(gomega.ContainSubstring("thisisaviref-ds1"))
 
 	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--Shared-L7-0", false)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Enabled).To(gomega.BeNil())
@@ -1087,15 +1249,27 @@ func TestApplyHostruleToParentVS(t *testing.T) {
 	g.Expect(nodes[0].VsDatascriptRefs).To(gomega.HaveLen(0))
 	g.Expect(nodes[0].SslProfileRef).To(gomega.BeNil())
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostRuleWithEmptyConfig(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:      hrname,
@@ -1113,7 +1287,7 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(*nodes[0].SniNodes[0].Enabled).To(gomega.Equal(true))
@@ -1129,7 +1303,7 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].VHDomainNames).To(gomega.ContainElement("foo.com"))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", false)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, false)
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].Enabled).To(gomega.BeNil())
@@ -1144,15 +1318,27 @@ func TestHostRuleWithEmptyConfig(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].SslProfileRef).To(gomega.BeNil())
 	g.Expect(nodes[0].SniNodes[0].VHDomainNames).To(gomega.ContainElement("foo.com"))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestSharedVSHostRuleNoListenerForSNI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:               hrname,
@@ -1179,7 +1365,7 @@ func TestSharedVSHostRuleNoListenerForSNI(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal("Accepted"))
 
 	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, true)
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(*nodes[0].Enabled).To(gomega.Equal(true))
@@ -1197,9 +1383,9 @@ func TestSharedVSHostRuleNoListenerForSNI(t *testing.T) {
 	g.Expect(nodes[0].VSVIPRefs[0].IPAddress).To(gomega.Equal("80.80.80.80"))
 
 	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
-	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/samplehr-foo", false)
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/"+hrname, false)
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 // HttpRule tests
@@ -1211,23 +1397,26 @@ func TestHTTPRuleCreateDelete(t *testing.T) {
 	// delete hostrule, httprule gets detached
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	rrname := "samplerr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	rrname := objNameMap.GenerateName("samplerr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	SetupDomain()
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 
@@ -1237,8 +1426,8 @@ func TestHTTPRuleCreateDelete(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 
-	poolFooKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_foo-foo-with-targets"}
-	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_bar-foo-with-targets"}
+	poolFooKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_foo-" + ingName}
+	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_bar-" + ingName}
 	httpRulePath := "/"
 	integrationtest.SetupHTTPRule(t, rrname, "foo.com", httpRulePath)
 	integrationtest.VerifyMetadataHTTPRule(t, g, poolFooKey, "default/"+rrname+"/"+httpRulePath, true)
@@ -1264,7 +1453,7 @@ func TestHTTPRuleCreateDelete(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].PkiProfile).To(gomega.BeNil())
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].HealthMonitorRefs).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHTTPRuleCreateDeleteWithPkiRef(t *testing.T) {
@@ -1274,23 +1463,26 @@ func TestHTTPRuleCreateDeleteWithPkiRef(t *testing.T) {
 	// delete hostrule, httprule gets detached
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	rrname := "samplerr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	rrname := objNameMap.GenerateName("samplerr-foo")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	SetupDomain()
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 
@@ -1300,8 +1492,8 @@ func TestHTTPRuleCreateDeleteWithPkiRef(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 
-	poolFooKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_foo-foo-with-targets"}
-	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_bar-foo-with-targets"}
+	poolFooKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_foo-" + ingName}
+	poolBarKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--default-foo.com_bar-" + ingName}
 
 	httpRulePath := "/"
 	httprule := integrationtest.FakeHTTPRule{
@@ -1338,7 +1530,7 @@ func TestHTTPRuleCreateDeleteWithPkiRef(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].PkiProfileRef).To(gomega.BeNil())
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].PkiProfile).To(gomega.BeNil())
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHTTPRuleHostSwitch(t *testing.T) {
@@ -1348,13 +1540,23 @@ func TestHTTPRuleHostSwitch(t *testing.T) {
 	// switch rr1 host to hr2
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrnameFoo := "samplehr-foo"
-	hrnameVoo := "samplehr-voo"
-	rrnameFoo := "samplerr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	hrnameFoo := objNameMap.GenerateName("samplehr-foo")
+	hrnameVoo := objNameMap.GenerateName("samplehr-voo")
+	rrnameFoo := objNameMap.GenerateName("samplerr-foo")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	// creates foo.com insecure
-	SetUpIngressForCacheSyncCheck(t, false, false, modelName)
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       false,
+		withSecret:  false,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	// creates voo.com insecure
 	ingressObject := integrationtest.FakeIngress{
@@ -1362,7 +1564,7 @@ func TestHTTPRuleHostSwitch(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"voo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}
 	ingrFake := ingressObject.Ingress()
 	if _, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
@@ -1424,29 +1626,32 @@ func TestHTTPRuleHostSwitch(t *testing.T) {
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrnameFoo)
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrnameVoo)
 	integrationtest.TeardownHTTPRule(t, rrnameFoo)
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, "", modelName)
 }
 
 func TestHTTPRuleWithInvalidPath(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	rrname := "samplerr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	rrname := objNameMap.GenerateName("samplerr-foo-1")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
 
 	SetupDomain()
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	integrationtest.PollForCompletion(t, modelName, 5)
 	ingressObject := integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}
 
@@ -1500,18 +1705,31 @@ func TestHTTPRuleWithInvalidPath(t *testing.T) {
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[1].PkiProfile).To(gomega.BeNil())
 	g.Expect(nodes[0].SniNodes[0].PoolRefs[1].HealthMonitorRefs).To(gomega.HaveLen(0))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostRuleUseRegex(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	hrname := objNameMap.GenerateName("samplehr-foo")
 	fqdn := "foo.com"
-	namespace := "default"
+	namespace := integrationtest.DEFAULT_NAMESPACE
 
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:      hrname,
@@ -1529,7 +1747,7 @@ func TestHostRuleUseRegex(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1549,7 +1767,7 @@ func TestHostRuleUseRegex(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCase).Should(gomega.Equal("INSENSITIVE"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(1))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_foo-foo-with-targets")))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_foo-" + ingName)))
 
 	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
 	time.Sleep(2 * time.Second)
@@ -1560,21 +1778,37 @@ func TestHostRuleUseRegex(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-foo-with-targets"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-" + ingName))
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostRuleAppRoot(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	hrname := objNameMap.GenerateName("samplehr-foo")
 	fqdn := "foo.com"
-	namespace := "default"
+	namespace := integrationtest.DEFAULT_NAMESPACE
 	appRootPath := "/foo"
 
-	SetUpIngressForCacheSyncCheckMultiPaths(t, true, true, []string{fqdn}, []string{"/"}, modelName)
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		namespace:   namespace,
+		dnsNames:    []string{fqdn},
+		paths:       []string{"/"},
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:                hrname,
@@ -1592,7 +1826,7 @@ func TestHostRuleAppRoot(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1612,7 +1846,7 @@ func TestHostRuleAppRoot(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].Path[0]).Should(gomega.Equal(appRootPath))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-app-root-test"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-" + ingName))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.HaveLen(1))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts[0].Path).To(gomega.Equal("/"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts[0].RedirectPort).To(gomega.Equal(int32(8080)))
@@ -1629,21 +1863,37 @@ func TestHostRuleAppRoot(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].Path[0]).To(gomega.Equal("/"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-app-root-test"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-" + ingName))
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestHostRuleRegexAppRoot(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	hrname := "samplehr-foo"
+	modelName := MODEL_NAME_PREFIX + "0"
+	hrname := objNameMap.GenerateName("samplehr-foo")
 	fqdn := "foo.com"
-	namespace := "default"
+	namespace := integrationtest.DEFAULT_NAMESPACE
 	appRootPath := "/foo"
 
-	SetUpIngressForCacheSyncCheckMultiPaths(t, true, true, []string{fqdn, fqdn}, []string{"/something(/|$)(.*)", "/"}, modelName)
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		namespace:   namespace,
+		dnsNames:    []string{fqdn, fqdn},
+		paths:       []string{"/something(/|$)(.*)", "/"},
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 
 	hostrule := integrationtest.FakeHostRule{
 		Name:                hrname,
@@ -1662,7 +1912,7 @@ func TestHostRuleRegexAppRoot(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal("Accepted"))
 
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
-	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
 
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1682,12 +1932,12 @@ func TestHostRuleRegexAppRoot(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCase).Should(gomega.Equal("INSENSITIVE"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(1))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_something(_|$)(.*)-app-root-test")))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_something(_|$)(.*)-" + ingName)))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCase).Should(gomega.Equal("INSENSITIVE"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].Path[0]).To(gomega.Equal(appRootPath))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(1))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_-app-root-test")))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_-" + ingName)))
 
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.HaveLen(1))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts[0].Path).To(gomega.Equal("/"))
@@ -1705,11 +1955,11 @@ func TestHostRuleRegexAppRoot(t *testing.T) {
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].Path[0]).To(gomega.Equal("/something(/|$)(.*)"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_something(_|$)(.*)-app-root-test"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com_something(_|$)(.*)-" + ingName))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].Path[0]).To(gomega.Equal("/"))
 	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(0))
-	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-app-root-test"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal("cluster--default-foo.com_-" + ingName))
 
-	TearDownIngressForCacheSyncCheckPath(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }

--- a/tests/ingresstests/ingressclass_test.go
+++ b/tests/ingresstests/ingressclass_test.go
@@ -81,19 +81,22 @@ func TestWrongClassMappingInIngress(t *testing.T) {
 
 	// SyncFunc is replaced with a wrapper to make sure that ingressClass
 	// is processed first and then ingress.
+	time.Sleep(time.Second * 5)
 	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
 	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	//time.Sleep(time.Second * 15)
 
-	ingClassName, ingressName, ns := "avi-lb", "foo-with-class", "default"
-	modelName := "admin/cluster--Shared-L7-1"
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
 
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.RemoveDefaultIngressClass()
 	waitAndVerify(t, integrationtest.DefaultIngressClass)
 	integrationtest.AddIngressClassWithName("xyz")
 	waitAndVerify(t, "xyz")
-	defer waitAndVerify(t, "xyz")
-	defer integrationtest.RemoveIngressClassWithName("xyz")
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, "")
 	waitAndVerify(t, ingClassName)
@@ -102,7 +105,7 @@ func TestWrongClassMappingInIngress(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
@@ -123,7 +126,7 @@ func TestWrongClassMappingInIngress(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   "xyz",
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.NetworkingV1().Ingresses(ns).Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{}); err != nil {
@@ -142,7 +145,7 @@ func TestWrongClassMappingInIngress(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "3"
 	if _, err := KubeClient.NetworkingV1().Ingresses(ns).Update(context.TODO(), ingressUpdate2, metav1.UpdateOptions{}); err != nil {
@@ -166,10 +169,15 @@ func TestWrongClassMappingInIngress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
 	VerifyPoolDeletionFromVsNode(g, modelName)
+
+	integrationtest.RemoveIngressClassWithName("xyz")
+	waitAndVerify(t, "xyz")
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
+
 }
 
 func TestDefaultIngressClassChange(t *testing.T) {
@@ -179,10 +187,16 @@ func TestDefaultIngressClassChange(t *testing.T) {
 	// ingress status IP comes back
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns := "avi-lb", "foo-with-class2", "default"
-	modelName := "admin/cluster--Shared-L7-1"
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingClass := (integrationtest.FakeIngressClass{
 		Name:       ingClassName,
@@ -199,7 +213,7 @@ func TestDefaultIngressClassChange(t *testing.T) {
 		Name:        ingressName,
 		Namespace:   ns,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
@@ -228,9 +242,10 @@ func TestDefaultIngressClassChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -239,10 +254,16 @@ func TestIngressWithNonAVILBIngressClass(t *testing.T) {
 	// update ingress with non-avi-lb ingressClass, observe VS delete
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns := "non-avi-lb", "foo-with-class", "default"
-	modelName := "admin/cluster--Shared-L7-1"
+	ingClassName := objNameMap.GenerateName("non-avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.AddIngressClassWithName(ingClassName)
 	waitAndVerify(t, ingClassName)
 
@@ -251,7 +272,7 @@ func TestIngressWithNonAVILBIngressClass(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
@@ -275,7 +296,7 @@ func TestIngressWithNonAVILBIngressClass(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   integrationtest.DefaultIngressClass,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
 	if _, err := KubeClient.NetworkingV1().Ingresses(ns).Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{}); err != nil {
@@ -296,11 +317,12 @@ func TestIngressWithNonAVILBIngressClass(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
 	integrationtest.RemoveDefaultIngressClass()
 	waitAndVerify(t, integrationtest.DefaultIngressClass)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -311,15 +333,18 @@ func TestAviInfraSettingForLBSvcWithInvalidLBClass(t *testing.T) {
 	// update SVC with aviinfrasetting annotation
 	// VS should not come up
 	g := gomega.NewWithT(t)
-	model_name, svc_name, ns, infraSettingName := "admin/cluster--default-testsvc", "testsvc", "default", "my-infrasetting"
+	svcName := objNameMap.GenerateName("testsvc")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	modelName := "admin/cluster--" + ns + "-" + svcName
+	infraSettingName := objNameMap.GenerateName("my-infrasetting")
 
-	objects.SharedAviGraphLister().Delete(model_name)
-	integrationtest.CreateSVCWithValidOrInvalidLBClass(t, ns, svc_name, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, integrationtest.INVALID_LB_CLASS)
-	integrationtest.CreateEPorEPS(t, ns, svc_name, false, false, "1.1.1")
-	integrationtest.PollForCompletion(t, model_name, 5)
+	objects.SharedAviGraphLister().Delete(modelName)
+	integrationtest.CreateSVCWithValidOrInvalidLBClass(t, ns, svcName, corev1.ProtocolTCP, corev1.ServiceTypeLoadBalancer, false, integrationtest.INVALID_LB_CLASS)
+	integrationtest.CreateEPorEPS(t, ns, svcName, false, false, "1.1.1")
+	integrationtest.PollForCompletion(t, modelName, 5)
 
 	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(model_name)
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 10*time.Second).Should(gomega.Equal(false))
 
@@ -333,7 +358,7 @@ func TestAviInfraSettingForLBSvcWithInvalidLBClass(t *testing.T) {
 	}
 
 	svcObj := (integrationtest.FakeService{
-		Name:      svc_name,
+		Name:      svcName,
 		Namespace: ns,
 		Type:      corev1.ServiceTypeLoadBalancer,
 	}).Service()
@@ -344,15 +369,15 @@ func TestAviInfraSettingForLBSvcWithInvalidLBClass(t *testing.T) {
 		t.Fatalf("error in updating Service: %v", err)
 	}
 	g.Eventually(func() bool {
-		found, _ := objects.SharedAviGraphLister().Get(model_name)
+		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 30*time.Second).Should(gomega.Equal(false))
 
-	objects.SharedAviGraphLister().Delete(model_name)
-	integrationtest.DelSVC(t, ns, svc_name)
-	integrationtest.DelEPorEPS(t, ns, svc_name)
+	objects.SharedAviGraphLister().Delete(modelName)
+	integrationtest.DelSVC(t, ns, svcName)
+	integrationtest.DelEPorEPS(t, ns, svcName)
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: fmt.Sprintf("cluster--%s-%s", ns, svc_name)}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: fmt.Sprintf("cluster--%s-%s", ns, svcName)}
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
 		return found
@@ -365,14 +390,21 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 	// check for names of all Avi objects
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
-	modelName := "admin/cluster--Shared-L7-1"
-	nsSettingName := "ns-my-infrasetting"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	nsSettingName := "ns-" + settingName
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-0"
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
 	integrationtest.SetupAviInfraSetting(t, nsSettingName, "DEDICATED")
 
@@ -386,7 +418,7 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -396,10 +428,10 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	shardVsName := "cluster--Shared-L7-my-infrasetting-0"
-	sniVsName := "cluster--my-infrasetting-baz.com"
-	shardPoolName := "cluster--my-infrasetting-bar.com_foo-default-foo-with-class"
-	sniPoolName := "cluster--my-infrasetting-default-baz.com_foo-foo-with-class"
+	shardVsName := "cluster--Shared-L7-" + settingName + "-0"
+	sniVsName := "cluster--" + settingName + "-baz.com"
+	shardPoolName := "cluster--" + settingName + "-bar.com_foo-default-" + ingressName
+	sniPoolName := "cluster--" + settingName + "-default-baz.com_foo-" + ingressName
 
 	g.Eventually(func() bool {
 		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
@@ -413,7 +445,7 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal(shardPoolName))
-	g.Expect(settingNodes[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
+	g.Expect(settingNodes[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-" + settingName + "-seGroup"))
 	g.Expect(settingNodes[0].PoolGroupRefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HTTPDSrefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
@@ -431,9 +463,10 @@ func TestAviInfraSettingNamingConvention(t *testing.T) {
 	integrationtest.RemoveAnnotateAKONamespaceWithInfraSetting(t, ns)
 	integrationtest.TeardownAviInfraSetting(t, nsSettingName)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -443,13 +476,20 @@ func TestAviInfraSettingPerNSNamingConvention(t *testing.T) {
 	// check for names of all Avi objects
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
-	modelName := "admin/cluster--Shared-L7-1"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
-	settingModelName := "admin/cluster--Shared-L7-0"
+	settingModelName := MODEL_NAME_PREFIX + "0"
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
 	integrationtest.AnnotateAKONamespaceWithInfraSetting(t, ns, settingName)
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, "")
@@ -461,7 +501,7 @@ func TestAviInfraSettingPerNSNamingConvention(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -473,8 +513,8 @@ func TestAviInfraSettingPerNSNamingConvention(t *testing.T) {
 
 	shardVsName := "cluster--Shared-L7-0"
 	sniVsName := "cluster--baz.com"
-	shardPoolName := "cluster--bar.com_foo-default-foo-with-class"
-	sniPoolName := "cluster--default-baz.com_foo-foo-with-class"
+	shardPoolName := "cluster--bar.com_foo-default-" + ingressName
+	sniPoolName := "cluster--default-baz.com_foo-" + ingressName
 
 	g.Eventually(func() bool {
 		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
@@ -488,7 +528,7 @@ func TestAviInfraSettingPerNSNamingConvention(t *testing.T) {
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal(shardPoolName))
-	g.Expect(settingNodes[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
+	g.Expect(settingNodes[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-" + settingName + "-seGroup"))
 	g.Expect(settingNodes[0].PoolGroupRefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HTTPDSrefs[0].Name).Should(gomega.Equal(shardVsName))
 	g.Expect(settingNodes[0].HttpPolicyRefs).Should(gomega.HaveLen(1))
@@ -506,9 +546,10 @@ func TestAviInfraSettingPerNSNamingConvention(t *testing.T) {
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.RemoveAnnotateAKONamespaceWithInfraSetting(t, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -518,11 +559,18 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	// remove infrasetting ref, model changes again
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, "")
 	waitAndVerify(t, ingClassName)
@@ -532,7 +580,7 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -552,7 +600,7 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(true))
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-0"
 
 	ingClassUpdate := (integrationtest.FakeIngressClass{
 		Name:            ingClassName,
@@ -578,13 +626,13 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName + "-bar.com_foo-default-" + ingressName))
 	g.Eventually(func() int {
 		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 		settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(settingNodes[0].SniNodes)
 	}, 40*time.Second).Should(gomega.Equal(1))
-	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal("cluster--my-infrasetting-baz.com"))
+	g.Expect(settingNodes[0].SniNodes[0].Name).Should(gomega.Equal("cluster--" + settingName + "-baz.com"))
 
 	VerifyPoolDeletionFromVsNode(g, modelName)
 
@@ -606,9 +654,10 @@ func TestAddRemoveInfraSettingInIngressClass(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -617,16 +666,24 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 	// update infrasetting ref in ingressclass, model changes
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName1, settingName2 := "avi-lb", "foo-with-class", "default", "my-infrasetting1", "my-infrasetting2"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	settingName1 := objNameMap.GenerateName("my-infrasetting")
+	settingName2 := objNameMap.GenerateName("my-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName1, "SMALL")
 	integrationtest.SetupAviInfraSetting(t, settingName2, "SMALL")
-	settingModelName1 := "admin/cluster--Shared-L7-my-infrasetting1-0"
-	settingModelName2 := "admin/cluster--Shared-L7-my-infrasetting2-0"
+	settingModelName1 := MODEL_NAME_PREFIX + settingName1 + "-0"
+	settingModelName2 := MODEL_NAME_PREFIX + settingName2 + "-0"
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName1)
 	waitAndVerify(t, ingClassName)
@@ -636,7 +693,7 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
@@ -650,7 +707,7 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 			}
 		}
 		return ""
-	}, 40*time.Second).Should(gomega.Equal("cluster--my-infrasetting1-bar.com_foo-default-foo-with-class"))
+	}, 40*time.Second).Should(gomega.Equal("cluster--" + settingName1 + "-bar.com_foo-default-" + ingressName))
 
 	ingClassUpdate := (integrationtest.FakeIngressClass{
 		Name:            ingClassName,
@@ -675,7 +732,7 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName2)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting2-bar.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName2 + "-bar.com_foo-default-" + ingressName))
 
 	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
@@ -684,10 +741,11 @@ func TestUpdateInfraSettingInIngressClass(t *testing.T) {
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName1)
 	integrationtest.TeardownAviInfraSetting(t, settingName2)
-	TearDownTestForIngress(t, modelName, settingModelName1)
-	TearDownTestForIngress(t, modelName, settingModelName2)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName1)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName2)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
@@ -697,14 +755,21 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 	// add ingressclass in ingress, delete ingress
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-0"
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
@@ -713,7 +778,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 		Name:        ingressName,
 		Namespace:   ns,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -728,7 +793,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingressUpdate.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses(ns).Update(context.TODO(), ingressUpdate, metav1.UpdateOptions{})
@@ -751,7 +816,7 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName + "-bar.com_foo-default-" + ingressName))
 
 	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName, metav1.DeleteOptions{})
 	if err != nil {
@@ -764,9 +829,10 @@ func TestAddIngressClassWithInfraSetting(t *testing.T) {
 
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, settingModelName)
 }
 
@@ -776,17 +842,25 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName1, ingClassName2 := "avi-lb1", "avi-lb2"
-	ingressName, ns := "foo-with-class", "default"
-	settingName1, settingName2 := "my-infrasetting1", "my-infrasetting2"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ingClassName1 := objNameMap.GenerateName("avi-lb")
+	ingClassName2 := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	settingName1 := objNameMap.GenerateName("my-infrasetting")
+	settingName2 := objNameMap.GenerateName("my-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName1, "SMALL")
 	integrationtest.SetupAviInfraSetting(t, settingName2, "MEDIUM")
-	settingModelName1, settingModelName2 := "admin/cluster--Shared-L7-my-infrasetting1-0", "admin/cluster--Shared-L7-my-infrasetting2-1"
+	settingModelName1 := MODEL_NAME_PREFIX + settingName1 + "-0"
+	settingModelName2 := MODEL_NAME_PREFIX + settingName2 + "-1"
 
 	integrationtest.SetupIngressClass(t, ingClassName1, lib.AviIngressController, settingName1)
 	waitAndVerify(t, ingClassName1)
@@ -798,7 +872,7 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName1,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -815,15 +889,15 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 	_, aviSettingModel1 := objects.SharedAviGraphLister().Get(settingModelName1)
 	settingNodes1 := aviSettingModel1.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes1[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(settingNodes1[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-my-infrasetting1-seGroup"))
-	g.Expect(settingNodes1[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting1-bar.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes1[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-" + settingName1 + "-seGroup"))
+	g.Expect(settingNodes1[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName1 + "-bar.com_foo-default-" + ingressName))
 
 	ingressUpdate := (integrationtest.FakeIngress{
 		Name:        ingressName,
 		Namespace:   ns,
 		ClassName:   ingClassName2,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -841,8 +915,8 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 	_, aviSettingModel2 := objects.SharedAviGraphLister().Get(settingModelName2)
 	settingNodes2 := aviSettingModel2.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes2[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(settingNodes2[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting2-bar.com_foo-default-foo-with-class"))
-	g.Expect(settingNodes2[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-my-infrasetting2-seGroup"))
+	g.Expect(settingNodes2[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName2 + "-bar.com_foo-default-" + ingressName))
+	g.Expect(settingNodes2[0].ServiceEngineGroup).Should(gomega.Equal("thisisaviref-" + settingName2 + "-seGroup"))
 	_, aviSettingModel1 = objects.SharedAviGraphLister().Get(settingModelName1)
 	settingNodes1 = aviSettingModel1.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(settingNodes1[0].PoolRefs).Should(gomega.HaveLen(0))
@@ -854,11 +928,12 @@ func TestUpdateIngressClassWithInfraSetting(t *testing.T) {
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName1)
 	integrationtest.TeardownAviInfraSetting(t, settingName2)
-	TearDownTestForIngress(t, modelName, settingModelName1, settingModelName2)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName1, settingModelName2)
 	integrationtest.TeardownIngressClass(t, ingClassName1)
 	waitAndVerify(t, ingClassName1)
 	integrationtest.TeardownIngressClass(t, ingClassName2)
 	waitAndVerify(t, ingClassName2)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, settingModelName2)
 }
 
@@ -868,11 +943,18 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
@@ -882,7 +964,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -892,7 +974,7 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-1"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 
 	settingsUpdate := integrationtest.FakeAviInfraSetting{
 		Name:        settingName,
@@ -980,9 +1062,10 @@ func TestUpdateWithInfraSetting(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 }
 
 func TestPublicIPStatusWithInfraSetting(t *testing.T) {
@@ -991,11 +1074,19 @@ func TestPublicIPStatusWithInfraSetting(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-public-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	//fake controller checks for public in name
+	settingName := objNameMap.GenerateName("my-public-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
@@ -1005,14 +1096,14 @@ func TestPublicIPStatusWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	settingModelName := "admin/cluster--Shared-L7-my-public-infrasetting-1"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 
 	settingsUpdate := integrationtest.FakeAviInfraSetting{
 		Name:           settingName,
@@ -1053,9 +1144,10 @@ func TestPublicIPStatusWithInfraSetting(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 }
 
 func TestMultiVipStatusWithInfraSetting(t *testing.T) {
@@ -1064,11 +1156,19 @@ func TestMultiVipStatusWithInfraSetting(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-multivip-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	//fake controller checks for multivip in name
+	settingName := objNameMap.GenerateName("my-multivip-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
@@ -1078,14 +1178,14 @@ func TestMultiVipStatusWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	settingModelName := "admin/cluster--Shared-L7-my-multivip-infrasetting-1"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 
 	settingsUpdate := integrationtest.FakeAviInfraSetting{
 		Name:     settingName,
@@ -1128,9 +1228,10 @@ func TestMultiVipStatusWithInfraSetting(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 }
 
 func TestMultiFipStatusWithInfraSetting(t *testing.T) {
@@ -1139,11 +1240,19 @@ func TestMultiFipStatusWithInfraSetting(t *testing.T) {
 
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-multivip-public-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	secretName := "my-secret"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	//fake controller checks for multivip and public in name
+	settingName := objNameMap.GenerateName("my-multivip-public-infrasetting")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
@@ -1153,14 +1262,14 @@ func TestMultiFipStatusWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	settingModelName := "admin/cluster--Shared-L7-my-multivip-public-infrasetting-1"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 
 	settingsUpdate := integrationtest.FakeAviInfraSetting{
 		Name:           settingName,
@@ -1204,23 +1313,30 @@ func TestMultiFipStatusWithInfraSetting(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	waitAndVerify(t, ingClassName)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 }
 
 func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	// update ingressclass (without infrasetting) in ingress
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName1, ingClassName2 := "avi-lb1", "avi-lb2"
-	ingressName, ns := "foo-with-class", "default"
-	settingName := "my-infrasetting"
-	modelName := "admin/cluster--Shared-L7-1"
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-1"
-	secretName := "my-secret"
+	ingClassName1 := objNameMap.GenerateName("avi-lb")
+	ingClassName2 := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
+	secretName := objNameMap.GenerateName("my-secret")
 
-	SetUpTestForIngress(t, modelName, settingModelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName, settingModelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "MEDIUM")
 
@@ -1234,7 +1350,7 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName1,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -1253,7 +1369,7 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 		settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return settingNodes[0].ServiceEngineGroup
-	}, 40*time.Second).Should(gomega.Equal("thisisaviref-my-infrasetting-seGroup"))
+	}, 40*time.Second).Should(gomega.Equal("thisisaviref-" + settingName + "-seGroup"))
 	g.Eventually(func() int {
 		_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 		settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -1261,14 +1377,14 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName + "-bar.com_foo-default-" + ingressName))
 
 	ingressUpdate := (integrationtest.FakeIngress{
 		Name:        ingressName,
 		Namespace:   ns,
 		ClassName:   ingClassName2,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -1286,7 +1402,7 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].PoolRefs).Should(gomega.HaveLen(1))
-	g.Expect(nodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--bar.com_foo-default-foo-with-class"))
+	g.Expect(nodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--bar.com_foo-default-" + ingressName))
 	g.Expect(nodes[0].ServiceEngineGroup).Should(gomega.Equal("Default-Group"))
 	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -1298,37 +1414,45 @@ func TestUpdateIngressClassWithoutInfraSetting(t *testing.T) {
 	}
 	integrationtest.DeleteSecret(secretName, ns)
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName1)
 	waitAndVerify(t, ingClassName1)
 	integrationtest.TeardownIngressClass(t, ingClassName2)
 	waitAndVerify(t, ingClassName2)
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	VerifyPoolDeletionFromVsNode(g, modelName)
 }
 
 func TestBGPConfigurationWithInfraSetting(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
-	modelName := "admin/cluster--Shared-L7-1"
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-1"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 
-	SetUpTestForIngress(t, modelName, settingModelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName, settingModelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "LARGE")
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
 	waitAndVerify(t, ingClassName)
 	integrationtest.AddSecret(secretName, ns, "tlsCert", "tlsKey")
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-my-infrasetting-1"}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-" + settingName + "-1"}
 
 	ingressCreate := (integrationtest.FakeIngress{
 		Name:        ingressName,
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -1338,8 +1462,8 @@ func TestBGPConfigurationWithInfraSetting(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	sniVsName := "cluster--my-infrasetting-baz.com"
-	shardPoolName := "cluster--my-infrasetting-bar.com_foo-default-foo-with-class"
+	sniVsName := "cluster--" + settingName + "-baz.com"
+	shardPoolName := "cluster--" + settingName + "-bar.com_foo-default-" + ingressName
 
 	g.Eventually(func() string {
 		if found, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName); found {
@@ -1381,6 +1505,7 @@ func TestBGPConfigurationWithInfraSetting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	integrationtest.DeleteSecret(secretName, ns)
 	// Shard VS remains, Pools are moved/removed
 	g.Eventually(func() bool {
@@ -1391,20 +1516,27 @@ func TestBGPConfigurationWithInfraSetting(t *testing.T) {
 		}
 		return false
 	}, 50*time.Second).Should(gomega.Equal(true))
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 }
 
 func TestBGPConfigurationUpdateLabelWithInfraSetting(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
-	modelName := "admin/cluster--Shared-L7-1"
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-1"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-my-infrasetting-1"}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-" + settingName + "-1"}
 
-	SetUpTestForIngress(t, modelName, settingModelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName, settingModelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "LARGE")
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
@@ -1416,7 +1548,7 @@ func TestBGPConfigurationUpdateLabelWithInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com", "bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -1455,6 +1587,7 @@ func TestBGPConfigurationUpdateLabelWithInfraSetting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
+	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	integrationtest.DeleteSecret(secretName, ns)
 	// Shard VS remains, Pools are moved/removed
 	g.Eventually(func() bool {
@@ -1465,23 +1598,31 @@ func TestBGPConfigurationUpdateLabelWithInfraSetting(t *testing.T) {
 		}
 		return false
 	}, 50*time.Second).Should(gomega.Equal(true))
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 }
 
 func TestCRDWithAviInfraSetting(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
-	modelName := "admin/cluster--Shared-L7-1"
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-1"
-	hrname, rrname := "samplehr-baz", "samplerr-baz"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-1"
+	hrname := objNameMap.GenerateName("samplehr-baz")
+	rrname := objNameMap.GenerateName("samplerr-baz")
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-my-infrasetting-1"}
-	sniKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-baz.com"}
-	poolKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-default-baz.com_foo-foo-with-class"}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-" + settingName + "-1"}
+	sniKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--" + settingName + "-baz.com"}
+	poolKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--" + settingName + "-default-baz.com_foo-" + ingressName}
 
-	SetUpTestForIngress(t, modelName, settingModelName)
+	time.Sleep(time.Second * 5)
+	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
+	ingestionQueue.SyncFunc = syncFromIngestionLayerWrapper
+	SetUpTestForIngress(t, svcName, modelName, settingModelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "LARGE")
 	integrationtest.SetupIngressClass(t, ingClassName, lib.AviIngressController, settingName)
@@ -1497,7 +1638,7 @@ func TestCRDWithAviInfraSetting(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"baz.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"baz.com"},
 		},
@@ -1552,22 +1693,25 @@ func TestCRDWithAviInfraSetting(t *testing.T) {
 		}
 		return false
 	}, 50*time.Second).Should(gomega.Equal(true))
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 
 	// Reverting the syncFunc of ingestion Queue.
-	ingestionQueue := utils.SharedWorkQueue().GetQueueByName(utils.ObjectIngestionLayer)
 	ingestionQueue.SyncFunc = k8s.SyncFromIngestionLayer
 	integrationtest.AddDefaultIngressClass()
 }
 
 func TestFQDNsCountForAviInfraSettingWithDedicatedShardSize(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--my-infrasetting-foo.com-L7-dedicated"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	svcName := objNameMap.GenerateName("avisvc")
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
+	modelName := "admin/cluster--" + settingName + "-foo.com-L7-dedicated"
 
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.RemoveDefaultIngressClass()
 	defer integrationtest.AddDefaultIngressClass()
 
@@ -1580,7 +1724,7 @@ func TestFQDNsCountForAviInfraSettingWithDedicatedShardSize(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"foo.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"foo.com"},
 		},
@@ -1616,23 +1760,27 @@ func TestFQDNsCountForAviInfraSettingWithDedicatedShardSize(t *testing.T) {
 	integrationtest.DeleteSecret(secretName, ns)
 
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-foo.com-L7-dedicated"}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--" + settingName + "-foo.com-L7-dedicated"}
 	// verify the removal of VS.
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
 		return found
 	}, 50*time.Second).Should(gomega.Equal(false))
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+	ns := integrationtest.DEFAULT_NAMESPACE
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ingressName := objNameMap.GenerateName("foo-with-class")
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	secretName := objNameMap.GenerateName("my-secret")
+	svcName := objNameMap.GenerateName("avisvc")
 
-	ingClassName, ingressName, ns, settingName := "avi-lb", "foo-with-class", "default", "my-infrasetting"
-	secretName := "my-secret"
+	modelName := MODEL_NAME_PREFIX + settingName + "-0"
 
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 	integrationtest.RemoveDefaultIngressClass()
 	defer integrationtest.AddDefaultIngressClass()
 
@@ -1645,7 +1793,7 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"foo.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
 			secretName: {"foo.com"},
 		},
@@ -1662,7 +1810,7 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 		}
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		return len(nodes)
-	}, 10*time.Second).Should(gomega.Equal(1))
+	}, 30*time.Second).Should(gomega.Equal(1))
 
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
@@ -1684,7 +1832,7 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 	integrationtest.DeleteSecret(secretName, ns)
 
 	mcache := cache.SharedAviObjCache()
-	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-my-infrasetting-0"}
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-" + settingName + "-0"}
 	// Shard VS remains, Pools are moved/removed
 	g.Eventually(func() bool {
 		sniCache1, found := mcache.VsCacheMeta.AviCacheGet(vsKey)
@@ -1694,7 +1842,7 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 		}
 		return false
 	}, 50*time.Second).Should(gomega.Equal(true))
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
@@ -1702,14 +1850,18 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 	// add ingressclass in ingress, delete ingress
 	g := gomega.NewGomegaWithT(t)
 
-	ingClassName, ns, settingName := "avi-lb", "default", "my-infrasetting"
-	ingressName1, ingressName2 := "foo-with-class", "bar-with-class"
-	modelName := "admin/cluster--Shared-L7-1"
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	ingressName1 := objNameMap.GenerateName("foo-with-class")
+	ingressName2 := objNameMap.GenerateName("foo-with-class")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
 
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.SetupAviInfraSetting(t, settingName, "SMALL")
-	settingModelName := "admin/cluster--Shared-L7-my-infrasetting-0"
+	settingModelName := MODEL_NAME_PREFIX + settingName + "-0"
 
 	integrationtest.RemoveDefaultIngressClass()
 	defer integrationtest.AddDefaultIngressClass()
@@ -1720,7 +1872,7 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"foo.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate1, metav1.CreateOptions{})
 	if err != nil {
@@ -1742,14 +1894,14 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel := objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes := aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-foo.com_foo-default-foo-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName + "-foo.com_foo-default-" + ingressName1))
 
 	ingressCreate2 := (integrationtest.FakeIngress{
 		Name:        ingressName2,
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate2, metav1.CreateOptions{})
 	if err != nil {
@@ -1771,7 +1923,7 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(2))
 	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[1].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-bar-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[1].Name).Should(gomega.Equal("cluster--" + settingName + "-bar.com_foo-default-" + ingressName2))
 
 	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName1, metav1.DeleteOptions{})
 	if err != nil {
@@ -1793,7 +1945,7 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 	}, 40*time.Second).Should(gomega.Equal(1))
 	_, aviSettingModel = objects.SharedAviGraphLister().Get(settingModelName)
 	settingNodes = aviSettingModel.(*avinodes.AviObjectGraph).GetAviVS()
-	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--my-infrasetting-bar.com_foo-default-bar-with-class"))
+	g.Expect(settingNodes[0].PoolRefs[0].Name).Should(gomega.Equal("cluster--" + settingName + "-bar.com_foo-default-" + ingressName2))
 
 	err = KubeClient.NetworkingV1().Ingresses(ns).Delete(context.TODO(), ingressName2, metav1.DeleteOptions{})
 	if err != nil {
@@ -1802,20 +1954,24 @@ func TestAddIngressClassWithInfraSettingMultipleIngress(t *testing.T) {
 	VerifyPoolDeletionFromVsNode(g, settingModelName)
 
 	integrationtest.TeardownAviInfraSetting(t, settingName)
-	TearDownTestForIngress(t, modelName, settingModelName)
+	TearDownTestForIngress(t, svcName, modelName, settingModelName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
 	VerifyPoolDeletionFromVsNode(g, settingModelName)
 }
 
 func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName1 := "admin/cluster--my-infrasetting-foo.com-L7-dedicated"
-	modelName2 := "admin/cluster--my-infrasetting-bar.com-L7-dedicated"
+	ingClassName := objNameMap.GenerateName("avi-lb")
+	ns := integrationtest.DEFAULT_NAMESPACE
+	settingName := objNameMap.GenerateName("my-infrasetting")
+	ingressName1 := objNameMap.GenerateName("foo-with-class")
+	ingressName2 := objNameMap.GenerateName("foo-with-class")
+	svcName := objNameMap.GenerateName("avisvc")
 
-	ingClassName, ns, settingName := "avi-lb", "default", "my-infrasetting"
-	ingressName1, ingressName2 := "foo-with-class", "bar-with-class"
+	modelName1 := "admin/cluster--" + settingName + "-foo.com-L7-dedicated"
+	modelName2 := "admin/cluster--" + settingName + "-bar.com-L7-dedicated"
 
-	SetUpTestForIngress(t, modelName1, modelName2)
+	SetUpTestForIngress(t, svcName, modelName1, modelName2)
 	integrationtest.RemoveDefaultIngressClass()
 	defer integrationtest.AddDefaultIngressClass()
 
@@ -1828,7 +1984,7 @@ func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"foo.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate1, metav1.CreateOptions{})
 	if err != nil {
@@ -1849,7 +2005,7 @@ func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
 		Namespace:   ns,
 		ClassName:   ingClassName,
 		DnsNames:    []string{"bar.com"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses(ns).Create(context.TODO(), ingressCreate2, metav1.CreateOptions{})
 	if err != nil {
@@ -1876,8 +2032,8 @@ func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
 	}
 
 	mcache := cache.SharedAviObjCache()
-	vsKey1 := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-foo.com-L7-dedicated"}
-	vsKey2 := cache.NamespaceName{Namespace: "admin", Name: "cluster--my-infrasetting-bar.com-L7-dedicated"}
+	vsKey1 := cache.NamespaceName{Namespace: "admin", Name: "cluster--" + settingName + "-foo.com-L7-dedicated"}
+	vsKey2 := cache.NamespaceName{Namespace: "admin", Name: "cluster--" + settingName + "-bar.com-L7-dedicated"}
 	// verify removal of VS.
 	g.Eventually(func() bool {
 		_, found := mcache.VsCacheMeta.AviCacheGet(vsKey1)
@@ -1890,5 +2046,5 @@ func TestAddIngressClassWithInfraSettingMultipleIngressDedicated(t *testing.T) {
 
 	integrationtest.TeardownAviInfraSetting(t, settingName)
 	integrationtest.TeardownIngressClass(t, ingClassName)
-	TearDownTestForIngress(t, modelName1, modelName2)
+	TearDownTestForIngress(t, svcName, modelName1, modelName2)
 }

--- a/tests/ingresstests/l7_graph_test.go
+++ b/tests/ingresstests/l7_graph_test.go
@@ -45,13 +45,20 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
-var KubeClient *k8sfake.Clientset
-var CRDClient *crdfake.Clientset
-var v1beta1CRDClient *v1beta1crdfake.Clientset
-var ctrl *k8s.AviController
-var akoApiServer *api.FakeApiServer
-var keyChan chan string
-var endpointSliceEnabled bool
+var (
+	KubeClient           *k8sfake.Clientset
+	CRDClient            *crdfake.Clientset
+	v1beta1CRDClient     *v1beta1crdfake.Clientset
+	ctrl                 *k8s.AviController
+	akoApiServer         *api.FakeApiServer
+	keyChan              chan string
+	endpointSliceEnabled bool
+	objNameMap           integrationtest.ObjectNameMap
+)
+
+const (
+	MODEL_NAME_PREFIX = "admin/cluster--Shared-L7-"
+)
 
 func TestMain(m *testing.M) {
 	os.Setenv("INGRESS_API", "extensionv1")
@@ -143,6 +150,7 @@ func TestMain(m *testing.M) {
 	integrationtest.AddDefaultNamespace("red")
 
 	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
+	objNameMap.InitMap()
 	os.Exit(m.Run())
 }
 
@@ -172,8 +180,10 @@ func VerifySNIIngressDeletion(t *testing.T, g *gomega.WithT, aviModel interface{
 func TestL7Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -182,12 +192,12 @@ func TestL7Model(t *testing.T) {
 		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
 	}
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -206,35 +216,38 @@ func TestL7Model(t *testing.T) {
 	g.Expect(nodes[0].Name).To(gomega.ContainSubstring("Shared-L7"))
 	g.Expect(nodes[0].Tenant).To(gomega.Equal("admin"))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestShardNamingConvention(t *testing.T) {
 	// checks naming convention of all generated nodes
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 
 	// foo.com and noo.com compute the same hashed shard vs num
 	ingrFake := (integrationtest.FakeIngress{
-		Name:      "foo-with-targets",
+		Name:      ingName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com", "noo.com"},
 		Ips:       []string{"8.8.8.8"},
 		Paths:     []string{"/foo/bar"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -243,7 +256,7 @@ func TestShardNamingConvention(t *testing.T) {
 	}
 	integrationtest.PollForCompletion(t, modelName, 5)
 
-	verifyIng, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), "foo-with-targets", metav1.GetOptions{})
+	verifyIng, _ := KubeClient.NetworkingV1().Ingresses("default").Get(context.TODO(), ingName, metav1.GetOptions{})
 	for i, host := range []string{"foo.com", "noo.com"} {
 		if verifyIng.Spec.Rules[i].Host == host {
 			g.Expect(verifyIng.Spec.Rules[i].Host).To(gomega.Equal(host))
@@ -259,27 +272,29 @@ func TestShardNamingConvention(t *testing.T) {
 	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].Name).To(gomega.Equal("cluster--Shared-L7-0"))
 	g.Expect(nodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--Shared-L7-0"))
-	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--noo.com_foo_bar-default-foo-with-targets"))
+	g.Expect(nodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--noo.com_foo_bar-default-" + ingName))
 	g.Expect(nodes[0].HTTPDSrefs[0].Name).To(gomega.Equal("cluster--Shared-L7-0"))
 	g.Expect(nodes[0].VSVIPRefs[0].Name).To(gomega.Equal("cluster--Shared-L7-0"))
 	g.Expect(nodes[0].SniNodes[0].Name).To(gomega.Equal("cluster--foo.com"))
-	g.Expect(nodes[0].SniNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
-	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].PoolGroupRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-" + ingName))
+	g.Expect(nodes[0].SniNodes[0].PoolRefs[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-" + ingName))
 	g.Expect(nodes[0].SniNodes[0].SSLKeyCertRefs[0].Name).To(gomega.Equal("cluster--foo.com"))
-	g.Expect(nodes[0].SniNodes[0].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-foo-with-targets"))
+	g.Expect(nodes[0].SniNodes[0].HttpPolicyRefs[0].HppMap[0].Name).To(gomega.Equal("cluster--default-foo.com_foo_bar-" + ingName))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestNoBackendL7Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -288,7 +303,7 @@ func TestNoBackendL7Model(t *testing.T) {
 		t.Fatalf("Couldn't find Model for DELETE event %v", modelName)
 	}
 	ingrFake := (integrationtest.FakeIngress{
-		Name:      "foo-with-targets",
+		Name:      ingName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com"},
 		Paths:     []string{"/"},
@@ -305,20 +320,23 @@ func TestNoBackendL7Model(t *testing.T) {
 		return found
 	}, 5*time.Second).Should(gomega.Equal(false))
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiIngressToSameSvc(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingName2 := objNameMap.GenerateName("foo-with-targets")
 	objects.SharedAviGraphLister().Delete(modelName)
 	svcExample := (integrationtest.FakeService{
-		Name:         "avisvc",
+		Name:         svcName,
 		Namespace:    "default",
 		Type:         corev1.ServiceTypeClusterIP,
 		ServicePorts: []integrationtest.Serviceport{{PortName: "foo", Protocol: "TCP", PortNumber: 8080, TargetPort: intstr.FromInt(8080)}},
@@ -329,14 +347,14 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 		t.Fatalf("error in adding Service: %v", err)
 	}
 
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 	ingrFake1 := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets1",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -344,12 +362,12 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 	ingrFake2 := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets2",
+		Name:        ingName2,
 		Namespace:   "default",
 		DnsNames:    []string{"bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -368,7 +386,7 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 		g.Expect(len(dsNodes)).To(gomega.Equal(1))
 		g.Expect(len(nodes[0].PoolRefs)).To(gomega.Equal(1))
 		for _, pool := range nodes[0].PoolRefs {
-			if pool.Name == "cluster--foo.com_foo-default-foo-with-targets1" {
+			if pool.Name == "cluster--foo.com_foo-default-"+ingName {
 				g.Expect(pool.PriorityLabel).To(gomega.Equal("foo.com/foo"))
 				g.Expect(len(pool.Servers)).To(gomega.Equal(1))
 			} else {
@@ -384,8 +402,8 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 	//====== VERIFICATION OF SERVICE DELETE
 	// Now we have cleared the layer 2 queue for both the models. Let's delete the service.
 
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
-	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	integrationtest.DelEPorEPS(t, "default", svcName)
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), svcName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Service %v", err)
 	}
@@ -405,11 +423,11 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 		t.Fatalf("Could not find model on service delete: %v", err)
 	}
 
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 
 	//====== VERIFICATION OF ONE INGRESS DELETE
 	// Now let's delete one ingress and expect the update for that.
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets1", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -450,7 +468,7 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 	}
 	//====== VERIFICATION OF ONE ENDPOINT DELETE
 
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	integrationtest.PollForCompletion(t, modelName, 5)
 	// Deletion should also give us the affected ingress objects
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
@@ -464,11 +482,11 @@ func TestMultiIngressToSameSvc(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model on service ADD: %v", err)
 	}
-	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), "avisvc", metav1.DeleteOptions{})
+	err = KubeClient.CoreV1().Services("default").Delete(context.TODO(), svcName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Service %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets2", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName2, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -478,16 +496,18 @@ func TestMultiVSIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	integrationtest.AddDefaultNamespace("randomNamespacethatyeildsdiff")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -519,7 +539,7 @@ func TestMultiVSIngress(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses("randomNamespacethatyeildsdiff").Create(context.TODO(), randoming, metav1.CreateOptions{})
 	integrationtest.PollForCompletion(t, modelName, 10)
@@ -544,7 +564,7 @@ func TestMultiVSIngress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
@@ -554,22 +574,23 @@ func TestMultiVSIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiPathIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multipath",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -616,23 +637,24 @@ func TestMultiPathIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiPortServiceIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	var err error
 
-	modelName := "admin/cluster--Shared-L7-0"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
 	objects.SharedAviGraphLister().Delete(modelName)
-	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, true)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", true, true, "1.1.1")
+	integrationtest.CreateSVC(t, "default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, true)
+	integrationtest.CreateEPorEPS(t, "default", svcName, true, true, "1.1.1")
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multipath",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPort()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -680,21 +702,22 @@ func TestMultiPortServiceIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiIngressSameHost(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-multi1",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -707,7 +730,7 @@ func TestMultiIngressSameHost(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -763,21 +786,22 @@ func TestMultiIngressSameHost(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestDeleteBackendService(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-multi1",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -790,7 +814,7 @@ func TestDeleteBackendService(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -833,8 +857,8 @@ func TestDeleteBackendService(t *testing.T) {
 	}
 
 	// Delete the service
-	integrationtest.DelSVC(t, "default", "avisvc")
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -880,14 +904,16 @@ func TestDeleteBackendService(t *testing.T) {
 
 func TestUpdateBackendService(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	svcName2 := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-backend-svc",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -904,15 +930,15 @@ func TestUpdateBackendService(t *testing.T) {
 	}
 	// Update the service
 
-	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc2", false, false, "2.2.2")
+	integrationtest.CreateSVC(t, "default", svcName2, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEPorEPS(t, "default", svcName2, false, false, "2.2.2")
 
 	_, err = (integrationtest.FakeIngress{
 		Name:        "ingress-backend-svc",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc2",
+		ServiceName: svcName2,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -937,18 +963,21 @@ func TestUpdateBackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc2")
-	integrationtest.DelEPorEPS(t, "default", "avisvc2")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL2ChecksumsUpdate(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	svcName2 := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 	//create ingress with tls secret
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:      "ingress-chksum",
@@ -958,9 +987,9 @@ func TestL2ChecksumsUpdate(t *testing.T) {
 		Paths:     []string{"/foo"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -989,9 +1018,10 @@ func TestL2ChecksumsUpdate(t *testing.T) {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
 
-	integrationtest.CreateSVC(t, "default", "avisvc2", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc2", false, false, "2.2.2")
-	integrationtest.AddSecret("my-secret-new", "default", "tlsCert-new", "tlsKey")
+	integrationtest.CreateSVC(t, "default", svcName2, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEPorEPS(t, "default", svcName2, false, false, "2.2.2")
+	secretName2 := secretName + "-new"
+	integrationtest.AddSecret(secretName2, "default", "tlsCert-new", "tlsKey")
 
 	_, err = (integrationtest.FakeIngress{
 		Name:      "ingress-chksum",
@@ -1003,10 +1033,10 @@ func TestL2ChecksumsUpdate(t *testing.T) {
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
 			//to update tls secret checksum
-			"my-secret-new": {"foo.com"},
+			secretName2: {"foo.com"},
 		},
 		//to update poolref checksum
-		ServiceName: "avisvc2",
+		ServiceName: svcName2,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -1043,13 +1073,13 @@ func TestL2ChecksumsUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc2")
-	integrationtest.DelEPorEPS(t, "default", "avisvc2")
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret-new", metav1.DeleteOptions{})
+	integrationtest.DelSVC(t, "default", svcName2)
+	integrationtest.DelEPorEPS(t, "default", svcName2)
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName2, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestSniHttpPolicy(t *testing.T) {
@@ -1060,9 +1090,11 @@ func TestSniHttpPolicy(t *testing.T) {
 	*/
 
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:      "ingress-shp",
 		Namespace: "default",
@@ -1071,9 +1103,9 @@ func TestSniHttpPolicy(t *testing.T) {
 		Paths:     []string{"/foo", "/bar"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -1118,9 +1150,9 @@ func TestSniHttpPolicy(t *testing.T) {
 		Paths:     []string{"/foo"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -1152,9 +1184,9 @@ func TestSniHttpPolicy(t *testing.T) {
 		Paths:     []string{"/foo", "/bar", "/baz"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).UpdateIngress()
 	if err != nil {
 		t.Fatalf("error in updating ingress %s", err)
@@ -1198,17 +1230,19 @@ func TestSniHttpPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestFullSyncCacheNoOp(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 	//create multipath ingress with tls secret
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:      "ingress-fsno",
@@ -1218,9 +1252,9 @@ func TestFullSyncCacheNoOp(t *testing.T) {
 		Paths:     []string{"/foo", "/bar"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -1229,8 +1263,14 @@ func TestFullSyncCacheNoOp(t *testing.T) {
 	integrationtest.PollForCompletion(t, modelName, 5)
 	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
 
-	//store old chksum
 	mcache := cache.SharedAviObjCache()
+
+	//store old chksum
+	g.Eventually(func() bool {
+		_, ok := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
+		return ok
+	}, 30*time.Second).Should(gomega.Equal(true))
+
 	oldSniCache, _ := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
 	oldSniCacheObj, _ := oldSniCache.(*cache.AviVsCache)
 	oldChksum := oldSniCacheObj.CloudConfigCksum
@@ -1257,23 +1297,24 @@ func TestFullSyncCacheNoOp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestMultiHostIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multihost",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1347,20 +1388,21 @@ func TestMultiHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, integrationtest.AllModels...)
+	TearDownTestForIngress(t, svcName, integrationtest.AllModels...)
 }
 
 func TestMultiHostSameHostNameIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multihost",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1408,20 +1450,21 @@ func TestMultiHostSameHostNameIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditPathIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-edit",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "1"
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1459,7 +1502,7 @@ func TestEditPathIngress(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1495,20 +1538,21 @@ func TestEditPathIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditMultiPathIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multipath-edit",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	ingrFake.ResourceVersion = "1"
 
@@ -1522,7 +1566,7 @@ func TestEditMultiPathIngress(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1571,7 +1615,7 @@ func TestEditMultiPathIngress(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/foobar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 	ingrFake.ResourceVersion = "3"
 	objects.SharedAviGraphLister().Delete(modelName)
@@ -1623,21 +1667,22 @@ func TestEditMultiPathIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditMultiIngressSameHost(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	model_name := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, model_name)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-multi1",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := integrationtest.KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -1650,7 +1695,7 @@ func TestEditMultiIngressSameHost(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -1663,7 +1708,7 @@ func TestEditMultiIngressSameHost(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foobar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake2, metav1.UpdateOptions{})
@@ -1671,8 +1716,8 @@ func TestEditMultiIngressSameHost(t *testing.T) {
 		t.Fatalf("error in adding Ingress: %v", err)
 	}
 
-	integrationtest.PollForCompletion(t, model_name, 5)
-	found, aviModel := objects.SharedAviGraphLister().Get(model_name)
+	integrationtest.PollForCompletion(t, modelName, 5)
+	found, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 		g.Expect(len(nodes)).To(gomega.Equal(1))
@@ -1702,7 +1747,7 @@ func TestEditMultiIngressSameHost(t *testing.T) {
 			}
 		}
 	} else {
-		t.Fatalf("Could not find model: %s", model_name)
+		t.Fatalf("Could not find model: %s", modelName)
 	}
 	err = integrationtest.KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "ingress-multi1", metav1.DeleteOptions{})
 	if err != nil {
@@ -1719,20 +1764,21 @@ func TestEditMultiIngressSameHost(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, model_name)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditMultiHostIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, integrationtest.AllModels...)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, integrationtest.AllModels...)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-multihost",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1745,7 +1791,7 @@ func TestEditMultiHostIngress(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "foobar.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1819,19 +1865,20 @@ func TestEditMultiHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestNoHostIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-2"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "2"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-nohost",
 		Namespace:   "default",
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1866,19 +1913,20 @@ func TestNoHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditNoHostIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-2"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "2"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-nohost",
 		Namespace:   "default",
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
 	if err != nil {
@@ -1889,7 +1937,7 @@ func TestEditNoHostIngress(t *testing.T) {
 		Name:        "ingress-nohost",
 		Namespace:   "default",
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -1926,19 +1974,20 @@ func TestEditNoHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditNoHostToHostIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-2"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "2"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "ingress-nohost",
 		Namespace:   "default",
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -1972,7 +2021,7 @@ func TestEditNoHostToHostIngress(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"bar.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	ingrFake.ResourceVersion = "2"
@@ -2014,19 +2063,20 @@ func TestEditNoHostToHostIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestEditNoHostMultiPathIngress(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-3"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "3"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
 		Name:        "nohost-multipath",
 		Namespace:   "default",
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2038,7 +2088,7 @@ func TestEditNoHostMultiPathIngress(t *testing.T) {
 		Name:        "nohost-multipath",
 		Namespace:   "default",
 		Paths:       []string{"/foo", "/foobar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).IngressNoHost()
 	ingrFake.ResourceVersion = "2"
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Update(context.TODO(), ingrFake, metav1.UpdateOptions{})
@@ -2089,21 +2139,22 @@ func TestEditNoHostMultiPathIngress(t *testing.T) {
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestScaleEndpoints(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-multi1",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -2116,7 +2167,7 @@ func TestScaleEndpoints(t *testing.T) {
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/bar"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
@@ -2157,7 +2208,7 @@ func TestScaleEndpoints(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	integrationtest.ScaleCreateEPorEPS(t, "default", "avisvc")
+	integrationtest.ScaleCreateEPorEPS(t, "default", svcName)
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -2199,7 +2250,7 @@ func TestScaleEndpoints(t *testing.T) {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 	VerifyIngressDeletion(t, g, aviModel, 0)
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 
 }
 
@@ -2207,23 +2258,26 @@ func TestScaleEndpoints(t *testing.T) {
 
 func TestL7ModelSNI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 
 	// foo.com and noo.com compute the same hashed shard vs num
 	ingrFake := (integrationtest.FakeIngress{
-		Name:      "foo-with-targets",
+		Name:      ingName,
 		Namespace: "default",
 		DnsNames:  []string{"foo.com", "noo.com"},
 		Ips:       []string{"8.8.8.8"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2253,20 +2307,22 @@ func TestL7ModelSNI(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find Model: %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelNoSecretToSecret(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -2280,9 +2336,9 @@ func TestL7ModelNoSecretToSecret(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2304,7 +2360,7 @@ func TestL7ModelNoSecretToSecret(t *testing.T) {
 	}
 
 	// Now create the secret and verify the models.
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		g.Eventually(func() int {
@@ -2320,16 +2376,18 @@ func TestL7ModelNoSecretToSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	integrationtest.PollForCompletion(t, modelName, 5)
 	found, _ := objects.SharedAviGraphLister().Get(modelName)
@@ -2343,9 +2401,9 @@ func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
@@ -2360,9 +2418,9 @@ func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 		Ips:       []string{"8.8.8.8"},
 		HostNames: []string{"v1"},
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake2, metav1.CreateOptions{})
 	if err != nil {
@@ -2381,7 +2439,7 @@ func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 	g.Expect(len(nodes[0].SniNodes)).To(gomega.Equal(0))
 
 	// Now create the secret and verify the models.
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	g.Eventually(func() bool {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
@@ -2395,7 +2453,7 @@ func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()
 	g.Expect(nodes[0].SniNodes[0].VHDomainNames[0]).To(gomega.Equal("foo.com"))
 
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 	// Since we deleted the secret, both SNIs should get removed.
 	g.Eventually(func() bool {
@@ -2417,24 +2475,27 @@ func TestL7ModelOneSecretToMultiIng(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelMultiSNI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com", "bar.com"},
+			secretName: {"foo.com", "bar.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2460,38 +2521,42 @@ func TestL7ModelMultiSNI(t *testing.T) {
 		t.Fatalf("Could not find Model: %v", err)
 	}
 
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7ModelMultiSNIMultiCreateEditSecret(t *testing.T) {
 	// This test covers creating multiple SNI nodes via multiple secrets.
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
+	secretName := objNameMap.GenerateName("my-secret")
+	secretName2 := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert", "tlsKey")
 	// Clean up any earlier models.
-	modelName := "admin/cluster--Shared-L7-1"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	modelName := MODEL_NAME_PREFIX + "1"
 	objects.SharedAviGraphLister().Delete(modelName)
 	modelName = "admin/cluster--Shared-L7-0"
 	objects.SharedAviGraphLister().Delete(modelName)
-	SetUpTestForIngress(t, modelName)
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "FOO.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.com"},
-			"my-secret2": {"FOO.com"},
+			secretName:  {"foo.com"},
+			secretName2: {"FOO.com"},
 		},
 	}).Ingress()
 
@@ -2521,15 +2586,15 @@ func TestL7ModelMultiSNIMultiCreateEditSecret(t *testing.T) {
 	}
 
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com", "bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.com"},
-			"my-secret2": {"bar.com"},
+			secretName:  {"foo.com"},
+			secretName2: {"bar.com"},
 		},
 	}).Ingress()
 	ingrFake.ResourceVersion = "2"
@@ -2563,34 +2628,38 @@ func TestL7ModelMultiSNIMultiCreateEditSecret(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find model: %s", modelName)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
 
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret2", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName2, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestL7WrongSubDomainMultiSNI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
-	integrationtest.AddSecret("my-secret2", "default", "tlsCert", "tlsKey")
-	modelName := "admin/cluster--Shared-L7-1"
-	SetUpTestForIngress(t, modelName)
+	secretName := objNameMap.GenerateName("my-secret")
+	secretName2 := objNameMap.GenerateName("my-secret")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName2, "default", "tlsCert", "tlsKey")
+	modelName := MODEL_NAME_PREFIX + "1"
+	svcName := objNameMap.GenerateName("avisvc")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	ingrFake := (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.org"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.org"},
+			secretName: {"foo.org"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2604,15 +2673,15 @@ func TestL7WrongSubDomainMultiSNI(t *testing.T) {
 		t.Fatalf("Could not find Model: %v", err)
 	}
 	ingrFake = (integrationtest.FakeIngress{
-		Name:        "foo-with-targets",
+		Name:        ingName,
 		Namespace:   "default",
 		DnsNames:    []string{"foo.org", "bar.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret":  {"foo.org"},
-			"my-secret2": {"bar.com"},
+			secretName:  {"foo.org"},
+			secretName2: {"bar.com"},
 		},
 	}).Ingress()
 	ingrFake.ResourceVersion = "2"
@@ -2634,14 +2703,14 @@ func TestL7WrongSubDomainMultiSNI(t *testing.T) {
 	} else {
 		t.Fatalf("Could not find Model: %v", err)
 	}
-	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{})
+	err = KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingName, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 	VerifySNIIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestClusterRuntimeUpSinceChange(t *testing.T) {
@@ -2675,8 +2744,20 @@ func TestClusterRuntimeUpSinceChange(t *testing.T) {
 
 func TestFQDNCountInL7Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
 	g.Eventually(func() int {
 		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 		if aviModel == nil {
@@ -2698,13 +2779,15 @@ func TestFQDNCountInL7Model(t *testing.T) {
 		g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7"))
 	}
 
-	TearDownIngressForCacheSyncCheck(t, modelName)
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
 func TestPortsForInsecureAndSecureSNI(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
-	SetUpTestForIngress(t, modelName)
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	SetUpTestForIngress(t, svcName, modelName)
 
 	// Insecure
 	integrationtest.PollForCompletion(t, modelName, 5)
@@ -2718,9 +2801,9 @@ func TestPortsForInsecureAndSecureSNI(t *testing.T) {
 		DnsNames:    []string{"foo.com"},
 		Ips:         []string{"8.8.8.8"},
 		HostNames:   []string{"v1"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 		TlsSecretDNS: map[string][]string{
-			"my-secret": {"foo.com"},
+			secretName: {"foo.com"},
 		},
 	}).Ingress()
 	_, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{})
@@ -2747,7 +2830,7 @@ func TestPortsForInsecureAndSecureSNI(t *testing.T) {
 	}
 
 	// Secure
-	integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	integrationtest.AddSecret(secretName, "default", "tlsCert", "tlsKey")
 	found, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	if found {
 		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
@@ -2770,17 +2853,18 @@ func TestPortsForInsecureAndSecureSNI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), secretName, metav1.DeleteOptions{})
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestV6BackendService(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
 	objects.SharedAviGraphLister().Delete(modelName)
 
-	v6Svc := integrationtest.ConstructService("default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
+	v6Svc := integrationtest.ConstructService("default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
 	ipFamilyPolicy := corev1.IPFamilyPolicy("SingleStack")
 	v6Svc.Spec.IPFamilies = []corev1.IPFamily{"IPv6"}
 	v6Svc.Spec.IPFamilyPolicy = &ipFamilyPolicy
@@ -2788,14 +2872,14 @@ func TestV6BackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "ff06::")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "ff06::")
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-v6-backend-svc",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -2815,19 +2899,20 @@ func TestV6BackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc")
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestDualStackBackendService(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
+	modelName := MODEL_NAME_PREFIX + "0"
+	svcName := objNameMap.GenerateName("avisvc")
 	objects.SharedAviGraphLister().Delete(modelName)
 
-	dsSvc := integrationtest.ConstructService("default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
+	dsSvc := integrationtest.ConstructService("default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
 	ipFamilyPolicy := corev1.IPFamilyPolicy("RequireDualStack")
 	dsSvc.Spec.IPFamilies = []corev1.IPFamily{"IPv4", "IPv6"}
 	dsSvc.Spec.IPFamilyPolicy = &ipFamilyPolicy
@@ -2835,14 +2920,14 @@ func TestDualStackBackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-ds-backend-svc",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo"},
-		ServiceName: "avisvc",
+		ServiceName: svcName,
 	}).Ingress()
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
@@ -2862,19 +2947,21 @@ func TestDualStackBackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc")
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }
 
 func TestDualStackMultipleBackendService(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	modelName := "admin/cluster--Shared-L7-0"
+	modelName := MODEL_NAME_PREFIX + "0"
 	objects.SharedAviGraphLister().Delete(modelName)
+	svcName := objNameMap.GenerateName("avisvc")
+	svcName2 := objNameMap.GenerateName("avisvc")
 
-	v4Svc := integrationtest.ConstructService("default", "avisvc1", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
+	v4Svc := integrationtest.ConstructService("default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
 	ipFamilyPolicy := corev1.IPFamilyPolicy("SingleStack")
 	v4Svc.Spec.IPFamilies = []corev1.IPFamily{"IPv4"}
 	v4Svc.Spec.IPFamilyPolicy = &ipFamilyPolicy
@@ -2882,26 +2969,26 @@ func TestDualStackMultipleBackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	integrationtest.CreateEPorEPS(t, "default", "avisvc1", false, false, "1.1.1")
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 
-	v6Svc := integrationtest.ConstructService("default", "avisvc2", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
+	v6Svc := integrationtest.ConstructService("default", svcName2, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false, make(map[string]string), "")
 	v6Svc.Spec.IPFamilies = []corev1.IPFamily{"IPv6"}
 	v6Svc.Spec.IPFamilyPolicy = &ipFamilyPolicy
 	_, err = KubeClient.CoreV1().Services("default").Create(context.TODO(), v6Svc, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Service: %v", err)
 	}
-	integrationtest.CreateEPorEPS(t, "default", "avisvc2", false, false, "ff06::")
+	integrationtest.CreateEPorEPS(t, "default", svcName2, false, false, "ff06::")
 
 	ingrFake1 := (integrationtest.FakeIngress{
 		Name:        "ingress-ds-multipath",
 		Namespace:   "default",
 		DnsNames:    []string{"foo.com"},
 		Paths:       []string{"/foo", "/bar"},
-		ServiceName: "avisvc1",
+		ServiceName: svcName,
 	}).IngressMultiPath()
 
-	ingrFake1.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend.Service.Name = "avisvc2"
+	ingrFake1.Spec.Rules[0].IngressRuleValue.HTTP.Paths[1].Backend.Service.Name = svcName2
 	_, err = KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake1, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("error in adding Ingress: %v", err)
@@ -2947,11 +3034,11 @@ func TestDualStackMultipleBackendService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't DELETE the Ingress %v", err)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc1")
-	integrationtest.DelEPorEPS(t, "default", "avisvc1")
-	integrationtest.DelSVC(t, "default", "avisvc2")
-	integrationtest.DelEPorEPS(t, "default", "avisvc2")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
+	integrationtest.DelSVC(t, "default", svcName2)
+	integrationtest.DelEPorEPS(t, "default", svcName2)
 	VerifyIngressDeletion(t, g, aviModel, 0)
 
-	TearDownTestForIngress(t, modelName)
+	TearDownTestForIngress(t, svcName, modelName)
 }

--- a/tests/ingresstests/lib.go
+++ b/tests/ingresstests/lib.go
@@ -23,18 +23,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func SetUpTestForIngress(t *testing.T, modelNames ...string) {
+func SetUpTestForIngress(t *testing.T, svcName string, modelNames ...string) {
 	for _, model := range modelNames {
 		objects.SharedAviGraphLister().Delete(model)
 	}
-	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
-	integrationtest.CreateEPorEPS(t, "default", "avisvc", false, false, "1.1.1")
+	integrationtest.CreateSVC(t, "default", svcName, corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEPorEPS(t, "default", svcName, false, false, "1.1.1")
 }
 
-func TearDownTestForIngress(t *testing.T, modelNames ...string) {
+func TearDownTestForIngress(t *testing.T, svcName string, modelNames ...string) {
 	for _, model := range modelNames {
 		objects.SharedAviGraphLister().Delete(model)
 	}
-	integrationtest.DelSVC(t, "default", "avisvc")
-	integrationtest.DelEPorEPS(t, "default", "avisvc")
+	integrationtest.DelSVC(t, "default", svcName)
+	integrationtest.DelEPorEPS(t, "default", svcName)
 }

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -79,6 +79,8 @@ const (
 	EXTDNSSVC           = "custom-fqdn-svc"
 	INVALID_LB_CLASS    = "not-ako-lb"
 	letterBytes         = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	DefaultRouteCert    = "router-certs-default"
+	DEFAULT_NAMESPACE   = "default"
 )
 
 var KubeClient *k8sfake.Clientset

--- a/tests/oshiftroutetests/oshift_secure_route_test.go
+++ b/tests/oshiftroutetests/oshift_secure_route_test.go
@@ -1042,7 +1042,7 @@ func TestAddPathSecureRouteNoKeyCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding route: %v", err)
 	}
-	integrationtest.AddSecret("router-certs-default", utils.GetAKONamespace(), "tlsCert", "tlsKey")
+	integrationtest.AddSecret(integrationtest.DefaultRouteCert, utils.GetAKONamespace(), "tlsCert", "tlsKey")
 
 	aviModel := ValidateSniModel(t, g, defaultModelName)
 
@@ -1054,7 +1054,7 @@ func TestAddPathSecureRouteNoKeyCert(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
 	VerifySniNodeNoCA(g, sniVS)
 
-	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), "router-certs-default", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), integrationtest.DefaultRouteCert, metav1.DeleteOptions{})
 	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
 	TearDownTestForRoute(t, defaultModelName)
 }
@@ -1067,7 +1067,7 @@ func TestUpdatePathSecureRouteNoKeyCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error in adding route: %v", err)
 	}
-	integrationtest.AddSecret("router-certs-default", utils.GetAKONamespace(), "tlsCert", "tlsKey")
+	integrationtest.AddSecret(integrationtest.DefaultRouteCert, utils.GetAKONamespace(), "tlsCert", "tlsKey")
 
 	routeExample = FakeRoute{Path: "/bar"}.SecureRoute()
 	routeExample.ObjectMeta.ResourceVersion = "2"
@@ -1086,7 +1086,7 @@ func TestUpdatePathSecureRouteNoKeyCert(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
 	VerifySniNodeNoCA(g, sniVS)
 
-	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), "router-certs-default", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), integrationtest.DefaultRouteCert, metav1.DeleteOptions{})
 	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
 	TearDownTestForRoute(t, defaultModelName)
 }
@@ -1094,7 +1094,7 @@ func TestUpdatePathSecureRouteNoKeyCert(t *testing.T) {
 func TestUpdateSecureRouteToNoKeyCert(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	SetUpTestForRoute(t, defaultModelName)
-	integrationtest.AddSecret("router-certs-default", utils.GetAKONamespace(), "tlsCert", "tlsKey")
+	integrationtest.AddSecret(integrationtest.DefaultRouteCert, utils.GetAKONamespace(), "tlsCert", "tlsKey")
 	routeExample := FakeRoute{Path: "/foo"}.SecureRoute()
 	_, err := OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), routeExample, metav1.CreateOptions{})
 	if err != nil {
@@ -1123,7 +1123,7 @@ func TestUpdateSecureRouteToNoKeyCert(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
 	VerifySniNodeNoCA(g, sniVS)
 
-	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), "router-certs-default", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), integrationtest.DefaultRouteCert, metav1.DeleteOptions{})
 	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
 	TearDownTestForRoute(t, defaultModelName)
 }
@@ -1131,7 +1131,7 @@ func TestUpdateSecureRouteToNoKeyCert(t *testing.T) {
 func TestUpdateSecureRouteNoKeyCertToKeyCert(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	SetUpTestForRoute(t, defaultModelName)
-	integrationtest.AddSecret("router-certs-default", utils.GetAKONamespace(), "tlsCert", "tlsKey")
+	integrationtest.AddSecret(integrationtest.DefaultRouteCert, utils.GetAKONamespace(), "tlsCert", "tlsKey")
 	routeExample := FakeRoute{Path: "/foo"}.SecureRouteNoCertKey()
 	_, err := OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), routeExample, metav1.CreateOptions{})
 	if err != nil {
@@ -1160,7 +1160,7 @@ func TestUpdateSecureRouteNoKeyCertToKeyCert(t *testing.T) {
 	}, 20*time.Second).Should(gomega.Equal(defaultHostname))
 	VerifySniNodeNoCA(g, sniVS)
 
-	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), "router-certs-default", metav1.DeleteOptions{})
+	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Delete(context.TODO(), integrationtest.DefaultRouteCert, metav1.DeleteOptions{})
 	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
 	TearDownTestForRoute(t, defaultModelName)
 }


### PR DESCRIPTION
this PR isolates changes required for https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1339

file changes for ingresstests

UT results

ok github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/ingresstests 1102.513s

NOTE: this PR skips the test case TestCreateIngressWithFaultCacheSync. the case will be updated and fixed as separate PR