### PR TITLE
AV-219313: Fix ako with non admin tenant fails to add static routes to global vrfcontext of the admin cloud

### DIFF
--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -202,6 +202,7 @@ const (
 	FullSyncInterval                           = 300
 	Namespace                                  = "Namespace"
 	VrfContextNotFoundError                    = "VrfContext not found"
+	VrfContextNoPermission                     = "Cannot modify VrfContext"
 	HTTPMethodGet                              = "GET"
 	HTTPMethodPut                              = "PUT"
 	VrfContextObjectNotFoundError              = "VrfContext object not found"

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -83,7 +83,7 @@ func (rest *RestOperations) AviVrfBuild(key string, vrfNode *nodes.AviVrfNode, u
 	vrf.StaticRoutes = append(vrf.StaticRoutes, mergedStaticRoutes...)
 
 	opTenant := lib.GetAdminTenant()
-	if lib.GetCloudType() == lib.CLOUD_OPENSTACK {
+	if lib.GetCloudType() == lib.CLOUD_OPENSTACK || lib.GetTenant() != "" {
 		//In case of Openstack cloud, use tenant vrf
 		opTenant = lib.GetTenant()
 	}


### PR DESCRIPTION
VRF can be tenant specific or in admin tenant. So this PR takes care of handling both the scenarios.