### PR TITLE
AV-209475 : Add maintainer label to ako-operator docker image

### DIFF
--- a/Dockerfile.ako-operator
+++ b/Dockerfile.ako-operator
@@ -24,6 +24,7 @@ LABEL version="v1.12.3"
 LABEL release="1"
 LABEL description="Manage configmap, statefulset and other artifacts for deploying AKO controller"
 LABEL vendor="VMware"
+LABEL maintainer="VMware"
 
 RUN yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
 


### PR DESCRIPTION
This change is change is added to fix the following error occurring while publishing the image.
```
"failed": [
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata.and that they do not violate Red Hat trademark.",
                "help": "Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description, maintainerand validate that they do not violate Red Hat trademark.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ]
```