### PR TITLE
AV-233670: VIP Per Namespace: Do not add auto fqdn to L7 VS

### DIFF
--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -321,7 +321,7 @@ func GetFqdns(vsName, key, tenant string, subDomains []string, shardSize uint32)
 		fqdns = append(fqdns, fqdn)
 	} else {
 		// Do not generate auto-fqdn for vipPerNS use case
-		if VIPPerNamespace() {
+		if VIPPerNamespace() && autoFQDN {
 			utils.AviLog.Warnf("key: %s, msg: Auto-FQDN is disabled for VIP PER NS mode.", key)
 		}
 		objects.SharedCRDLister().UpdateFQDNSharedVSModelMappings(vsName, GetModelName(tenant, vsName))

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -291,7 +291,8 @@ func GetFqdns(vsName, key, tenant string, subDomains []string, shardSize uint32)
 	if GetL4FqdnFormat() == AutoFQDNDisabled {
 		autoFQDN = false
 	}
-	if subDomains != nil && autoFQDN {
+
+	if subDomains != nil && autoFQDN && !VIPPerNamespace() {
 		//Replace all non valid dns label characters with - in tenant name
 		tenantNameWithValidChars := nonDnsLabelRegex.ReplaceAllString(tenant, "-")
 		// honour defaultSubDomain from values.yaml if specified
@@ -308,15 +309,21 @@ func GetFqdns(vsName, key, tenant string, subDomains []string, shardSize uint32)
 		}
 		if GetL4FqdnFormat() == AutoFQDNDefault {
 			// Generate the FQDN based on the logic: <svc_name>.<namespace>.<sub-domain>
+			// TODO: check label length for vsName, tenantName so that it doesn't exceed 63 characters.
 			fqdn = vsName + "." + tenantNameWithValidChars + "." + subdomain
 		} else if GetL4FqdnFormat() == AutoFQDNFlat {
 			// Generate the FQDN based on the logic: <svc_name>-<namespace>.<sub-domain>
+			// TODO: check label length for vsName-tenantName so that it doesn't exceed 63 characters.
 			fqdn = vsName + "-" + tenantNameWithValidChars + "." + subdomain
 		}
 		objects.SharedCRDLister().UpdateFQDNSharedVSModelMappings(fqdn, GetModelName(tenant, vsName))
 		utils.AviLog.Infof("key: %s, msg: Configured the shared VS with default fqdn as: %s", key, fqdn)
 		fqdns = append(fqdns, fqdn)
 	} else {
+		// Do not generate auto-fqdn for vipPerNS use case
+		if VIPPerNamespace() {
+			utils.AviLog.Warnf("key: %s, msg: Auto-FQDN is disabled for VIP PER NS mode.", key)
+		}
 		objects.SharedCRDLister().UpdateFQDNSharedVSModelMappings(vsName, GetModelName(tenant, vsName))
 	}
 	return fqdns, fqdn

--- a/tests/evhtests/l7_evh_crd_test.go
+++ b/tests/evhtests/l7_evh_crd_test.go
@@ -422,7 +422,7 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 
 	fqdn := "cluster--Shared-L7-EVH-0.admin.com"
 	if lib.VIPPerNamespace() {
-		fqdn = "cluster--Shared-L7-EVH-NS-default.admin.com"
+		fqdn = "Shared-L7-EVH-NS"
 	}
 	hostrule := integrationtest.FakeHostRule{
 		Name:                  hrName,
@@ -442,6 +442,9 @@ func TestCreateDeleteSharedVSHostRuleForEvh(t *testing.T) {
 		Listeners: []v1beta1.HostRuleTCPListeners{
 			{Port: 8081}, {Port: 8082}, {Port: 8083, EnableSSL: true},
 		},
+	}
+	if lib.VIPPerNamespace() {
+		hrCreate.Spec.VirtualHost.FqdnType = "Contains"
 	}
 	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules("default").Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding HostRule: %v", err)
@@ -1255,7 +1258,7 @@ func TestSharedVSHostRuleNoListenerForEvh(t *testing.T) {
 
 	fqdn := "cluster--Shared-L7-EVH-0.admin.com"
 	if lib.VIPPerNamespace() {
-		fqdn = "cluster--Shared-L7-EVH-NS-default.admin.com"
+		fqdn = "Shared-L7-EVH-NS"
 	}
 	hostrule := integrationtest.FakeHostRule{
 		Name:               hrName,
@@ -1272,6 +1275,9 @@ func TestSharedVSHostRuleNoListenerForEvh(t *testing.T) {
 	hrCreate := hostrule.HostRule()
 	hrCreate.Spec.VirtualHost.TCPSettings = &v1beta1.HostRuleTCPSettings{
 		LoadBalancerIP: "80.80.80.80",
+	}
+	if lib.VIPPerNamespace() {
+		hrCreate.Spec.VirtualHost.FqdnType = "Contains"
 	}
 	if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().HostRules("default").Create(context.TODO(), hrCreate, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding HostRule: %v", err)

--- a/tests/evhtests/l7_evh_graph_test.go
+++ b/tests/evhtests/l7_evh_graph_test.go
@@ -2071,13 +2071,19 @@ func TestFQDNCountInL7Model(t *testing.T) {
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	node := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()[0]
 
+	fqdnCount := 2
+	if lib.VIPPerNamespace() {
+		fqdnCount = 1
+	}
 	g.Expect(node.VSVIPRefs).To(gomega.HaveLen(1))
-	g.Expect(node.VSVIPRefs[0].FQDNs).To(gomega.HaveLen(2))
+	g.Expect(node.VSVIPRefs[0].FQDNs).To(gomega.HaveLen(fqdnCount))
 	for _, fqdn := range node.VSVIPRefs[0].FQDNs {
 		if fqdn == "foo.com" {
 			continue
 		}
-		g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7"))
+		if !lib.VIPPerNamespace() {
+			g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7"))
+		}
 	}
 
 	TearDownIngressForCacheSyncCheck(t, secretName, ingressName, svcName, modelName)

--- a/tests/evhtests/l7_evh_ingressclass_test.go
+++ b/tests/evhtests/l7_evh_ingressclass_test.go
@@ -1505,14 +1505,19 @@ func TestFQDNsCountForAviInfraSettingWithLargeShardSize(t *testing.T) {
 
 	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
 	node := aviModel.(*avinodes.AviObjectGraph).GetAviEvhVS()[0]
-
+	fqdnCount := 2
+	if lib.VIPPerNamespace() {
+		fqdnCount = 1
+	}
 	g.Expect(node.VSVIPRefs).To(gomega.HaveLen(1))
-	g.Expect(node.VSVIPRefs[0].FQDNs).To(gomega.HaveLen(2))
+	g.Expect(node.VSVIPRefs[0].FQDNs).To(gomega.HaveLen(fqdnCount))
 	for _, fqdn := range node.VSVIPRefs[0].FQDNs {
 		if fqdn == "foo.com" {
 			continue
 		}
-		g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7-EVH"))
+		if !lib.VIPPerNamespace() {
+			g.Expect(fqdn).Should(gomega.ContainSubstring("Shared-L7-EVH"))
+		}
 	}
 	integrationtest.TeardownAviInfraSetting(t, settingName)
 	integrationtest.TeardownIngressClass(t, ingClassName)


### PR DESCRIPTION
With this change:
1. For VIPPerNS: Hostrule for shared VS has to be created with FQDNType Contains.

There are bunch of UTs not enabled for vip per ns. In future PR, we can enable those/ change as per VIP Per NS.