### PR TITLE
AV-228166 Relax subnet validation check for EKS deployments

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -1000,27 +1000,28 @@ func checkRefOnController(key, refKey, refValue, tenant string) error {
 
 	// For public clouds, check using network UUID in AWS, normal network API for GCP, skip altogether for Azure.
 	// If reference key is network uuid , then check using UUID.
-	//
-	// During the portal-webapp migration from Python to Go, network views were not correctly ported. However, network APIs are now being routed through Go code,
-	// which is incorrect. The Avi Controller needs to be fixed.
-	// For now, disabling the subnet UUID validation for AWS to avoid impact on EKS deployments.
-	if lib.GetCloudType() != lib.CLOUD_AWS {
-		if (lib.IsPublicCloud() && refModelMap[refKey] == "network") || refKey == "NetworkUUID" {
-			if lib.UsesNetworkRef() || refKey == "NetworkUUID" {
-				var rest_response interface{}
-				utils.AviLog.Infof("Cloud is  %s, checking network ref using uuid", lib.GetCloudType())
-				uri := fmt.Sprintf("/api/%s/%s?cloud_uuid=%s", refModelMap[refKey], refValue, lib.GetCloudUUID())
-				err := lib.AviGet(clients.AviClient[aviClientLen], uri, &rest_response)
-				if err != nil {
-					utils.AviLog.Warnf("key: %s, msg: Get uri %v returned err %v", key, uri, err)
-					return fmt.Errorf("%s \"%s\" not found on controller", refModelMap[refKey], refValue)
-				} else if rest_response != nil {
-					utils.AviLog.Infof("Found %s %s on controller", refModelMap[refKey], refValue)
-					return nil
-				} else {
-					utils.AviLog.Warnf("key: %s, msg: No Objects found for refName: %s/%s", key, refModelMap[refKey], refValue)
-					return fmt.Errorf("%s \"%s\" not found on controller", refModelMap[refKey], refValue)
-				}
+	if (lib.IsPublicCloud() && refModelMap[refKey] == "network") || refKey == "NetworkUUID" {
+		if lib.UsesNetworkRef() || refKey == "NetworkUUID" {
+			// During the portal-webapp migration from Python to Go, network views were not correctly ported. However, network APIs are now being routed through Go code,
+			// which is incorrect. The Avi Controller needs to be fixed.
+			// For now, disabling the subnet UUID validation for AWS to avoid impact on EKS deployments.
+			if lib.GetCloudType() == lib.CLOUD_AWS {
+				utils.AviLog.Infof("Cloud Type is AWS, skip validating references on controller")
+				return nil
+			}
+			var rest_response interface{}
+			utils.AviLog.Infof("Cloud is  %s, checking network ref using uuid", lib.GetCloudType())
+			uri := fmt.Sprintf("/api/%s/%s?cloud_uuid=%s", refModelMap[refKey], refValue, lib.GetCloudUUID())
+			err := lib.AviGet(clients.AviClient[aviClientLen], uri, &rest_response)
+			if err != nil {
+				utils.AviLog.Warnf("key: %s, msg: Get uri %v returned err %v", key, uri, err)
+				return fmt.Errorf("%s \"%s\" not found on controller", refModelMap[refKey], refValue)
+			} else if rest_response != nil {
+				utils.AviLog.Infof("Found %s %s on controller", refModelMap[refKey], refValue)
+				return nil
+			} else {
+				utils.AviLog.Warnf("key: %s, msg: No Objects found for refName: %s/%s", key, refModelMap[refKey], refValue)
+				return fmt.Errorf("%s \"%s\" not found on controller", refModelMap[refKey], refValue)
 			}
 		}
 	}


### PR DESCRIPTION
```
			// During the portal-webapp migration from Python to Go, network views were not correctly ported. However, network APIs are now being routed through Go code,
			// which is incorrect. The Avi Controller needs to be fixed.
			// For now, disabling the subnet UUID validation for AWS to avoid impact on EKS deployments.
```

EKS tests have been passed after this change.

```
16:50:41 functional/ako/test_multivip.py::TestMultiVipSNI::test_create_ingress PASSED [  5%]
16:51:45 functional/ako/test_multivip.py::TestMultiVipSNI::test_update_to_multivip_ingress PASSED [ 10%]
16:53:07 functional/ako/test_multivip.py::TestMultiVipSNI::test_update_to_single_vip_ingress PASSED [ 15%]
16:53:54 functional/ako/test_multivip.py::TestMultiVipSNI::test_create_l4 PASSED  [ 20%]
16:54:20 functional/ako/test_multivip.py::TestMultiVipSNI::test_update_to_multivip_l4 PASSED [ 25%]
16:55:07 functional/ako/test_multivip.py::TestMultiVipSNI::test_update_to_single_vip_l4 PASSED [ 30%]
16:55:55 functional/ako/test_multivip.py::TestMultiVipSNI::test_create_ingress_class PASSED [ 35%]
16:56:29 functional/ako/test_multivip.py::TestMultiVipSNI::test_update_to_multivip_ingress_class PASSED [ 40%]
17:01:47 functional/ako/test_multivip.py::TestMultiVipSNI::test_status_update_ingress PASSED [ 45%]
```