### PR TITLE
Added support for Proxy Enabled Application Profile in WCP env

### DIFF
--- a/internal/k8s/advl4_controller.go
+++ b/internal/k8s/advl4_controller.go
@@ -80,8 +80,10 @@ func (c *AviController) SetupAdvL4EventHandlers(numWorkers uint32) {
 			}
 			oldObj := old.(*advl4v1alpha1pre1.Gateway)
 			gw := new.(*advl4v1alpha1pre1.Gateway)
+			oldAnnotVal := oldObj.Annotations[lib.GwProxyProtocolEnableAnnotation]
+			newAnnotVal := gw.Annotations[lib.GwProxyProtocolEnableAnnotation]
 
-			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil {
+			if !reflect.DeepEqual(oldObj.Spec, gw.Spec) || gw.GetDeletionTimestamp() != nil || oldAnnotVal != newAnnotVal {
 				namespace, _, _ := cache.SplitMetaNamespaceKey(utils.ObjKey(gw))
 				key := lib.Gateway + "/" + utils.ObjKey(gw)
 				utils.AviLog.Infof("key: %s, msg: UPDATE", key)

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -1264,6 +1264,17 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 			}
 		}
 
+		// Proxy Enabled Application Profile GET/CREATE/UPDATE
+		aviClientPool := avicache.SharedAVIClients(lib.GetAdminTenant())
+		if aviClientPool == nil || len(aviClientPool.AviClient) == 0 {
+			return fmt.Errorf("avi Rest client initialization failed")
+		}
+		err = lib.ProxyEnabledAppProfileCU(aviClientPool.AviClient[0])
+		if err != nil {
+			utils.AviLog.Errorf("Proxy enabled application profile Get/Create/Update failed: %s", err)
+			return err
+		}
+
 		//Ingress Section
 		if utils.GetInformers().IngressInformer != nil {
 			for namespace := range acceptedNamespaces {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -167,6 +167,7 @@ const (
 	PriorityLabel                              = "PriorityLabel"
 	SSLKeyCert                                 = "SSLKeyandCertificate"
 	PKIProfile                                 = "PKI Profile"
+	ApplicationProfile                         = "ApplicationProfile"
 	PassthroughPG                              = "Passthrough PG"
 	Passthroughpool                            = "Passthrough pool"
 	PassthroughVS                              = "Passthrough VirtualService"
@@ -274,6 +275,7 @@ const (
 	CalicoIPv6AddressAnnotation      = "projectcalico.org/IPv6Address"
 	AntreaTransportAddressAnnotation = "node.antrea.io/transport-addresses"
 	TenantAnnotation                 = "ako.vmware.com/tenant-name"
+	GwProxyProtocolEnableAnnotation  = "iaas.vmware.com/proxy-protocol-enabled"
 
 	// Specifies command used in namespace event handler
 	NsFilterAdd                    = "ADD"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -717,6 +717,11 @@ func GetVrf() string {
 	return VRFContext
 }
 
+// One proxy enabled app profile per cluster
+func GetProxyEnabledApplicationProfileName() string {
+	return Encode(GetClusterName()+"-proxy-applicationprofile", ApplicationProfile)
+}
+
 func GetVPCMode() bool {
 	if vpcMode, _ := strconv.ParseBool(os.Getenv(utils.VPC_MODE)); vpcMode {
 		return true

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vmware/alb-sdk/go/clients"
 	"github.com/vmware/alb-sdk/go/models"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/objects"
 	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
@@ -593,4 +594,70 @@ func (s *LockSet) Unlock(lockName string) {
 
 func GetLockSet() *LockSet {
 	return &lockSet
+}
+
+func ProxyEnabledAppProfileGet(client *clients.AviClient) (error, []models.ApplicationProfile) {
+	var appProfs []models.ApplicationProfile
+	uri := fmt.Sprintf("/api/applicationprofile/?name=%s", GetProxyEnabledApplicationProfileName())
+	result, err := AviGetCollectionRaw(client, uri)
+	if err != nil {
+		utils.AviLog.Warnf("Application profile Get uri %v returned err %v", uri, err)
+		return err, appProfs
+	}
+	elems := make([]json.RawMessage, result.Count)
+	err = json.Unmarshal(result.Results, &elems)
+	if err != nil {
+		utils.AviLog.Warnf("Failed to unmarshal application profile result, err: %v", err)
+		return err, appProfs
+	}
+	for i := 0; i < len(elems); i++ {
+		appProf := models.ApplicationProfile{}
+		if err = json.Unmarshal(elems[i], &appProf); err != nil {
+			utils.AviLog.Warnf("Failed to unmarshal application profile data, err: %v", err)
+			return err, appProfs
+		}
+		appProfs = append(appProfs, appProf)
+	}
+	return nil, appProfs
+}
+
+func ProxyEnabledAppProfileCU(client *clients.AviClient) error {
+	name := GetProxyEnabledApplicationProfileName()
+	tenant := fmt.Sprintf("/api/tenant/?name=%s", GetAdminTenant())
+	tcpAppProfile := models.TCPApplicationProfile{
+		ProxyProtocolEnabled: proto.Bool(true),
+	}
+	appProfile := models.ApplicationProfile{
+		Name:          proto.String(name),
+		TenantRef:     proto.String(tenant),
+		Type:          proto.String(AllowedL4ApplicationProfile),
+		CreatedBy:     proto.String(GetAKOUser()),
+		TCPAppProfile: &tcpAppProfile,
+	}
+	resp := models.ApplicationProfileAPIResponse{}
+	err, appProfs := ProxyEnabledAppProfileGet(client)
+	if err == nil && len(appProfs) == 1 {
+		appProf := appProfs[0]
+		if appProf.TCPAppProfile != nil &&
+			appProf.TCPAppProfile.ProxyProtocolEnabled != nil &&
+			*appProf.TCPAppProfile.ProxyProtocolEnabled {
+			utils.AviLog.Debugf("Proxy enabled application profile %s present", name)
+			return nil
+		}
+		uri := fmt.Sprintf("/api/applicationprofile/%s", *appProf.UUID)
+		err = AviPut(client, uri, appProfile, resp)
+	} else {
+		if len(appProfs) > 1 {
+			return fmt.Errorf("More than one app profile with name %s found", name)
+		}
+		if len(appProfs) == 0 {
+			uri := "/api/applicationprofile"
+			err = AviPost(client, uri, appProfile, resp)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	utils.AviLog.Infof("Proxy enabled application profile %s created/updated", name)
+	return nil
 }

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -16,6 +16,7 @@ package nodes
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
@@ -138,6 +139,12 @@ func (o *AviObjectGraph) ConstructAdvL4VsNode(gatewayName, namespace, key string
 
 	avi_vs_meta.PortProto = portProtocols
 	avi_vs_meta.ApplicationProfile = utils.DEFAULT_L4_APP_PROFILE
+	if proxyProtoEnb, ok := gw.GetAnnotations()[lib.GwProxyProtocolEnableAnnotation]; ok {
+		proxyProtocolEnabled, err := strconv.ParseBool(proxyProtoEnb)
+		if err == nil && proxyProtocolEnabled {
+			avi_vs_meta.ApplicationProfile = lib.GetProxyEnabledApplicationProfileName()
+		}
+	}
 
 	avi_vs_meta.NetworkProfile = getNetworkProfile(isSCTP, isTCP, isUDP)
 

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -130,7 +130,7 @@ func TestAdvL4BestCase(t *testing.T) {
 	svcName := "svc-1"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
@@ -183,7 +183,7 @@ func TestAdvL4WithInvalidLoadBalancerClass(t *testing.T) {
 	svcName := "svc-2"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBServiceWithLoadBalancerClass(t, svcName, ns, gatewayName, ns, integrationtest.INVALID_LB_CLASS)
 
 	g.Eventually(func() string {
@@ -234,7 +234,7 @@ func TestAdvL4NamingConvention(t *testing.T) {
 	svcName := "svc-3"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
@@ -319,7 +319,7 @@ func TestAdvL4WrongControllerGWClass(t *testing.T) {
 	modelName := "admin/abc--default-" + gatewayName
 	svcName := "svc-5"
 
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
@@ -366,7 +366,7 @@ func TestAdvL4WrongClassMappingInGateway(t *testing.T) {
 	modelName := "admin/abc--default-" + gatewayName
 	svcName := "svc-6"
 
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
@@ -440,7 +440,7 @@ func TestAdvL4ProtocolChangeInService(t *testing.T) {
 	svcName := "svc-7"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -496,7 +496,7 @@ func TestAdvL4PortChangeInService(t *testing.T) {
 	svcName := "svc-8"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -551,7 +551,7 @@ func TestAdvL4LabelUpdatesInService(t *testing.T) {
 	svcName := "svc-9"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -606,7 +606,7 @@ func TestAdvL4LabelUpdatesInGateway(t *testing.T) {
 	svcName := "svc-10"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -663,7 +663,7 @@ func TestAdvL4GatewayListenerPortUpdate(t *testing.T) {
 	svcName := "svc-11"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -754,7 +754,7 @@ func TestAdvL4GatewayListenerProtocolUpdate(t *testing.T) {
 	svcName := "svc-12"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	g.Eventually(func() bool {
@@ -845,8 +845,8 @@ func TestAdvL4MultiGatewayServiceUpdate(t *testing.T) {
 	svcName := "svc-13"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gateway1Name, ns, gwClassName)
-	SetupGateway(t, gateway2Name, ns, gwClassName)
+	SetupGateway(t, gateway1Name, ns, gwClassName, false)
+	SetupGateway(t, gateway2Name, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gateway1Name, ns)
 
 	g.Eventually(func() bool {
@@ -918,7 +918,7 @@ func TestAdvL4EndpointDeleteCreate(t *testing.T) {
 	svcName := "svc-15"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
 	// delete endpoints
@@ -976,7 +976,7 @@ func TestAdvL4MultiTenancyWithInfraSettting(t *testing.T) {
 	integrationtest.AnnotateNamespaceWithTenant(t, ns, "nonadmin")
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
@@ -1033,7 +1033,7 @@ func TestAdvL4MultiTenancyWithTenantAddition(t *testing.T) {
 	svcName := "svc-17"
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
@@ -1117,7 +1117,7 @@ func TestAdvL4MultiTenancyWithTenantDeannotationInNS(t *testing.T) {
 	integrationtest.AnnotateNamespaceWithTenant(t, ns, "nonadmin")
 
 	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	SetupGateway(t, gatewayName, ns, gwClassName)
+	SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 
@@ -1171,4 +1171,58 @@ func TestAdvL4MultiTenancyWithTenantDeannotationInNS(t *testing.T) {
 	TeardownAdvLBService(t, svcName, ns)
 	TeardownGateway(t, gatewayName, ns)
 	VerifyGatewayVSNodeDeletion(g, newModelName)
+}
+
+func TestAdvL4WithProxyEnabledAppProfile(t *testing.T) {
+	// create a gw object with proxy-enabled annotation
+	// graph layer VS should come up with correct app profile
+	// delete the gw object, graph layer object deletion
+	g := gomega.NewGomegaWithT(t)
+
+	gwClassName, gatewayName, ns := "avi-lb", "my-gateway", "default"
+	modelName := "admin/abc--default-my-gateway"
+
+	SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
+	SetupGateway(t, gatewayName, ns, gwClassName, true)
+
+	SetupAdvLBService(t, "svc", ns, gatewayName, ns)
+
+	g.Eventually(func() string {
+		gw, _ := AdvL4Client.NetworkingV1alpha1pre1().Gateways(ns).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		if len(gw.Status.Addresses) > 0 {
+			return gw.Status.Addresses[0].Value
+		}
+		return ""
+	}, 40*time.Second).Should(gomega.Equal("10.250.250.1"))
+
+	g.Eventually(func() string {
+		svc, _ := KubeClient.CoreV1().Services(ns).Get(context.TODO(), "svc", metav1.GetOptions{})
+		if len(svc.Status.LoadBalancer.Ingress) > 0 {
+			return svc.Status.LoadBalancer.Ingress[0].IP
+		}
+		return ""
+	}, 30*time.Second).Should(gomega.Equal("10.250.250.1"))
+
+	_, aviModel := objects.SharedAviGraphLister().Get(modelName)
+	nodes := aviModel.(*avinodes.AviObjectGraph).GetAviVS()
+	g.Expect(nodes[0].Name).To(gomega.Equal("abc--default-my-gateway"))
+	g.Expect(nodes[0].PortProto[0].Port).To(gomega.Equal(int32(8081)))
+	g.Expect(nodes[0].HttpPolicySetRefs).To(gomega.HaveLen(0))
+	g.Expect(nodes[0].L4PolicyRefs).To(gomega.HaveLen(1))
+	g.Expect(nodes[0].L4PolicyRefs[0].PortPool[0].Port).To(gomega.Equal(uint32(8081)))
+	g.Expect(nodes[0].L4PolicyRefs[0].PortPool[0].Protocol).To(gomega.Equal("TCP"))
+	g.Expect(nodes[0].ServiceMetadata.NamespaceServiceName[0]).To(gomega.Equal("default/svc"))
+	g.Expect(nodes[0].ServiceMetadata.Gateway).To(gomega.Equal("default/my-gateway"))
+	g.Expect(nodes[0].PoolRefs[0].Servers).To(gomega.HaveLen(3))
+	g.Expect(nodes[0].ApplicationProfile).To(gomega.Equal(lib.GetProxyEnabledApplicationProfileName()))
+
+	TeardownGatewayClass(t, gwClassName)
+	g.Eventually(func() int {
+		gw, _ := AdvL4Client.NetworkingV1alpha1pre1().Gateways(ns).Get(context.TODO(), gatewayName, metav1.GetOptions{})
+		return len(gw.Status.Addresses)
+	}, 40*time.Second).Should(gomega.Equal(0))
+
+	TeardownAdvLBService(t, "svc", ns)
+	TeardownGateway(t, gatewayName, ns)
+	VerifyGatewayVSNodeDeletion(g, modelName)
 }

--- a/tests/advl4tests/informers/advl4_informer_test.go
+++ b/tests/advl4tests/informers/advl4_informer_test.go
@@ -180,7 +180,7 @@ func TestAdvL4InformerError(t *testing.T) {
 	svcName := "svc-1"
 
 	advl4tests.SetupGatewayClass(t, gwClassName, lib.AviGatewayController)
-	advl4tests.SetupGateway(t, gatewayName, ns, gwClassName)
+	advl4tests.SetupGateway(t, gatewayName, ns, gwClassName, false)
 
 	advl4tests.SetupAdvLBService(t, svcName, ns, gatewayName, ns)
 

--- a/tests/advl4tests/setup.go
+++ b/tests/advl4tests/setup.go
@@ -77,7 +77,7 @@ func (gw FakeGateway) Gateway() *advl4v1alpha1pre1.Gateway {
 	return gateway
 }
 
-func SetupGateway(t *testing.T, gwname, namespace, gwclass string) {
+func SetupGateway(t *testing.T, gwname, namespace, gwclass string, proxyAnnotate bool) {
 	gateway := FakeGateway{
 		Name:      gwname,
 		Namespace: namespace,
@@ -94,6 +94,10 @@ func SetupGateway(t *testing.T, gwname, namespace, gwclass string) {
 	}
 
 	gwCreate := gateway.Gateway()
+	if proxyAnnotate {
+		ann := map[string]string{lib.GwProxyProtocolEnableAnnotation: "true"}
+		gwCreate.SetAnnotations(ann)
+	}
 	if _, err := lib.AKOControlConfig().AdvL4Clientset().NetworkingV1alpha1pre1().Gateways(namespace).Create(context.TODO(), gwCreate, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("error in adding Gateway: %v", err)
 	}


### PR DESCRIPTION
WCP Doc : https://vmw-confluence.broadcom.net/pages/viewpage.action?spaceKey=WCP&title=Log+Client+IP+-+Proxy+Protocol+-+Notes

Change:
When AKO comes up in WCP environment, it will create proxy enabled application profile in AVI. This app profile will get used when any advL4LB service gets created with certain annotation as a hint to AKO to add it as ref in VS. This application profile will be deleted using cleanup when supervisor/wcp gets disabled.