### PR TITLE
Av 221779 Fix secret and gateway re-ordering

### DIFF
--- a/ako-gateway-api/k8s/validator.go
+++ b/ako-gateway-api/k8s/validator.go
@@ -356,7 +356,7 @@ func ValidateGatewayListenerWithSecret(namespace, name string, deleteFlag bool) 
 						}
 						// add condition for checking gateway status
 						if gwStatus != nil && string(certRef.Name) == name && certNamespace == namespace {
-							setConditions(gwStatus, listenerIndex, gatewayObj.ObjectMeta.Generation, deleteFlag)
+							setListenerConditions(gwStatus, listenerIndex, gatewayObj.ObjectMeta.Generation, deleteFlag)
 							certFound = true
 							break
 						}
@@ -380,7 +380,7 @@ func ValidateGatewayListenerWithSecret(namespace, name string, deleteFlag bool) 
 }
 
 // Mapping has to be taken care between secret and gateway
-func setConditions(gwStatus *gatewayv1.GatewayStatus, index int, generation int64, isDelete bool) {
+func setListenerConditions(gwStatus *gatewayv1.GatewayStatus, index int, generation int64, isDelete bool) {
 	if !isDelete {
 		akogatewayapistatus.NewCondition().
 			Type(string(gatewayv1.ListenerConditionAccepted)).
@@ -427,7 +427,7 @@ func setGatewayCondition(gwStatus *gatewayv1.GatewayStatus, validListenerCount, 
 			Type(string(gatewayv1.GatewayConditionAccepted)).
 			Reason(string(gatewayv1.GatewayReasonListenersNotValid)).
 			Message("Gateway contains atleast one valid listener").
-			Status(metav1.ConditionFalse).
+			Status(metav1.ConditionTrue).
 			ObservedGeneration(observedGeneration).SetIn(&gwStatus.Conditions)
 		return
 	}

--- a/ako-gateway-api/k8s/validator.go
+++ b/ako-gateway-api/k8s/validator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
@@ -27,7 +28,6 @@ import (
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func IsGatewayClassValid(key string, gatewayClass *gatewayv1.GatewayClass) bool {

--- a/ako-gateway-api/k8s/validator.go
+++ b/ako-gateway-api/k8s/validator.go
@@ -21,12 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"k8s.io/apimachinery/pkg/labels"
-
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
+	akogatewayapiobjects "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/objects"
 	akogatewayapistatus "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/status"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/status"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func IsGatewayClassValid(key string, gatewayClass *gatewayv1.GatewayClass) bool {
@@ -252,6 +253,9 @@ func isValidListener(key string, gateway *gatewayv1.Gateway, gatewayStatus *gate
 			_, err := utils.GetInformers().ClientSet.CoreV1().Secrets(gateway.ObjectMeta.Namespace).Get(context.TODO(), name, metav1.GetOptions{})
 			if err != nil {
 				utils.AviLog.Errorf("key: %s, msg: Secret specified in CertificateRef does not exist %+v/%+v", key, gateway.Name, listener.Name)
+				gWNSName := gateway.ObjectMeta.Namespace + "/" + gateway.ObjectMeta.Name
+				secretNSName := gateway.ObjectMeta.Namespace + "/" + name
+				akogatewayapiobjects.GatewayApiLister().UpdateSecretToGateway(secretNSName, []string{gWNSName})
 				defaultCondition.SetIn(&gatewayStatus.Listeners[index].Conditions)
 				resolvedRefCondition.
 					Reason(string(gatewayv1.ListenerReasonInvalidCertificateRef)).
@@ -317,4 +321,120 @@ func IsHTTPRouteConfigValid(key string, obj *gatewayv1.HTTPRoute) bool {
 		return false
 	}
 	return true
+}
+
+func ValidateGatewayListenerWithSecret(namespace, name string, deleteFlag bool) {
+	secretNSName := namespace + "/" + name
+	present, gwList := akogatewayapiobjects.GatewayApiLister().GetSecretToGateway(secretNSName)
+
+	if present {
+		clonedGWList := make([]string, len(gwList))
+		copy(clonedGWList, gwList)
+		for _, gwNSName := range gwList {
+			gwNamespace, _, gwName := lib.ExtractTypeNameNamespace(gwNSName)
+			// Check gateway present or not
+			gatewayObj, err := akogatewayapilib.AKOControlConfig().GatewayApiInformers().GatewayInformer.Lister().Gateways(gwNamespace).Get(gwName)
+			if err != nil {
+				// ignore gateway
+				continue
+			}
+			gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gwNamespace + "/" + gwName)
+
+			// go through listeners, check cert is present there or not.
+			validListenerCount := 0
+			certFound := false
+			for listenerIndex, listener := range gatewayObj.Spec.Listeners {
+				if listener.TLS != nil {
+					if (listener.TLS.Mode != nil && *listener.TLS.Mode != gatewayv1.TLSModeTerminate) || len(listener.TLS.CertificateRefs) == 0 {
+						continue
+					}
+					for _, certRef := range listener.TLS.CertificateRefs {
+						// TODO: In future, ref grant impact needs to be considered.
+						certNamespace := namespace
+						if certRef.Namespace != nil {
+							certNamespace = string(*certRef.Namespace)
+						}
+						// add condition for checking gateway status
+						if gwStatus != nil && string(certRef.Name) == name && certNamespace == namespace {
+							setConditions(gwStatus, listenerIndex, gatewayObj.ObjectMeta.Generation, deleteFlag)
+							certFound = true
+							break
+						}
+					}
+				}
+				if gwStatus != nil && !akogatewayapilib.IsListenerInvalid(gwStatus, listenerIndex) {
+					validListenerCount += 1
+				}
+			} // listener loop ends
+			// if cert not found, that means it is stale entry in secret to gateway map
+			if certFound {
+				setGatewayCondition(gwStatus, validListenerCount, len(gatewayObj.Spec.Listeners), gatewayObj.ObjectMeta.Generation)
+			} else {
+				//remove the entry from the clone
+				clonedGWList = utils.Remove(clonedGWList, gwNSName)
+			}
+		} // gw loop ends
+		// update the mapping
+		akogatewayapiobjects.GatewayApiLister().UpdateSecretToGateway(secretNSName, clonedGWList)
+	}
+}
+
+// Mapping has to be taken care between secret and gateway
+func setConditions(gwStatus *gatewayv1.GatewayStatus, index int, generation int64, isDelete bool) {
+	if !isDelete {
+		akogatewayapistatus.NewCondition().
+			Type(string(gatewayv1.ListenerConditionAccepted)).
+			Reason(string(gatewayv1.ListenerReasonAccepted)).
+			Message("Listener is valid").
+			Status(metav1.ConditionTrue).
+			ObservedGeneration(generation).SetIn(&gwStatus.Listeners[index].Conditions)
+
+		akogatewayapistatus.NewCondition().
+			Type(string(gatewayv1.ListenerConditionResolvedRefs)).
+			Reason(string(gatewayv1.ListenerReasonResolvedRefs)).
+			Message("Reference is valid").
+			Status(metav1.ConditionTrue).
+			ObservedGeneration(generation).SetIn(&gwStatus.Listeners[index].Conditions)
+		return
+	}
+	akogatewayapistatus.NewCondition().
+		Type(string(gatewayv1.ListenerConditionAccepted)).
+		Reason(string(gatewayv1.ListenerReasonInvalid)).
+		Message("Listener is Invalid").
+		Status(metav1.ConditionFalse).
+		ObservedGeneration(generation).SetIn(&gwStatus.Listeners[index].Conditions)
+
+	akogatewayapistatus.NewCondition().
+		Type(string(gatewayv1.ListenerConditionResolvedRefs)).
+		Reason(string(gatewayv1.ListenerReasonInvalidCertificateRef)).
+		Message("Secret does not exist").
+		Status(metav1.ConditionFalse).
+		ObservedGeneration(generation).SetIn(&gwStatus.Listeners[index].Conditions)
+}
+
+func setGatewayCondition(gwStatus *gatewayv1.GatewayStatus, validListenerCount, totalListenerCount int, observedGeneration int64) {
+	if validListenerCount == 0 {
+		akogatewayapistatus.NewCondition().
+			Type(string(gatewayv1.GatewayConditionAccepted)).
+			Reason(string(gatewayv1.GatewayReasonListenersNotValid)).
+			Message("Gateway does not contain any valid listener").
+			Status(metav1.ConditionFalse).
+			ObservedGeneration(observedGeneration).SetIn(&gwStatus.Conditions)
+		return
+	}
+	if validListenerCount < totalListenerCount {
+		akogatewayapistatus.NewCondition().
+			Type(string(gatewayv1.GatewayConditionAccepted)).
+			Reason(string(gatewayv1.GatewayReasonListenersNotValid)).
+			Message("Gateway contains atleast one valid listener").
+			Status(metav1.ConditionFalse).
+			ObservedGeneration(observedGeneration).SetIn(&gwStatus.Conditions)
+		return
+	}
+	akogatewayapistatus.NewCondition().
+		Type(string(gatewayv1.GatewayConditionAccepted)).
+		Reason(string(gatewayv1.GatewayReasonAccepted)).
+		Message("Gateway configuration is valid").
+		Status(metav1.ConditionTrue).
+		ObservedGeneration(observedGeneration).SetIn(&gwStatus.Conditions)
 }

--- a/ako-gateway-api/lib/lib.go
+++ b/ako-gateway-api/lib/lib.go
@@ -151,7 +151,12 @@ func FindTargetPort(serviceName, ns string, svcPort int32, key string) intstr.In
 	}
 	return intstr.IntOrString{}
 }
-
+func IsListenerInvalid(gwStatus *gatewayv1.GatewayStatus, listenerIndex int) bool {
+	if len(gwStatus.Listeners) > int(listenerIndex) && gwStatus.Listeners[listenerIndex].Conditions[0].Type == string(gatewayv1.ListenerConditionAccepted) && gwStatus.Listeners[listenerIndex].Conditions[0].Status == "False" {
+		return true
+	}
+	return false
+}
 func VerifyHostnameSubdomainMatch(hostname string) bool {
 	// Check if a hostname is valid or not by verifying if it has a prefix that
 	// matches any of the sub-domains.

--- a/ako-gateway-api/nodes/dequeue_ingestion.go
+++ b/ako-gateway-api/nodes/dequeue_ingestion.go
@@ -74,7 +74,12 @@ func DequeueIngestion(key string, fullsync bool) {
 		modelNil := !modelFound || modelIntf == nil
 		if objType == utils.Secret && modelNil {
 			handleGateway(parentNs, parentName, fullsync, key)
-			_, modelIntf = objects.SharedAviGraphLister().Get(modelName)
+			modelFound, modelIntf = objects.SharedAviGraphLister().Get(modelName)
+			modelNil = !modelFound || modelIntf == nil
+			if modelNil {
+				utils.AviLog.Warnf("key: %s, msg: no model found: %s", key, modelName)
+				continue
+			}
 		} else if modelNil {
 			utils.AviLog.Warnf("key: %s, msg: no model found: %s", key, modelName)
 			continue

--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -80,18 +80,11 @@ func (o *AviObjectGraph) BuildGatewayParent(gateway *gatewayv1.Gateway, key stri
 	return parentVsNode
 }
 
-func IsListenerInvalid(gwStatus *gatewayv1.GatewayStatus, listenerIndex int) bool {
-	if len(gwStatus.Listeners) > int(listenerIndex) && gwStatus.Listeners[listenerIndex].Conditions[0].Type == string(gatewayv1.ListenerConditionAccepted) && gwStatus.Listeners[listenerIndex].Conditions[0].Status == "False" {
-		return true
-	}
-	return false
-}
-
 func BuildPortProtocols(gateway *gatewayv1.Gateway, key string) []nodes.AviPortHostProtocol {
 	var portProtocols []nodes.AviPortHostProtocol
 	gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gateway.Namespace + "/" + gateway.Name)
 	for i, listener := range gateway.Spec.Listeners {
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			continue
 		}
 		pp := nodes.AviPortHostProtocol{Port: int32(listener.Port), Protocol: string(listener.Protocol)}
@@ -113,7 +106,7 @@ func BuildTLSNodesForGateway(gateway *gatewayv1.Gateway, key string) []*nodes.Av
 	cs := utils.GetInformers().ClientSet
 	gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gateway.Namespace + "/" + gateway.Name)
 	for i, listener := range gateway.Spec.Listeners {
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			continue
 		}
 		if listener.TLS != nil {
@@ -187,7 +180,7 @@ func DeleteTLSNode(key string, object *AviObjectGraph, gateway *gatewayv1.Gatewa
 	evhVsCertRefs := object.GetAviEvhVS()[0].SSLKeyCertRefs
 	gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gateway.Namespace + "/" + gateway.Name)
 	for i, listener := range gateway.Spec.Listeners {
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			continue
 		}
 		if listener.TLS != nil {
@@ -218,7 +211,7 @@ func AddTLSNode(key string, object *AviObjectGraph, gateway *gatewayv1.Gateway, 
 	evhVsCertRefs := object.GetAviEvhVS()[0].SSLKeyCertRefs
 	gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gateway.Namespace + "/" + gateway.Name)
 	for i, listener := range gateway.Spec.Listeners {
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			continue
 		}
 		if listener.TLS != nil {

--- a/ako-gateway-api/nodes/gateway_model_rel.go
+++ b/ako-gateway-api/nodes/gateway_model_rel.go
@@ -131,7 +131,7 @@ func GatewayGetGw(namespace, name, key string) ([]string, bool) {
 	gwStatus := akogatewayapiobjects.GatewayApiLister().GetGatewayToGatewayStatusMapping(gwNsName)
 
 	for i, listenerObj := range gwObj.Spec.Listeners {
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			continue
 		}
 		gwListener := akogatewayapiobjects.GatewayListenerStore{}

--- a/ako-gateway-api/nodes/route_validator.go
+++ b/ako-gateway-api/nodes/route_validator.go
@@ -188,7 +188,7 @@ func validateParentReference(key string, httpRoute *gatewayv1.HTTPRoute, httpRou
 			*parentRefIndexInHttpRouteStatus = *parentRefIndexInHttpRouteStatus + 1
 			return err
 		}
-		if IsListenerInvalid(gwStatus, i) {
+		if akogatewayapilib.IsListenerInvalid(gwStatus, i) {
 			// listener is present in gateway but is in invalid state
 			utils.AviLog.Errorf("key: %s, msg: Matching gateway listener %s in Parent Reference is in invalid state", key, listenerName)
 			err := fmt.Errorf("Matching gateway listener is in Invalid state")

--- a/ako-gateway-api/objects/gateway_store.go
+++ b/ako-gateway-api/objects/gateway_store.go
@@ -545,7 +545,22 @@ func (g *GWLister) GetSecretToGateway(secretNsName string) (bool, []string) {
 		return true, obj.([]string)
 	}
 	return false, []string{}
+}
 
+func (g *GWLister) UpdateSecretToGateway(secretNsName string, gwNSNameList []string) {
+	g.gwLock.Lock()
+	defer g.gwLock.Unlock()
+	if found, obj := g.secretToGateway.Get(secretNsName); found {
+		gwList := obj.([]string)
+		for _, gwNSName := range gwNSNameList {
+			if !utils.HasElem(gwList, gwNSName) {
+				gwList = append(gwList, gwNSName)
+			}
+		}
+		g.secretToGateway.AddOrUpdate(secretNsName, gwList)
+	} else {
+		g.secretToGateway.AddOrUpdate(secretNsName, gwNSNameList)
+	}
 }
 func (g *GWLister) UpdateGatewayToSecret(gwNsName string, secretNsNameList []string) {
 	g.gwLock.Lock()

--- a/tests/gatewayapitests/graphlayer/gateway_test.go
+++ b/tests/gatewayapitests/graphlayer/gateway_test.go
@@ -428,10 +428,8 @@ func TestSecretCreateDelete(t *testing.T) {
 		found, _ := objects.SharedAviGraphLister().Get(modelName)
 		return found
 	}, 30*time.Second).Should(gomega.Equal(false))
-
-	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
-	g.Expect(aviModel).To(gomega.BeNil())
-
+	// add delay
+	time.Sleep(1 * time.Second)
 	integrationtest.AddSecret(secrets[0], DEFAULT_NAMESPACE, "cert", "key")
 
 	g.Eventually(func() bool {


### PR DESCRIPTION
This PR contains fix for 2 issues:
1. [AV-221779] : Fix secret and gateway re-ordering
2. [AV-222515]: AKO-Gateway: Gateway status conditions are not reflected correctly on deleting certificate associated with gateway

TODO: It doesn't take care of deleting Parent VS if no certificate attached to it. Parent VS will be there with default-cert.