### PR TITLE
AV-228261 : Add release notes for AKO 1.13.1 release

### DIFF
--- a/AKO_GATEWAY_CHANGELOG.md
+++ b/AKO_GATEWAY_CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to this project will be documented in this file. The format 
 ### Added:
  - AKO now claims support for v1 for HttpRoute, Gateway, GatewayClass.
 
+## AKO-Gateway-1.12.2
+
+### Fixed:
+ - Fix: AKO Gateway does not create a virtual service if Gateway has multiple listeners with the same host name.
+ - Fix: AKO Gateway container crashes when it boots up in NPL mode.
+
 ## AKO-Gateway-1.13.1
 
 ### Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,3 +445,45 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
  - Fix: Certificate, from hostrule CRD, can not be assigned to L7 VirtualService when AKO is deployed in Dedicated mode.
  - Fix: Virtualservices are getting deleted when there is an issue with an access to the kube_api server which results in setting up `deleteConfig` flag to true.
+
+## AKO-1.12.1
+
+### Added
+- AKO now claims support for Kubernetes 1.29, OCP version 4.14.
+- AKO supports LoadBalancerClass for LoadBalancer type services.
+- AKO allows pool member to be IPV6 or IPV4 in dual stack deployment for `CALICO` and `ANTREA` CNI.
+- IPV6 address can be used to connect to the Avi Controller.
+- VRF support within VCenter Cloud
+- AKO now has a `L7Rule` CRD to change default parameters of L7 VirtualService in addition to `HostRule` CRD.
+- Support for Network Security policy in `HostRule` CRD.
+- AKO can use pre-existing avi-secret, present in AKO helm installation namespace to connect to the Avi Controller. Customer should not specify credentials as part of values.yaml during installation.
+
+### Changed
+- L4 CRD can be applied to LoadBalancer type service present in different namespace.
+- AKO shows all IPV4 and IPV6 addresses associated with VirtualService as part of Ingress, LoadBalancer status.
+- AKO updates Route's `Status:Reason` field with vsuuid and controller uuid.
+
+### Fixed
+- AKO allows VIP to be IPV6 for LoadBalancer type services.
+- Fix: Static routes are not added due to an error: `Field check for static_routes failed: Unique constraints route_id has duplicated value` when calico CNI allocates multiple block-affinities for a node and that may result in AKO crash.
+- Fix: Failure in creating Virtual Service, PoolGroup and other Pools if name of one of the Pool, attached to PoolGroup, exceeds maximum Avi Controller name length limit.
+
+### Known Issue
+- L4 Rule CRD, with `enableSSL: true` in listener propterties, will not be applied to L4 Virtual Service if Avi Controller license is of type `Enterprise with Cloud Service`.
+
+## AKO-1.12.2
+
+### Added
+ - AKO now claims support for Kubernetes 1.30, OCP 4.15
+
+### Changed
+ - AKO now creates single SSLKeyCertificate per tenant for default secret present in the cluster.
+
+### Fixed
+ - Fix: AKO Gateway does not create virtual service if Gateway have multiple listeners with same host name.
+ - Fix: AKO Gateway container crashes when it boots up in NPL mode.
+ - Fix: AKO does not honour readiness probe for pods when AKO boots up in NPL mode.
+ - Fix: AKO Shared VIP functionality doesn't work in NSX-T setup.
+ - Fix: AKO crashes in NSX-T shared L4 vip environment with no subdomain configured.
+ - Fix: L4Rule, with SSL enabled, is not applied to L4 VS if license type is Enterprise with Cloud Services.
+ - Fix: Cloud name with spaces in causes AKO to fail to start after upgrading Avi to 30.x.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,3 +487,22 @@ All notable changes to this project will be documented in this file. The format 
  - Fix: AKO crashes in NSX-T shared L4 vip environment with no subdomain configured.
  - Fix: L4Rule, with SSL enabled, is not applied to L4 VS if license type is Enterprise with Cloud Services.
  - Fix: Cloud name with spaces in causes AKO to fail to start after upgrading Avi to 30.x.
