### PR TITLE
Changed AVIInfraSettingCR Name

### DIFF
--- a/ako-infra/avirest/netinfo_handler.go
+++ b/ako-infra/avirest/netinfo_handler.go
@@ -153,13 +153,13 @@ func (t *T1LRNetworking) createInfraSettingAndAnnotateNS(nsLRMap map[string]stri
 
 	processedInfraSettingCRSet := make(map[string]struct{})
 	for ns, lr := range nsLRMap {
-		infraSettingName := getInfraSettingNameFromT1LR(lr)
+		arr := strings.Split(lr, "/")
+		infraSettingName := lib.GetAviInfraSettingName(arr[len(arr)-1])
 		netName := lib.GetVCFNetworkName()
 		if _, ok := cidrs[ns]; ok {
 			netName = lib.GetVCFNetworkNameWithNS(ns)
-			infraSettingName = infraSettingName + "-" + ns
+			infraSettingName = ns + "-" + infraSettingName
 		}
-		infraSettingName = strings.ReplaceAll(infraSettingName, "_", "-")
 		// multiple namespaces can have the same lr, and there will always be only 1 infrasetting per lr
 		// so no need to attempt Infrasetting creation
 		// just annotate the namespace with the infrasetting name
@@ -502,13 +502,4 @@ func (t *T1LRNetworking) NewLRLSFullSyncWorker() *utils.FullSyncThread {
 	worker.SyncFunction = t.SyncLSLRNetwork
 	worker.QuickSyncFunction = func(qSync bool) error { return nil }
 	return worker
-}
-
-func getInfraSettingNameFromT1LR(lr string) string {
-	arr := strings.Split(lr, "/")
-	infraSettingName := arr[len(arr)-1]
-	if strings.Contains(infraSettingName, ":") {
-		infraSettingName = strings.Split(infraSettingName, ":")[1]
-	}
-	return strings.Replace(infraSettingName, "_", "-", -1)
 }

--- a/ako-infra/avirest/vpc_handler.go
+++ b/ako-infra/avirest/vpc_handler.go
@@ -73,9 +73,9 @@ func (v *VPCHandler) createInfraSettingAndAnnotateNS(nsToVPCMap map[string]strin
 	processedInfraSettingCRSet := make(map[string]struct{})
 	for ns, vpc := range nsToVPCMap {
 		arr := strings.Split(vpc, "/vpcs/")
-		infraSettingName := strings.ReplaceAll(arr[len(arr)-1], "_", "-")
-		project := strings.Split(arr[0], "/projects/")[1]
-		tenant, err := getTenantForProject(project)
+		projectArr := strings.Split(arr[0], "/projects/")
+		infraSettingName := lib.GetAviInfraSettingName(projectArr[len(projectArr)-1] + arr[len(arr)-1])
+		tenant, err := getTenantForProject(projectArr[len(projectArr)-1])
 		if err != nil {
 			utils.AviLog.Warnf("failed to fetch admin tenant from Avi, error: %s", err.Error())
 			continue

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -2227,3 +2227,8 @@ func init() {
 	}
 	SEGroupName = seGroupToUse
 }
+
+func GetAviInfraSettingName(projVpc string) string {
+	hash := sha1.Sum([]byte(projVpc))
+	return hex.EncodeToString(hash[:])
+}

--- a/internal/rest/avi_obj_vsvip.go
+++ b/internal/rest/avi_obj_vsvip.go
@@ -119,8 +119,8 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 				vsvip.Vip = append(vsvip.Vip, vips...)
 			} else if lib.GetCloudType() == lib.CLOUD_NSXT && lib.GetVPCMode() {
 				vpcArr := strings.Split(vsvip_meta.T1Lr, "/vpcs/")
-				project := strings.Split(vpcArr[0], "/projects/")[1]
-				vipNetwork := fmt.Sprintf("%s_AVISEPARATOR_%s_AVISEPARATOR_PUBLIC", project, vpcArr[len(vpcArr)-1])
+				projectArr := strings.Split(vpcArr[0], "/projects/")
+				vipNetwork := fmt.Sprintf("%s_AVISEPARATOR_%s_AVISEPARATOR_PUBLIC", projectArr[len(projectArr)-1], vpcArr[len(vpcArr)-1])
 				vip.SubnetUUID = &vipNetwork
 			} else {
 				// Set the IPAM network subnet for all clouds except AWS and Azure
@@ -198,8 +198,8 @@ func (rest *RestOperations) AviVsVipBuild(vsvip_meta *nodes.AviVSVIPNode, vsCach
 			vips = networkNamesToVips(vsvip_meta.VipNetworks, vsvip_meta.EnablePublicIP)
 		} else if lib.GetCloudType() == lib.CLOUD_NSXT && lib.GetVPCMode() {
 			vpcArr := strings.Split(vsvip_meta.T1Lr, "/vpcs/")
-			project := strings.Split(vpcArr[0], "/projects/")[1]
-			vipNetwork := fmt.Sprintf("%s_AVISEPARATOR_%s_AVISEPARATOR_PUBLIC", project, vpcArr[len(vpcArr)-1])
+			projectArr := strings.Split(vpcArr[0], "/projects/")
+			vipNetwork := fmt.Sprintf("%s_AVISEPARATOR_%s_AVISEPARATOR_PUBLIC", projectArr[len(projectArr)-1], vpcArr[len(vpcArr)-1])
 			vip.SubnetUUID = &vipNetwork
 		} else {
 			// Set the IPAM network subnet for all clouds except AWS and Azure

--- a/tests/avimockobjects/ipamdnsproviderprofile_mock.json
+++ b/tests/avimockobjects/ipamdnsproviderprofile_mock.json
@@ -1,40 +1,10 @@
 {
-    "count": 3,
+    "count": 1,
     "results": [
       {
         "allocate_ip_in_vrf": false,
         "_last_modified": "1571450562728944",
         "url": "https://10.52.3.116:9443/api/ipamdnsproviderprofile/ipamdnsproviderprofile-d49243f3-65f3-4cd1-b93a-e0ec41df409e",
-        "tenant_ref": "https://10.52.3.116:9443/api/tenant/admin",
-        "internal_profile": {
-          "usable_network_refs": [
-            "https://10.52.3.116:9443/api/network/network-bbf5b8e8-db93-4b93-9483-f1c59f16a707"
-          ],
-          "ttl": 30
-        },
-        "uuid": "ipamdnsproviderprofile-d49243f3-65f3-4cd1-b93a-e0ec41df409e",
-        "type": "IPAMDNS_TYPE_INTERNAL",
-        "name": "ns-ipam"
-      },
-      {
-        "allocate_ip_in_vrf": false,
-        "_last_modified": "1571450574591332",
-        "url": "https://10.52.3.116:9443/api/ipamdnsproviderprofile/ipamdnsproviderprofile-be7aa26d-3bc8-4213-9f73-b23b4e1d9c39",
-        "tenant_ref": "https://10.52.3.116:9443/api/tenant/admin",
-        "internal_profile": {
-          "usable_network_refs": [
-            "https://10.52.3.116:9443/api/network/network-18046219-3b49-4cef-9230-74d7c2ccaec9"
-          ],
-          "ttl": 30
-        },
-        "uuid": "ipamdnsproviderprofile-be7aa26d-3bc8-4213-9f73-b23b4e1d9c39",
-        "type": "IPAMDNS_TYPE_INTERNAL",
-        "name": "ew-ipam"
-      },
-      {
-        "allocate_ip_in_vrf": false,
-        "_last_modified": "1571450618936372",
-        "url": "https://10.52.3.116:9443/api/ipamdnsproviderprofile/ipamdnsproviderprofile-19a05809-a373-4892-a318-74702c2237ca",
         "tenant_ref": "https://10.52.3.116:9443/api/tenant/admin",
         "internal_profile": {
           "dns_service_domain": [
@@ -54,11 +24,14 @@
               "pass_through": true
             }
           ],
+          "usable_network_refs": [
+            "https://10.52.3.116:9443/api/network/network-bbf5b8e8-db93-4b93-9483-f1c59f16a707"
+          ],
           "ttl": 30
         },
-        "uuid": "ipamdnsproviderprofile-19a05809-a373-4892-a318-74702c2237ca",
-        "type": "IPAMDNS_TYPE_INTERNAL_DNS",
-        "name": "avi-dns"
+        "uuid": "ipamdnsproviderprofile-d49243f3-65f3-4cd1-b93a-e0ec41df409e",
+        "type": "IPAMDNS_TYPE_INTERNAL",
+        "name": "avi-ipam"
       }
     ]
   }

--- a/tests/infratests/akoinfra_test.go
+++ b/tests/infratests/akoinfra_test.go
@@ -169,8 +169,9 @@ func TestAKOInfraAviInfraSettingCreationT1(t *testing.T) {
 		t.Fatalf("failed to create namespacenetworkinfos CR, error: %s", err.Error())
 	}
 
+	infraSettingName := lib.GetAviInfraSettingName("testGW")
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "testGW" &&
@@ -183,7 +184,7 @@ func TestAKOInfraAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -193,7 +194,7 @@ func TestAKOInfraAviInfraSettingCreationT1(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
@@ -203,7 +204,7 @@ func TestAKOInfraAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -248,13 +249,14 @@ func TestAKOInfraAviInfraSettingCreationVPC(t *testing.T) {
 		t.Fatalf("failed to create namespacenetworkinfos CR, error: %s", err.Error())
 	}
 
+	infraSettingName := lib.GetAviInfraSettingName("test-project" + "testGW")
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "/orgs/default/projects/test-project/vpcs/testGW" &&
 				len(infraSetting.Spec.Network.VipNetworks) == 0 &&
-				infraSetting.Spec.SeGroup.Name == lib.GetClusterID()
+				infraSetting.Spec.SeGroup.Name == "Default-Group"
 		}
 	}, 30*time.Second).Should(gomega.Equal(true))
 
@@ -262,7 +264,7 @@ func TestAKOInfraAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW" &&
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName &&
 				ns.Annotations[lib.TenantAnnotation] == "test-project"
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
@@ -273,7 +275,7 @@ func TestAKOInfraAviInfraSettingCreationVPC(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
@@ -283,7 +285,7 @@ func TestAKOInfraAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -364,8 +366,10 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 		t.Fatalf("failed to create namespacenetworkinfos CR, error: %s", err.Error())
 	}
 
+	infraSettingName1 := lib.GetAviInfraSettingName("testGW")
+	infraSettingName2 := "red-" + lib.GetAviInfraSettingName("testGW")
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName1, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "testGW" &&
@@ -375,7 +379,7 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 	}, 30*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW-red", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName2, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "testGW" &&
@@ -388,7 +392,7 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -396,7 +400,7 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW-red"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName2
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -404,7 +408,7 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red-ns", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -424,14 +428,14 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName1, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
 	}, 10*time.Second).Should(gomega.Equal(false))
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW-red", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName2, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
@@ -441,21 +445,21 @@ func TestAKOInfraMultiAviInfraSettingCreationT1(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 	g.Eventually(func() bool {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW-red"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName2
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 	g.Eventually(func() bool {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red-ns", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 
@@ -526,23 +530,25 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 		t.Fatalf("failed to create namespacenetworkinfos CR, error: %s", err.Error())
 	}
 
+	infraSettingName1 := lib.GetAviInfraSettingName("test-project" + "testGW")
+	infraSettingName2 := lib.GetAviInfraSettingName("test-project" + "testGW-red")
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName1, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "/orgs/default/projects/test-project/vpcs/testGW" &&
 				len(infraSetting.Spec.Network.VipNetworks) == 0 &&
-				infraSetting.Spec.SeGroup.Name == lib.GetClusterID()
+				infraSetting.Spec.SeGroup.Name == "Default-Group"
 		}
 	}, 30*time.Second).Should(gomega.Equal(true))
 
 	g.Eventually(func() bool {
-		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW-red", metav1.GetOptions{}); err != nil {
+		if infraSetting, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName2, metav1.GetOptions{}); err != nil {
 			return false
 		} else {
 			return *infraSetting.Spec.NSXSettings.T1LR == "/orgs/default/projects/test-project/vpcs/testGW-red" &&
 				len(infraSetting.Spec.Network.VipNetworks) == 0 &&
-				infraSetting.Spec.SeGroup.Name == lib.GetClusterID()
+				infraSetting.Spec.SeGroup.Name == "Default-Group"
 		}
 	}, 30*time.Second).Should(gomega.Equal(true))
 
