### PR TITLE
AV-232009 Fix label creation on SE group by Gateway container

### DIFF
--- a/cmd/gateway-api/main.go
+++ b/cmd/gateway-api/main.go
@@ -59,7 +59,7 @@ func Initialize() {
 	os.Setenv("ISTIO_ENABLED", "false")
 	os.Setenv("SHARD_VS_SIZE", "LARGE")
 	os.Setenv("PASSTHROUGH_SHARD_SIZE", "LARGE")
-	os.Setenv(lib.DISABLE_STATIC_ROUTE_SYNC, "false")
+	os.Setenv(lib.DISABLE_STATIC_ROUTE_SYNC, "true")
 	os.Setenv("PROMETHEUS_ENABLED", "false")
 	os.Setenv("PRIMARY_AKO_FLAG", "false")
 


### PR DESCRIPTION
AV-232009 Fix label creation on SE group by Gateway container.

Testing Status:
Manually tested for following scenario:
1) Remove existing staticroutes from vrfcontext, remove label from SE group, set disableStaticRouteSync to "true" in configmap. Reboot ako. Static routes were not populated and label was not added to SE group as expected.
2) Set disableStaticRouteSync to "false" in configmap. Reboot ako. Static routes were popoulated in controller and label was added to Service Engine Group as expected.