### PR TITLE
AV-206823: Update gateway parent FQDNs on update to http route hostnames

### DIFF
--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -223,20 +223,12 @@ func (o *AviObjectGraph) ProcessRouteDeletion(key, parentNsName string, routeMod
 	copy(childVSNames, childVSNamesTemp)
 	if found {
 		utils.AviLog.Infof("key: %s, msg: child VSes retrieved for deletion %v", key, childVSNames)
-
 		for _, childVSName := range childVSNames {
 			o.RemovePoolNameFromStringGroups(childVSName, parentNode, key)
 			removed := nodes.RemoveEvhInModel(childVSName, parentNode, key)
 			if removed {
 				akogatewayapiobjects.GatewayApiLister().DeleteRouteChildVSMappings(routeTypeNsName, childVSName)
 			}
-		}
-
-		modelName := lib.GetTenant() + "/" + parentNode[0].Name
-		ok := saveAviModel(modelName, o.AviObjectGraph, key)
-		if ok && len(o.AviObjectGraph.GetOrderedNodes()) != 0 && !fullsync {
-			sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
-			nodes.PublishKeyToRestLayer(modelName, key, sharedQueue)
 		}
 	} else {
 		// check parent association
@@ -276,13 +268,13 @@ func (o *AviObjectGraph) ProcessRouteDeletion(key, parentNsName string, routeMod
 			}
 		}
 		akogatewayapiobjects.GatewayApiLister().DeleteGatewayRouteToHTTPSPGPool(parentNsName + "/" + routeModel.GetType() + "/" + routeModel.GetNamespace() + "/" + routeModel.GetName())
-		modelName := lib.GetTenant() + "/" + parentNode[0].Name
-
-		ok := saveAviModel(modelName, o.AviObjectGraph, key)
-		if ok && len(o.AviObjectGraph.GetOrderedNodes()) != 0 && !fullsync {
-			sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
-			nodes.PublishKeyToRestLayer(modelName, key, sharedQueue)
-		}
+	}
+	updateHostname(key, parentNsName, parentNode[0])
+	modelName := lib.GetTenant() + "/" + parentNode[0].Name
+	ok := saveAviModel(modelName, o.AviObjectGraph, key)
+	if ok && len(o.AviObjectGraph.GetOrderedNodes()) != 0 && !fullsync {
+		sharedQueue := utils.SharedWorkQueue().GetQueueByName(utils.GraphLayer)
+		nodes.PublishKeyToRestLayer(modelName, key, sharedQueue)
 	}
 
 }

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -304,6 +304,7 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 		}
 		uniqueHosts := sets.NewString(hostnameIntersection...)
 
+		akogatewayapiobjects.GatewayApiLister().UpdateRouteToHostname(routeTypeNsName, uniqueHosts.List())
 		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteToHostname(gwNsName, uniqueHosts.List())
 		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteMappings(gwNsName, listenerList, routeTypeNsName)
 		if !utils.HasElem(gwNsNameList, gwNsName) {


### PR DESCRIPTION
Case tested 1:
1. Create gateway with 2 listener.
2. Create 2 http route with different hostname
3. Verify both FQDN are present in parent gateway

Case tested 2:
1. Update hostname in one of the http route
2. Verify FQDN updated in parent gateway

Case tested 3:
1. Delete httproute
2. Verify FQDN deleted in parent gateway

Case tested 4:
1. update httproute to not match the listener hostname
2. Verify FQDN deleted in parent gateway

TODO:
UT