+
+## AKO-1.13.1
+
+### Added
+ - AKO now claims support for Kubernetes 1.31 and OCP 4.17.
+ - AKO now supports `multitenancy`. This feature allows AKO to map each Kubernetes/OpenShift cluster uniquely to a tenant in Avi or to map each namespace in a single Kubernetes/OpenShift cluster uniquely to a tenant in Avi.
+ - Support for EndpointSlices as the default mechanism to determine the network endpoints backing a service in Kubernetes. The preferred mechanism between EndpointSlices and Endpoints can be set using the `enableEndpointSlice` flag in ConfigMap.
+ - Support for graceful shutdown of backend servers when EndpointSlices usage is enabled.
+ - Support for `useRegex` and `applicationRootPath` fields in HostRule CRD. These will enable users to define paths that are regular expressions and the application root path, respectively, for an Ingress/OpenShift Route.
+ - Support for `enableHTTP2` field in HTTPRule CRD. This field can be used to enable HTTP/2 traffic support to the backend for L7 virtual services.
+ - Support for restricting cross-namespace usage of FQDNs/hostnames using the `fqdnReusePolicy` flag in ConfigMap.
+ - AKO now supports OpenShift Routes with `spec.subdomain` field specified instead of `spec.host` field, using the `defaultDomain` field in ConfigMap. The default domain specified is appended to `spec.subdomain` to form the FQDN for the VS.
+
+### Changed
+ - The `L4Settings.defaultDomain` field in Helm values.yaml is deprecated in favour of the newly introduced `NetworkSettings.defaultDomain` field. The value in the latter will be preferred for populating `defaultDomain` field in ConfigMap.
+
+### Fixed
+ - Fix: AKO is crashing when a HostRule object, with `analyticsPolicy.logAllHeaders` set, is applied to an Ingress.
+ - Fix: AKO does not configure the **Error Page Profile** for an EVH parent shared virtual service, when `errorPageProfile` is set in a matching HostRule object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,16 +490,16 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
  - AKO now claims support for Kubernetes 1.31 and OCP 4.17.
