### PR TITLE
AV-232614 Static Route fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     name: Golangci-lint
     strategy:
       matrix:
-        platform: [ ubuntu-20.04 ]
+        platform: [ ubuntu-24.04 ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.23.0

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/google/uuid"
 
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -660,4 +663,12 @@ func ProxyEnabledAppProfileCU(client *clients.AviClient) error {
 	}
 	utils.AviLog.Infof("Proxy enabled application profile %s created/updated", name)
 	return nil
+}
+
+func Uuid4() string {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return id.String()
 }

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -323,9 +323,8 @@ func (o *AviObjectGraph) GetOrderedNodes() []AviModelNode {
 }
 
 type StaticRouteDetails struct {
-	StartIndex int
-	Count      int
-	routeID    int
+	Count         int
+	RouteIDPrefix string
 }
 type AviVrfNode struct {
 	Name             string
@@ -333,7 +332,6 @@ type AviVrfNode struct {
 	CloudConfigCksum uint32
 	NodeStaticRoutes map[string]StaticRouteDetails
 	Nodes            []string
-	NodeIds          map[int]struct{}
 }
 
 func (v *AviVrfNode) GetCheckSum() uint32 {

--- a/internal/nodes/avi_vrf_translator.go
+++ b/internal/nodes/avi_vrf_translator.go
@@ -11,28 +11,82 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
 package nodes
 
 import (
 	"errors"
-	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
-
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 
 	"github.com/vmware/alb-sdk/go/models"
 	v1 "k8s.io/api/core/v1"
 )
 
+func GetStaticRoutesForOtherNodes(aviVrfNode *AviVrfNode, routeId string) []*models.StaticRoute {
+	var staticRouteCopy []*models.StaticRoute
+	nodePrefix := lib.GetClusterName() + "-" + routeId
+	for i := 0; i < len(aviVrfNode.StaticRoutes); i++ {
+		if routeId == "" || !strings.HasPrefix(*aviVrfNode.StaticRoutes[i].RouteID, nodePrefix) {
+			staticRouteCopy = append(staticRouteCopy, aviVrfNode.StaticRoutes[i])
+		}
+	}
+	return staticRouteCopy
+}
+
+func (o *AviObjectGraph) CheckAndDeduplicateRecords(key string) {
+	aviVrfNodes := o.GetAviVRF()
+	if len(aviVrfNodes) == 0 {
+		return
+	}
+	// Each AKO should have single VRF node as it deals with single cluster only.
+	aviVrfNode := aviVrfNodes[0]
+
+	podCidrNextHopMap := make(map[string]string)
+	hasDuplicateRecords := false
+	// Check if duplicate records for staticroutes exist
+	for i := 0; i < len(aviVrfNode.StaticRoutes); i++ {
+		_, ok := podCidrNextHopMap[*aviVrfNode.StaticRoutes[i].Prefix.IPAddr.Addr]
+		if ok {
+			utils.AviLog.Warnf("key: %s, VRFContext has duplicate records.", key)
+			hasDuplicateRecords = true
+			break
+		} else {
+			podCidrNextHopMap[*aviVrfNode.StaticRoutes[i].Prefix.IPAddr.Addr] = *aviVrfNode.StaticRoutes[i].NextHop.Addr
+		}
+	}
+	if !hasDuplicateRecords {
+		return
+	}
+
+	utils.AviLog.Infof("key: %s, Starting deduplication of records in VRFContext", key)
+
+	// Clean VRFCache
+	aviVrfNode.Nodes = nil
+	aviVrfNode.StaticRoutes = nil
+	aviVrfNode.NodeStaticRoutes = nil
+
+	// send sorted list of nodes from here.
+	allNodes := objects.SharedNodeLister().CopyAllObjects()
+	var nodeNames []string
+	for k := range allNodes {
+		nodeNames = append(nodeNames, k)
+	}
+	sort.Strings(nodeNames)
+	for _, nodeKey := range nodeNames {
+		o.BuildVRFGraph(key, aviVrfNode.Name, nodeKey, false)
+	}
+
+	utils.AviLog.Infof("key: %s, Deduplication of records in VRFContext finished", key)
+}
+
 // BuildVRFGraph : build vrf graph from k8s nodes
 func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag bool) error {
-	o.Lock.Lock()
-	defer o.Lock.Unlock()
 	//fetch vrf Node
 	aviVrfNodes := o.GetAviVRF()
 	if len(aviVrfNodes) == 0 {
@@ -45,10 +99,8 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 	// Each AKO should have single VRF node as it deals with single cluster only.
 	aviVrfNode := aviVrfNodes[0]
 
-	routeid := 1
 	if len(aviVrfNode.StaticRoutes) == 0 {
 		aviVrfNode.NodeStaticRoutes = make(map[string]StaticRouteDetails)
-		aviVrfNode.NodeIds = make(map[int]struct{})
 	}
 	var nodeRoutes []*models.StaticRoute
 	// For new node addition (coming from ingestion layer), nodes static routes will be attahced at the end
@@ -60,19 +112,22 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 		node, err := utils.GetInformers().NodeInformer.Lister().Get(nodeName)
 		if err != nil {
 			utils.AviLog.Errorf("key: %s, Error in fetching node details: %s: %v", key, nodeName, err)
+			aviVrfNode.StaticRoutes = GetStaticRoutesForOtherNodes(aviVrfNode, nodeStaticRouteDetails.RouteIDPrefix)
+			processNodeStaticRouteAndNodeDeletion(nodeName, aviVrfNode)
 			return err
 		}
+		var routeIdPrefix string
 		if ok {
-			routeid = nodeStaticRouteDetails.routeID
+			routeIdPrefix = nodeStaticRouteDetails.RouteIDPrefix
 		} else {
-			//O(n) for each node. But it will re-use previous index. So used instead of always incrementing index.
-			routeid = findFreeRouteId(aviVrfNode.NodeIds)
+			routeIdPrefix = lib.Uuid4()
 		}
-		aviVrfNode.NodeIds[routeid] = struct{}{}
-		nodeRoutes, err = o.addRouteForNode(node, vrfName, routeid, aviVrfNode.NodeIds)
+
+		nodeRoutes, err = o.addRouteForNode(node, vrfName, routeIdPrefix)
 		if err != nil {
 			utils.AviLog.Errorf("key: %s, Error Adding vrf for node %s: %v", key, nodeName, err)
-			delete(aviVrfNode.NodeIds, routeid)
+			aviVrfNode.StaticRoutes = GetStaticRoutesForOtherNodes(aviVrfNode, routeIdPrefix)
+			processNodeStaticRouteAndNodeDeletion(nodeName, aviVrfNode)
 			return err
 		}
 		if !ok {
@@ -81,62 +136,45 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 				// node is not present and no overlapping of cidr, append at last
 				aviVrfNode.StaticRoutes = append(aviVrfNode.StaticRoutes, nodeRoutes...)
 				nodeStaticRoute := StaticRouteDetails{}
-				// start index shows at what index of StaticRoutes, nodes routes start (index based zero)
-				nodeStaticRoute.StartIndex = routeid - 1
 				nodeStaticRoute.Count = len(nodeRoutes)
-				nodeStaticRoute.routeID = routeid
+				nodeStaticRoute.RouteIDPrefix = routeIdPrefix
 				aviVrfNode.NodeStaticRoutes[nodeName] = nodeStaticRoute
 				aviVrfNode.Nodes = append(aviVrfNode.Nodes, nodeName)
 			} else {
 				if len(nodeRoutes) == 0 {
-					delete(aviVrfNode.NodeIds, routeid)
+					//delete all the routes and details of this node
+					aviVrfNode.StaticRoutes = GetStaticRoutesForOtherNodes(aviVrfNode, routeIdPrefix)
+					processNodeStaticRouteAndNodeDeletion(nodeName, aviVrfNode)
 				}
 			}
 		} else {
 			// update case
-			// Assumption: updated routes (values) for given node will not overlap with other nodes.
+			// Assumption: updated routes (values) for given node will not overlap with other nodes
 			// So only updating existing routes of that node.
 			utils.AviLog.Debugf("key: %s, StaticRoutes before updation/deletion: [%v]", key, utils.Stringify(aviVrfNode.StaticRoutes))
-			startIndex := nodeStaticRouteDetails.StartIndex
 			lenNewNodeRoutes := len(nodeRoutes)
 			diff := lenNewNodeRoutes - nodeStaticRouteDetails.Count
 
-			var staticRouteCopy []*models.StaticRoute
-			copyTill := int(math.Min(float64(startIndex), float64(len(aviVrfNode.StaticRoutes))))
-			staticRouteCopy = append(staticRouteCopy, aviVrfNode.StaticRoutes[:copyTill]...)
-
+			staticRouteCopy := GetStaticRoutesForOtherNodes(aviVrfNode, routeIdPrefix)
 			staticRouteCopy = append(staticRouteCopy, nodeRoutes...)
-
-			copyFrom := int(math.Min(float64(startIndex+nodeStaticRouteDetails.Count), float64(len(aviVrfNode.StaticRoutes))))
-			staticRouteCopy = append(staticRouteCopy, aviVrfNode.StaticRoutes[copyFrom:]...)
-
 			aviVrfNode.StaticRoutes = staticRouteCopy
 
 			//if diff is 0, there is no change in number of routes previously exist and newly created.
 			if diff != 0 {
-				updateNodeStaticRoutes(aviVrfNode, deleteFlag, nodeName, lenNewNodeRoutes, diff)
+				//update all the routes of this node
+				updateNodeStaticRoutes(aviVrfNode, deleteFlag, nodeName, lenNewNodeRoutes)
 			}
 			if lenNewNodeRoutes == 0 {
-				processNodeStaticRouteAndNodeIdDeletion(nodeName, aviVrfNode)
+				//delete all the routes of this node
+				processNodeStaticRouteAndNodeDeletion(nodeName, aviVrfNode)
 			}
 			utils.AviLog.Debugf("key: %s, StaticRoutes after updation/deletion: [%v]", key, utils.Stringify(aviVrfNode.StaticRoutes))
 		}
 	} else {
-		//delete case
+		//delete flag is turned on and node is deleted
 		utils.AviLog.Debugf("key: %s, StaticRoutes before deletion: [%v]", key, utils.Stringify(aviVrfNode.StaticRoutes))
-		startIndex := nodeStaticRouteDetails.StartIndex
-		count := nodeStaticRouteDetails.Count
-		var staticRouteCopy []*models.StaticRoute
-		updateNodeStaticRoutes(aviVrfNode, deleteFlag, nodeName, 0, -count)
-
-		copyTill := int(math.Min(float64(startIndex), float64(len(aviVrfNode.StaticRoutes))))
-		staticRouteCopy = append(staticRouteCopy, aviVrfNode.StaticRoutes[:copyTill]...)
-
-		copyFrom := int(math.Min(float64(startIndex+nodeStaticRouteDetails.Count), float64(len(aviVrfNode.StaticRoutes))))
-		staticRouteCopy = append(staticRouteCopy, aviVrfNode.StaticRoutes[copyFrom:]...)
-
-		aviVrfNode.StaticRoutes = staticRouteCopy
-		processNodeStaticRouteAndNodeIdDeletion(nodeName, aviVrfNode)
+		aviVrfNode.StaticRoutes = GetStaticRoutesForOtherNodes(aviVrfNode, nodeStaticRouteDetails.RouteIDPrefix)
+		processNodeStaticRouteAndNodeDeletion(nodeName, aviVrfNode)
 		utils.AviLog.Debugf("key: %s, StaticRoutes after deletion: [%v]", key, utils.Stringify(aviVrfNode.StaticRoutes))
 	}
 	aviVrfNode.CalculateCheckSum()
@@ -145,29 +183,25 @@ func (o *AviObjectGraph) BuildVRFGraph(key, vrfName, nodeName string, deleteFlag
 	utils.AviLog.Debugf("key: %s, vrf node: [%v]", key, utils.Stringify(aviVrfNode))
 	return nil
 }
-func processNodeStaticRouteAndNodeIdDeletion(nodeName string, aviVrfNode *AviVrfNode) {
+func processNodeStaticRouteAndNodeDeletion(nodeName string, aviVrfNode *AviVrfNode) {
 	delete(aviVrfNode.NodeStaticRoutes, nodeName)
-	for nodeId := len(aviVrfNode.NodeIds); nodeId > len(aviVrfNode.StaticRoutes); nodeId-- {
-		delete(aviVrfNode.NodeIds, nodeId)
-	}
-}
-func findFreeRouteId(routeIdList map[int]struct{}) int {
-	for i := 1; i < math.MaxInt32; i++ {
-		if _, ok := routeIdList[i]; !ok {
-			return i
+	nodesCopy := []string{}
+	for _, node := range aviVrfNode.Nodes {
+		if node != nodeName {
+			nodesCopy = append(nodesCopy, node)
 		}
 	}
-	return -1
+	aviVrfNode.Nodes = nodesCopy
 }
-func updateNodeStaticRoutes(aviVrfNode *AviVrfNode, isDelete bool, nodeName string, lenNewNodeRoutes, diff int) {
+
+func updateNodeStaticRoutes(aviVrfNode *AviVrfNode, isDelete bool, nodeNameToUpdate string, lenNewNodeRoutes int) {
 	//get index of nodename in node array
 	indexOfNodeUnderUpdation := -1
 
 	for i := 0; i < len(aviVrfNode.Nodes); i++ {
-		if aviVrfNode.Nodes[i] == nodeName {
+		if aviVrfNode.Nodes[i] == nodeNameToUpdate {
 			indexOfNodeUnderUpdation = i
 			if !isDelete {
-				nodeNameToUpdate := aviVrfNode.Nodes[indexOfNodeUnderUpdation]
 				nodeDetails := aviVrfNode.NodeStaticRoutes[nodeNameToUpdate]
 				nodeDetails.Count = lenNewNodeRoutes
 				aviVrfNode.NodeStaticRoutes[nodeNameToUpdate] = nodeDetails
@@ -176,32 +210,6 @@ func updateNodeStaticRoutes(aviVrfNode *AviVrfNode, isDelete bool, nodeName stri
 		}
 	}
 	if indexOfNodeUnderUpdation != -1 {
-		clusterName := lib.GetClusterName()
-		//Change nodemap entries till index
-		for nodeIndex := len(aviVrfNode.Nodes) - 1; nodeIndex > indexOfNodeUnderUpdation; nodeIndex-- {
-			nodeNameToUpdate := aviVrfNode.Nodes[nodeIndex]
-			nodeDetails := aviVrfNode.NodeStaticRoutes[nodeNameToUpdate]
-			oldStartIndex := nodeDetails.StartIndex
-			nodeDetails.StartIndex = nodeDetails.StartIndex + diff
-			nodeDetails.routeID = nodeDetails.StartIndex + 1
-			aviVrfNode.NodeStaticRoutes[nodeNameToUpdate] = nodeDetails
-			newRouteId := nodeDetails.routeID
-			var tempStartIndex int
-			if isDelete {
-				tempStartIndex = oldStartIndex
-			} else {
-				tempStartIndex = nodeDetails.StartIndex
-			}
-			for staticRouteIndex := tempStartIndex; staticRouteIndex < nodeDetails.Count+tempStartIndex; staticRouteIndex++ {
-				newRouteName := clusterName + "-" + strconv.Itoa(newRouteId)
-				if staticRouteIndex > (len(aviVrfNode.StaticRoutes)-1) || staticRouteIndex < 0 {
-					utils.AviLog.Warnf("Some StaticRoutes could not be updated.")
-					continue
-				}
-				aviVrfNode.StaticRoutes[staticRouteIndex].RouteID = &newRouteName
-				newRouteId++
-			}
-		}
 		// lenNewNodeRoutes will be zero if Node exists without any PodCidr/BloackAffinity attached to it.
 		if isDelete || lenNewNodeRoutes == 0 {
 			// now remove nodename from Nodes list
@@ -226,7 +234,7 @@ func findRoutePrefix(nodeRoutes, aviRoutes []*models.StaticRoute, key string) bo
 	return false
 }
 
-func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid int, routeIdList map[int]struct{}) ([]*models.StaticRoute, error) {
+func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeIdPrefix string) ([]*models.StaticRoute, error) {
 	var nodeIP, nodeIP6 string
 	var nodeRoutes []*models.StaticRoute
 
@@ -243,7 +251,7 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 		utils.AviLog.Errorf("Error in fetching Pod CIDR for %v: %s", node.ObjectMeta.Name, err.Error())
 		return nil, errors.New("podcidr not found")
 	}
-	for _, podCIDR := range podCIDRs {
+	for index, podCIDR := range podCIDRs {
 		podCIDRAndMask := strings.Split(podCIDR, "/")
 		if len(podCIDRAndMask) != 2 {
 			utils.AviLog.Errorf("Error in splitting Pod CIDR for %v", node.ObjectMeta.Name)
@@ -273,7 +281,7 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 			continue
 		}
 		mask32 := int32(mask)
-		routeIDString := clusterName + "-" + strconv.Itoa(routeid)
+		routeIDString := clusterName + "-" + routeIdPrefix + "-" + strconv.Itoa(index)
 		nodeRoute := models.StaticRoute{
 			RouteID: &routeIDString,
 			Prefix: &models.IPAddrPrefix{
@@ -291,8 +299,6 @@ func (o *AviObjectGraph) addRouteForNode(node *v1.Node, vrfName string, routeid 
 		}
 
 		nodeRoutes = append(nodeRoutes, &nodeRoute)
-		routeIdList[routeid] = struct{}{}
-		routeid++
 	}
 	return nodeRoutes, nil
 }

--- a/internal/nodes/dequeue_ingestion.go
+++ b/internal/nodes/dequeue_ingestion.go
@@ -884,9 +884,9 @@ func processNodeObj(key, nodename string, sharedQueue *utils.WorkerQueue, fullsy
 	}
 	aviModelGraph := aviModel.(*AviObjectGraph)
 	aviModelGraph.IsVrf = true
-	err = aviModelGraph.BuildVRFGraph(key, vrfcontext, nodename, deleteFlag)
+	err = aviModelGraph.processVrfGraphForNode(key, nodename, deleteFlag, fullsync)
 	if err != nil {
-		utils.AviLog.Errorf("key: %s, msg: Error creating vrf graph: %v", key, err)
+		utils.AviLog.Errorf("key: %s, msg: Error processing vrf graph for node: %v", key, err)
 		return
 	}
 
@@ -894,7 +894,20 @@ func processNodeObj(key, nodename string, sharedQueue *utils.WorkerQueue, fullsy
 	if ok && !fullsync {
 		PublishKeyToRestLayer(model_name, key, sharedQueue)
 	}
-
+}
+func (aviModelGraph *AviObjectGraph) processVrfGraphForNode(key string, nodename string, deleteFlag bool, fullsync bool) error {
+	vrfcontext := lib.GetVrf()
+	aviModelGraph.Lock.Lock()
+	defer aviModelGraph.Lock.Unlock()
+	err := aviModelGraph.BuildVRFGraph(key, vrfcontext, nodename, deleteFlag)
+	if err != nil {
+		utils.AviLog.Errorf("key: %s, msg: Error creating vrf graph: %v", key, err)
+		return err
+	}
+	if !fullsync {
+		aviModelGraph.CheckAndDeduplicateRecords(key)
+	}
+	return nil
 }
 
 func PublishKeyToRestLayer(modelName string, key string, sharedQueue *utils.WorkerQueue) {

--- a/internal/rest/avi_obj_vrf.go
+++ b/internal/rest/avi_obj_vrf.go
@@ -17,8 +17,6 @@ package rest
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"regexp"
 
 	avicache "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/cache"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -69,9 +67,8 @@ func (rest *RestOperations) AviVrfBuild(key string, vrfNode *nodes.AviVrfNode, u
 	aviStaticRoutes := vrf.StaticRoutes
 	mergedStaticRoutes := []*avimodels.StaticRoute{}
 	clusterName := lib.GetClusterName()
-	re := regexp.MustCompile(fmt.Sprintf(`%s\-[1-9]+`, clusterName))
 	for _, aviStaticRoute := range aviStaticRoutes {
-		if !re.MatchString(*aviStaticRoute.RouteID) {
+		if len(aviStaticRoute.Labels) == 0 || (*aviStaticRoute.Labels[0].Key == "clustername" && *aviStaticRoute.Labels[0].Value != clusterName) {
 			mergedStaticRoutes = append(mergedStaticRoutes, aviStaticRoute)
 		}
 	}

--- a/tests/cnitests/static_route_test.go
+++ b/tests/cnitests/static_route_test.go
@@ -817,11 +817,12 @@ func TestMultipleBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes)).To(gomega.Equal(1))
 
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
-	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-2"))
 	time.Sleep(10 * time.Second)
 
 	// deleting the BlockAffinity objects for the node
@@ -833,9 +834,9 @@ func TestMultipleBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(3))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
 
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName1, metav1.DeleteOptions{})
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
@@ -845,8 +846,8 @@ func TestMultipleBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(2))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
 	g.Eventually(func() int {
@@ -855,7 +856,7 @@ func TestMultipleBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(1))
 	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
 
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName2, metav1.DeleteOptions{})
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
@@ -1369,7 +1370,6 @@ func TestStaticRoutesWithMultipleBlockAffinityDeletion(t *testing.T) {
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(0))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(0))
 }
 func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	if *cniPlugin != "calico" {
@@ -1482,11 +1482,10 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(1))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(1))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
 
 	g.Eventually(func() bool {
 		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
@@ -1544,12 +1543,11 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(2))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
 
 	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
 	var testData4 unstructured.Unstructured
@@ -1602,13 +1600,12 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(4))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(4))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
 
 	var banode4 unstructured.Unstructured
 	banode4.SetUnstructuredContent(map[string]interface{}{
@@ -1643,14 +1640,13 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes)).To(gomega.Equal(1))
 
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
-	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData2, v1.CreateOptions{})
 	g.Eventually(func() bool {
@@ -1666,15 +1662,14 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(6))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(6))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(4))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
-	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
-	g.Expect(*nodes[0].StaticRoutes[5].RouteID).To(gomega.Equal("cluster-6"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[5].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity2", v1.DeleteOptions{})
 	g.Eventually(func() bool {
@@ -1700,14 +1695,13 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
-	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample2, metav1.CreateOptions{})
 	if err != nil {
@@ -1724,14 +1718,13 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(3))
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
-	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-4"))
-	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-5"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity11", v1.DeleteOptions{})
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
@@ -1754,10 +1747,9 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(2))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodesNameList[1], metav1.DeleteOptions{})
 	g.Eventually(func() bool {
@@ -1779,10 +1771,9 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(3))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(2))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(3))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
-	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-3"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico3"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
 
@@ -1806,9 +1797,8 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(2))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(1))
 	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(1))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(2))
