### PR TITLE
AV-220244: Check for Namespace annotation and VS lb svc for determining the correct cloud

### DIFF
--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/vmware/alb-sdk/go/models"
-	avimodels "github.com/vmware/alb-sdk/go/models"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,54 +97,43 @@ func (a *AviControllerInfra) checkNSAnnotations() (error, string) {
 		utils.AviLog.Errorf("Failed to GET the %s namespace details due to the following error :%v", nsName, err.Error())
 		return err, cloudName
 	}
-	if nsObj.Annotations != nil {
-		cloudName = nsObj.Annotations["ako.vmware.com/wcp-cloud-name"]
-		if cloudName != "" {
-			utils.AviLog.Infof("Found cloud %s in ns annotation", cloudName)
-		}
+	cloudName = nsObj.Annotations[lib.WCPCloud]
+	if cloudName != "" {
+		utils.AviLog.Infof("Found cloud %s in ns annotation", cloudName)
 	}
 	return nil, cloudName
 }
 
 func (a *AviControllerInfra) checkVirtualService() (error, string) {
 	cloudName := ""
-	tenants := make(map[string]struct{})
-	err := lib.GetAllTenants(a.AviRestClient, tenants)
-	if err != nil {
-		utils.AviLog.Errorf("Error during GET tenants %v", err)
-		return err, cloudName
-	}
-	createdBy := lib.AKOPrefix + lib.GetClusterName()
 	vsName := lib.GetClusterName() + "--kube-system-kube-apiserver-lb-svc"
 	SetAdminTenant := session.SetTenant(lib.GetAdminTenant())
 	defer SetAdminTenant(a.AviRestClient.AviSession)
-	for tenantName := range tenants {
-		SetTenant := session.SetTenant(tenantName)
-		SetTenant(a.AviRestClient.AviSession)
-		uri := "/api/virtualservice/?include_name&created_by=" + createdBy + "&name=" + vsName
-		result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
+	SetTenant := session.SetTenant("*")
+	SetTenant(a.AviRestClient.AviSession)
+	uri := "/api/virtualservice/?include_name&created_by=" + lib.GetAKOUser() + "&name=" + vsName
+	result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
+	if err != nil {
+		utils.AviLog.Warnf("Get uri %v returned err %v", uri, err)
+		return err, cloudName
+	}
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
+		return err, cloudName
+	}
+	for i := 0; i < len(elems); i++ {
+		vs := models.VirtualService{}
+		err = json.Unmarshal(elems[i], &vs)
 		if err != nil {
-			utils.AviLog.Warnf("Get uri %v returned err %v", uri, err)
+			utils.AviLog.Warnf("Failed to unmarshal vs data, err: %v", err)
 			continue
 		}
-		elems := make([]json.RawMessage, result.Count)
-		err = json.Unmarshal(result.Results, &elems)
-		if err != nil {
-			utils.AviLog.Warnf("Failed to unmarshal data, err: %v", err)
-			continue
-		}
-		for i := 0; i < len(elems); i++ {
-			vs := models.VirtualService{}
-			err = json.Unmarshal(elems[i], &vs)
-			if err != nil {
-				utils.AviLog.Warnf("Failed to unmarshal vs data, err: %v", err)
-				continue
-			}
-			if vs.CloudRef != nil && strings.Contains(*vs.CloudRef, "#") {
-				cloudName = strings.Split(*vs.CloudRef, "#")[1]
-				utils.AviLog.Infof("Found cloud %s associated with vs %s", cloudName, vsName)
-				return nil, cloudName
-			}
+		if vs.CloudRef != nil && strings.Contains(*vs.CloudRef, "#") {
+			cloudName = strings.Split(*vs.CloudRef, "#")[1]
+			utils.AviLog.Infof("Found cloud %s associated with vs %s", cloudName, vsName)
+			return nil, cloudName
 		}
 	}
 	return nil, cloudName
@@ -154,9 +142,15 @@ func (a *AviControllerInfra) checkVirtualService() (error, string) {
 func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, string, string) {
 	uri := "/api/cloud/"
 
-	_, cloudName := a.checkNSAnnotations()
+	err, cloudName := a.checkNSAnnotations()
+	if err != nil {
+		utils.AviLog.Errorf("Failed to find cloud from NSAnnotation check :%v", err.Error())
+	}
 	if cloudName == "" {
-		_, cloudName = a.checkVirtualService()
+		err, cloudName = a.checkVirtualService()
+		if err != nil {
+			utils.AviLog.Errorf("Failed to find cloud from VS check :%v", err.Error())
+		}
 	}
 	if cloudName != "" {
 		uri = "/api/cloud/?include_name&name=" + cloudName
@@ -173,9 +167,8 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
 		return err, cloudName, ""
 	}
-	matchCloud := new(models.Cloud)
 	for i := 0; i < len(elems); i++ {
-		cloud := new(models.Cloud)
+		cloud := models.Cloud{}
 		err = json.Unmarshal(elems[i], &cloud)
 		if err != nil {
 			utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
@@ -198,48 +191,47 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 			continue
 		}
 		utils.AviLog.Infof("Found NSX-T cloud: %s match Transport Zone: %s", *cloud.Name, tz)
-		matchCloud = cloud
-		break
+		return a.checkSEGroup(cloud)
 	}
-	if matchCloud == nil {
-		return errors.New("cloud not found matching transport zone " + tz), "", ""
-	}
-	if matchCloud.SeGroupTemplateRef != nil && *matchCloud.SeGroupTemplateRef != "" {
-		tokenized := strings.Split(*matchCloud.SeGroupTemplateRef, "/api/serviceenginegroup/")
+	return errors.New("cloud not found matching transport zone " + tz), "", ""
+}
+
+func (a *AviControllerInfra) checkSEGroup(cloud models.Cloud) (error, string, string) {
+	if cloud.SeGroupTemplateRef != nil && *cloud.SeGroupTemplateRef != "" {
+		tokenized := strings.Split(*cloud.SeGroupTemplateRef, "/api/serviceenginegroup/")
 		if len(tokenized) == 2 {
-			return nil, *matchCloud.Name, tokenized[1]
+			return nil, *cloud.Name, tokenized[1]
 		}
 	}
-
 	// fetch Default-SEGroup uuid
-	uri = "/api/serviceenginegroup/?include_name&cloud_ref.name=" + *matchCloud.Name + "&name=Default-Group"
+	uri := "/api/serviceenginegroup/?include_name&cloud_ref.name=" + *cloud.Name + "&name=Default-Group"
 	results, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
 	if err != nil {
 		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
-		return err, *matchCloud.Name, ""
+		return err, *cloud.Name, ""
 	}
 
-	elem := make([]json.RawMessage, results.Count)
-	err = json.Unmarshal(results.Results, &elem)
+	elems := make([]json.RawMessage, results.Count)
+	err = json.Unmarshal(results.Results, &elems)
 	if err != nil {
 		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
-		return err, *matchCloud.Name, ""
+		return err, *cloud.Name, ""
 	}
-	if len(elem) == 0 {
+	if len(elems) == 0 {
 		utils.AviLog.Errorf("No ServiceEngine Group with name Default-Group found.")
-		return errors.New("No ServiceEngine Group with name Default-Group found."), *matchCloud.Name, ""
+		return errors.New("No ServiceEngine Group with name Default-Group found."), *cloud.Name, ""
 	}
 
 	defaultSEG := models.ServiceEngineGroup{}
 	err = json.Unmarshal(elems[0], &defaultSEG)
 	if err != nil {
 		utils.AviLog.Errorf("Failed to unmarshal cloud data, err: %v", err)
-		return err, *matchCloud.Name, ""
+		return err, *cloud.Name, ""
 	}
-	return nil, *matchCloud.Name, *defaultSEG.UUID
+	return nil, *cloud.Name, *defaultSEG.UUID
 }
 
-func isPlacementScopeConfigured(configuredSEGroup *avimodels.ServiceEngineGroup) bool {
+func isPlacementScopeConfigured(configuredSEGroup *models.ServiceEngineGroup) bool {
 	configured := false
 	for _, vc := range configuredSEGroup.Vcenters {
 		if vc.NsxtClusters == nil {
@@ -345,11 +337,8 @@ func fetchSEGroup(client *clients.AviClient, overrideUri ...lib.NextPage) (error
 }
 
 func fetchVcenterServer(client *clients.AviClient) (string, error) {
-	uri := "/api/vcenterserver"
-	if utils.CloudName != "" {
-		utils.AviLog.Infof("Get vcenterserver for cloud %s", utils.CloudName)
-		uri = "/api/vcenterserver?include_name=true&cloud_ref.name=" + utils.CloudName
-	}
+	utils.AviLog.Infof("Get vcenterserver for cloud %s", utils.CloudName)
+	uri := "/api/vcenterserver?include_name=true&cloud_ref.name=" + utils.CloudName
 	result, err := lib.AviGetCollectionRaw(client, uri)
 	if err != nil {
 		return "", err
@@ -362,7 +351,7 @@ func fetchVcenterServer(client *clients.AviClient) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	vc := avimodels.VCenterServer{}
+	vc := models.VCenterServer{}
 	err = json.Unmarshal(elems[0], &vc)
 	if err != nil {
 		return "", err
@@ -411,10 +400,10 @@ func updateSEGroup() {
 	}
 	vcRef := fmt.Sprintf("/api/vcenterserver/?name=%s", vcenterServerName)
 	if len(seGroup.Vcenters) == 0 {
-		seGroup.Vcenters = []*avimodels.PlacementScopeConfig{
+		seGroup.Vcenters = []*models.PlacementScopeConfig{
 			{
 				VcenterRef: &vcRef,
-				NsxtClusters: &avimodels.NsxtClusters{
+				NsxtClusters: &models.NsxtClusters{
 					ClusterIds: clusterIDs,
 					Include:    &include,
 				},
@@ -422,7 +411,7 @@ func updateSEGroup() {
 		}
 	} else {
 		seGroup.Vcenters[0].VcenterRef = &vcRef
-		seGroup.Vcenters[0].NsxtClusters = &avimodels.NsxtClusters{
+		seGroup.Vcenters[0].NsxtClusters = &models.NsxtClusters{
 			ClusterIds: clusterIDs,
 			Include:    &include,
 		}
@@ -442,7 +431,7 @@ func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGr
 	var err error
 	// Change the name of the SE group, and add markers
 	*seGroup.Name = lib.GetClusterID()
-	markers := []*avimodels.RoleFilterMatchLabel{{
+	markers := []*models.RoleFilterMatchLabel{{
 		Key:    proto.String(lib.ClusterNameLabelKey),
 		Values: []string{lib.GetClusterID()},
 	}}
@@ -456,9 +445,9 @@ func ConfigureSeGroup(client *clients.AviClient, seGroup *models.ServiceEngineGr
 		}
 		vcRef := fmt.Sprintf("/api/vcenterserver/?name=%s", vcenterServerName)
 		seGroup.Vcenters = append(seGroup.Vcenters,
-			&avimodels.PlacementScopeConfig{
+			&models.PlacementScopeConfig{
 				VcenterRef: &vcRef,
-				NsxtClusters: &avimodels.NsxtClusters{
+				NsxtClusters: &models.NsxtClusters{
 					ClusterIds: []string{lib.GetClusterName()},
 					Include:    &include,
 				},

--- a/ako-infra/ingestion/avi_infra_controller.go
+++ b/ako-infra/ingestion/avi_infra_controller.go
@@ -90,9 +90,47 @@ func (a *AviControllerInfra) VerifyAviControllerLicense() error {
 	return fmt.Errorf("Avi Controller license is not in accepted list %s. License tier is: %s", acceptedLicensesInAvi, *response.DefaultLicenseTier)
 }
 
+func (a *AviControllerInfra) checkVirtualService() (error, string) {
+	createdBy := "ako-" + lib.GetClusterID()
+	uri := "/api/virtualservice/?include_name&created_by=" + createdBy
+	result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
+	if err != nil {
+		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+		return err, ""
+	}
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
+		return err, ""
+	}
+	expName := lib.GetClusterID() + "--kube-system-kube-apiserver-lb-svc"
+	for i := 0; i < len(elems); i++ {
+		vs := models.VirtualService{}
+		err = json.Unmarshal(elems[i], &vs)
+		if err != nil {
+			utils.AviLog.Warnf("Failed to unmarshal vs data, err: %v", err)
+			continue
+		}
+		if vs.CloudRef != nil && strings.Contains(*vs.CloudRef, "#") {
+			cloudName := strings.Split(*vs.CloudRef, "#")[1]
+			if *vs.Name == expName {
+				utils.AviLog.Infof("Found vs %s associated with cloud %s", expName, cloudName)
+				return nil, cloudName
+			}
+		}
+	}
+	return nil, ""
+}
+
 func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, string, string) {
 	// This method queries the Avi controller for all available cloud and then returns the cloud that matches the supplied transport zone
 	uri := "/api/cloud/"
+	_, cloudName := a.checkVirtualService()
+	if cloudName != "" {
+		uri = "/api/cloud/?include_name&name=" + cloudName
+	}
+
 	result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
 	if err != nil {
 		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
@@ -105,8 +143,9 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
 		return err, "", ""
 	}
+	matchCloud := new(models.Cloud)
 	for i := 0; i < len(elems); i++ {
-		cloud := models.Cloud{}
+		cloud := new(models.Cloud)
 		err = json.Unmarshal(elems[i], &cloud)
 		if err != nil {
 			utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
@@ -129,42 +168,45 @@ func (a *AviControllerInfra) DeriveCloudNameAndSEGroupTmpl(tz string) (error, st
 			continue
 		}
 		utils.AviLog.Infof("Found NSX-T cloud: %s match Transport Zone: %s", *cloud.Name, tz)
-		if cloud.SeGroupTemplateRef != nil && *cloud.SeGroupTemplateRef != "" {
-			tokenized := strings.Split(*cloud.SeGroupTemplateRef, "/api/serviceenginegroup/")
-			if len(tokenized) == 2 {
-				return nil, *cloud.Name, tokenized[1]
-			}
-		}
-
-		// fetch Default-SEGroup uuid
-		uri = "/api/serviceenginegroup/?include_name&cloud_ref.name=" + *cloud.Name + "&name=Default-Group"
-		result, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
-		if err != nil {
-			utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
-			return err, *cloud.Name, ""
-		}
-
-		elems := make([]json.RawMessage, result.Count)
-		err = json.Unmarshal(result.Results, &elems)
-		if err != nil {
-			utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
-			return err, *cloud.Name, ""
-		}
-
-		if len(elems) == 0 {
-			utils.AviLog.Errorf("No ServiceEngine Group with name Default-Group found.")
-			return errors.New("No ServiceEngine Group with name Default-Group found."), *cloud.Name, ""
-		}
-
-		defaultSEG := models.ServiceEngineGroup{}
-		err = json.Unmarshal(elems[0], &defaultSEG)
-		if err != nil {
-			utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
-			return err, *cloud.Name, ""
-		}
-		return nil, *cloud.Name, *defaultSEG.UUID
+		matchCloud = cloud
+		break
 	}
-	return errors.New("cloud not found matching transport zone " + tz), "", ""
+	if matchCloud == nil {
+		return errors.New("cloud not found matching transport zone " + tz), "", ""
+	}
+	if matchCloud.SeGroupTemplateRef != nil && *matchCloud.SeGroupTemplateRef != "" {
+		tokenized := strings.Split(*matchCloud.SeGroupTemplateRef, "/api/serviceenginegroup/")
+		if len(tokenized) == 2 {
+			return nil, *matchCloud.Name, tokenized[1]
+		}
+	}
+
+	// fetch Default-SEGroup uuid
+	uri = "/api/serviceenginegroup/?include_name&cloud_ref.name=" + *matchCloud.Name + "&name=Default-Group"
+	results, err := lib.AviGetCollectionRaw(a.AviRestClient, uri)
+	if err != nil {
+		utils.AviLog.Errorf("Get uri %v returned err %v", uri, err)
+		return err, *matchCloud.Name, ""
+	}
+
+	elem := make([]json.RawMessage, results.Count)
+	err = json.Unmarshal(results.Results, &elem)
+	if err != nil {
+		utils.AviLog.Errorf("Failed to unmarshal data, err: %v", err)
+		return err, *matchCloud.Name, ""
+	}
+	if len(elem) == 0 {
+		utils.AviLog.Errorf("No ServiceEngine Group with name Default-Group found.")
+		return errors.New("No ServiceEngine Group with name Default-Group found."), *matchCloud.Name, ""
+	}
+
+	defaultSEG := models.ServiceEngineGroup{}
+	err = json.Unmarshal(elems[0], &defaultSEG)
+	if err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal cloud data, err: %v", err)
+		return err, *matchCloud.Name, ""
+	}
+	return nil, *matchCloud.Name, *defaultSEG.UUID
 }
 
 func isPlacementScopeConfigured(configuredSEGroup *avimodels.ServiceEngineGroup) bool {

--- a/cmd/infra-main/main.go
+++ b/cmd/infra-main/main.go
@@ -112,6 +112,7 @@ func InitializeAKOInfra() {
 
 	transportZone := c.HandleVCF(stopCh, ctrlCh)
 	lib.VCFInitialized = true
+	lib.SetAKOUser(lib.AKOPrefix)
 
 	// Checking/Setting up Avi pre-reqs
 	a := ingestion.NewAviControllerInfra(kubeClient)

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -810,7 +810,7 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 			if vip.Ip6Address != nil {
 				v6ips = append(v6ips, *vip.Ip6Address.Addr)
 			}
-			if ipamNetworkSubnet := vip.IPAMNetworkSubnet; ipamNetworkSubnet != nil {
+			if ipamNetworkSubnet := vip.IPAMNetworkSubnet; ipamNetworkSubnet != nil && ipamNetworkSubnet.NetworkRef != nil {
 				if networkRef := *ipamNetworkSubnet.NetworkRef; networkRef != "" {
 					if networkRefName := strings.Split(networkRef, "#"); len(networkRefName) == 2 {
 						networkNames = append(networkNames, networkRefName[1])


### PR DESCRIPTION
Tests Done -
1)Restarted AKO in SV cluster for already working setup, cloud gets picked using old value set in namespace annotation.
2)Removed cloud from namespace annotation and restart AKO, cloud associated with VS "'cluster name'--kube-system-kube-apiserver-lb-svc" gets picked.
3)Failed/Bypassed the above 2 check by introducing some code and cloud gets picked through old method.