### PR TITLE
AV-223927 : Check PKIProfile Cache for existing pkiprofile while computing pkiprofile for new pool

### DIFF
--- a/internal/rest/ssl_key_certificate.go
+++ b/internal/rest/ssl_key_certificate.go
@@ -252,14 +252,29 @@ func (rest *RestOperations) AviPkiProfileBuild(pki_node *nodes.AviPkiProfileNode
 			Model:   "PKIprofile",
 		}
 	} else {
-		path = "/api/pkiprofile/"
-		rest_op = utils.RestOp{
-			ObjName: pki_node.Name,
-			Path:    path,
-			Method:  utils.RestPost,
-			Obj:     pkiobject,
-			Tenant:  pki_node.Tenant,
-			Model:   "PKIprofile",
+		pki_key := avicache.NamespaceName{Namespace: pki_node.Tenant, Name: name}
+		pki_cache, ok := rest.cache.PKIProfileCache.AviCacheGet(pki_key)
+		if ok {
+			pki_cache_obj, _ := pki_cache.(*avicache.AviPkiProfileCache)
+			path = "/api/pkiprofile/" + pki_cache_obj.Uuid
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPut,
+				Obj:     pkiobject,
+				Tenant:  pki_node.Tenant,
+				Model:   "PKIprofile",
+			}
+		} else {
+			path = "/api/pkiprofile"
+			rest_op = utils.RestOp{
+				ObjName: name,
+				Path:    path,
+				Method:  utils.RestPost,
+				Obj:     pkiobject,
+				Tenant:  pki_node.Tenant,
+				Model:   "PKIprofile",
+			}
 		}
 	}
 	return &rest_op


