### PR TITLE
AV-206829 move gateway/route status updates to status layer

### DIFF
--- a/ako-gateway-api/k8s/gateway_controller.go
+++ b/ako-gateway-api/k8s/gateway_controller.go
@@ -30,6 +30,7 @@ import (
 	gatewayexternalversions "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapiobjects "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
@@ -530,6 +531,7 @@ func (c *GatewayController) SetupGatewayApiEventHandlers(numWorkers uint32) {
 			namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 			bkt := utils.Bkt(namespace, numWorkers)
 			c.workqueue[bkt].AddRateLimited(key)
+			akogatewayapiobjects.GatewayApiLister().DeleteGatewayToGatewayStatusMapping(utils.ObjKey(gw))
 			utils.AviLog.Debugf("key: %s, msg: DELETE", key)
 		},
 		UpdateFunc: func(old, obj interface{}) {

--- a/ako-gateway-api/status/gatewayclass_status.go
+++ b/ako-gateway-api/status/gatewayclass_status.go
@@ -72,7 +72,7 @@ func (o *gatewayClass) BulkUpdate(key string, options []status.StatusOptions) {
 	// TODO: Add this code when we publish the status from the rest layer
 }
 
-func (o *gatewayClass) Patch(key string, obj runtime.Object, status *Status, retryNum ...int) {
+func (o *gatewayClass) Patch(key string, obj runtime.Object, status *status.Status, retryNum ...int) {
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]

--- a/ako-gateway-api/status/httproute_status.go
+++ b/ako-gateway-api/status/httproute_status.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -65,14 +66,24 @@ func (o *httproute) Delete(key string, option status.StatusOptions) {
 }
 
 func (o *httproute) Update(key string, option status.StatusOptions) {
-	// TODO: Add this code when we publish the status from the rest layer
+	nsName := strings.Split(option.Options.ServiceMetadata.HTTPRoute, "/")
+	if len(nsName) != 2 {
+		utils.AviLog.Warnf("key: %s, msg: invalid HttpRoute name and namespace", key)
+		return
+	}
+	namespace := nsName[0]
+	name := nsName[1]
+	httpRoute := o.Get(key, name, namespace)
+	if httpRoute != nil {
+		o.Patch(key, httpRoute, option.Options.Status)
+	}
 }
 
 func (o *httproute) BulkUpdate(key string, options []status.StatusOptions) {
 	// TODO: Add this code when we publish the status from the rest layer
 }
 
-func (o *httproute) Patch(key string, obj runtime.Object, status *Status, retryNum ...int) {
+func (o *httproute) Patch(key string, obj runtime.Object, status *status.Status, retryNum ...int) {
 	retry := 0
 	if len(retryNum) > 0 {
 		retry = retryNum[0]

--- a/ako-gateway-api/status/status.go
+++ b/ako-gateway-api/status/status.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	akogatewayapiobjects "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
@@ -26,14 +27,8 @@ import (
 type StatusUpdater interface {
 	Update(key string, option status.StatusOptions)
 	BulkUpdate(key string, options []status.StatusOptions)
-	Patch(key string, obj runtime.Object, status *Status, retryNum ...int)
+	Patch(key string, obj runtime.Object, status *status.Status, retryNum ...int)
 	Delete(key string, option status.StatusOptions)
-}
-
-type Status struct {
-	*gatewayv1.GatewayClassStatus
-	*gatewayv1.GatewayStatus
-	*gatewayv1.HTTPRouteStatus
 }
 
 func New(ObjectType string) StatusUpdater {
@@ -60,7 +55,7 @@ func DequeueStatus(objIntf interface{}) error {
 		utils.AviLog.Debugf("key: %s, msg: unknown object received", option.Key)
 		return nil
 	}
-	if option.Options.ServiceMetadata.HTTPRoute != "" {
+	if option.Options.ServiceMetadata.HTTPRoute != "" && option.Options.Status == nil {
 		utils.AviLog.Debugf("key: %s, msg: Status update for ChildVs received", option.Options.ServiceMetadata.HTTPRoute)
 		return nil
 	}
@@ -80,19 +75,36 @@ func BulkUpdate(key string, objectType string, options []status.StatusOptions) e
 	return nil
 }
 
-func Record(key string, obj runtime.Object, status *Status) {
+func Record(key string, obj runtime.Object, objStatus *status.Status) {
 	var objectType string
-	switch obj.(type) {
+	var statusOption status.StatusOptions
+	var updateOption status.UpdateOptions
+	var serviceMetadata lib.ServiceMetadataObj
+
+	switch gwObject := obj.(type) {
 	case *gatewayv1.GatewayClass:
 		objectType = lib.GatewayClass
+		o := New(objectType)
+		o.Patch(key, obj, objStatus)
+		return
 	case *gatewayv1.Gateway:
 		objectType = lib.Gateway
+		serviceMetadata.Gateway = gwObject.Namespace + "/" + gwObject.Name
+		key = serviceMetadata.Gateway
+		akogatewayapiobjects.GatewayApiLister().UpdateGatewayToGatewayStatusMapping(serviceMetadata.Gateway, objStatus.GatewayStatus)
 	case *gatewayv1.HTTPRoute:
 		objectType = lib.HTTPRoute
+		serviceMetadata.HTTPRoute = gwObject.Namespace + "/" + gwObject.Name
+		key = serviceMetadata.HTTPRoute
 	default:
 		utils.AviLog.Warnf("key %s, msg: Unsupported object received at the status layer, %T", key, obj)
 		return
 	}
-	o := New(objectType)
-	o.Patch(key, obj, status)
+	updateOption.Status = objStatus
+	updateOption.ServiceMetadata = serviceMetadata
+	statusOption.Options = &updateOption
+	statusOption.Op = lib.UpdateStatus
+	statusOption.ObjType = objectType
+	statusOption.Key = key
+	status.PublishToStatusQueue(key, statusOption)
 }

--- a/internal/status/ing_status.go
+++ b/internal/status/ing_status.go
@@ -33,8 +33,14 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+type Status struct {
+	*gatewayv1.GatewayClassStatus
+	*gatewayv1.GatewayStatus
+	*gatewayv1.HTTPRouteStatus
+}
 type UpdateOptions struct {
 	// IngSvc format: namespace/name, not supposed to be provided by the caller
 	IngSvc             string
@@ -45,6 +51,7 @@ type UpdateOptions struct {
 	VSName             string
 	Message            string
 	Tenant             string
+	Status             *Status
 }
 
 // VSUuidAnnotation is maps a hostname to the UUID of the virtual service where it is placed.


### PR DESCRIPTION
```
**********************************************************************************************************************************
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : test/avitest/functional/ako/ako-gw-              |                |                     |             |             |
| api/test_http_route.py                                                           |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| TestHttpRoute.test_setup_configuration                                           |     PASSED     |       00:01:14      |   06:05:38  |   06:06:52  |
| TestHttpRoute.test_insecure_httproute                                            |     PASSED     |       00:01:43      |   06:06:52  |   06:08:36  |
| TestHttpRoute.test_secure_httproute                                              |     PASSED     |       00:01:43      |   06:08:36  |   06:10:19  |
| TestHttpRoute.test_httproute_match_crud                                          |     PASSED     |       00:02:29      |   06:10:19  |   06:12:49  |
| TestHttpRoute.test_httproute_match_append_header_crud                            |     PASSED     |       00:02:29      |   06:12:49  |   06:15:19  |
| TestHttpRoute.test_httproute_match_replace_header_crud                           |     PASSED     |       00:02:30      |   06:15:19  |   06:17:49  |
| TestHttpRoute.test_httproute_filter_crud                                         |    SKIPPED     |       00:00:41      |   06:17:49  |   06:18:30  |
| TestHttpRoute.test_httproute_backendref_crud                                     |     PASSED     |       00:02:13      |   06:18:30  |   06:20:44  |
| TestHttpRoute.test_httproute_multiple_rules                                      |     PASSED     |       00:02:14      |   06:20:44  |   06:22:59  |
| TestHttpRoute.test_http_route_with_multiple_gateways                             |     PASSED     |       00:02:44      |   06:22:59  |   06:25:44  |
| TestHttpRoute.test_multiple_http_routes_with_gateway                             |     PASSED     |       00:03:15      |   06:25:44  |   06:29:00  |
| TestHttpRoute.test_http_route_same_path_different_headers                        |     PASSED     |       00:02:15      |   06:29:00  |   06:31:15  |
| TestHttpRoute.test_httproute_multiple_hosts                                      |     PASSED     |       00:02:45      |   06:31:15  |   06:34:00  |
| TestHttpRoute.test_traffic_split                                                 |     PASSED     |       00:04:23      |   06:34:00  |   06:38:24  |
| TestHttpRoute.test_delete_configurations                                         |     PASSED     |       00:02:01      |   06:38:24  |   06:40:25  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |   Passed: 14   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 15                                                            |    Skipped:1   | Total Time:00:34:47 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+

*********************************************************************************************************************************
*                                          AviTest Test Cases Execution Summary Report                                           *
**********************************************************************************************************************************
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : test/avitest/functional/ako/ako-gw-              |                |                     |             |             |
| api/test_gateway.py                                                              |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| TestGateway.test_setup_configuration                                             |     PASSED     |       00:00:43      |   09:22:36  |   09:23:19  |
| TestGateway.test_gateway_crud                                                    |     PASSED     |       00:02:11      |   09:23:19  |   09:25:31  |
| TestGateway.test_update_gateway_without_gateway_class                            |     PASSED     |       00:02:12      |   09:25:31  |   09:27:44  |
| TestGateway.test_gateway_with_different_hosts                                    |     PASSED     |       00:01:26      |   09:27:44  |   09:29:10  |
| TestGateway.test_parent_vs_from_secure_gateway                                   |     PASSED     |       00:01:26      |   09:29:10  |   09:30:37  |
| TestGateway.test_parent_vs_from_insecure_gateway                                 |     PASSED     |       00:01:56      |   09:30:37  |   09:32:33  |
| TestGateway.test_gateway_with_static_ip_address                                  |     PASSED     |       00:01:27      |   09:32:33  |   09:34:00  |
| TestGateway.test_gateway_with_invalid_secret_ref                                 |     PASSED     |       00:02:27      |   09:34:00  |   09:36:27  |
| TestGateway.test_delete_configurations                                           |     PASSED     |       00:00:50      |   09:36:27  |   09:37:18  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:14:42 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```