### PR TITLE
AV-206824 Update port in vhmatch of child vs

### DIFF
--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -327,13 +327,13 @@ func HTTPRouteToGateway(namespace, name, key string) ([]string, bool) {
 		uniqueHosts := sets.NewString(hostnameIntersection...)
 		gwRouteNsName := fmt.Sprintf("%s/%s", gwNsName, routeTypeNsName)
 		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteToHostname(gwRouteNsName, uniqueHosts.List())
-		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteMappings(gwNsName, listenerList, routeTypeNsName)
+		akogatewayapiobjects.GatewayApiLister().UpdateGatewayRouteMappings(gwNsName, routeTypeNsName)
 		if !utils.HasElem(gwNsNameList, gwNsName) {
 			gwNsNameList = append(gwNsNameList, gwNsName)
 		}
 		parentNameToHostnameMap[string(parentRef.Name)] = hostnameIntersection
 	}
-
+	akogatewayapiobjects.GatewayApiLister().UpdateRouteToGatewayListenerMappings(listenerList, routeTypeNsName)
 	utils.AviLog.Debugf("key: %s, msg: Gateways retrieved %s", key, gwNsNameList)
 	return gwNsNameList, true
 }

--- a/ako-gateway-api/objects/gateway_store.go
+++ b/ako-gateway-api/objects/gateway_store.go
@@ -291,7 +291,7 @@ func (g *GWLister) GetGatewayToRoute(gwNsName string) (bool, []string) {
 	return false, []string{}
 }
 
-func (g *GWLister) UpdateGatewayRouteMappings(gwNsName string, gwListeners []GatewayListenerStore, routeTypeNsName string) {
+func (g *GWLister) UpdateGatewayRouteMappings(gwNsName string, routeTypeNsName string) {
 	g.gwLock.Lock()
 	defer g.gwLock.Unlock()
 
@@ -306,18 +306,6 @@ func (g *GWLister) UpdateGatewayRouteMappings(gwNsName string, gwListeners []Gat
 		g.routeToGateway.AddOrUpdate(routeTypeNsName, []string{gwNsName})
 	}
 
-	if found, gwListenerList := g.routeToGatewayListener.Get(routeTypeNsName); found {
-		gwListenerListObj := gwListenerList.([]GatewayListenerStore)
-		for _, gwListener := range gwListeners {
-			if !utils.HasElem(gwListenerList, gwListener) {
-				gwListenerListObj = append(gwListenerListObj, gwListener)
-			}
-		}
-		g.routeToGatewayListener.AddOrUpdate(routeTypeNsName, gwListenerListObj)
-	} else {
-		g.routeToGatewayListener.AddOrUpdate(routeTypeNsName, gwListeners)
-	}
-
 	// update gateway to route mapping
 	if found, routeTypeNsNameList := g.gatewayToRoute.Get(gwNsName); found {
 		routeTypeNsNameListObj := routeTypeNsNameList.([]string)
@@ -328,6 +316,12 @@ func (g *GWLister) UpdateGatewayRouteMappings(gwNsName string, gwListeners []Gat
 	} else {
 		g.gatewayToRoute.AddOrUpdate(gwNsName, []string{routeTypeNsName})
 	}
+}
+
+func (g *GWLister) UpdateRouteToGatewayListenerMappings(gwListeners []GatewayListenerStore, routeTypeNsName string) {
+	g.gwLock.Lock()
+	defer g.gwLock.Unlock()
+	g.routeToGatewayListener.AddOrUpdate(routeTypeNsName, gwListeners)
 }
 
 //=====All gateway <-> service mappings go here.

--- a/ako-gateway-api/status/gateway_status.go
+++ b/ako-gateway-api/status/gateway_status.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,6 +30,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
@@ -225,6 +227,7 @@ func (o *gateway) Patch(key string, obj runtime.Object, status *status.Status, r
 		retry = retryNum[0]
 		if retry >= 5 {
 			utils.AviLog.Errorf("key: %s, msg: Patch retried 5 times, aborting", key)
+			akogatewayapilib.AKOControlConfig().EventRecorder().Eventf(obj, corev1.EventTypeWarning, lib.PatchFailed, "Patch of status failed after multiple retries")
 			return errors.New("Patch retried 5 times, aborting")
 		}
 	}

--- a/ako-gateway-api/status/httproute_status.go
+++ b/ako-gateway-api/status/httproute_status.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,6 +29,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 )
@@ -90,6 +92,7 @@ func (o *httproute) Patch(key string, obj runtime.Object, status *status.Status,
 		retry = retryNum[0]
 		if retry >= 5 {
 			utils.AviLog.Errorf("key: %s, msg: Patch retried 5 times, aborting", key)
+			akogatewayapilib.AKOControlConfig().EventRecorder().Eventf(obj, corev1.EventTypeWarning, lib.PatchFailed, "Patch of status failed after multiple retries")
 			return errors.New("Patch retried 5 times, aborting")
 		}
 	}


### PR DESCRIPTION
```
 make gatewayapitests 
sudo docker run \
-e ENDPOINTSLICES_ENABLED="false" \
-w=/go/src/github.com/vmware/load-balancer-and-ingress-services-for-kubernetes \
-v /home/aviuser/myfork/load-balancer-and-ingress-services-for-kubernetes:/go/src/github.com/vmware/load-balancer-and-ingress-services-for-kubernetes golang:bullseye \
go test -mod=vendor github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/... -failfast -timeout 0 -coverprofile cover-20.out -coverpkg=./...
        github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests               coverage: 0.0% of statements
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer    472.123s        coverage: 18.4% of statements in ./...
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/ingestion     220.594s        coverage: 2.8% of statements in ./...
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/npltests      60.369s coverage: 15.8% of statements in ./...
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/status        300.894s        coverage: 12.7% of statements in ./...

```
