### PR TITLE
AV-225892 : PKIProfile cache is not updated as cloud_ref is used in the get request URI

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -99,7 +99,7 @@ func (c *AviObjCache) AviRefreshObjectCache(client []*clients.AviClient, cloud s
 		defer wg.Done()
 		c.PopulateVsVipDataToCache(client[7], cloud, tenant)
 	}()
-	c.PopulatePkiProfilesToCache(client[0], cloud, tenant)
+	c.PopulatePkiProfilesToCache(client[0], tenant)
 	c.PopulatePoolsToCache(client[1], cloud, tenant)
 	c.PopulatePgDataToCache(client[2], cloud, tenant)
 	c.PopulateStringGroupDataToCache(client[8], cloud, tenant)
@@ -560,14 +560,14 @@ func (c *AviObjCache) PopulatePgDataToCache(client *clients.AviClient, cloud, te
 	}
 }
 
-func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, cloud string, pkiData *[]AviPkiProfileCache, overrideUri ...NextPage) (*[]AviPkiProfileCache, int, error) {
+func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, pkiData *[]AviPkiProfileCache, overrideUri ...NextPage) (*[]AviPkiProfileCache, int, error) {
 	var uri string
 	akoUser := lib.AKOUser
 
 	if len(overrideUri) == 1 {
 		uri = overrideUri[0].NextURI
 	} else {
-		uri = "/api/pkiprofile/?" + "&include_name=true&cloud_ref.name=" + cloud + "&created_by=" + akoUser + "&page_size=100"
+		uri = "/api/pkiprofile/?" + "&include_name=true&created_by=" + akoUser + "&page_size=100"
 	}
 
 	result, err := lib.AviGetCollectionRaw(client, uri)
@@ -608,7 +608,7 @@ func (c *AviObjCache) AviPopulateAllPkiPRofiles(client *clients.AviClient, cloud
 		if len(next_uri) > 1 {
 			overrideUri := "/api/pkiprofile" + next_uri[1]
 			nextPage := NextPage{NextURI: overrideUri}
-			_, _, err := c.AviPopulateAllPkiPRofiles(client, cloud, pkiData, nextPage)
+			_, _, err := c.AviPopulateAllPkiPRofiles(client, pkiData, nextPage)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -693,9 +693,9 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 	return poolData, result.Count, nil
 }
 
-func (c *AviObjCache) PopulatePkiProfilesToCache(client *clients.AviClient, cloud string, tenant string, overrideUri ...NextPage) {
+func (c *AviObjCache) PopulatePkiProfilesToCache(client *clients.AviClient, tenant string, overrideUri ...NextPage) {
 	var pkiProfData []AviPkiProfileCache
-	c.AviPopulateAllPkiPRofiles(client, cloud, &pkiProfData)
+	c.AviPopulateAllPkiPRofiles(client, &pkiProfData)
 
 	pkiCacheData := c.PKIProfileCache.ShallowCopy()
 	for i, pkiCacheObj := range pkiProfData {


### PR DESCRIPTION
On AKO boot-up, PKIProfile cache is not updated as cloud_ref is used in the get request URI. But, when PKIProfile is created cloud_ref is not populated. So, removed cloud_ref from the get request URI.

Without the fix, PKIProfile cache is not not populated and leads to POST request for existing PKIProfile causing 409 error.
```
2024-12-19T08:53:12.842Z	INFO	cache/controller_obj_cache.go:136	Refreshing all object cache
2024-12-19T08:53:12.883Z	DEBUG	cache/controller_obj_cache.go:1637	Adding key to sslkey cache :{admin kubernetes-calico--my-infrasetting-test-grpc-host.avi.internal}
.
.
.
2024-12-19T08:53:14.275Z	WARN	rest/rest_operation.go:307	key: admin/kubernetes-calico--Shared-L7-0, msg: RestOp method POST path /api/pkiprofile tenant admin Obj {"ca_certs":[{"certificate":"-----BEGIN CERTIFICATE-----\nMIIFozCCA4ugAwIBAgIUJ+yp+5voAh9ktxqR60zZ8wVBPU8wDQYJKoZIhvcNAQEL\nBQAwYTELMAkGA1UEBhMCSU4xCzAJBgNVBAgMAktBMRIwEAYDVQQHDAlCZW5nYWx1\ncnUxDDAKBgNVBAoMA0F2aTEMMAoGA1UECwwDQUtPMRUwEwYDVQQDDAxhdmkuaW50\nZXJuYWwwHhcNMjQwODE2MTIyNTQ1WhcNMjkwODE1MTIyNTQ1WjBhMQswCQYDVQQG\nEwJJTjELMAkGA1UECAwCS0ExEjAQBgNVBAcMCUJlbmdhbHVydTEMMAoGA1UECgwD\nQXZpMQwwCgYDVQQLDANBS08xFTATBgNVBAMMDGF2aS5pbnRlcm5hbDCCAiIwDQYJ\nKoZIhvcNAQEBBQADggIPADCCAgoCggIBALQMcDHg6yp/6sNh2aard/ScMywS1JWv\nyDVSX2/kZgEU992XdXA6iMWzQkW1cqv+Rdo9MUoDIke2EIU0yy9CV8o+4FNGEWXB\nfnl3x6tj2DIak67f/COLDE+xzSHw18ocPeUqPDD1y19Ciq0jg2XzImQ7BoPRWCiz\nKGkmTpHc1UMgZpWLBrdI8T6wzIulhL9u2RnL/8f+9RW0L4fElzhqZAj6HoIpupoX\nfMPtlrId426gMlduRnVg0d6D21Saj8FgXRnw6fYivk+JQnRpG26uu8jGzn7VB7Ry\nboks42KxWxFOeaaHix20U4xs5ZIJWdB+3YOdlP/YaDd9vAsS5putQPxgdW2Qqvt2\nqTeFR+ozLQW//BSQfjnHEq2OeLC3YcY1R7np7EZ89KIaSFEMp/lPwu/VXDzR5que\nlEYwUhvWAkS9Mdcb3wQoaVbp0oSM283S+EpRZCPiSEAOZLQe6IlwRc/azbyQvACX\nLtNSUBNGk1aufHR6AwfrfRSPkLQJTGGW/rBydonbYQdmLed33v3hNCnt/Hxq7OJF\nVO0MRzbFwuvzufQ2DkCWDeK1Ed6a/aCK86bUQ+RRMwUuzEKZVnx05uhSN/Jye7Fb\n+xymROn5bRXaEWN3WaH6U22gap54QdmCqE2BNFGXs4N8mdKnsdEzHpMdjr6Wu7Ob\ndH/SdX3Um6QZAgMBAAGjUzBRMB0GA1UdDgQWBBRAU++GWZc0Ar3wpWJovofDHcWA\nZjAfBgNVHSMEGDAWgBRAU++GWZc0Ar3wpWJovofDHcWAZjAPBgNVHRMBAf8EBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAvk+TAYqMhdKJJJ8hxX+k9MC2Zrz3JkpZt\n6iQnnqeAEhP5xrl+1GK/K6CXvEKcS3mta0HmPuqlSteyxBnQpnmBrAg+UcwGe9a7\n9/g7O+T9o9ar9QZVqeg0ur4kzqiJpxbfP+ZvpDAJvWLtMOtfaMtyvA7jyjh8yNoq\nAIJ7uI/DPZi05G8QGMkubl+VTdRcpjAz2hkIV+AdMxkPWywSQ98V29elzkWNwH/M\nUcUa/8k42ZgOgcz9F55UYMnEy6B4dcgZMVchnw15UkYvGjVCnI2nBemI195FEAkZ\n3008b5tVn/Ib0wZZua3K0cm73WMO22hduG8wZZAQEmWHcyJIt7bjP4VPq0E3afxt\nj/uxeum3dxCW1NhYdv1+8ItEf86d++I4hQ0iHchjTpTDDfursZVDAwQpOc1R3fvz\n08lZbh0jIspJUty0lcbzx8sV2VNeCALR/qHSADIQw/ygaEZKgQv4gj7/yp/z+66W\n+SDBFS6Qgjq4bCT/4Xqeafw7dpKvL4frB8/WqY55e70w9xCC8pMAuSckar1/YQ+r\n4vkoblw6inMXSontDKc+qdtUULBSUHPc8AL9tgn5ygHDi6Mpr/SetAF10vZyPzP3\nU9X0gtyOkGJad3tnP8NUhp/uhjKOLEEJXH5musS+QS9bxndECAwFdSV+8FAIIclB\nMZ4/aCc2QQ==\n-----END CERTIFICATE-----"}],"created_by":"ako-kubernetes-calico","crl_check":false,"markers":[{"key":"clustername","values":["kubernetes-calico"]},{"key":"Namespace","values":["test-httprule-ns"]},{"key":"Host","values":["test-httprules-multipath-secure.avi.internal"]},{"key":"ServiceName","values":["ew-app"]},{"key":"Path","values":["/"]},{"key":"IngressName","values":["test-ingress-multipath-secure-2"]}],"name":"kubernetes-calico--test-httprule-ns-test-httprules-multipath-secure.avi.internal_-test-ingress-multipath-secure-2-pkiprofile","tenant_ref":"/api/tenant/?name=admin"} returned err {"code":0,"message":"map[error:Pki profile with this Name and Tenant ref already exists.]","Verb":"POST","Url":"https://100.65.8.127//api/pkiprofile","HttpStatusCode":409} with response null
```

After adding the fix, the PKIProfile cache is populated as expected and no POST request is seen.
```
2024-12-19T08:52:10.054Z	INFO	cache/controller_obj_cache.go:136	Refreshing all object cache
2024-12-19T08:52:10.116Z	INFO	cache/controller_obj_cache.go:715	Adding key to pki cache :{admin kubernetes-calico--test-httprule-ns-test-httprules-multipath-secure.avi.internal_bar-test-ingress-multipath-secure-3-pkiprofile} value :pkiprofile-ee5cad84-74f6-43b7-9119-11c93b9870d0
2024-12-19T08:52:10.116Z	INFO	cache/controller_obj_cache.go:715	Adding key to pki cache :{admin kubernetes-calico--test-httprule-ns-test-httprules-multipath-secure.avi.internal_baz.*-test-ingress-multipath-secure-1-pkiprofile} value :pkiprofile-a4e1c482-fb2a-4e3d-81c3-d4262594ded1
2024-12-19T08:52:10.116Z	INFO	cache/controller_obj_cache.go:715	Adding key to pki cache :{admin kubernetes-calico--test-httprule-ns-test-httprules-multipath-secure.avi.internal_-test-ingress-multipath-secure-2-pkiprofile} value :pkiprofile-86a874ee-7f5e-44f3-b6b2-482757c9b424
2024-12-19T08:52:10.146Z	DEBUG	cache/controller_obj_cache.go:881	Adding key to vsvip cache: {admin kubernetes-calico--Shared-L7-0}, fqdns: [kubernetes-calico--Shared-L7-0.admin.avi.internal test-httprules-bar.avi.internal test-httprules-foo.avi.internal test-httprules-multipath-secure.avi.internal test-httprules-multipath.avi.internal test-httprules-nested-path.avi.internal test-httprules-reencrypt.avi.internal test-httprules.avi.internal]
2024-12-19T08:52:10.146Z	DEBUG	cache/controller_obj_cache.go:881	Adding key to vsvip cache: {admin kubernetes-calico--Shared-L7-my-infrasetting-0}, fqdns: [kubernetes-calico--Shared-L7-my-infrasetting-0.admin.avi.internal test-grpc-host.avi.internal]
2024-12-19T08:52:10.164Z	DEBUG	cache/controller_obj_cache.go:1637	Adding key to sslkey cache :{admin kubernetes-calico--my-infrasetting-test-grpc-host.avi.internal}
```