-	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-1"))
-	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-2"))
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico4"].RouteIDPrefix + "-1"))
 
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity44", v1.DeleteOptions{})
 	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
@@ -1834,5 +1824,629 @@ func TestNodeWithoutBlockAffinityAddition(t *testing.T) {
 	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].NodeStaticRoutes)).To(gomega.Equal(0))
 	g.Expect(len(nodes[0].Nodes)).To(gomega.Equal(0))
-	g.Expect(len(nodes[0].NodeIds)).To(gomega.Equal(0))
+}
+func TestStaticRoutesRecordsDeduplication(t *testing.T) {
+	if *cniPlugin != "calico" {
+		t.Skip("Skipping BlockAffinity test since CNI plugin is not Calico")
+	}
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/global"
+	nodeip1 := "10.102.99.232"
+	nodeName1 := "testNodeCalico1"
+	objects.SharedAviGraphLister().Delete(modelName)
+	time.Sleep(10 * time.Second)
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData1 unstructured.Unstructured
+	testData1.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity1",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.29.64/26",
+			"deleted": "false",
+			"node":    nodeName1,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData1, v1.CreateOptions{})
+
+	nodeExample := (integrationtest.FakeNode{
+		Name:    nodeName1,
+		Version: "1",
+		NodeIP:  nodeip1,
+	}).NodeCalico()
+
+	_, err := KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	// creating a new BlockAffinity object for the node
+	var testData2 unstructured.Unstructured
+	testData2.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity2",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.30.64/26",
+			"deleted": "false",
+			"node":    nodeName1,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData2, v1.CreateOptions{})
+
+	nodeip2 := "10.102.99.146"
+	nodeName2 := "testNodeCalico2"
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData3 unstructured.Unstructured
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.247.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	nodeExample2 := (integrationtest.FakeNode{
+		Name:    nodeName2,
+		Version: "1",
+		NodeIP:  nodeip2,
+	}).NodeCalico()
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	// creating a new BlockAffinity object for the node
+	var testData4 unstructured.Unstructured
+	testData4.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity4",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.246.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData4, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(4))
+	g.Expect(*(nodes[0].StaticRoutes[3].NextHop.Addr)).To(gomega.Equal(nodeip2))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.246.0"))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.Mask)).To(gomega.Equal(int32(26)))
+
+	//Manipulate internal cache to mimic duplicate records
+	nodes[0].StaticRoutes[3] = nodes[0].StaticRoutes[2]
+
+	var testData5 unstructured.Unstructured
+	testData5.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity5",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.31.64/26",
+			"deleted": "false",
+			"node":    nodeName1,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData5, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 5 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	g.Expect(len(nodes[0].StaticRoutes)).To(gomega.Equal(5))
+
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-2"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[4].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+	g.Expect(*(nodes[0].StaticRoutes[0].NextHop.Addr)).To(gomega.Equal(nodeip1))
+	g.Expect(*(nodes[0].StaticRoutes[0].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.29.64"))
+	g.Expect(*(nodes[0].StaticRoutes[0].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[1].NextHop.Addr)).To(gomega.Equal(nodeip1))
+	g.Expect(*(nodes[0].StaticRoutes[1].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.30.64"))
+	g.Expect(*(nodes[0].StaticRoutes[1].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[2].NextHop.Addr)).To(gomega.Equal(nodeip1))
+	g.Expect(*(nodes[0].StaticRoutes[2].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.31.64"))
+	g.Expect(*(nodes[0].StaticRoutes[2].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[3].NextHop.Addr)).To(gomega.Equal(nodeip2))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.247.0"))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[4].NextHop.Addr)).To(gomega.Equal(nodeip2))
+	g.Expect(*(nodes[0].StaticRoutes[4].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.246.0"))
+	g.Expect(*(nodes[0].StaticRoutes[4].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	time.Sleep(10 * time.Second)
+
+	// deleting the BlockAffinity objects for the node
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity2", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity5", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName1, metav1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(2))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(1))
+	_, aviModel = objects.SharedAviGraphLister().Get(modelName)
+	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName2, metav1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(0))
+}
+func TestStaticRoutesWithIncompleteNodeData(t *testing.T) {
+	if *cniPlugin != "calico" {
+		t.Skip("Skipping BlockAffinity test since CNI plugin is not Calico")
+	}
+	g := gomega.NewGomegaWithT(t)
+	modelName := "admin/global"
+	nodeip1 := "10.102.99.232"
+	nodeName1 := "testNodeCalico1"
+	objects.SharedAviGraphLister().Delete(modelName)
+	time.Sleep(10 * time.Second)
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData1 unstructured.Unstructured
+	testData1.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity1",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.29.64/26",
+			"deleted": "false",
+			"node":    nodeName1,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData1, v1.CreateOptions{})
+
+	nodeExample := (integrationtest.FakeNode{
+		Name:    nodeName1,
+		Version: "1",
+		NodeIP:  nodeip1,
+	}).NodeCalico()
+
+	_, err := KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	// creating a new BlockAffinity object for the node
+	var testData2 unstructured.Unstructured
+	testData2.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity2",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.30.64/26",
+			"deleted": "false",
+			"node":    nodeName1,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData2, v1.CreateOptions{})
+
+	nodeip2 := "10.102.99.146"
+	nodeName2 := "testNodeCalico2"
+
+	// mimicking actual scenario where the node will have atleast one BlockAffinity object created from start
+	var testData3 unstructured.Unstructured
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.247.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	nodeExample2 := (integrationtest.FakeNode{
+		Name:    nodeName2,
+		Version: "1",
+		NodeIP:  nodeip2,
+	}).NodeCalico()
+
+	_, err = KubeClient.CoreV1().Nodes().Create(context.TODO(), nodeExample2, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error in adding Node: %v", err)
+	}
+
+	integrationtest.PollForCompletion(t, modelName, 5)
+
+	// creating a new BlockAffinity object for the node
+	var testData4 unstructured.Unstructured
+	testData4.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity4",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.246.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData4, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) < 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	g.Expect(aviModel.(*avinodes.AviObjectGraph).IsVrf).To(gomega.Equal(true))
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+	g.Expect(len(nodes)).To(gomega.Equal(1))
+
+	g.Expect(*nodes[0].StaticRoutes[0].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[1].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico1"].RouteIDPrefix + "-1"))
+	g.Expect(*nodes[0].StaticRoutes[2].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-0"))
+	g.Expect(*nodes[0].StaticRoutes[3].RouteID).To(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNodeCalico2"].RouteIDPrefix + "-1"))
+	g.Expect(*(nodes[0].StaticRoutes[0].NextHop.Addr)).To(gomega.Equal(nodeip1))
+	g.Expect(*(nodes[0].StaticRoutes[0].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.29.64"))
+	g.Expect(*(nodes[0].StaticRoutes[0].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[1].NextHop.Addr)).To(gomega.Equal(nodeip1))
+	g.Expect(*(nodes[0].StaticRoutes[1].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.30.64"))
+	g.Expect(*(nodes[0].StaticRoutes[1].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[2].NextHop.Addr)).To(gomega.Equal(nodeip2))
+	g.Expect(*(nodes[0].StaticRoutes[2].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.247.0"))
+	g.Expect(*(nodes[0].StaticRoutes[2].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	g.Expect(*(nodes[0].StaticRoutes[3].NextHop.Addr)).To(gomega.Equal(nodeip2))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.IPAddr.Addr)).To(gomega.Equal("192.168.246.0"))
+	g.Expect(*(nodes[0].StaticRoutes[3].Prefix.Mask)).To(gomega.Equal(int32(26)))
+	time.Sleep(10 * time.Second)
+
+	// Update node data to not have any nodeIP
+	nodeExample = (integrationtest.FakeNode{
+		Name:    nodeName1,
+		Version: "1",
+	}).NodeCalico()
+
+	KubeClient.CoreV1().Nodes().Update(context.TODO(), nodeExample, metav1.UpdateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) > 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	// Adding NodeIp back
+	nodeExample = (integrationtest.FakeNode{
+		Name:    nodeName1,
+		Version: "1",
+		NodeIP:  nodeip1,
+	}).NodeCalico()
+
+	KubeClient.CoreV1().Nodes().Update(context.TODO(), nodeExample, metav1.UpdateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr to not have any IP
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr with IP
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.247.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr to have malformed IP
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "malformedIp",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr with IP
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.247.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr to have malformed mask
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "ip/nonintegermask",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 2 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(3))
+
+	// Updating PODCidr with IP
+	testData3.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "crd.projectcalico.org/v1",
+		"kind":       "blockaffinities",
+		"metadata": map[string]interface{}{
+			"name":      "testblockaffinity3",
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"cidr":    "192.168.247.0/26",
+			"deleted": "false",
+			"node":    nodeName2,
+			"state":   "confirmed",
+		},
+	})
+
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Create(context.TODO(), &testData3, v1.CreateOptions{})
+
+	g.Eventually(func() bool {
+		found, aviModel := objects.SharedAviGraphLister().Get(modelName)
+		nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
+		if len(nodes[0].StaticRoutes) != 4 {
+			found = false
+		}
+		return found
+	}, 10*time.Second).Should(gomega.Equal(true))
+
+	// deleting the BlockAffinity objects for the node
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity1", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity2", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity3", v1.DeleteOptions{})
+	DynamicClient.Resource(lib.CalicoBlockaffinityGVR).Namespace("default").Delete(context.TODO(), "testblockaffinity4", v1.DeleteOptions{})
+
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName1, metav1.DeleteOptions{})
+	KubeClient.CoreV1().Nodes().Delete(context.TODO(), nodeName2, metav1.DeleteOptions{})
+
+	g.Eventually(func() int {
+		num_routes := len(nodes[0].StaticRoutes)
+		return num_routes
+	}, 10*time.Second).Should(gomega.Equal(0))
 }

--- a/tests/integrationtest/static_route_test.go
+++ b/tests/integrationtest/static_route_test.go
@@ -291,8 +291,7 @@ func TestMultiNodeUpdate(t *testing.T) {
 	nodes = aviModel.(*avinodes.AviObjectGraph).GetAviVRF()
 	g.Expect(len(nodes)).To(gomega.Equal(1))
 	//AV-171818-Route ID should not change for update
-	g.Expect(*(nodes[0].StaticRoutes[1].RouteID)).Should(gomega.Equal("cluster-2"))
-
+	g.Expect(*(nodes[0].StaticRoutes[1].RouteID)).Should(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNode4"].RouteIDPrefix + "-0"))
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), "testNode3", metav1.DeleteOptions{})
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), "testNode4", metav1.DeleteOptions{})
 	PollForCompletion(t, modelName, 10)
@@ -375,7 +374,7 @@ func TestMultiNodeCDC(t *testing.T) {
 	}, 10*time.Second).Should(gomega.Equal(1))
 	//After delete, Now testNode6 should be at index 0.
 	g.Expect(*(nodes[0].StaticRoutes[0].NextHop.Addr)).Should(gomega.Equal(nodeip2))
-	g.Expect(*(nodes[0].StaticRoutes[0].RouteID)).Should(gomega.Equal("cluster-1"))
+	g.Expect(*(nodes[0].StaticRoutes[0].RouteID)).Should(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNode6"].RouteIDPrefix + "-0"))
 	// Add another node
 	nodeExample := (FakeNode{
 		Name:     "testNode7",
@@ -405,7 +404,7 @@ func TestMultiNodeCDC(t *testing.T) {
 		num_static_routes := len(nodes[0].StaticRoutes)
 		return num_static_routes
 	}, 10*time.Second).Should(gomega.Equal(2))
-	g.Expect(*(nodes[0].StaticRoutes[1].RouteID)).Should(gomega.Equal("cluster-2"))
+	g.Expect(*(nodes[0].StaticRoutes[1].RouteID)).Should(gomega.Equal("cluster-" + nodes[0].NodeStaticRoutes["testNode7"].RouteIDPrefix + "-0"))
 	g.Expect(*(nodes[0].StaticRoutes[1].NextHop.Addr)).Should(gomega.Equal(nodeip3))
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), "testNode6", metav1.DeleteOptions{})
 	KubeClient.CoreV1().Nodes().Delete(context.TODO(), "testNode7", metav1.DeleteOptions{})


### PR DESCRIPTION
AV-232614 Static Route fixes.

This PR includes following changes:
1) Replace route ids generation with golang's UUID generation(For nodes CRUD). Modify logic for addition/updation/deletion of block affinities respectively as per new UUIDs
2) Safely Remove redundant data structures earlier needed when allocating route ids in serial order.
3) Remove all the internal data in cache corresponding to a node, when there is any error while fetching node data/ node ip, which may have lead to multiple duplicate records in the past.
4) Fixed existing UnitTestCases.
5) Removing records with duplicate route_ids(not needed)
6) Add logic to sanitize data before sending to controller to check for occurence of duplicate records.
7) Addition of new unittest cases if needed to simulate the above error.
8) Manual Testing.
9) Run configmap fts
10) Tested for deadlock/race conditions using Gemini Code Assist
11) Check ako upgrade from 1.12.1 to 1.14.1
12) Check K8s version upgrade from 1.28 to 1.29