### PR TITLE
Fix UT Failure in evh

### DIFF
--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -3947,4 +3947,11 @@ func TestApplyHostruleToParentVSWithEmptyDomains(t *testing.T) {
 	g.Expect(nodes[0].SslProfileRef).To(gomega.BeNil())
 
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
+
+	mcache := cache.SharedAviObjCache()
+	cloudObj := &cache.AviCloudPropertyCache{Name: "Default-Cloud", VType: "mock"}
+	subdomains := []string{"avi.internal", ".com"}
+	cloudObj.NSIpamDNS = subdomains
+	mcache.CloudKeyCache.AviCacheAdd("Default-Cloud", cloudObj)
+
 }


### PR DESCRIPTION
No hostname ingress Test case in EVH was failing due to EVH child was not getting created as there was no subdomain presents as it was getting removed in latest added UT