### PR DESCRIPTION
The **test_regex_app_root_secure_vs** test in test_http_rules test suite was failing because of this issue and now it runs fine. FT Run Results :
```
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_config                        |     PASSED     |       00:00:43      |   06:44:34  |   06:45:17  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule                      |     PASSED     |       00:00:51      |   06:45:17  |   06:46:08  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_httprule_allrefs_set_unset           |     PASSED     |       00:00:48      |   06:46:08  |   06:46:57  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_httprule_with_reencrypt              |     PASSED     |       00:00:17      |   06:46:57  |   06:47:15  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule_for_nested_paths     |     PASSED     |       00:00:32      |   06:47:15  |   06:47:47  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule_http2_backend        |     PASSED     |       00:00:25      |   06:47:47  |   06:48:12  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_create_httprule_subdomain_route      |    SKIPPED     |       00:00:01      |   06:48:12  |   06:48:14  |
| Test_HTTP_Rules_SNI_NonDedicated_Shard.test_delete_rules                         |     PASSED     |       00:00:41      |   06:48:14  |   06:48:56  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 7   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 8                                                             |    Skipped:1   | Total Time:00:04:22 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+


+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_config                           |     PASSED     |       00:00:41      |   07:44:42  |   07:45:24  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule                         |     PASSED     |       00:01:41      |   07:45:24  |   07:47:05  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_httprule_allrefs_set_unset              |     PASSED     |       00:00:48      |   07:47:05  |   07:47:54  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_httprule_with_reencrypt                 |     PASSED     |       00:00:33      |   07:47:54  |   07:48:28  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule_for_nested_paths        |     PASSED     |       00:00:12      |   07:48:28  |   07:48:40  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule_http2_backend           |     PASSED     |       00:00:24      |   07:48:40  |   07:49:04  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_create_httprule_subdomain_route         |    SKIPPED     |       00:00:01      |   07:49:04  |   07:49:06  |
| Test_HTTP_Rules_SNI_Dedicated_Shard.test_delete_rules                            |     PASSED     |       00:00:41      |   07:49:06  |   07:49:47  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 7   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 8                                                             |    Skipped:1   | Total Time:00:05:05 |          |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+


+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_config                        |     PASSED     |       00:00:40      |   07:50:43  |   07:51:23  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule                      |     PASSED     |       00:00:52      |   07:51:23  |   07:52:16  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_httprule_allrefs_set_unset           |     PASSED     |       00:00:33      |   07:52:16  |   07:52:50  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_httprule_with_reencrypt              |     PASSED     |       00:00:33      |   07:52:50  |   07:53:23  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule_for_nested_paths     |     PASSED     |       00:00:23      |   07:53:23  |   07:53:46  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule_http2_backend        |     PASSED     |       00:00:40      |   07:53:46  |   07:54:27  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_create_httprule_subdomain_route      |    SKIPPED     |       00:00:01      |   07:54:27  |   07:54:29  |
| Test_HTTP_Rules_EVH_NonDedicated_Shard.test_delete_rules                         |     PASSED     |       00:00:41      |   07:54:29  |   07:55:11  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 7   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 8                                                             |    Skipped:1   | Total Time:00:04:27 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+


+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_config                           |     PASSED     |       00:00:41      |   07:55:44  |   07:56:26  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule                         |     PASSED     |       00:00:56      |   07:56:26  |   07:57:22  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_httprule_allrefs_set_unset              |     PASSED     |       00:00:49      |   07:57:22  |   07:58:11  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_httprule_with_reencrypt                 |     PASSED     |       00:00:18      |   07:58:11  |   07:58:30  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule_for_nested_paths        |     PASSED     |       00:00:22      |   07:58:30  |   07:58:52  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule_http2_backend           |     PASSED     |       00:00:29      |   07:58:52  |   07:59:22  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_create_httprule_subdomain_route         |    SKIPPED     |       00:00:01      |   07:59:22  |   07:59:23  |
| Test_HTTP_Rules_EVH_Dedicated_Shard.test_delete_rules                            |     PASSED     |       00:00:41      |   07:59:23  |   08:00:04  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 7   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 8                                                             |    Skipped:1   | Total Time:00:04:20 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+





+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_config      |     PASSED     |       00:00:38      |   10:45:08  |   10:45:47  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_multi_ingre |     PASSED     |                     |             |             |
| ss                                                                               |                |       00:00:26      |   10:45:47  |   10:46:14  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_update_http |     PASSED     |                     |             |             |
| _rule                                                                            |                |       00:00:12      |   10:46:14  |   10:46:26  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_create_multipath_i |     PASSED     |                     |             |             |
| ngress                                                                           |                |       00:00:22      |   10:46:26  |   10:46:49  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_regex_secure_vs    |     PASSED     |       00:00:34      |   10:46:49  |   10:47:23  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_app_root_secure_vs |     PASSED     |       00:00:24      |   10:47:23  |   10:47:47  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_regex_app_root_sec |     PASSED     |                     |             |             |
| ure_vs                                                                           |                |       00:00:46      |   10:47:47  |   10:48:34  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_teardown_hostrule_ |     PASSED     |                     |             |             |
| switch_objects                                                                   |                |       00:00:57      |   10:48:34  |   10:49:31  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_NonDedicated_Shard.test_delete_config      |     PASSED     |       00:00:02      |   10:49:31  |   10:49:34  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:04:25 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+



+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_config         |     PASSED     |       00:00:37      |   12:11:23  |   12:12:01  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_multi_ingress  |     PASSED     |       00:00:42      |   12:12:01  |   12:12:44  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_update_http_ru |     PASSED     |                     |             |             |
| le                                                                               |                |       00:00:23      |   12:12:44  |   12:13:07  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_create_multipath_ingr |     PASSED     |                     |             |             |
| ess                                                                              |                |       00:00:22      |   12:13:07  |   12:13:30  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_regex_secure_vs       |     PASSED     |       00:00:34      |   12:13:30  |   12:14:04  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_app_root_secure_vs    |     PASSED     |       00:00:19      |   12:14:04  |   12:14:23  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_regex_app_root_secure |     PASSED     |                     |             |             |
| _vs                                                                              |                |       00:01:01      |   12:14:23  |   12:15:25  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_teardown_hostrule_swi |     PASSED     |                     |             |             |
| tch_objects                                                                      |                |       00:00:56      |   12:15:25  |   12:16:21  |
| Test_HTTP_Rules_Host_Rules_Update_SNI_Dedicated_Shard.test_delete_config         |     PASSED     |       00:00:02      |   12:16:21  |   12:16:23  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:04:59 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+



+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_config      |     PASSED     |       00:00:36      |   12:31:41  |   12:32:17  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_multi_ingre |     PASSED     |                     |             |             |
| ss                                                                               |                |       00:00:27      |   12:32:17  |   12:32:45  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_update_http |     PASSED     |                     |             |             |
| _rule                                                                            |                |       00:00:23      |   12:32:45  |   12:33:08  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_create_multipath_i |     PASSED     |                     |             |             |
| ngress                                                                           |                |       00:00:22      |   12:33:08  |   12:33:31  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_regex_secure_vs    |     PASSED     |       00:00:45      |   12:33:31  |   12:34:16  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_app_root_secure_vs |     PASSED     |       00:00:33      |   12:34:16  |   12:34:50  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_regex_app_root_sec |     PASSED     |                     |             |             |
| ure_vs                                                                           |                |       00:00:51      |   12:34:50  |   12:35:41  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_teardown_hostrule_ |     PASSED     |                     |             |             |
| switch_objects                                                                   |                |       00:00:55      |   12:35:41  |   12:36:36  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_NonDedicated_Shard.test_delete_config      |     PASSED     |       00:00:01      |   12:36:36  |   12:36:38  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:04:57 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+



+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
| Absolute Path:Test case                                                          |     Results    |       Duration      |  Start Time |   End Time  |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
|      Test Suite Path and Name : avi-                                             |                |                     |             |             |
| test/avitest/functional/ako/test_http_rules.py                                   |                |                     |             |             |
| ++++++++++++++++++++++++++++++++++++++++                                         |                |                     |             |             |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_config         |     PASSED     |       00:00:41      |   12:37:33  |   12:38:15  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_multi_ingress  |     PASSED     |       00:06:05      |   12:38:15  |   12:44:21  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_update_http_ru |     PASSED     |                     |             |             |
| le                                                                               |                |       00:00:23      |   12:44:21  |   12:44:44  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_create_multipath_ingr |     PASSED     |                     |             |             |
| ess                                                                              |                |       00:00:22      |   12:44:44  |   12:45:07  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_regex_secure_vs       |     PASSED     |       00:00:53      |   12:45:07  |   12:46:00  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_app_root_secure_vs    |     PASSED     |       00:00:26      |   12:46:00  |   12:46:27  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_regex_app_root_secure |     PASSED     |                     |             |             |
| _vs                                                                              |                |       00:00:45      |   12:46:27  |   12:47:12  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_teardown_hostrule_swi |     PASSED     |                     |             |             |
| tch_objects                                                                      |                |       00:00:56      |   12:47:12  |   12:48:08  |
| Test_HTTP_Rules_Host_Rules_Update_EVH_Dedicated_Shard.test_delete_config         |     PASSED     |       00:00:02      |   12:48:08  |   12:48:11  |
| -------------------------------------------------------------------------------- |  ------------  |     -----------     | ----------- | ----------- |
|                                                                                  |    Passed: 9   |                     |             |             |
|                                                                                  |    Failed:0    |                     |             |             |
|  Total test cases: 9                                                             |    Skipped:0   | Total Time:00:10:37 |             |             |
+----------------------------------------------------------------------------------+----------------+---------------------+-------------+-------------+
```