### PR TITLE
AV-231827 Fix AKO Avi tenant role

### DIFF
--- a/docs/roles/ako-tenant.json
+++ b/docs/roles/ako-tenant.json
@@ -190,10 +190,6 @@
         "resource": "PERMISSION_SYSTEMCONFIGURATION"
     },
     {
-        "type": "READ_ACCESS",
-        "resource": "PERMISSION_CONTROLLER"
-    },
-    {
         "type": "NO_ACCESS",
         "resource": "PERMISSION_REBOOT"
     },


### PR DESCRIPTION
As part of the tenant role, we add read access to the PERMISSION_CONTROLLER resource. However, this role is being rejected by the Avi Controller. We are removing it for to ensure the role functions correctly.

The ako-essential.json file contains a role that can be used to set the same access when needed (for the AMKO use case, cc @akshayhavile).