### PR TITLE
AV-237682 Disable se group label updation by follower ako

### DIFF
--- a/internal/lib/avi_api.go
+++ b/internal/lib/avi_api.go
@@ -173,7 +173,7 @@ func AviPut(client *clients.AviClient, uri string, payload interface{}, response
 		}
 		CheckForInvalidCredentials(uri, err)
 		apimodels.RestStatus.UpdateAviApiRestStatus("", err)
-		if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 400 {
+		if aviError, ok := err.(session.AviError); ok && (aviError.HttpStatusCode == 400 || aviError.HttpStatusCode == 412) {
 			return err
 		}
 		return AviPut(client, uri, payload, response, retry+1)


### PR DESCRIPTION
AV-237682 Disable se group label updation by follower ako

Tested Locally:

**Setup:**
Multinode cluster with ako running in HA mode.

- On bootup, segroup has labels with clustername added and static routes added to vrfcontext.
- On setting **deleteConfig** flag to **true** , ako-0(Leader pod) removed the clustername label from SE group.
- On setting  **deleteConfig** flag to **false** , ako-0(Leader pod ) added the clustername label to SE group. ako-1, the follower node also tried adding the same clustername label to SE however, it failed with "HTTP code: 412; error from Controller: map[error:Concurrent Update Error" and then it have fetched and refreshed SEGroup data from controller and compared the label and since the label matched, it gave, "labels: [{"key":"clustername","value":"priya-koshta-k8s-2"}] set on Service Engine Group :Default-Group" message
- On setting **deleteConfig** flag to **true** , ako-0(Leader pod) removed the clustername label from SE group.
- On uninstalling and reinstalling ako, ako-0 again added the SEGroup label. ako-1 did not try updating the label since it saw that labels were already updated


**Logs from ako-0:**
`2025-04-29T12:41:29.172Z	INFO	cache/controller_obj_cache.go:3488	labels: [{"key":"clustername","value":"priya-koshta-k8s-2"}] set on Service Engine Group :Default-Group`

**Logs from ako-1:**
`2025-04-29T12:41:17.611Z	WARN	lib/avi_api.go:162	msg: Unable to execute Put on uri /api/serviceenginegroup/serviceenginegroup-4f789b1b-c48f-4c2b-b134-1fb6557fe1c7 Encountered an error on PUT request to URL https://100.65.8.44//api/serviceenginegroup/serviceenginegroup-4f789b1b-c48f-4c2b-b134-1fb6557fe1c7: HTTP code: 412; error from Controller: map[error:Concurrent Update Error: Need to reload object data ServiceEngineGroup]
2025-04-29T12:41:17.653Z	INFO	cache/controller_obj_cache.go:3534	labels: [{"key":"clustername","value":"priya-koshta-k8s-2"}] set on Service Engine Group :Default-Group`

**After reboot logs from ako-0**
2025-04-30T06:42:50.255Z	INFO	cache/controller_obj_cache.go:3488	labels: [{"key":"clustername","value":"priya-koshta-k8s-2"}] set on Service Engine Group :Default-Group
