### PR TITLE
AV-228166 relax subnet uuid validation check for AKS deployments as well

### DIFF
--- a/internal/k8s/crdcontroller.go
+++ b/internal/k8s/crdcontroller.go
@@ -1004,9 +1004,10 @@ func checkRefOnController(key, refKey, refValue, tenant string) error {
 		if lib.UsesNetworkRef() || refKey == "NetworkUUID" {
 			// During the portal-webapp migration from Python to Go, network views were not correctly ported. However, network APIs are now being routed through Go code,
 			// which is incorrect. The Avi Controller needs to be fixed.
-			// For now, disabling the subnet UUID validation for AWS to avoid impact on EKS deployments.
-			if lib.GetCloudType() == lib.CLOUD_AWS {
-				utils.AviLog.Infof("Cloud Type is AWS, skip validating references on controller")
+			// For now, subnet UUID validation is disabled for AWS and Azure clouds to avoid impact on EKS and AKS deployments.
+			cloudType := lib.GetCloudType()
+			if cloudType == lib.CLOUD_AWS || cloudType == lib.CLOUD_AZURE {
+				utils.AviLog.Infof("Cloud Type is %q, skip validating references on controller", cloudType)
 				return nil
 			}
 			var rest_response interface{}


### PR DESCRIPTION
This is a follow-up of https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/1731
