### PR TITLE
AV-232182: Retry on url error(client)

### DIFF
--- a/internal/rest/dequeue_nodes.go
+++ b/internal/rest/dequeue_nodes.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -290,7 +291,8 @@ func (rest *RestOperations) CheckAndPublishForRetry(err error, publishKey avicac
 			}
 		}
 	}
-	if strings.Contains(err.Error(), "Rest request error") || strings.Contains(err.Error(), "timed out waiting for rest response") {
+	var urlError *url.Error
+	if strings.Contains(err.Error(), "Rest request error") || strings.Contains(err.Error(), "timed out waiting for rest response") || errors.As(err, &urlError) {
 		utils.AviLog.Warnf("key: %s, msg: got error while executing rest request: %s, adding to slow retry queue", key, err.Error())
 		rest.PublishKeyToSlowRetryLayer(publishKey, key)
 		return true

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -303,6 +303,7 @@ type WebSyncError struct {
 func (e *WebSyncError) Error() string         { return fmt.Sprintf("Error during %s: %v", e.Operation, e.Err) }
 func (e *SkipSyncError) Error() string        { return e.Msg }
 func (e *WebSyncError) GetWebAPIError() error { return e.Err }
+func (e *WebSyncError) Unwrap() error         { return e.Err }
 
 var CloudName string
 


### PR DESCRIPTION
Simulated client connection error(introduced 100% loss to controller IP). The key will be added to slow retry queue for any connection error. Logs:
[retry.txt](https://github.com/user-attachments/files/19429301/retry.txt)