@@ -550,7 +556,7 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW" &&
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName1 &&
 				ns.Annotations[lib.TenantAnnotation] == "test-project"
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
@@ -559,7 +565,7 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW-red" &&
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName2 &&
 				ns.Annotations[lib.TenantAnnotation] == "test-project"
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
@@ -568,7 +574,7 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red-ns", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] == "testGW" &&
+			return ns.Annotations[lib.InfraSettingNameAnnotation] == infraSettingName1 &&
 				ns.Annotations[lib.TenantAnnotation] == "test-project"
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
@@ -584,14 +590,14 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 	}
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName1, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
 	}, 10*time.Second).Should(gomega.Equal(false))
 
 	g.Eventually(func() bool {
-		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), "testGW-red", metav1.GetOptions{}); err != nil {
+		if _, err := lib.AKOControlConfig().V1beta1CRDClientset().AkoV1beta1().AviInfraSettings().Get(context.TODO(), infraSettingName2, metav1.GetOptions{}); err != nil {
 			return false
 		}
 		return true
@@ -601,21 +607,21 @@ func TestAKOInfraMultiAviInfraSettingCreationVPC(t *testing.T) {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 	g.Eventually(func() bool {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW-red"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName2
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 	g.Eventually(func() bool {
 		if ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), "red-ns", metav1.GetOptions{}); err != nil {
 			return false
 		} else {
-			return ns.Annotations[lib.InfraSettingNameAnnotation] != "testGW"
+			return ns.Annotations[lib.InfraSettingNameAnnotation] != infraSettingName1
 		}
 	}, 10*time.Second).Should(gomega.Equal(true))
 


### PR DESCRIPTION
Issue : VPC with name "VPC-foo" gets used as name for AVIInfraSetting CR which is not DNS compliant. As a result, AVIInfraSetting CR won't get created.
Fix : Create hash of project name and vpc name, and use it as AVIInfraSetting CR name.
For parity, same change has been done in case of T1 based WCP environment.