### PR TITLE
AV-238793 : Update platform as ubuntu-20.04 support d

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     name: Golangci-lint
     strategy:
       matrix:
-        platform: [ ubuntu-20.04 ]
+        platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.21


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11101 : The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15