### PR TITLE
AV-216533 : Remove double encoding for URI (#1522)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,9 +351,16 @@ multitenancytests:
 	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(GO_IMG_TEST) \
 	$(GOTEST) -mod=vendor $(PACKAGE_PATH_AKO)/tests/multitenancytests -failfast -timeout 0 -coverprofile cover-21.out -coverpkg=./...
 
+.PHONY: urltests
+urltests:
+	sudo docker run \
+	-w=/go/src/$(PACKAGE_PATH_AKO) \
+	-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(GO_IMG_TEST) \
+	$(GOTEST) -v -mod=vendor $(PACKAGE_PATH_AKO)/tests/urltests -failfast -coverprofile cover-22.out -coverpkg=./...
+
 .PHONY: int_test
 int_test:
-	make -j 1 k8stest integrationtest ingresstests evhtests vippernstests dedicatedevhtests dedicatedvippernstests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc dedicatedvstests hatests calicotests ciliumtests helmtests infratests gatewayapitests
+	make -j 1 k8stest integrationtest ingresstests evhtests vippernstests dedicatedevhtests dedicatedvippernstests oshiftroutetests bootuptests multicloudtests advl4tests namespacesynctests servicesapitests npltests misc dedicatedvstests hatests calicotests ciliumtests helmtests infratests urltests gatewayapitests
 
 .PHONY: multi_tenancy
 multi_tenancy:

--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -1122,9 +1122,11 @@ func checkForL4SSLAppProfile(key, refValue string) (bool, error) {
 	}
 	if appProfType, ok := item["type"].(string); ok {
 		if appProfType == lib.AllowedL4SSLApplicationProfile {
+			utils.AviLog.Infof("key: %s, msg: Ref found for %s/%s", key, refModelMap[refKey], refValue)
 			return true, nil
 		}
 		if appProfType == lib.AllowedL4ApplicationProfile {
+			utils.AviLog.Infof("key: %s, msg: Ref found for %s/%s", key, refModelMap[refKey], refValue)
 			return false, nil
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -655,13 +655,6 @@ func GetUriEncoded(uri string) string {
 	if len(queryValues) == 0 {
 		return uri
 	}
-
-	for key := range queryValues {
-		for i := range queryValues[key] {
-			queryValues[key][i] = url.QueryEscape(queryValues[key][i])
-		}
-	}
-
 	newUri.RawQuery = queryValues.Encode()
 	return newUri.String()
 }

--- a/tests/urltests/url_validation_test.go
+++ b/tests/urltests/url_validation_test.go
@@ -1,0 +1,236 @@
+package urltests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
+	avinodes "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/nodes"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/api"
+	crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1alpha1/clientset/versioned/fake"
+	v1beta1crdfake "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/fake"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	KubeClient       *k8sfake.Clientset
+	CRDClient        *crdfake.Clientset
+	v1beta1CRDClient *v1beta1crdfake.Clientset
+	ctrl             *k8s.AviController
+	akoApiServer     *api.FakeApiServer
+	keyChan          chan string
+)
+
+func SetupDomain() {
+	mcache := cache.SharedAviObjCache()
+	cloudObj := &cache.AviCloudPropertyCache{Name: "Default-Cloud", VType: "mock"}
+	subdomains := []string{"avi.internal", ".com"}
+	cloudObj.NSIpamDNS = subdomains
+	mcache.CloudKeyCache.AviCacheAdd("Default-Cloud", cloudObj)
+}
+
+func SetUpTestForIngress(t *testing.T, modelNames ...string) {
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
+	integrationtest.CreateSVC(t, "default", "avisvc", corev1.ProtocolTCP, corev1.ServiceTypeClusterIP, false)
+	integrationtest.CreateEP(t, "default", "avisvc", false, false, "1.1.1")
+}
+
+func TearDownTestForIngress(t *testing.T, modelNames ...string) {
+	for _, model := range modelNames {
+		objects.SharedAviGraphLister().Delete(model)
+	}
+	integrationtest.DelSVC(t, "default", "avisvc")
+	integrationtest.DelEP(t, "default", "avisvc")
+}
+
+func SetUpIngressForCacheSyncCheck(t *testing.T, tlsIngress, withSecret bool, modelNames ...string) {
+	SetupDomain()
+	SetUpTestForIngress(t, modelNames...)
+	ingressObject := integrationtest.FakeIngress{
+		Name:        "foo-with-targets",
+		Namespace:   "default",
+		DnsNames:    []string{"foo.com"},
+		Ips:         []string{"8.8.8.8"},
+		HostNames:   []string{"v1"},
+		Paths:       []string{"/foo"},
+		ServiceName: "avisvc",
+	}
+	if withSecret {
+		integrationtest.AddSecret("my-secret", "default", "tlsCert", "tlsKey")
+	}
+	if tlsIngress {
+		ingressObject.TlsSecretDNS = map[string][]string{
+			"my-secret": {"foo.com"},
+		}
+	}
+	ingrFake := ingressObject.Ingress()
+	if _, err := KubeClient.NetworkingV1().Ingresses("default").Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, modelNames[0], 5)
+}
+
+func TearDownIngressForCacheSyncCheck(t *testing.T, modelName string) {
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), "foo-with-targets", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	KubeClient.CoreV1().Secrets("default").Delete(context.TODO(), "my-secret", metav1.DeleteOptions{})
+	TearDownTestForIngress(t, modelName)
+}
+
+func TestMain(m *testing.M) {
+	os.Setenv("INGRESS_API", "extensionv1")
+	os.Setenv("VIP_NETWORK_LIST", `[{"networkName":"my test network"}]`)
+	os.Setenv("CLUSTER_NAME", "cluster")
+	os.Setenv("CLOUD_NAME", "my cloud")
+	utils.SetCloudName("my cloud")
+	os.Setenv("SEG_NAME", "my se group")
+	lib.SetSEGName("my se group")
+	os.Setenv("NODE_NETWORK_LIST", `[{"networkName":"my test network","cidrs":["10.79.168.0/22"]}]`)
+	os.Setenv("POD_NAMESPACE", utils.AKO_DEFAULT_NS)
+	os.Setenv("SHARD_VS_SIZE", "LARGE")
+	os.Setenv("AUTO_L4_FQDN", "default")
+	os.Setenv("POD_NAME", "ako-0")
+
+	akoControlConfig := lib.AKOControlConfig()
+	KubeClient = k8sfake.NewSimpleClientset()
+	CRDClient = crdfake.NewSimpleClientset()
+	v1beta1CRDClient = v1beta1crdfake.NewSimpleClientset()
+	akoControlConfig.SetCRDClientset(CRDClient)
+	akoControlConfig.Setv1beta1CRDClientset(v1beta1CRDClient)
+	akoControlConfig.SetAKOInstanceFlag(true)
+	akoControlConfig.SetEventRecorder(lib.AKOEventComponent, KubeClient, true)
+	akoControlConfig.SetDefaultLBController(true)
+	data := map[string][]byte{
+		"username": []byte("admin"),
+		"password": []byte("admin"),
+	}
+	object := metav1.ObjectMeta{Name: "avi-secret", Namespace: utils.GetAKONamespace()}
+	secret := &corev1.Secret{Data: data, ObjectMeta: object}
+	KubeClient.CoreV1().Secrets(utils.GetAKONamespace()).Create(context.TODO(), secret, metav1.CreateOptions{})
+
+	registeredInformers := []string{
+		utils.ServiceInformer,
+		utils.EndpointInformer,
+		utils.IngressInformer,
+		utils.IngressClassInformer,
+		utils.SecretInformer,
+		utils.NSInformer,
+		utils.NodeInformer,
+		utils.ConfigMapInformer,
+	}
+	utils.NewInformers(utils.KubeClientIntf{ClientSet: KubeClient}, registeredInformers)
+	informers := k8s.K8sinformers{Cs: KubeClient}
+	k8s.NewCRDInformers()
+
+	mcache := cache.SharedAviObjCache()
+	cloudObj := &cache.AviCloudPropertyCache{Name: "Default-Cloud", VType: "mock"}
+	subdomains := []string{"avi.internal", ".com"}
+	cloudObj.NSIpamDNS = subdomains
+	mcache.CloudKeyCache.AviCacheAdd("Default-Cloud", cloudObj)
+
+	akoApiServer = integrationtest.InitializeFakeAKOAPIServer()
+
+	integrationtest.AddMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		url := r.URL.EscapedPath()
+		if r.Method == http.MethodGet &&
+			(strings.Contains(url, "/api/serviceenginegroup") || strings.Contains(url, "/api/network") || strings.Contains(url, "/api/cloud")) {
+			if strings.Contains(url, "/api/serviceenginegroup") &&
+				(!strings.Contains(r.URL.RawQuery, "my+se+group") || !strings.Contains(r.URL.RawQuery, "my+cloud")) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			} else if strings.Contains(url, "/api/network") && ((!strings.Contains(r.URL.RawQuery, "vxw-dvs-34-virtualwire-182-sid-2200181-wdc-02-vc20-avi-dev178") && !strings.Contains(r.URL.RawQuery, "my+test+network")) || !strings.Contains(r.URL.RawQuery, "my+cloud")) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			} else if strings.Contains(url, "/api/cloud") && !strings.Contains(r.URL.RawQuery, "my+cloud") {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			integrationtest.NormalControllerServer(w, r)
+			return
+		}
+		integrationtest.NormalControllerServer(w, r)
+	})
+	defer integrationtest.ResetMiddleware()
+
+	integrationtest.NewAviFakeClientInstance(KubeClient)
+	defer integrationtest.AviFakeClientInstance.Close()
+
+	ctrl = k8s.SharedAviController()
+	stopCh := utils.SetupSignalHandler()
+	ctrlCh := make(chan struct{})
+	quickSyncCh := make(chan struct{})
+	waitGroupMap := make(map[string]*sync.WaitGroup)
+	wgIngestion := &sync.WaitGroup{}
+	waitGroupMap["ingestion"] = wgIngestion
+	wgFastRetry := &sync.WaitGroup{}
+	waitGroupMap["fastretry"] = wgFastRetry
+	wgSlowRetry := &sync.WaitGroup{}
+	waitGroupMap["slowretry"] = wgSlowRetry
+	wgGraph := &sync.WaitGroup{}
+	waitGroupMap["graph"] = wgGraph
+	wgStatus := &sync.WaitGroup{}
+	waitGroupMap["status"] = wgStatus
+	wgLeaderElection := &sync.WaitGroup{}
+	waitGroupMap["leaderElection"] = wgLeaderElection
+
+	integrationtest.AddConfigMap(KubeClient)
+	integrationtest.PollForSyncStart(ctrl, 10)
+	keyChan = make(chan string)
+	ctrl.HandleConfigMap(informers, ctrlCh, stopCh, quickSyncCh)
+	integrationtest.KubeClient = KubeClient
+	integrationtest.AddDefaultIngressClass()
+	ctrl.SetSEGroupCloudNameFromNSAnnotations()
+	integrationtest.AddDefaultNamespace()
+	integrationtest.AddDefaultNamespace("red")
+
+	go ctrl.InitController(informers, registeredInformers, ctrlCh, stopCh, quickSyncCh, waitGroupMap)
+	os.Exit(m.Run())
+}
+
+func TestURIEncodingWithIngressCreation(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-0"
+	SetUpIngressForCacheSyncCheck(t, true, true, modelName)
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes, ok := aviModel.(*avinodes.AviObjectGraph)
+		if !ok {
+			return 0
+		}
+		return len(nodes.GetAviVS())
+	}, 30*time.Second).Should(gomega.Equal(1))
+
+	mcache := cache.SharedAviObjCache()
+	parentVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--Shared-L7-0"}
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
+
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(parentVSKey)
+		return found
+	}, 60*time.Second).Should(gomega.Equal(true))
+
+	g.Eventually(func() bool {
+		_, found := mcache.VsCacheMeta.AviCacheGet(sniVSKey)
+		return found
+	}, 60*time.Second).Should(gomega.Equal(true))
+
+	TearDownIngressForCacheSyncCheck(t, modelName)
+}


### PR DESCRIPTION
This PR removes double encoding for URI. Also adds two log statements. Similar changes have already been merged to release-1.12.2 branch as part of https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1522.