### PR TITLE
Include Pool name in L4 Policy checksum calculation

### DIFF
--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -1584,7 +1584,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 			}
 		}
 		emptyIngestionMarkers := utils.AviObjectMarkers{}
-		cksum := lib.L4PolicyChecksum(ports, protocols, emptyIngestionMarkers, l4pol.Markers, true)
+		cksum := lib.L4PolicyChecksum(ports, protocols, pools, emptyIngestionMarkers, l4pol.Markers, true)
 		tenant := getTenantFromTenantRef(*l4pol.TenantRef)
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,
@@ -1815,7 +1815,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 		}
 
 		emptyIngestionMarkers := utils.AviObjectMarkers{}
-		cksum := lib.L4PolicyChecksum(ports, protocols, emptyIngestionMarkers, l4pol.Markers, true)
+		cksum := lib.L4PolicyChecksum(ports, protocols, pools, emptyIngestionMarkers, l4pol.Markers, true)
 		l4PolCacheObj := AviL4PolicyCache{
 			Name:             *l4pol.Name,
 			Tenant:           getTenantFromTenantRef(*l4pol.TenantRef),

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -1431,14 +1431,15 @@ func SSLKeyCertChecksum(sslName, certificate, cacert string, ingestionMarkers ut
 	return checksum
 }
 
-func L4PolicyChecksum(ports []int64, protocols []string, ingestionMarkers utils.AviObjectMarkers, markers []*models.RoleFilterMatchLabel, populateCache bool) uint32 {
+func L4PolicyChecksum(ports []int64, protocols []string, pools []string, ingestionMarkers utils.AviObjectMarkers, markers []*models.RoleFilterMatchLabel, populateCache bool) uint32 {
 	var portsInt []int
 	for _, port := range ports {
 		portsInt = append(portsInt, int(port))
 	}
 	sort.Ints(portsInt)
 	sort.Strings(protocols)
-	checksum := utils.Hash(utils.Stringify(portsInt)) + utils.Hash(utils.Stringify(protocols))
+	sort.Strings(pools)
+	checksum := utils.Hash(utils.Stringify(portsInt)) + utils.Hash(utils.Stringify(protocols)) + utils.Hash(utils.Stringify(pools))
 	if populateCache {
 		if markers != nil {
 			checksum += ObjectLabelChecksum(markers)

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -1086,6 +1086,7 @@ func (v *AviL4PolicyNode) CalculateCheckSum() {
 	var checksum uint32
 	var ports []int64
 	var protocols []string
+	var pools []string
 	if len(v.PortPool) > 0 {
 		sort.Slice(v.PortPool, func(i, j int) bool {
 			return v.PortPool[i].Name < v.PortPool[j].Name
@@ -1094,9 +1095,13 @@ func (v *AviL4PolicyNode) CalculateCheckSum() {
 	for _, hpp := range v.PortPool {
 		ports = append(ports, int64(hpp.Port))
 		protocols = append(protocols, hpp.Protocol)
+		// Include Pool name in checksum logic
+		pool := strings.TrimPrefix(hpp.Pool, "/api/pool?name=")
+		pools = append(pools, pool)
+
 	}
 	if len(v.PortPool) > 0 {
-		checksum = lib.L4PolicyChecksum(ports, protocols, v.AviMarkers, nil, false)
+		checksum = lib.L4PolicyChecksum(ports, protocols, pools, v.AviMarkers, nil, false)
 	}
 	v.CloudConfigCksum = checksum
 }

--- a/internal/rest/avi_obj_l4ps.go
+++ b/internal/rest/avi_obj_l4ps.go
@@ -217,7 +217,7 @@ func (rest *RestOperations) AviL4PolicyCacheAdd(rest_op *utils.RestOp, vsKey avi
 		}
 		emptyIngestionMarkers := utils.AviObjectMarkers{}
 		//This is fetching data from response send at avi controller.
-		cksum := lib.L4PolicyChecksum(ports, protocols, emptyIngestionMarkers, l4policyset.Markers, true)
+		cksum := lib.L4PolicyChecksum(ports, protocols, pools, emptyIngestionMarkers, l4policyset.Markers, true)
 		l4_cache_obj := avicache.AviL4PolicyCache{Name: name, Tenant: rest_op.Tenant,
 			Uuid:             uuid,
 			LastModified:     lastModifiedStr,


### PR DESCRIPTION
This change fixes the issue observed in the PR https://bugzilla-vcf.lvn.broadcom.net/show_bug.cgi?id=3499916#c1