- - AKO now supports `multitenancy`. This feature allows AKO to map each Kubernetes/OpenShift cluster uniquely to a tenant in Avi or to map each namespace in a single Kubernetes/OpenShift cluster uniquely to a tenant in Avi.
- - Support for EndpointSlices as the default mechanism to determine the network endpoints backing a service in Kubernetes. The preferred mechanism between EndpointSlices and Endpoints can be set using the `enableEndpointSlice` flag in ConfigMap.
- - Support for graceful shutdown of backend servers when EndpointSlices usage is enabled.
- - Support for `useRegex` and `applicationRootPath` fields in HostRule CRD. These will enable users to define paths that are regular expressions and the application root path, respectively, for an Ingress/OpenShift Route.
- - Support for `enableHTTP2` field in HTTPRule CRD. This field can be used to enable HTTP/2 traffic support to the backend for L7 virtual services.
- - Support for restricting cross-namespace usage of FQDNs/hostnames using the `fqdnReusePolicy` flag in ConfigMap.
- - AKO now supports OpenShift Routes with `spec.subdomain` field specified instead of `spec.host` field, using the `defaultDomain` field in ConfigMap. The default domain specified is appended to `spec.subdomain` to form the FQDN for the VS.
+ - AKO now supports `multitenancy`. This feature allows AKO to map each Kubernetes/OpenShift cluster uniquely to a tenant in Avi or to map each namespace in a single Kubernetes/OpenShift cluster uniquely to a tenant in Avi. See [AKO Tenancy](docs/ako_tenancy.md) for more details.
+ - Support for EndpointSlices as the default mechanism to determine the network endpoints backing a service in Kubernetes. The preferred mechanism between EndpointSlices and Endpoints can be set using the `enableEndpointSlice` flag in ConfigMap. See [enableEndpointSlice](docs/values.md#featuregatesenableendpointslice) for more details.
+ - Support for graceful shutdown of backend servers when EndpointSlices usage is enabled. See [enableEndpointSlice](docs/values.md#featuregatesenableendpointslice) for more details.
+ - Support for `useRegex` and `applicationRootPath` fields in HostRule CRD. These will enable users to define paths that are regular expressions and the application root path, respectively, for an Ingress/OpenShift Route. See [useRegex](docs/crds/hostrule.md#enable-regular-expression-in-path) and [applicationRootPath](docs/crds/hostrule.md#specifying-application-root-redirect-path) for more details.
+ - Support for `enableHTTP2` field in HTTPRule CRD. This field can be used to enable HTTP/2 traffic support to the backend for L7 virtual services. See [enableHTTP2](docs/crds/httprule.md#enable-http2-protocol-support-for-backend) for more details.
+ - Support for restricting cross-namespace usage of FQDNs/hostnames using the `fqdnReusePolicy` flag in ConfigMap. See [FQDN Restriction](docs/ako_fqdnrestriction.md) for more details.
+ - AKO now supports OpenShift Routes with `spec.subdomain` field specified instead of `spec.host` field, using the `defaultDomain` field in ConfigMap. The default domain specified is appended to `spec.subdomain` to form the FQDN for the VS. See [defaultDomain](docs/values.md#networksettingsdefaultdomain) for more details.
 
 ### Changed
- - The `L4Settings.defaultDomain` field in Helm values.yaml is deprecated in favour of the newly introduced `NetworkSettings.defaultDomain` field. The value in the latter will be preferred for populating `defaultDomain` field in ConfigMap.
+ - The `L4Settings.defaultDomain` field in Helm values.yaml is deprecated in favour of the newly introduced `NetworkSettings.defaultDomain` field. The value in the latter will be preferred for populating `defaultDomain` field in ConfigMap. See [defaultDomain](docs/values.md#networksettingsdefaultdomain) for more details.
 
 ### Fixed
  - Fix: AKO is crashing when a HostRule object, with `analyticsPolicy.logAllHeaders` set, is applied to an Ingress.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,8 +480,6 @@ All notable changes to this project will be documented in this file. The format 
  - AKO now creates single SSLKeyCertificate per tenant for default secret present in the cluster.
 
 ### Fixed
- - Fix: AKO Gateway does not create virtual service if Gateway have multiple listeners with same host name.
- - Fix: AKO Gateway container crashes when it boots up in NPL mode.
  - Fix: AKO does not honour readiness probe for pods when AKO boots up in NPL mode.
  - Fix: AKO Shared VIP functionality doesn't work in NSX-T setup.
  - Fix: AKO crashes in NSX-T shared L4 vip environment with no subdomain configured.

--- a/docs/install/helm.md
+++ b/docs/install/helm.md
@@ -59,7 +59,7 @@ Step 4: Check the installation
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED     STATUS  	CHART    	APP VERSION
-ako-1691752136	avi-system	1       	2023-09-28	deployed	ako-1.13.1	1.13.1
+ako-1691752136	avi-system	1       	2025-01-31	deployed	ako-1.13.1	1.13.1
 ```
 
 ## Uninstall using *helm*
@@ -105,7 +105,7 @@ kubectl apply -f <output_dir>/ako/crds/
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED                             	    STATUS  	CHART    	APP VERSION
-ako-1593523840	avi-system	1       	2023-04-16 13:44:31.609195757 +0000 UTC	    deployed	ako-1.10.3	1.10.3
+ako-1593523840	avi-system	1       	2024-08-04 13:44:31.609195757 +0000 UTC	    deployed	ako-1.12.2	1.12.2
 ```
 
 *Step3*

--- a/docs/openshift/openshift_helm.md
+++ b/docs/openshift/openshift_helm.md
@@ -55,7 +55,5 @@ Verify the installation
 helm list -n avi-system
 
 NAME          	NAMESPACE 	REVISION	UPDATED     STATUS  	CHART    	APP VERSION
-ako-1691752136	avi-system	1       	2023-09-28	deployed	ako-1.13.1	1.13.1
+ako-1691752136	avi-system	1       	2025-01-31	deployed	ako-1.13.1	1.13.1
 ```
-
-


### PR DESCRIPTION
This PR adds release notes for AKO 1.13.1 release. It also updates missing release notes for older 1.12.x releases in changelog for master branch.
**Note :** I have changed the base/destination branch from master to release-1.13.1 in this PR as Jeya's automation already update the helm chart version to 1.14.1 after we had the build leading to conflicts.
