### PR TITLE
AV-209475 : Update required feature annotations in the bundle

### DIFF
--- a/ako-operator/Makefile
+++ b/ako-operator/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 1.5.1
+VERSION ?= 1.12.3
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 # Options for 'bundle-build'
@@ -10,6 +10,7 @@ ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 PACKAGE_PATH_AKO=github.com/vmware/load-balancer-and-ingress-services-for-kubernetes
 ifdef GOLANG_SRC_REPO
 	BUILD_GO_IMG=$(GOLANG_SRC_REPO)
@@ -112,12 +113,20 @@ else
 KUSTOMIZE=$(shell which kustomize)
 endif
 
+# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
+# You can enable this value if you would like to use SHA Based Digests
+# To enable set flag to true
+USE_IMAGE_DIGESTS ?= false
+ifeq ($(USE_IMAGE_DIGESTS), true)
+	BUNDLE_GEN_FLAGS += --use-image-digests
+endif
+
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
 bundle: manifests
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: ako-operator-tests

--- a/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
+++ b/ako-operator/bundle/manifests/ako-operator.clusterserviceversion.yaml
@@ -116,6 +116,13 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     operatorframework.io/suggested-namespace: avi-system
     containerImage: projects.packages.broadcom.com/ako/ako-operator@sha256:cfc30e3a06fd3afa54e6a0a10a3aac1604395a60f04b291fcbba61e3529b4876
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   name: ako-operator.v1.12.3
   namespace: placeholder
 spec:


### PR DESCRIPTION
These annotations are now mandated by RedHat for certification. The previous attempt to complete the certification had failed with the below error.
```
"failed": [
[evaluate-preflight-result : evaluate-results]       {
[evaluate-preflight-result : evaluate-results]         "name": "RequiredAnnotations",
[evaluate-preflight-result : evaluate-results]         "elapsed_time": 14,
[evaluate-preflight-result : evaluate-results]         "description": "Checks that the CSV has all of the required feature annotations.",
[evaluate-preflight-result : evaluate-results]         "help": "Check that the CSV has all of the required feature annotations.",
[evaluate-preflight-result : evaluate-results]         "suggestion": "Add all of the required annotations, and make sure the value is set to either 'true' or 'false'",
[evaluate-preflight-result : evaluate-results]         "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed",
[evaluate-preflight-result : evaluate-results]         "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed"
[evaluate-preflight-result : evaluate-results]       }
[evaluate-preflight-result : evaluate-results]     ],
```