### PR TITLE
AV-218385 ChildVS Deletion should not update Gateway listener status

### DIFF
--- a/ako-gateway-api/nodes/avi_model_l7_translator.go
+++ b/ako-gateway-api/nodes/avi_model_l7_translator.go
@@ -153,7 +153,8 @@ func (o *AviObjectGraph) BuildChildVS(key string, routeModel RouteModel, parentN
 	childNode.EVHParent = false
 
 	childNode.ServiceMetadata = lib.ServiceMetadataObj{
-		Gateway: parentNsName,
+		Gateway:   parentNsName,
+		HTTPRoute: routeModel.GetNamespace() + "/" + routeModel.GetName(),
 	}
 	childNode.ApplicationProfile = utils.DEFAULT_L7_APP_PROFILE
 	childNode.ServiceEngineGroup = lib.GetSEGName()

--- a/ako-gateway-api/status/status.go
+++ b/ako-gateway-api/status/status.go
@@ -60,6 +60,10 @@ func DequeueStatus(objIntf interface{}) error {
 		utils.AviLog.Debugf("key: %s, msg: unknown object received", option.Key)
 		return nil
 	}
+	if option.Options.ServiceMetadata.HTTPRoute != "" {
+		utils.AviLog.Debugf("key: %s, msg: Status update for ChildVs received", option.Options.ServiceMetadata.HTTPRoute)
+		return nil
+	}
 	if option.Op == lib.UpdateStatus {
 		obj.Update(option.Key, option)
 	} else if option.Op == lib.DeleteStatus {

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -490,7 +490,7 @@ func (c *AviObjCache) AviPopulateAllPGs(client *clients.AviClient, cloud string,
 		for _, member := range pg.Members {
 			// Parse each pool and populate inside pools.
 			// Find out the uuid of the pool and then corresponding name
-			poolUuid := ExtractUuid(*member.PoolRef, "pool-.*.#")
+			poolUuid := ExtractUUID(*member.PoolRef, "pool-.*.#")
 			// Search the poolName using this Uuid in the poolcache.
 			poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 			if found {
@@ -658,7 +658,7 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 
 		var pkiKey NamespaceName
 		if pool.PkiProfileRef != nil {
-			pkiUuid := ExtractUuid(*pool.PkiProfileRef, "pkiprofile-.*.#")
+			pkiUuid := ExtractUUID(*pool.PkiProfileRef, "pkiprofile-.*.#")
 			pkiName, foundPki := c.PKIProfileCache.AviCacheGetNameByUuid(pkiUuid)
 			if foundPki {
 				pkiKey = NamespaceName{Namespace: tenant, Name: pkiName.(string)}
@@ -929,7 +929,7 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 		for _, pg := range ds.PoolGroupRefs {
 			// Parse each pool and populate inside pools.
 			// Find out the uuid of the pool and then corresponding name
-			pgUuid := ExtractUuid(pg, "poolgroup-.*.#")
+			pgUuid := ExtractUUID(pg, "poolgroup-.*.#")
 			// Search the poolName using this Uuid in the poolcache.
 			pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 			if found {
@@ -1037,7 +1037,7 @@ func (c *AviObjCache) AviPopulateAllSSLKeys(client *clients.AviClient, cloud str
 		if len(sslkey.CaCerts) != 0 {
 			if sslkey.CaCerts[0].CaRef != nil {
 				hasCA = true
-				cacertUUID = ExtractUuidWithoutHash(*sslkey.CaCerts[0].CaRef, "sslkeyandcertificate-.*.")
+				cacertUUID = ExtractUUIDWithoutHash(*sslkey.CaCerts[0].CaRef, "sslkeyandcertificate-.*.")
 				cacertIntf, found := c.SSLKeyCache.AviCacheGetNameByUuid(cacertUUID)
 				if found {
 					cacert = cacertIntf.(string)
@@ -1111,7 +1111,7 @@ func (c *AviObjCache) AviPopulateOneSSLCache(client *clients.AviClient,
 		if len(sslkey.CaCerts) != 0 {
 			if sslkey.CaCerts[0].CaRef != nil {
 				hasCA = true
-				cacertUUID := ExtractUuidWithoutHash(*sslkey.CaCerts[0].CaRef, "sslkeyandcertificate-.*.")
+				cacertUUID := ExtractUUIDWithoutHash(*sslkey.CaCerts[0].CaRef, "sslkeyandcertificate-.*.")
 				cacertIntf, found := c.SSLKeyCache.AviCacheGetNameByUuid(cacertUUID)
 				if found {
 					cacert = cacertIntf.(string)
@@ -1226,7 +1226,7 @@ func (c *AviObjCache) AviPopulateOnePoolCache(client *clients.AviClient,
 		tenant := getTenantFromTenantRef(*pool.TenantRef)
 		var pkiKey NamespaceName
 		if pool.PkiProfileRef != nil {
-			pkiUuid := ExtractUuid(*pool.PkiProfileRef, "pkiprofile-.*.#")
+			pkiUuid := ExtractUUID(*pool.PkiProfileRef, "pkiprofile-.*.#")
 			pkiName, foundPki := c.PKIProfileCache.AviCacheGetNameByUuid(pkiUuid)
 			if foundPki {
 				pkiKey = NamespaceName{Namespace: tenant, Name: pkiName.(string)}
@@ -1286,7 +1286,7 @@ func (c *AviObjCache) AviPopulateOneVsDSCache(client *clients.AviClient,
 		for _, pg := range ds.PoolGroupRefs {
 			// Parse each pool and populate inside pools.
 			// Find out the uuid of the pool and then corresponding name
-			pgUuid := ExtractUuid(pg, "poolgroup-.*.#")
+			pgUuid := ExtractUUID(pg, "poolgroup-.*.#")
 			// Search the poolName using this Uuid in the poolcache.
 			pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 			if found {
@@ -1350,7 +1350,7 @@ func (c *AviObjCache) AviPopulateOnePGCache(client *clients.AviClient,
 		for _, member := range pg.Members {
 			// Parse each pool and populate inside pools.
 			// Find out the uuid of the pool and then corresponding name
-			poolUuid := ExtractUuid(*member.PoolRef, "pool-.*.#")
+			poolUuid := ExtractUUID(*member.PoolRef, "pool-.*.#")
 			// Search the poolName using this Uuid in the poolcache.
 			poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 			if found {
@@ -1501,13 +1501,13 @@ func (c *AviObjCache) AviPopulateOneVsHttpPolCache(client *clients.AviClient,
 				if rule.SwitchingAction != nil {
 					val := reflect.ValueOf(rule.SwitchingAction)
 					if !val.Elem().FieldByName("PoolGroupRef").IsNil() {
-						pgUuid := ExtractUuid(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
+						pgUuid := ExtractUUID(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
 						pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 						if found {
 							poolGroups = append(poolGroups, pgName.(string))
 						}
 					} else if !val.Elem().FieldByName("PoolRef").IsNil() {
-						poolUuid := ExtractUuid(*rule.SwitchingAction.PoolRef, "pool-.*.#")
+						poolUuid := ExtractUUID(*rule.SwitchingAction.PoolRef, "pool-.*.#")
 						poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 						if found {
 							pools = append(pools, poolName.(string))
@@ -1516,7 +1516,7 @@ func (c *AviObjCache) AviPopulateOneVsHttpPolCache(client *clients.AviClient,
 				}
 				if rule.Match != nil && rule.Match.Path != nil {
 					for _, sg := range rule.Match.Path.StringGroupRefs {
-						sgUuid := ExtractUuid(sg, "stringgroup-.*.#")
+						sgUuid := ExtractUUID(sg, "stringgroup-.*.#")
 						// Search the string group name using this Uuid in the string group cache.
 						sgName, found := c.StringGroupCache.AviCacheGetNameByUuid(sgUuid)
 						if found {
@@ -1586,7 +1586,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 			for _, rule := range l4pol.L4ConnectionPolicy.Rules {
 				protocols = append(protocols, *rule.Match.Protocol.Protocol)
 				if rule.Action != nil {
-					poolUuid := ExtractUuid(*rule.Action.SelectPool.PoolRef, "pool-.*.#")
+					poolUuid := ExtractUUID(*rule.Action.SelectPool.PoolRef, "pool-.*.#")
 					poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 					if found {
 						pools = append(pools, poolName.(string))
@@ -1690,13 +1690,13 @@ func (c *AviObjCache) AviPopulateAllHttpPolicySets(client *clients.AviClient, cl
 				if rule.SwitchingAction != nil {
 					val := reflect.ValueOf(rule.SwitchingAction)
 					if !val.Elem().FieldByName("PoolGroupRef").IsNil() {
-						pgUuid := ExtractUuid(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
+						pgUuid := ExtractUUID(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
 						pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 						if found {
 							poolGroups = append(poolGroups, pgName.(string))
 						}
 					} else if !val.Elem().FieldByName("PoolRef").IsNil() {
-						poolUuid := ExtractUuid(*rule.SwitchingAction.PoolRef, "pool-.*.#")
+						poolUuid := ExtractUUID(*rule.SwitchingAction.PoolRef, "pool-.*.#")
 						poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 						if found {
 							pools = append(pools, poolName.(string))
@@ -1705,7 +1705,7 @@ func (c *AviObjCache) AviPopulateAllHttpPolicySets(client *clients.AviClient, cl
 				}
 				if rule.Match != nil && rule.Match.Path != nil {
 					for _, sg := range rule.Match.Path.StringGroupRefs {
-						sgUuid := ExtractUuid(sg, "stringgroup-.*.#")
+						sgUuid := ExtractUUID(sg, "stringgroup-.*.#")
 						// Search the string group name using this Uuid in the string group cache.
 						sgName, found := c.StringGroupCache.AviCacheGetNameByUuid(sgUuid)
 						if found {
@@ -1770,13 +1770,13 @@ func (c *AviObjCache) AviPopulateHttpPolicySetbyUUID(client *clients.AviClient, 
 			if rule.SwitchingAction != nil {
 				val := reflect.ValueOf(rule.SwitchingAction)
 				if !val.Elem().FieldByName("PoolGroupRef").IsNil() {
-					pgUuid := ExtractUuid(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
+					pgUuid := ExtractUUID(*rule.SwitchingAction.PoolGroupRef, "poolgroup-.*.#")
 					pgName, found := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 					if found {
 						poolGroups = append(poolGroups, pgName.(string))
 					}
 				} else if !val.Elem().FieldByName("PoolRef").IsNil() {
-					poolUuid := ExtractUuid(*rule.SwitchingAction.PoolRef, "pool-.*.#")
+					poolUuid := ExtractUUID(*rule.SwitchingAction.PoolRef, "pool-.*.#")
 					poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 					if found {
 						pools = append(pools, poolName.(string))
@@ -1883,7 +1883,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 						protocol = utils.UDP
 					}
 					protocols = append(protocols, protocol)
-					poolUuid := ExtractUuid(*rule.Action.SelectPool.PoolRef, "pool-.*.#")
+					poolUuid := ExtractUUID(*rule.Action.SelectPool.PoolRef, "pool-.*.#")
 					poolName, found := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 					if found {
 						pools = append(pools, poolName.(string))
@@ -2199,7 +2199,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 			vs_parent_ref, foundParent := vs["vh_parent_vs_ref"]
 			var parentVSKey NamespaceName
 			if foundParent {
-				vs_uuid := ExtractUuid(vs_parent_ref.(string), "virtualservice-.*.#")
+				vs_uuid := ExtractUUID(vs_parent_ref.(string), "virtualservice-.*.#")
 				utils.AviLog.Debugf("extracted the vs uuid from parent ref during cache population: %s", vs_uuid)
 				// Now let's get the VS key from this uuid
 				vsKey, gotVS := c.VsCacheLocal.AviCacheGetKeyByUuid(vs_uuid)
@@ -2226,7 +2226,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 				// Populate the VSVIP cache
 				if vs["vsvip_ref"] != nil {
 					// find the vsvip name from the vsvip cache
-					vsVipUuid := ExtractUuid(vs["vsvip_ref"].(string), "vsvip-.*.#")
+					vsVipUuid := ExtractUUID(vs["vsvip_ref"].(string), "vsvip-.*.#")
 					objKey, objFound := c.VSVIPCache.AviCacheGetKeyByUuid(vsVipUuid)
 					if objFound {
 						vsVip, foundVip := c.VSVIPCache.AviCacheGet(objKey)
@@ -2243,7 +2243,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 				if vs["ssl_key_and_certificate_refs"] != nil {
 					for _, ssl := range vs["ssl_key_and_certificate_refs"].([]interface{}) {
 						// find the sslkey name from the ssl key cache
-						sslUuid := ExtractUuid(ssl.(string), "sslkeyandcertificate-.*.#")
+						sslUuid := ExtractUUID(ssl.(string), "sslkeyandcertificate-.*.#")
 						sslName, foundssl := c.SSLKeyCache.AviCacheGetNameByUuid(sslUuid)
 						if foundssl {
 							sslKey := NamespaceName{Namespace: tenant, Name: sslName.(string)}
@@ -2267,7 +2267,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 						// find the sslkey name from the ssl key cache
 						dsmap, ok := ds_intf.(map[string]interface{})
 						if ok {
-							dsUuid := ExtractUuid(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.#")
+							dsUuid := ExtractUUID(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.#")
 
 							dsName, foundDs := c.DSCache.AviCacheGetNameByUuid(dsUuid)
 							if foundDs {
@@ -2293,7 +2293,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 						// find the sslkey name from the ssl key cache
 						pgmap, ok := pg_intf.(map[string]interface{})
 						if ok {
-							pgUuid := ExtractUuid(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.#")
+							pgUuid := ExtractUUID(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.#")
 
 							pgName, foundpg := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 							if foundpg {
@@ -2310,7 +2310,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 					for _, l4_intf := range vs["l4_policies"].([]interface{}) {
 						l4map, ok := l4_intf.(map[string]interface{})
 						if ok {
-							l4PolUuid := ExtractUuid(l4map["l4_policy_set_ref"].(string), "l4policyset-.*.#")
+							l4PolUuid := ExtractUUID(l4map["l4_policy_set_ref"].(string), "l4policyset-.*.#")
 							l4Name, foundl4pol := c.L4PolicyCache.AviCacheGetNameByUuid(l4PolUuid)
 							if foundl4pol {
 								sharedVsOrL4 = true
@@ -2329,7 +2329,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 					for _, http_intf := range vs["http_policies"].([]interface{}) {
 						httpmap, ok := http_intf.(map[string]interface{})
 						if ok {
-							httpUuid := ExtractUuid(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.#")
+							httpUuid := ExtractUUID(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.#")
 							httpName, foundhttp := c.HTTPPolicyCache.AviCacheGetNameByUuid(httpUuid)
 							// If the httppol is not found in the cache, do an explicit get
 							if !foundhttp && !sharedVsOrL4 {
@@ -2364,7 +2364,7 @@ func (c *AviObjCache) AviObjVSCachePopulate(client *clients.AviClient, cloud str
 					poolRef, ok := vs["pool_ref"].(string)
 					if ok {
 						poolNameFromRef := strings.Split(poolRef, "#")[1]
-						poolUuid := ExtractUuid(poolRef, "pool-.*.#")
+						poolUuid := ExtractUUID(poolRef, "pool-.*.#")
 						poolNameFromCache, foundPool := c.PoolCache.AviCacheGetNameByUuid(poolUuid)
 						if foundPool && poolNameFromCache.(string) == poolNameFromRef {
 							poolKey := NamespaceName{Namespace: tenant, Name: poolNameFromCache.(string)}
@@ -2471,10 +2471,10 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 			vs_parent_ref, foundParent := vs["vh_parent_vs_ref"]
 			var parentVSKey NamespaceName
 			if foundParent {
-				vs_uuid := ExtractUuid(vs_parent_ref.(string), "virtualservice-.*.#")
-				utils.AviLog.Debugf("extracted the vs uuid from parent ref during cache population: %s", vs_uuid)
+				vsUUID := ExtractUUID(vs_parent_ref.(string), "virtualservice-.*.#")
+				utils.AviLog.Debugf("Extracted the vs uuid from parent ref during cache population: %s", vsUUID)
 				// Now let's get the VS key from this uuid
-				vsKey, gotVS := c.VsCacheMeta.AviCacheGetKeyByUuid(vs_uuid)
+				vsKey, gotVS := c.VsCacheMeta.AviCacheGetKeyByUuid(vsUUID)
 				if gotVS {
 					parentVSKey = vsKey.(NamespaceName)
 				}
@@ -2495,7 +2495,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				// Populate the VSVIP cache
 				if vs["vsvip_ref"] != nil {
 					// find the vsvip name from the vsvip cache
-					vsVipUuid := ExtractUuid(vs["vsvip_ref"].(string), "vsvip-.*.#")
+					vsVipUuid := ExtractUUID(vs["vsvip_ref"].(string), "vsvip-.*.#")
 					vsVipName, foundVip := c.VSVIPCache.AviCacheGetNameByUuid(vsVipUuid)
 
 					if foundVip {
@@ -2507,7 +2507,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				if vs["ssl_key_and_certificate_refs"] != nil {
 					for _, ssl := range vs["ssl_key_and_certificate_refs"].([]interface{}) {
 						// find the sslkey name from the ssl key cache
-						sslUuid := ExtractUuid(ssl.(string), "sslkeyandcertificate-.*.#")
+						sslUuid := ExtractUUID(ssl.(string), "sslkeyandcertificate-.*.#")
 						sslName, foundssl := c.SSLKeyCache.AviCacheGetNameByUuid(sslUuid)
 						if foundssl {
 							sslKey := NamespaceName{Namespace: tenant, Name: sslName.(string)}
@@ -2531,7 +2531,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						dsmap, ok := ds_intf.(map[string]interface{})
 						if ok {
-							dsUuid := ExtractUuid(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.#")
+							dsUuid := ExtractUUID(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.#")
 
 							dsName, foundDs := c.DSCache.AviCacheGetNameByUuid(dsUuid)
 							if foundDs && !strings.Contains(dsName.(string), "ako-gw") {
@@ -2556,7 +2556,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						pgmap, ok := pg_intf.(map[string]interface{})
 						if ok {
-							pgUuid := ExtractUuid(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.#")
+							pgUuid := ExtractUUID(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.#")
 
 							pgName, foundpg := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 							if foundpg {
@@ -2572,7 +2572,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 					for _, l4_intf := range vs["l4_policies"].([]interface{}) {
 						l4map, ok := l4_intf.(map[string]interface{})
 						if ok {
-							l4PolUuid := ExtractUuid(l4map["l4_policy_set_ref"].(string), "l4policyset-.*.#")
+							l4PolUuid := ExtractUUID(l4map["l4_policy_set_ref"].(string), "l4policyset-.*.#")
 							l4Name, foundl4pol := c.L4PolicyCache.AviCacheGetNameByUuid(l4PolUuid)
 							if foundl4pol {
 								l4key := NamespaceName{Namespace: tenant, Name: l4Name.(string)}
@@ -2591,7 +2591,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						httpmap, ok := http_intf.(map[string]interface{})
 						if ok {
-							httpUuid := ExtractUuid(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.#")
+							httpUuid := ExtractUUID(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.#")
 
 							httpName, foundhttp := c.HTTPPolicyCache.AviCacheGetNameByUuid(httpUuid)
 							if foundhttp {
@@ -2616,7 +2616,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				if vs["pool_group_ref"] != nil {
 					pgRef, ok := vs["pool_group_ref"].(string)
 					if ok {
-						pgUuid := ExtractUuid(pgRef, "poolgroup-.*.#")
+						pgUuid := ExtractUUID(pgRef, "poolgroup-.*.#")
 						pgName, foundpg := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 						if foundpg {
 							pgKey := NamespaceName{Namespace: tenant, Name: pgName.(string)}
@@ -4177,17 +4177,17 @@ func ExtractPattern(word string, pattern string) (string, error) {
 	return "", nil
 }
 
-func ExtractUuid(word, pattern string) string {
+func ExtractUUID(word, pattern string) string {
 	r, _ := regexp.Compile(pattern)
 	result := r.FindAllString(word, -1)
 	if len(result) == 1 {
 		return result[0][:len(result[0])-1]
 	}
 	utils.AviLog.Debugf("Uid extraction not successful from: %s, will retry without hash pattern", word)
-	return ExtractUuidWithoutHash(word, pattern[:len(pattern)-1])
+	return ExtractUUIDWithoutHash(word, pattern[:len(pattern)-1])
 }
 
-func ExtractUuidWithoutHash(word, pattern string) string {
+func ExtractUUIDWithoutHash(word, pattern string) string {
 	r, _ := regexp.Compile(pattern)
 	result := r.FindAllString(word, -1)
 	if len(result) == 1 {

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -2471,7 +2471,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 			vs_parent_ref, foundParent := vs["vh_parent_vs_ref"]
 			var parentVSKey NamespaceName
 			if foundParent {
-				vs_uuid := ExtractUuidWithoutHash(vs_parent_ref.(string), "virtualservice-.*.")
+				vs_uuid := ExtractUuid(vs_parent_ref.(string), "virtualservice-.*.#")
 				utils.AviLog.Debugf("extracted the vs uuid from parent ref during cache population: %s", vs_uuid)
 				// Now let's get the VS key from this uuid
 				vsKey, gotVS := c.VsCacheMeta.AviCacheGetKeyByUuid(vs_uuid)
@@ -2495,7 +2495,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				// Populate the VSVIP cache
 				if vs["vsvip_ref"] != nil {
 					// find the vsvip name from the vsvip cache
-					vsVipUuid := ExtractUuidWithoutHash(vs["vsvip_ref"].(string), "vsvip-.*.")
+					vsVipUuid := ExtractUuid(vs["vsvip_ref"].(string), "vsvip-.*.#")
 					vsVipName, foundVip := c.VSVIPCache.AviCacheGetNameByUuid(vsVipUuid)
 
 					if foundVip {
@@ -2507,7 +2507,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 				if vs["ssl_key_and_certificate_refs"] != nil {
 					for _, ssl := range vs["ssl_key_and_certificate_refs"].([]interface{}) {
 						// find the sslkey name from the ssl key cache
-						sslUuid := ExtractUuidWithoutHash(ssl.(string), "sslkeyandcertificate-.*.")
+						sslUuid := ExtractUuid(ssl.(string), "sslkeyandcertificate-.*.#")
 						sslName, foundssl := c.SSLKeyCache.AviCacheGetNameByUuid(sslUuid)
 						if foundssl {
 							sslKey := NamespaceName{Namespace: tenant, Name: sslName.(string)}
@@ -2531,7 +2531,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						dsmap, ok := ds_intf.(map[string]interface{})
 						if ok {
-							dsUuid := ExtractUuidWithoutHash(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.")
+							dsUuid := ExtractUuid(dsmap["vs_datascript_set_ref"].(string), "vsdatascriptset-.*.#")
 
 							dsName, foundDs := c.DSCache.AviCacheGetNameByUuid(dsUuid)
 							if foundDs && !strings.Contains(dsName.(string), "ako-gw") {
@@ -2556,7 +2556,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						pgmap, ok := pg_intf.(map[string]interface{})
 						if ok {
-							pgUuid := ExtractUuidWithoutHash(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.")
+							pgUuid := ExtractUuid(pgmap["service_pool_group_ref"].(string), "poolgroup-.*.#")
 
 							pgName, foundpg := c.PgCache.AviCacheGetNameByUuid(pgUuid)
 							if foundpg {
@@ -2591,7 +2591,7 @@ func (c *AviObjCache) AviObjOneVSCachePopulate(client *clients.AviClient, cloud 
 						// find the sslkey name from the ssl key cache
 						httpmap, ok := http_intf.(map[string]interface{})
 						if ok {
-							httpUuid := ExtractUuidWithoutHash(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.")
+							httpUuid := ExtractUuid(httpmap["http_policy_set_ref"].(string), "httppolicyset-.*.#")
 
 							httpName, foundhttp := c.HTTPPolicyCache.AviCacheGetNameByUuid(httpUuid)
 							if foundhttp {

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -89,7 +89,8 @@ type ServiceMetadataObj struct {
 	PoolRatio             uint32      `json:"pool_ratio"`
 	PassthroughParentRef  string      `json:"passthrough_parent_ref"`
 	PassthroughChildRef   string      `json:"passthrough_child_ref"`
-	Gateway               string      `json:"gateway"` // ns/name
+	Gateway               string      `json:"gateway"`   // ns/name
+	HTTPRoute             string      `json:"httproute"` // ns/name
 	InsecureEdgeTermAllow bool        `json:"insecureedgetermallow"`
 	IsMCIIngress          bool        `json:"is_mci_ingress"`
 }

--- a/internal/rest/avi_datascript.go
+++ b/internal/rest/avi_datascript.go
@@ -147,7 +147,7 @@ func (rest *RestOperations) AviDSCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 		if resp["pool_group_refs"] != nil {
 			pgs, _ := resp["pool_group_refs"].([]interface{})
 			for _, pg := range pgs {
-				pgUuid := avicache.ExtractUuid(pg.(string), "poolgroup-.*.#")
+				pgUuid := avicache.ExtractUUID(pg.(string), "poolgroup-.*.#")
 				pgName, found := rest.cache.PgCache.AviCacheGetNameByUuid(pgUuid)
 				if found {
 					poolgroups = append(poolgroups, pgName.(string))

--- a/internal/rest/avi_obj_httpps.go
+++ b/internal/rest/avi_obj_httpps.go
@@ -388,14 +388,14 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 						if rulemap["switching_action"] != nil {
 							switchAction := rulemap["switching_action"].(map[string]interface{})
 							if switchAction["pool_group_ref"] != nil {
-								pgUuid := avicache.ExtractUuid(switchAction["pool_group_ref"].(string), "poolgroup-.*.#")
+								pgUuid := avicache.ExtractUUID(switchAction["pool_group_ref"].(string), "poolgroup-.*.#")
 								// Search the poolName using this Uuid in the poolcache.
 								pgName, found := rest.cache.PgCache.AviCacheGetNameByUuid(pgUuid)
 								if found {
 									pgMembers = append(pgMembers, pgName.(string))
 								}
 							} else if switchAction["pool_ref"] != nil {
-								poolUuid := avicache.ExtractUuid(switchAction["pool_ref"].(string), "pool-.*.#")
+								poolUuid := avicache.ExtractUUID(switchAction["pool_ref"].(string), "pool-.*.#")
 								poolName, found := rest.cache.PoolCache.AviCacheGetNameByUuid(poolUuid)
 								if found {
 									poolMembers = append(poolMembers, poolName.(string))
@@ -409,7 +409,7 @@ func (rest *RestOperations) AviHTTPPolicyCacheAdd(rest_op *utils.RestOp, vsKey a
 								if pathMap["string_group_refs"] != nil {
 									sgRefs, _ := pathMap["string_group_refs"].([]interface{})
 									for _, sg := range sgRefs {
-										sgUuid := avicache.ExtractUuid(sg.(string), "stringgroup-.*.#")
+										sgUuid := avicache.ExtractUUID(sg.(string), "stringgroup-.*.#")
 										// Search the string group name using this Uuid in the string group cache.
 										sgName, found := rest.cache.StringGroupCache.AviCacheGetNameByUuid(sgUuid)
 										if found {

--- a/internal/rest/avi_obj_pool.go
+++ b/internal/rest/avi_obj_pool.go
@@ -284,7 +284,7 @@ func (rest *RestOperations) AviPoolCacheAdd(rest_op *utils.RestOp, vsKey avicach
 
 		var pkiKey avicache.NamespaceName
 		if pkiprof, ok := resp["pki_profile_ref"]; ok && pkiprof != "" {
-			pkiUuid := avicache.ExtractUuid(pkiprof.(string), "pkiprofile-.*.#")
+			pkiUuid := avicache.ExtractUUID(pkiprof.(string), "pkiprofile-.*.#")
 			pkiName, foundPki := rest.cache.PKIProfileCache.AviCacheGetNameByUuid(pkiUuid)
 			if foundPki {
 				pkiKey = avicache.NamespaceName{Namespace: lib.GetTenant(), Name: pkiName.(string)}

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -560,44 +560,24 @@ func (rest *RestOperations) StatusUpdateForVS(restMethod utils.RestMethod, vsCac
 	serviceMetadataObj := vsCacheObj.ServiceMetadataObj
 	switch serviceMetadataObj.ServiceMetadataMapping("VS") {
 	case lib.GatewayVS:
-		if vsCacheObj.ParentVSRef.Name != "" {
-			updateOptions := status.UpdateOptions{
-				ServiceMetadata: serviceMetadataObj,
-				Key:             key,
-				VSName:          vsCacheObj.Name,
-				Tenant:          vsCacheObj.Tenant,
-			}
-			statusOption := status.StatusOptions{
-				ObjType: lib.HTTPRoute,
-				Op:      lib.UpdateStatus,
-				Key:     key,
-				Options: &updateOptions,
-			}
-			if lib.UseServicesAPI() {
-				statusOption.ObjType = lib.SERVICES_API
-			}
-			utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", key, utils.Stringify(statusOption))
-			status.PublishToStatusQueue(key, statusOption)
-		} else {
-			updateOptions := status.UpdateOptions{
-				Vip:             IPAddrs,
-				ServiceMetadata: serviceMetadataObj,
-				Key:             key,
-				VSName:          vsCacheObj.Name,
-				Tenant:          vsCacheObj.Tenant,
-			}
-			statusOption := status.StatusOptions{
-				ObjType: lib.Gateway,
-				Op:      lib.UpdateStatus,
-				Key:     key,
-				Options: &updateOptions,
-			}
-			if lib.UseServicesAPI() {
-				statusOption.ObjType = lib.SERVICES_API
-			}
-			utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.Gateway, utils.Stringify(statusOption))
-			status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
+		updateOptions := status.UpdateOptions{
+			Vip:             IPAddrs,
+			ServiceMetadata: serviceMetadataObj,
+			Key:             key,
+			VSName:          vsCacheObj.Name,
+			Tenant:          vsCacheObj.Tenant,
 		}
+		statusOption := status.StatusOptions{
+			ObjType: lib.Gateway,
+			Op:      lib.UpdateStatus,
+			Key:     key,
+			Options: &updateOptions,
+		}
+		if lib.UseServicesAPI() {
+			statusOption.ObjType = lib.SERVICES_API
+		}
+		utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.Gateway, utils.Stringify(statusOption))
+		status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
 	case lib.ServiceTypeLBVS:
 		updateOptions := status.UpdateOptions{
 			Vip:                IPAddrs,
@@ -682,7 +662,7 @@ func (rest *RestOperations) AviVsCacheAdd(rest_op *utils.RestOp, key string) err
 		var vhParentKey interface{}
 		if found_parent {
 			// the uuid is expected to be in the format: "https://IP:PORT/api/virtualservice/virtualservice-88fd9718-f4f9-4e2b-9552-d31336330e0e#mygateway"
-			vs_uuid := avicache.ExtractUuid(vh_parent_uuid.(string), "virtualservice-.*.#")
+			vs_uuid := avicache.ExtractUUID(vh_parent_uuid.(string), "virtualservice-.*.#")
 			utils.AviLog.Debugf("key: %s, msg: extracted the vs uuid from parent ref: %s", key, vs_uuid)
 			// Now let's get the VS key from this uuid
 			var foundvscache bool
@@ -777,10 +757,10 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 	// Delete the SNI Child ref
 	vs_cache, ok := rest.cache.VsCacheMeta.AviCacheGet(vsKey)
 	if ok {
-		vs_cache_obj, found := vs_cache.(*avicache.AviVsCache)
+		vsCacheObj, found := vs_cache.(*avicache.AviVsCache)
 		if found {
 			hostFoundInParentPool := false
-			parent_vs_cache, parent_ok := rest.cache.VsCacheMeta.AviCacheGet(vs_cache_obj.ParentVSRef)
+			parent_vs_cache, parent_ok := rest.cache.VsCacheMeta.AviCacheGet(vsCacheObj.ParentVSRef)
 			if parent_ok {
 				parent_vs_cache_obj, parent_found := parent_vs_cache.(*avicache.AviVsCache)
 				if parent_found {
@@ -789,8 +769,8 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 
 					// if we find a L7Shared pool that has the secure VS host then don't delete status
 					// update is also not required since the shard would not change, IP should remain same
-					if len(vs_cache_obj.ServiceMetadataObj.HostNames) > 0 {
-						hostname := vs_cache_obj.ServiceMetadataObj.HostNames[0]
+					if len(vsCacheObj.ServiceMetadataObj.HostNames) > 0 {
+						hostname := vsCacheObj.ServiceMetadataObj.HostNames[0]
 						hostFoundInParentPool = rest.isHostPresentInSharedPool(hostname, parent_vs_cache_obj, key)
 					}
 
@@ -799,63 +779,42 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 
 			// try to delete the vsvip from cache only if the vs is not of type insecure passthrough
 			// and if controller version is >= 20.1.1
-			if vs_cache_obj.ServiceMetadataObj.PassthroughParentRef == "" {
-				if len(vs_cache_obj.VSVipKeyCollection) > 0 {
-					vsvip := vs_cache_obj.VSVipKeyCollection[0].Name
+			if vsCacheObj.ServiceMetadataObj.PassthroughParentRef == "" {
+				if len(vsCacheObj.VSVipKeyCollection) > 0 {
+					vsvip := vsCacheObj.VSVipKeyCollection[0].Name
 					vsvipKey := avicache.NamespaceName{Namespace: vsKey.Namespace, Name: vsvip}
 					utils.AviLog.Infof("key: %s, msg: deleting vsvip cache for key: %s", key, vsvipKey)
 					rest.cache.VSVIPCache.AviCacheDelete(vsvipKey)
 				}
 			}
-
-			switch vs_cache_obj.ServiceMetadataObj.ServiceMetadataMapping("VS") {
+			switch vsCacheObj.ServiceMetadataObj.ServiceMetadataMapping("VS") {
 			case lib.GatewayVS:
-				if vs_cache_obj.ParentVSRef.Name != "" {
-					updateOptions := status.UpdateOptions{
-						ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
-						Key:             key,
-						VSName:          vs_cache_obj.Name,
-						Tenant:          vs_cache_obj.Tenant,
-					}
-					statusOption := status.StatusOptions{
-						ObjType: lib.HTTPRoute,
-						Op:      lib.DeleteStatus,
-						Key:     key,
-						Options: &updateOptions,
-					}
-					if lib.UseServicesAPI() {
-						statusOption.ObjType = lib.SERVICES_API
-					}
-					utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", key, utils.Stringify(statusOption))
-					status.PublishToStatusQueue(key, statusOption)
-				} else {
-					updateOptions := status.UpdateOptions{
-						ServiceMetadata: vs_cache_obj.ServiceMetadataObj,
-						Key:             key,
-						VSName:          vs_cache_obj.Name,
-						Tenant:          vs_cache_obj.Tenant,
-					}
-					statusOption := status.StatusOptions{
-						ObjType: lib.Gateway,
-						Op:      lib.DeleteStatus,
-						Key:     key,
-						Options: &updateOptions,
-					}
-					utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.Gateway, utils.Stringify(statusOption))
-					status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
-					// The pools would have service metadata for backend services, corresponding to which
-					// statuses need to be deleted.
-					for _, poolKey := range vs_cache_obj.PoolKeyCollection {
-						rest.DeletePoolIngressStatus(poolKey, true, vs_cache_obj.Name, key)
-					}
+				updateOptions := status.UpdateOptions{
+					ServiceMetadata: vsCacheObj.ServiceMetadataObj,
+					Key:             key,
+					VSName:          vsCacheObj.Name,
+					Tenant:          vsCacheObj.Tenant,
+				}
+				statusOption := status.StatusOptions{
+					ObjType: lib.Gateway,
+					Op:      lib.DeleteStatus,
+					Key:     key,
+					Options: &updateOptions,
+				}
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", updateOptions.ServiceMetadata.Gateway, utils.Stringify(statusOption))
+				status.PublishToStatusQueue(updateOptions.ServiceMetadata.Gateway, statusOption)
+				// The pools would have service metadata for backend services, corresponding to which
+				// statuses need to be deleted.
+				for _, poolKey := range vsCacheObj.PoolKeyCollection {
+					rest.DeletePoolIngressStatus(poolKey, true, vsCacheObj.Name, key)
 				}
 			case lib.ServiceTypeLBVS:
 				updateOptions := status.UpdateOptions{
-					ServiceMetadata:    vs_cache_obj.ServiceMetadataObj,
+					ServiceMetadata:    vsCacheObj.ServiceMetadataObj,
 					Key:                key,
-					VirtualServiceUUID: vs_cache_obj.Uuid,
-					VSName:             vs_cache_obj.Name,
-					Tenant:             vs_cache_obj.Tenant,
+					VirtualServiceUUID: vsCacheObj.Uuid,
+					VSName:             vsCacheObj.Name,
+					Tenant:             vsCacheObj.Tenant,
 				}
 				statusOption := status.StatusOptions{
 					ObjType: utils.L4LBService,
@@ -863,8 +822,8 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					Key:     key,
 					Options: &updateOptions,
 				}
-				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", vs_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
-				status.PublishToStatusQueue(vs_cache_obj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
+				utils.AviLog.Infof("key: %s Publishing to status queue, options: %v", vsCacheObj.ServiceMetadataObj.NamespaceServiceName[0], utils.Stringify(statusOption))
+				status.PublishToStatusQueue(vsCacheObj.ServiceMetadataObj.NamespaceServiceName[0], statusOption)
 			case lib.ChildVS:
 				if !hostFoundInParentPool {
 					// TODO: revisit
@@ -884,17 +843,17 @@ func (rest *RestOperations) AviVsCacheDel(rest_op *utils.RestOp, vsKey avicache.
 					// }
 					// status.PublishToStatusQueue(updateOptions.ServiceMetadata.IngressName, statusOption)
 
-					for _, poolKey := range vs_cache_obj.PoolKeyCollection {
-						rest.DeletePoolIngressStatus(poolKey, true, vs_cache_obj.Name, key)
+					for _, poolKey := range vsCacheObj.PoolKeyCollection {
+						rest.DeletePoolIngressStatus(poolKey, true, vsCacheObj.Name, key)
 					}
 				}
 
-				status.HostRuleEventBroadcast(vs_cache_obj.Name, vs_cache_obj.ServiceMetadataObj.CRDStatus, lib.CRDMetadata{})
-				status.SSORuleEventBroadcast(vs_cache_obj.Name, vs_cache_obj.ServiceMetadataObj.CRDStatus, lib.CRDMetadata{})
+				status.HostRuleEventBroadcast(vsCacheObj.Name, vsCacheObj.ServiceMetadataObj.CRDStatus, lib.CRDMetadata{})
+				status.SSORuleEventBroadcast(vsCacheObj.Name, vsCacheObj.ServiceMetadataObj.CRDStatus, lib.CRDMetadata{})
 			default:
 				// insecure ingress status updates in regular AKO.
-				for _, poolKey := range vs_cache_obj.PoolKeyCollection {
-					rest.DeletePoolIngressStatus(poolKey, true, vs_cache_obj.Name, key)
+				for _, poolKey := range vsCacheObj.PoolKeyCollection {
+					rest.DeletePoolIngressStatus(poolKey, true, vsCacheObj.Name, key)
 				}
 			}
 		}

--- a/internal/rest/avi_pool_group.go
+++ b/internal/rest/avi_pool_group.go
@@ -167,7 +167,7 @@ func (rest *RestOperations) AviPGCacheAdd(rest_op *utils.RestOp, vsKey avicache.
 			if poolsOk {
 				for _, poolIntf := range pools {
 					poolmap, _ := poolIntf.(map[string]interface{})
-					poolUuid := avicache.ExtractUuid(poolmap["pool_ref"].(string), "pool-.*.#")
+					poolUuid := avicache.ExtractUUID(poolmap["pool_ref"].(string), "pool-.*.#")
 					// Search the poolName using this Uuid in the poolcache.
 					poolName, found := rest.cache.PoolCache.AviCacheGetNameByUuid(poolUuid)
 					if found {


### PR DESCRIPTION
AV-218385 ChildVS Deletion should not update Gateway listener status

This pr will make sure that creation/updation/deletion of childVS should not update gateway listener status

Testing status:
Manually tested creation/updation/deletion of HTTPRoute leading to the deletion of childVS and not updating anything in gateway status.

TODO:
Attach UT run results
Attach FT run results