### PR TITLE
AV-232413 : Encode pg and pool name in SNI mode for ingress/route host with no path defined

### DIFF
--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -378,16 +378,17 @@ func BuildRegexAppRootForHostRule(hostrule *akov1beta1.HostRule, vsNode AviVsEvh
 					vsStringGroupRefs = append(vsStringGroupRefs, &aviStringGroupNode)
 					stringGroupRef := []string{"/api/stringgroup?name=" + regexStringGroupName}
 					hppMap.StringGroupRefs = stringGroupRef
-					if !lib.IsEvhEnabled() {
-						if hppMap.PoolGroup != "" && !lib.IsNameEncoded(hppMap.PoolGroup) {
-							hppMap.PoolGroup = lib.GetEncodedSniPGPoolNameforRegex(hppMap.PoolGroup)
-						}
-						if hppMap.Pool != "" && !lib.IsNameEncoded(hppMap.Pool) {
-							hppMap.Pool = lib.GetEncodedSniPGPoolNameforRegex(hppMap.Pool)
-						}
-					}
-					hppMap.CalculateCheckSum()
 				}
+				if !lib.IsEvhEnabled() {
+					if hppMap.PoolGroup != "" && !lib.IsNameEncoded(hppMap.PoolGroup) {
+						hppMap.PoolGroup = lib.GetEncodedSniPGPoolNameforRegex(hppMap.PoolGroup)
+					}
+					if hppMap.Pool != "" && !lib.IsNameEncoded(hppMap.Pool) {
+						hppMap.Pool = lib.GetEncodedSniPGPoolNameforRegex(hppMap.Pool)
+					}
+				}
+				hppMap.CalculateCheckSum()
+
 			}
 			regexhppMap = append(regexhppMap, hppMap)
 		}

--- a/tests/dedicatedvstests/l7_dedicated_crd_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_crd_test.go
@@ -1071,6 +1071,184 @@ func TestHostRuleRegexAppRootListenerPorts(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
 }
 
+func TestHostRuleUseRegexNoPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--foo.com-L7-dedicated"
+	hrname := "hr-cluster--foo.com-L7-dedicated"
+	fqdn := "foo.com"
+	namespace := "default"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	ingTestObj.paths = []string{}
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := V1beta1Client.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com-L7-dedicated"}
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--foo.com-L7-dedicated", true)
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-" + ingressName + "-L7-dedicated")))
+	g.Expect(node.HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Path).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPort).To(gomega.Equal(int32(443)))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].MatchCriteriaPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
+
+	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-" + ingressName + "-L7-dedicated"))
+	g.Expect(node.HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Path).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPort).To(gomega.Equal(int32(443)))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].MatchCriteriaPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
+
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
+}
+
+func TestHostRuleUseRegexMultiIngressNoPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--foo.com-L7-dedicated"
+	hrname := "hr-cluster--foo.com-L7-dedicated"
+	fqdn := "foo.com"
+	namespace := "default"
+	secretName := objNameMap.GenerateName("my-secret")
+	ingressName := objNameMap.GenerateName("foo-with-targets")
+	svcName := objNameMap.GenerateName("avisvc")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingressName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	ingTestObj.paths = []string{}
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj2 := IngressTestObject{
+		ingressName: ingressName2,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj2.FillParams()
+	// only creating ingress
+	CreateIngress(t, ingTestObj2)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := V1beta1Client.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	vsKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com-L7-dedicated"}
+	integrationtest.VerifyMetadataHostRule(t, g, vsKey, "default/hr-cluster--foo.com-L7-dedicated", true)
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-" + ingressName + "-L7-dedicated")))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].MatchCase).Should(gomega.Equal("INSENSITIVE"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_foo-" + ingressName2 + "-L7-dedicated")))
+	g.Expect(node.HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Path).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPort).To(gomega.Equal(int32(443)))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].MatchCriteriaPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
+
+	integrationtest.TeardownHostRule(t, g, vsKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-" + ingressName + "-L7-dedicated"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-" + ingressName2 + "-L7-dedicated"))
+	g.Expect(node.HttpPolicyRefs[1].HppMap).To(gomega.BeNil())
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Path).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPort).To(gomega.Equal(int32(443)))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].RedirectPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].MatchCriteriaPath).To(gomega.Equal(""))
+	g.Expect(node.HttpPolicyRefs[1].RedirectPorts[0].Hosts[0]).To(gomega.Equal("foo.com"))
+
+	// deleting the second created ingress
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)
+}
+
 func TestHTTPRuleCreateDeleteEnableHTTP2(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/tests/dedicatedvstests/l7_dedicated_graph_test.go
+++ b/tests/dedicatedvstests/l7_dedicated_graph_test.go
@@ -201,6 +201,37 @@ func SetUpIngressForCacheSyncCheck(t *testing.T, ingTestObj IngressTestObject) {
 		Paths:       ingTestObj.paths,
 		ServiceName: ingTestObj.serviceName,
 	}
+	if len(ingTestObj.paths) == 0 {
+		ingressObject.NoPath = true
+	}
+	if ingTestObj.withSecret {
+		integrationtest.AddSecret(ingTestObj.secretName, ingTestObj.namespace, "tlsCert", "tlsKey")
+	}
+	if ingTestObj.isTLS {
+		ingressObject.TlsSecretDNS = map[string][]string{
+			ingTestObj.secretName: {"foo.com"},
+		}
+	}
+	ingrFake := ingressObject.Ingress()
+	if _, err := KubeClient.NetworkingV1().Ingresses(ingTestObj.namespace).Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, ingTestObj.modelNames[0], 5)
+}
+
+func CreateIngress(t *testing.T, ingTestObj IngressTestObject) {
+	ingressObject := integrationtest.FakeIngress{
+		Name:        ingTestObj.ingressName,
+		Namespace:   ingTestObj.namespace,
+		DnsNames:    ingTestObj.dnsNames,
+		Ips:         ingTestObj.ipAddrs,
+		HostNames:   ingTestObj.hostnames,
+		Paths:       ingTestObj.paths,
+		ServiceName: ingTestObj.serviceName,
+	}
+	if len(ingTestObj.paths) == 0 {
+		ingressObject.NoPath = true
+	}
 	if ingTestObj.withSecret {
 		integrationtest.AddSecret(ingTestObj.secretName, ingTestObj.namespace, "tlsCert", "tlsKey")
 	}

--- a/tests/ingresstests/crd_test.go
+++ b/tests/ingresstests/crd_test.go
@@ -1915,6 +1915,180 @@ func TestHostRuleUseRegex(t *testing.T) {
 	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
 }
 
+func TestHostRuleUseRegexNoPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := MODEL_NAME_PREFIX + "0"
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	fqdn := "foo.com"
+	namespace := integrationtest.DEFAULT_NAMESPACE
+
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	ingTestObj.paths = []string{}
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].SniNodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts[0].Hosts).Should(gomega.ContainElements(fqdn))
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-" + ingName)))
+
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-" + ingName))
+
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
+}
+
+func TestHostRuleUseRegexMultiIngressNoPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := MODEL_NAME_PREFIX + "0"
+	hrname := objNameMap.GenerateName("samplehr-foo")
+	fqdn := "foo.com"
+	namespace := integrationtest.DEFAULT_NAMESPACE
+
+	svcName := objNameMap.GenerateName("avisvc")
+	secretName := objNameMap.GenerateName("my-secret")
+	ingName := objNameMap.GenerateName("foo-with-targets")
+
+	ingTestObj := IngressTestObject{
+		ingressName: ingName,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj.FillParams()
+	ingTestObj.paths = []string{}
+	SetUpIngressForCacheSyncCheck(t, ingTestObj)
+
+	ingressName2 := objNameMap.GenerateName("foo-with-targets")
+	ingTestObj2 := IngressTestObject{
+		ingressName: ingressName2,
+		isTLS:       true,
+		withSecret:  true,
+		secretName:  secretName,
+		serviceName: svcName,
+		modelNames:  []string{modelName},
+	}
+	ingTestObj2.FillParams()
+	// only creating ingress
+	CreateIngress(t, ingTestObj2)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := v1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/"+hrname, true)
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].SniNodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts).To(gomega.HaveLen(1))
+	g.Expect(node.HttpPolicyRefs[0].RedirectPorts[0].Hosts).Should(gomega.ContainElements(fqdn))
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-" + ingName)))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCase).Should(gomega.Equal("INSENSITIVE"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_foo-" + ingressName2)))
+
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-" + ingName))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-" + ingressName2))
+
+	// deleting the second created ingress
+	if err := KubeClient.NetworkingV1().Ingresses("default").Delete(context.TODO(), ingressName2, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Couldn't DELETE the Ingress %v", err)
+	}
+	TearDownIngressForCacheSyncCheck(t, ingName, svcName, secretName, modelName)
+}
+
 func TestHostRuleAppRoot(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/tests/ingresstests/l7_rest_test.go
+++ b/tests/ingresstests/l7_rest_test.go
@@ -87,12 +87,43 @@ func SetUpIngressForCacheSyncCheck(t *testing.T, ingTestObj IngressTestObject) {
 		Paths:       ingTestObj.paths,
 		ServiceName: ingTestObj.serviceName,
 	}
+	if len(ingTestObj.paths) == 0 {
+		ingressObject.NoPath = true
+	}
 	if ingTestObj.withSecret {
 		integrationtest.AddSecret(ingTestObj.secretName, ingTestObj.namespace, "tlsCert", "tlsKey")
 	}
 	if ingTestObj.isTLS {
 		ingressObject.TlsSecretDNS = map[string][]string{
 			ingTestObj.secretName: {ingTestObj.dnsNames[0]},
+		}
+	}
+	ingrFake := ingressObject.Ingress()
+	if _, err := KubeClient.NetworkingV1().Ingresses(ingTestObj.namespace).Create(context.TODO(), ingrFake, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding Ingress: %v", err)
+	}
+	integrationtest.PollForCompletion(t, ingTestObj.modelNames[0], 5)
+}
+
+func CreateIngress(t *testing.T, ingTestObj IngressTestObject) {
+	ingressObject := integrationtest.FakeIngress{
+		Name:        ingTestObj.ingressName,
+		Namespace:   ingTestObj.namespace,
+		DnsNames:    ingTestObj.dnsNames,
+		Ips:         ingTestObj.ipAddrs,
+		HostNames:   ingTestObj.hostnames,
+		Paths:       ingTestObj.paths,
+		ServiceName: ingTestObj.serviceName,
+	}
+	if len(ingTestObj.paths) == 0 {
+		ingressObject.NoPath = true
+	}
+	if ingTestObj.withSecret {
+		integrationtest.AddSecret(ingTestObj.secretName, ingTestObj.namespace, "tlsCert", "tlsKey")
+	}
+	if ingTestObj.isTLS {
+		ingressObject.TlsSecretDNS = map[string][]string{
+			ingTestObj.secretName: {"foo.com"},
 		}
 	}
 	ingrFake := ingressObject.Ingress()

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -299,6 +299,7 @@ type FakeIngress struct {
 	annotations  map[string]string
 	ServiceName  string
 	TlsSecretDNS map[string][]string
+	NoPath       bool
 }
 
 func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
@@ -346,17 +347,30 @@ func (ing FakeIngress) Ingress(multiport ...bool) *networking.Ingress {
 							}}}}}}},
 			)
 		} else {
-			ingress.Spec.Rules = append(ingress.Spec.Rules, networking.IngressRule{
-				Host: dnsName,
-				IngressRuleValue: networking.IngressRuleValue{
-					HTTP: &networking.HTTPIngressRuleValue{
-						Paths: []networking.HTTPIngressPath{{
-							Path: path,
-							Backend: networking.IngressBackend{Service: &networking.IngressServiceBackend{
-								Name: ing.ServiceName,
-								Port: networking.ServiceBackendPort{Number: 8080},
-							}}}}}}},
-			)
+			if ing.NoPath {
+				ingress.Spec.Rules = append(ingress.Spec.Rules, networking.IngressRule{
+					Host: dnsName,
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{{
+								Backend: networking.IngressBackend{Service: &networking.IngressServiceBackend{
+									Name: ing.ServiceName,
+									Port: networking.ServiceBackendPort{Number: 8080},
+								}}}}}}},
+				)
+			} else {
+				ingress.Spec.Rules = append(ingress.Spec.Rules, networking.IngressRule{
+					Host: dnsName,
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{{
+								Path: path,
+								Backend: networking.IngressBackend{Service: &networking.IngressServiceBackend{
+									Name: ing.ServiceName,
+									Port: networking.ServiceBackendPort{Number: 8080},
+								}}}}}}},
+				)
+			}
 		}
 	}
 	for secret, hosts := range ing.TlsSecretDNS {

--- a/tests/oshiftroutetests/lib.go
+++ b/tests/oshiftroutetests/lib.go
@@ -245,15 +245,21 @@ func TearDownTestForRoute(t *testing.T, modelName string) {
 
 // TO DO (Aakash) : Rename function to DeleteRouteAndVerify
 func VerifyRouteDeletion(t *testing.T, g *gomega.WithT, aviModel interface{}, poolCount int, nsname ...string) {
-	namespace, name := defaultNamespace, defaultRouteName
 	if len(nsname) > 0 {
-		namespace, name = strings.Split(nsname[0], "/")[0], strings.Split(nsname[0], "/")[1]
+		for _, nsNameVal := range nsname {
+			namespace, name := strings.Split(nsNameVal, "/")[0], strings.Split(nsNameVal, "/")[1]
+			err := OshiftClient.RouteV1().Routes(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("Couldn't DELETE the route %v", err)
+			}
+		}
+	} else {
+		err := OshiftClient.RouteV1().Routes(defaultNamespace).Delete(context.TODO(), defaultRouteName, metav1.DeleteOptions{})
+		if err != nil {
+			t.Fatalf("Couldn't DELETE the route %v", err)
+		}
 	}
 
-	err := OshiftClient.RouteV1().Routes(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't DELETE the route %v", err)
-	}
 	var nodes []*avinodes.AviVsNode
 	g.Eventually(func() []*avinodes.AviPoolNode {
 		nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVS()

--- a/tests/oshiftroutetests/oshift_crd_test.go
+++ b/tests/oshiftroutetests/oshift_crd_test.go
@@ -1307,6 +1307,151 @@ func TestHostRuleRegexAppRootListenerPorts(t *testing.T) {
 	TearDownTestForRoute(t, defaultModelName)
 }
 
+func TestHostRuleUseRegexNoPortPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-0"
+	hrname := "samplehr-foo"
+	fqdn := "foo.com"
+	namespace := "default"
+
+	SetUpTestForRoute(t, modelName)
+	routeExample := FakeRoute{}.SecureRoute()
+	_, err := OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), routeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	ValidateSniModel(t, g, modelName)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := V1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].SniNodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-foo")))
+
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-foo"))
+
+	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0)
+	TearDownTestForRoute(t, defaultModelName)
+}
+
+func TestHostRuleUseRegexMultiRouteNoPortPath(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	modelName := "admin/cluster--Shared-L7-0"
+	hrname := "samplehr-foo"
+	fqdn := "foo.com"
+	namespace := "default"
+	pathRouteName := "pathRoute"
+
+	SetUpTestForRoute(t, modelName)
+	routeExample := FakeRoute{}.SecureRoute()
+	_, err := OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), routeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	routeExample = FakeRoute{Name: pathRouteName, Path: "/foo"}.SecureRoute()
+	_, err = OshiftClient.RouteV1().Routes(defaultNamespace).Create(context.TODO(), routeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding route: %v", err)
+	}
+
+	ValidateSniModel(t, g, modelName)
+
+	hostrule := integrationtest.FakeHostRule{
+		Name:      hrname,
+		Namespace: namespace,
+		Fqdn:      fqdn,
+		UseRegex:  true,
+	}
+	hrCreate := hostrule.HostRule()
+	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules(namespace).Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error in adding HostRule: %v", err)
+	}
+	g.Eventually(func() string {
+		hostrule, _ := V1beta1CRDClient.AkoV1beta1().HostRules("default").Get(context.TODO(), hrname, metav1.GetOptions{})
+		return hostrule.Status.Status
+	}, 20*time.Second).Should(gomega.Equal("Accepted"))
+
+	sniVSKey := cache.NamespaceName{Namespace: "admin", Name: "cluster--foo.com"}
+	integrationtest.VerifyMetadataHostRule(t, g, sniVSKey, "default/samplehr-foo", true)
+
+	g.Eventually(func() int {
+		_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+		return len(nodes[0].SniNodes)
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	node := aviModel.(*avinodes.AviObjectGraph).GetAviVS()[0]
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com-foo")))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("REGEX_MATCH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCase).Should(gomega.Equal("INSENSITIVE"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal(lib.GetEncodedSniPGPoolNameforRegex("cluster--default-foo.com_foo-pathRoute")))
+
+	integrationtest.TeardownHostRule(t, g, sniVSKey, hrname)
+	time.Sleep(2 * time.Second)
+
+	g.Expect(node.SniNodes).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].RedirectPorts).To(gomega.BeNil())
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap).To(gomega.HaveLen(2))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[0].PoolGroup).To(gomega.Equal("cluster--default-foo.com-foo"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].MatchCriteria).Should(gomega.Equal("BEGINS_WITH"))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].StringGroupRefs).To(gomega.HaveLen(0))
+	g.Expect(node.SniNodes[0].HttpPolicyRefs[0].HppMap[1].PoolGroup).To(gomega.Equal("cluster--default-foo.com_foo-pathRoute"))
+
+	routeNSNameList := []string{defaultNamespace + "/" + defaultRouteName, defaultNamespace + "/" + pathRouteName}
+	VerifySecureRouteDeletion(t, g, defaultModelName, 0, 0, routeNSNameList...)
+	TearDownTestForRoute(t, defaultModelName)
+}
+
 func TestRouteHostRuleWithSubdomainNoHost(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	hrname := "samplehr-foo"


### PR DESCRIPTION
This PR fixes the underlying issue seen in the following bugs https://vmw-jira.broadcom.net/browse/AV-232211 and https://vmw-jira.broadcom.net/browse/AV-232413.
The primary issue is that If an ingress/route does not specify a path in spec, and the corresponding hostrule has useRegex field set to true, the PG name in httppolicyset is not being encoded for the empty path in SNI mode. This leads to httppolicyset creation failure as the actual pg and pools are re-created with encoded names, but httppolicyset tries to use the old not encoded pg name.