### PR TITLE
AV-239969 Add FullClientLogs 'Duration' field support to hostrule crd

### DIFF
--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -122,9 +122,6 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
-                          duration:
-                            type: integer
-                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean
@@ -272,7 +269,7 @@ spec:
                             type: string
                           duration:
                             type: integer
-                            default: 30
+                            default: 0
                         type: object
                       logAllHeaders:
                         type: boolean

--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -267,9 +267,6 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
-                          duration:
-                            type: integer
-                            default: 0
                         type: object
                       logAllHeaders:
                         type: boolean

--- a/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
+++ b/ako-operator/helm/ako-operator/crds/ako.vmware.com_hostrules.yaml
@@ -122,6 +122,9 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
+                          duration:
+                            type: integer
+                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean
@@ -267,6 +270,9 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
+                          duration:
+                            type: integer
+                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean

--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -232,7 +232,7 @@ The HostRule CRD can be used to configure analytics policies such as enable/disa
 
 The `throttle` will be in effect only when `enabled` is set to `true`. The possible values of `throttle` are DISABLED (0), LOW (50), MEDIUM (30) and HIGH (10).
 
-AKO sets the duration of logging the non-significant logs to infinity by default. `duration` field can be used to modify the duration for which the system should capture all logs, measured in minutes.
+AKO sets the duration of logging the non-significant logs to infinity by default. `duration` field can be used to modify the duration for which the system should capture non-significant logs, measured in minutes.
 
 #### Configure TCP Settings
 

--- a/docs/crds/hostrule.md
+++ b/docs/crds/hostrule.md
@@ -47,6 +47,7 @@ A sample HostRule CRD looks like this:
           fullClientLogs:
             enabled: true
             throttle: HIGH
+            duration: 30
           logAllHeaders: true
         tcpSettings:
           listeners:
@@ -226,11 +227,12 @@ The HostRule CRD can be used to configure analytics policies such as enable/disa
           fullClientLogs:
             enabled: true
             throttle: HIGH
+            duration: 30
           logAllHeaders: true
 
 The `throttle` will be in effect only when `enabled` is set to `true`. The possible values of `throttle` are DISABLED (0), LOW (50), MEDIUM (30) and HIGH (10).
 
-The AKO sets the duration of logging the non-significant logs to infinity by default. It is the responsibility of the user to disable the non-significant logs when it is no longer required.
+AKO sets the duration of logging the non-significant logs to infinity by default. `duration` field can be used to modify the duration for which the system should capture all logs, measured in minutes.
 
 #### Configure TCP Settings
 

--- a/helm/ako/crds/ako.vmware.com_hostrules.yaml
+++ b/helm/ako/crds/ako.vmware.com_hostrules.yaml
@@ -122,9 +122,6 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
-                          duration:
-                            type: integer
-                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean
@@ -276,7 +273,7 @@ spec:
                             type: string
                           duration:
                             type: integer
-                            default: 30
+                            default: 0
                         type: object
                       logAllHeaders:
                         type: boolean

--- a/helm/ako/crds/ako.vmware.com_hostrules.yaml
+++ b/helm/ako/crds/ako.vmware.com_hostrules.yaml
@@ -122,6 +122,9 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
+                          duration:
+                            type: integer
+                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean
@@ -271,6 +274,9 @@ spec:
                             - DISABLED
                             default: HIGH
                             type: string
+                          duration:
+                            type: integer
+                            default: 30
                         type: object
                       logAllHeaders:
                         type: boolean

--- a/internal/nodes/crd_translator.go
+++ b/internal/nodes/crd_translator.go
@@ -181,6 +181,7 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 
 		if hostrule.Spec.VirtualHost.AnalyticsPolicy != nil {
 			var infinite uint32 = 0 // Special value to set log duration as infinite
+			// defaults to 'infinite' if hostrule doesn't specify a duration
 			analyticsPolicy = &models.AnalyticsPolicy{
 				FullClientLogs: &models.FullClientLogs{
 					Duration: &infinite,
@@ -190,6 +191,11 @@ func BuildL7HostRule(host, key string, vsNode AviVsEvhSniModel) {
 			if hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs != nil {
 				analyticsPolicy.FullClientLogs.Enabled = hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Enabled
 				analyticsPolicy.FullClientLogs.Throttle = lib.GetThrottle(hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Throttle)
+
+				// only update duration if duration is actually specified in hr
+				if hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Duration != nil {
+					analyticsPolicy.FullClientLogs.Duration = hostrule.Spec.VirtualHost.AnalyticsPolicy.FullClientLogs.Duration
+				}
 			}
 		}
 

--- a/pkg/apis/ako/v1beta1/hostrule.go
+++ b/pkg/apis/ako/v1beta1/hostrule.go
@@ -160,7 +160,7 @@ type FullClientLogs struct {
 	Enabled  *bool  `json:"enabled,omitempty"`
 	Throttle string `json:"throttle,omitempty"`
 
-	// How long should the system capture all logs, measured in minutes.
+	// How long should the system capture Non-significant logs, measured in minutes.
 	// Set to 0 for infinite. Special values are 0 - infinite. Unit is MIN.
 	Duration *uint32 `json:"duration,omitempty"`
 }

--- a/pkg/apis/ako/v1beta1/hostrule.go
+++ b/pkg/apis/ako/v1beta1/hostrule.go
@@ -159,4 +159,8 @@ type HostRuleAnalyticsPolicy struct {
 type FullClientLogs struct {
 	Enabled  *bool  `json:"enabled,omitempty"`
 	Throttle string `json:"throttle,omitempty"`
+
+	// How long should the system capture all logs, measured in minutes.
+	// Set to 0 for infinite. Special values are 0 - infinite. Unit is MIN.
+	Duration *uint32 `json:"duration,omitempty"`
 }

--- a/pkg/apis/ako/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/ako/v1beta1/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *FullClientLogs) DeepCopyInto(out *FullClientLogs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(uint32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/v1beta1/clientset/versioned/clientset.go
+++ b/pkg/client/v1beta1/clientset/versioned/clientset.go
@@ -19,8 +19,8 @@ limitations under the License.
 package versioned
 
 import (
-	"fmt"
-	"net/http"
+	fmt "fmt"
+	http "net/http"
 
 	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1"
 	discovery "k8s.io/client-go/discovery"

--- a/pkg/client/v1beta1/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/v1beta1/clientset/versioned/fake/clientset_generated.go
@@ -31,8 +31,12 @@ import (
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// without applying any field management, validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
+//
+// DEPRECATED: NewClientset replaces this with support for field management, which significantly improves
+// server side apply testing. NewClientset is only available when apply configurations are generated (e.g.
+// via --with-applyconfig).
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/ako_client.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/ako_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
-	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/scheme"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	scheme "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -95,10 +95,10 @@ func New(c rest.Interface) *AkoV1beta1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1beta1.SchemeGroupVersion
+	gv := akov1beta1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/aviinfrasetting.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/aviinfrasetting.go
@@ -19,15 +19,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-	"time"
+	context "context"
 
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	scheme "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // AviInfraSettingsGetter has a method to return a AviInfraSettingInterface.
@@ -38,147 +37,34 @@ type AviInfraSettingsGetter interface {
 
 // AviInfraSettingInterface has methods to work with AviInfraSetting resources.
 type AviInfraSettingInterface interface {
-	Create(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.CreateOptions) (*v1beta1.AviInfraSetting, error)
-	Update(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (*v1beta1.AviInfraSetting, error)
-	UpdateStatus(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (*v1beta1.AviInfraSetting, error)
+	Create(ctx context.Context, aviInfraSetting *akov1beta1.AviInfraSetting, opts v1.CreateOptions) (*akov1beta1.AviInfraSetting, error)
+	Update(ctx context.Context, aviInfraSetting *akov1beta1.AviInfraSetting, opts v1.UpdateOptions) (*akov1beta1.AviInfraSetting, error)
+	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+	UpdateStatus(ctx context.Context, aviInfraSetting *akov1beta1.AviInfraSetting, opts v1.UpdateOptions) (*akov1beta1.AviInfraSetting, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.AviInfraSetting, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.AviInfraSettingList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*akov1beta1.AviInfraSetting, error)
+	List(ctx context.Context, opts v1.ListOptions) (*akov1beta1.AviInfraSettingList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.AviInfraSetting, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *akov1beta1.AviInfraSetting, err error)
 	AviInfraSettingExpansion
 }
 
 // aviInfraSettings implements AviInfraSettingInterface
 type aviInfraSettings struct {
-	client rest.Interface
+	*gentype.ClientWithList[*akov1beta1.AviInfraSetting, *akov1beta1.AviInfraSettingList]
 }
 
 // newAviInfraSettings returns a AviInfraSettings
 func newAviInfraSettings(c *AkoV1beta1Client) *aviInfraSettings {
 	return &aviInfraSettings{
-		client: c.RESTClient(),
+		gentype.NewClientWithList[*akov1beta1.AviInfraSetting, *akov1beta1.AviInfraSettingList](
+			"aviinfrasettings",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			"",
+			func() *akov1beta1.AviInfraSetting { return &akov1beta1.AviInfraSetting{} },
+			func() *akov1beta1.AviInfraSettingList { return &akov1beta1.AviInfraSettingList{} },
+		),
 	}
-}
-
-// Get takes name of the aviInfraSetting, and returns the corresponding aviInfraSetting object, and an error if there is any.
-func (c *aviInfraSettings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.AviInfraSetting, err error) {
-	result = &v1beta1.AviInfraSetting{}
-	err = c.client.Get().
-		Resource("aviinfrasettings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of AviInfraSettings that match those selectors.
-func (c *aviInfraSettings) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.AviInfraSettingList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1beta1.AviInfraSettingList{}
-	err = c.client.Get().
-		Resource("aviinfrasettings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested aviInfraSettings.
-func (c *aviInfraSettings) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Resource("aviinfrasettings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a aviInfraSetting and creates it.  Returns the server's representation of the aviInfraSetting, and an error, if there is any.
-func (c *aviInfraSettings) Create(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.CreateOptions) (result *v1beta1.AviInfraSetting, err error) {
-	result = &v1beta1.AviInfraSetting{}
-	err = c.client.Post().
-		Resource("aviinfrasettings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(aviInfraSetting).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a aviInfraSetting and updates it. Returns the server's representation of the aviInfraSetting, and an error, if there is any.
-func (c *aviInfraSettings) Update(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (result *v1beta1.AviInfraSetting, err error) {
-	result = &v1beta1.AviInfraSetting{}
-	err = c.client.Put().
-		Resource("aviinfrasettings").
-		Name(aviInfraSetting.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(aviInfraSetting).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *aviInfraSettings) UpdateStatus(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (result *v1beta1.AviInfraSetting, err error) {
-	result = &v1beta1.AviInfraSetting{}
-	err = c.client.Put().
-		Resource("aviinfrasettings").
-		Name(aviInfraSetting.Name).
-		SubResource("status").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(aviInfraSetting).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the aviInfraSetting and deletes it. Returns an error if one occurs.
-func (c *aviInfraSettings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Resource("aviinfrasettings").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *aviInfraSettings) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Resource("aviinfrasettings").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched aviInfraSetting.
-func (c *aviInfraSettings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.AviInfraSetting, err error) {
-	result = &v1beta1.AviInfraSetting{}
-	err = c.client.Patch(pt).
-		Resource("aviinfrasettings").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_ako_client.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_ako_client.go
@@ -29,15 +29,15 @@ type FakeAkoV1beta1 struct {
 }
 
 func (c *FakeAkoV1beta1) AviInfraSettings() v1beta1.AviInfraSettingInterface {
-	return &FakeAviInfraSettings{c}
+	return newFakeAviInfraSettings(c)
 }
 
 func (c *FakeAkoV1beta1) HTTPRules(namespace string) v1beta1.HTTPRuleInterface {
-	return &FakeHTTPRules{c, namespace}
+	return newFakeHTTPRules(c, namespace)
 }
 
 func (c *FakeAkoV1beta1) HostRules(namespace string) v1beta1.HostRuleInterface {
-	return &FakeHostRules{c, namespace}
+	return newFakeHostRules(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_aviinfrasetting.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_aviinfrasetting.go
@@ -19,114 +19,34 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeAviInfraSettings implements AviInfraSettingInterface
-type FakeAviInfraSettings struct {
+// fakeAviInfraSettings implements AviInfraSettingInterface
+type fakeAviInfraSettings struct {
+	*gentype.FakeClientWithList[*v1beta1.AviInfraSetting, *v1beta1.AviInfraSettingList]
 	Fake *FakeAkoV1beta1
 }
 
-var aviinfrasettingsResource = v1beta1.SchemeGroupVersion.WithResource("aviinfrasettings")
-
-var aviinfrasettingsKind = v1beta1.SchemeGroupVersion.WithKind("AviInfraSetting")
-
-// Get takes name of the aviInfraSetting, and returns the corresponding aviInfraSetting object, and an error if there is any.
-func (c *FakeAviInfraSettings) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.AviInfraSetting, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(aviinfrasettingsResource, name), &v1beta1.AviInfraSetting{})
-	if obj == nil {
-		return nil, err
+func newFakeAviInfraSettings(fake *FakeAkoV1beta1) akov1beta1.AviInfraSettingInterface {
+	return &fakeAviInfraSettings{
+		gentype.NewFakeClientWithList[*v1beta1.AviInfraSetting, *v1beta1.AviInfraSettingList](
+			fake.Fake,
+			"",
+			v1beta1.SchemeGroupVersion.WithResource("aviinfrasettings"),
+			v1beta1.SchemeGroupVersion.WithKind("AviInfraSetting"),
+			func() *v1beta1.AviInfraSetting { return &v1beta1.AviInfraSetting{} },
+			func() *v1beta1.AviInfraSettingList { return &v1beta1.AviInfraSettingList{} },
+			func(dst, src *v1beta1.AviInfraSettingList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta1.AviInfraSettingList) []*v1beta1.AviInfraSetting {
+				return gentype.ToPointerSlice(list.Items)
+			},
+			func(list *v1beta1.AviInfraSettingList, items []*v1beta1.AviInfraSetting) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta1.AviInfraSetting), err
-}
-
-// List takes label and field selectors, and returns the list of AviInfraSettings that match those selectors.
-func (c *FakeAviInfraSettings) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.AviInfraSettingList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(aviinfrasettingsResource, aviinfrasettingsKind, opts), &v1beta1.AviInfraSettingList{})
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.AviInfraSettingList{ListMeta: obj.(*v1beta1.AviInfraSettingList).ListMeta}
-	for _, item := range obj.(*v1beta1.AviInfraSettingList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested aviInfraSettings.
-func (c *FakeAviInfraSettings) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(aviinfrasettingsResource, opts))
-}
-
-// Create takes the representation of a aviInfraSetting and creates it.  Returns the server's representation of the aviInfraSetting, and an error, if there is any.
-func (c *FakeAviInfraSettings) Create(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.CreateOptions) (result *v1beta1.AviInfraSetting, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(aviinfrasettingsResource, aviInfraSetting), &v1beta1.AviInfraSetting{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.AviInfraSetting), err
-}
-
-// Update takes the representation of a aviInfraSetting and updates it. Returns the server's representation of the aviInfraSetting, and an error, if there is any.
-func (c *FakeAviInfraSettings) Update(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (result *v1beta1.AviInfraSetting, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(aviinfrasettingsResource, aviInfraSetting), &v1beta1.AviInfraSetting{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.AviInfraSetting), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeAviInfraSettings) UpdateStatus(ctx context.Context, aviInfraSetting *v1beta1.AviInfraSetting, opts v1.UpdateOptions) (*v1beta1.AviInfraSetting, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(aviinfrasettingsResource, "status", aviInfraSetting), &v1beta1.AviInfraSetting{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.AviInfraSetting), err
-}
-
-// Delete takes name of the aviInfraSetting and deletes it. Returns an error if one occurs.
-func (c *FakeAviInfraSettings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteActionWithOptions(aviinfrasettingsResource, name, opts), &v1beta1.AviInfraSetting{})
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeAviInfraSettings) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(aviinfrasettingsResource, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.AviInfraSettingList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched aviInfraSetting.
-func (c *FakeAviInfraSettings) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.AviInfraSetting, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(aviinfrasettingsResource, name, pt, data, subresources...), &v1beta1.AviInfraSetting{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.AviInfraSetting), err
 }

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_hostrule.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_hostrule.go
@@ -19,123 +19,32 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeHostRules implements HostRuleInterface
-type FakeHostRules struct {
+// fakeHostRules implements HostRuleInterface
+type fakeHostRules struct {
+	*gentype.FakeClientWithList[*v1beta1.HostRule, *v1beta1.HostRuleList]
 	Fake *FakeAkoV1beta1
-	ns   string
 }
 
-var hostrulesResource = v1beta1.SchemeGroupVersion.WithResource("hostrules")
-
-var hostrulesKind = v1beta1.SchemeGroupVersion.WithKind("HostRule")
-
-// Get takes name of the hostRule, and returns the corresponding hostRule object, and an error if there is any.
-func (c *FakeHostRules) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.HostRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(hostrulesResource, c.ns, name), &v1beta1.HostRule{})
-
-	if obj == nil {
-		return nil, err
+func newFakeHostRules(fake *FakeAkoV1beta1, namespace string) akov1beta1.HostRuleInterface {
+	return &fakeHostRules{
+		gentype.NewFakeClientWithList[*v1beta1.HostRule, *v1beta1.HostRuleList](
+			fake.Fake,
+			namespace,
+			v1beta1.SchemeGroupVersion.WithResource("hostrules"),
+			v1beta1.SchemeGroupVersion.WithKind("HostRule"),
+			func() *v1beta1.HostRule { return &v1beta1.HostRule{} },
+			func() *v1beta1.HostRuleList { return &v1beta1.HostRuleList{} },
+			func(dst, src *v1beta1.HostRuleList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta1.HostRuleList) []*v1beta1.HostRule { return gentype.ToPointerSlice(list.Items) },
+			func(list *v1beta1.HostRuleList, items []*v1beta1.HostRule) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta1.HostRule), err
-}
-
-// List takes label and field selectors, and returns the list of HostRules that match those selectors.
-func (c *FakeHostRules) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.HostRuleList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(hostrulesResource, hostrulesKind, c.ns, opts), &v1beta1.HostRuleList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.HostRuleList{ListMeta: obj.(*v1beta1.HostRuleList).ListMeta}
-	for _, item := range obj.(*v1beta1.HostRuleList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested hostRules.
-func (c *FakeHostRules) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(hostrulesResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a hostRule and creates it.  Returns the server's representation of the hostRule, and an error, if there is any.
-func (c *FakeHostRules) Create(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.CreateOptions) (result *v1beta1.HostRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(hostrulesResource, c.ns, hostRule), &v1beta1.HostRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HostRule), err
-}
-
-// Update takes the representation of a hostRule and updates it. Returns the server's representation of the hostRule, and an error, if there is any.
-func (c *FakeHostRules) Update(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (result *v1beta1.HostRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(hostrulesResource, c.ns, hostRule), &v1beta1.HostRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HostRule), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeHostRules) UpdateStatus(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (*v1beta1.HostRule, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(hostrulesResource, "status", c.ns, hostRule), &v1beta1.HostRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HostRule), err
-}
-
-// Delete takes name of the hostRule and deletes it. Returns an error if one occurs.
-func (c *FakeHostRules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(hostrulesResource, c.ns, name, opts), &v1beta1.HostRule{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeHostRules) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(hostrulesResource, c.ns, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.HostRuleList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched hostRule.
-func (c *FakeHostRules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HostRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(hostrulesResource, c.ns, name, pt, data, subresources...), &v1beta1.HostRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HostRule), err
 }

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_httprule.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/fake/fake_httprule.go
@@ -19,123 +19,32 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeHTTPRules implements HTTPRuleInterface
-type FakeHTTPRules struct {
+// fakeHTTPRules implements HTTPRuleInterface
+type fakeHTTPRules struct {
+	*gentype.FakeClientWithList[*v1beta1.HTTPRule, *v1beta1.HTTPRuleList]
 	Fake *FakeAkoV1beta1
-	ns   string
 }
 
-var httprulesResource = v1beta1.SchemeGroupVersion.WithResource("httprules")
-
-var httprulesKind = v1beta1.SchemeGroupVersion.WithKind("HTTPRule")
-
-// Get takes name of the hTTPRule, and returns the corresponding hTTPRule object, and an error if there is any.
-func (c *FakeHTTPRules) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.HTTPRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(httprulesResource, c.ns, name), &v1beta1.HTTPRule{})
-
-	if obj == nil {
-		return nil, err
+func newFakeHTTPRules(fake *FakeAkoV1beta1, namespace string) akov1beta1.HTTPRuleInterface {
+	return &fakeHTTPRules{
+		gentype.NewFakeClientWithList[*v1beta1.HTTPRule, *v1beta1.HTTPRuleList](
+			fake.Fake,
+			namespace,
+			v1beta1.SchemeGroupVersion.WithResource("httprules"),
+			v1beta1.SchemeGroupVersion.WithKind("HTTPRule"),
+			func() *v1beta1.HTTPRule { return &v1beta1.HTTPRule{} },
+			func() *v1beta1.HTTPRuleList { return &v1beta1.HTTPRuleList{} },
+			func(dst, src *v1beta1.HTTPRuleList) { dst.ListMeta = src.ListMeta },
+			func(list *v1beta1.HTTPRuleList) []*v1beta1.HTTPRule { return gentype.ToPointerSlice(list.Items) },
+			func(list *v1beta1.HTTPRuleList, items []*v1beta1.HTTPRule) {
+				list.Items = gentype.FromPointerSlice(items)
+			},
+		),
+		fake,
 	}
-	return obj.(*v1beta1.HTTPRule), err
-}
-
-// List takes label and field selectors, and returns the list of HTTPRules that match those selectors.
-func (c *FakeHTTPRules) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.HTTPRuleList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(httprulesResource, httprulesKind, c.ns, opts), &v1beta1.HTTPRuleList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.HTTPRuleList{ListMeta: obj.(*v1beta1.HTTPRuleList).ListMeta}
-	for _, item := range obj.(*v1beta1.HTTPRuleList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested hTTPRules.
-func (c *FakeHTTPRules) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(httprulesResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a hTTPRule and creates it.  Returns the server's representation of the hTTPRule, and an error, if there is any.
-func (c *FakeHTTPRules) Create(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.CreateOptions) (result *v1beta1.HTTPRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(httprulesResource, c.ns, hTTPRule), &v1beta1.HTTPRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HTTPRule), err
-}
-
-// Update takes the representation of a hTTPRule and updates it. Returns the server's representation of the hTTPRule, and an error, if there is any.
-func (c *FakeHTTPRules) Update(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (result *v1beta1.HTTPRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(httprulesResource, c.ns, hTTPRule), &v1beta1.HTTPRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HTTPRule), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeHTTPRules) UpdateStatus(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (*v1beta1.HTTPRule, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(httprulesResource, "status", c.ns, hTTPRule), &v1beta1.HTTPRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HTTPRule), err
-}
-
-// Delete takes name of the hTTPRule and deletes it. Returns an error if one occurs.
-func (c *FakeHTTPRules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(httprulesResource, c.ns, name, opts), &v1beta1.HTTPRule{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeHTTPRules) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(httprulesResource, c.ns, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.HTTPRuleList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched hTTPRule.
-func (c *FakeHTTPRules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HTTPRule, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(httprulesResource, c.ns, name, pt, data, subresources...), &v1beta1.HTTPRule{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.HTTPRule), err
 }

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/hostrule.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/hostrule.go
@@ -19,15 +19,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-	"time"
+	context "context"
 
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	scheme "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // HostRulesGetter has a method to return a HostRuleInterface.
@@ -38,158 +37,34 @@ type HostRulesGetter interface {
 
 // HostRuleInterface has methods to work with HostRule resources.
 type HostRuleInterface interface {
-	Create(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.CreateOptions) (*v1beta1.HostRule, error)
-	Update(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (*v1beta1.HostRule, error)
-	UpdateStatus(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (*v1beta1.HostRule, error)
+	Create(ctx context.Context, hostRule *akov1beta1.HostRule, opts v1.CreateOptions) (*akov1beta1.HostRule, error)
+	Update(ctx context.Context, hostRule *akov1beta1.HostRule, opts v1.UpdateOptions) (*akov1beta1.HostRule, error)
+	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+	UpdateStatus(ctx context.Context, hostRule *akov1beta1.HostRule, opts v1.UpdateOptions) (*akov1beta1.HostRule, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.HostRule, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.HostRuleList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*akov1beta1.HostRule, error)
+	List(ctx context.Context, opts v1.ListOptions) (*akov1beta1.HostRuleList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HostRule, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *akov1beta1.HostRule, err error)
 	HostRuleExpansion
 }
 
 // hostRules implements HostRuleInterface
 type hostRules struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithList[*akov1beta1.HostRule, *akov1beta1.HostRuleList]
 }
 
 // newHostRules returns a HostRules
 func newHostRules(c *AkoV1beta1Client, namespace string) *hostRules {
 	return &hostRules{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithList[*akov1beta1.HostRule, *akov1beta1.HostRuleList](
+			"hostrules",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *akov1beta1.HostRule { return &akov1beta1.HostRule{} },
+			func() *akov1beta1.HostRuleList { return &akov1beta1.HostRuleList{} },
+		),
 	}
-}
-
-// Get takes name of the hostRule, and returns the corresponding hostRule object, and an error if there is any.
-func (c *hostRules) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.HostRule, err error) {
-	result = &v1beta1.HostRule{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("hostrules").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HostRules that match those selectors.
-func (c *hostRules) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.HostRuleList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1beta1.HostRuleList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("hostrules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested hostRules.
-func (c *hostRules) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("hostrules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a hostRule and creates it.  Returns the server's representation of the hostRule, and an error, if there is any.
-func (c *hostRules) Create(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.CreateOptions) (result *v1beta1.HostRule, err error) {
-	result = &v1beta1.HostRule{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("hostrules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hostRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a hostRule and updates it. Returns the server's representation of the hostRule, and an error, if there is any.
-func (c *hostRules) Update(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (result *v1beta1.HostRule, err error) {
-	result = &v1beta1.HostRule{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("hostrules").
-		Name(hostRule.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hostRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *hostRules) UpdateStatus(ctx context.Context, hostRule *v1beta1.HostRule, opts v1.UpdateOptions) (result *v1beta1.HostRule, err error) {
-	result = &v1beta1.HostRule{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("hostrules").
-		Name(hostRule.Name).
-		SubResource("status").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hostRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the hostRule and deletes it. Returns an error if one occurs.
-func (c *hostRules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("hostrules").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *hostRules) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("hostrules").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched hostRule.
-func (c *hostRules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HostRule, err error) {
-	result = &v1beta1.HostRule{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("hostrules").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/httprule.go
+++ b/pkg/client/v1beta1/clientset/versioned/typed/ako/v1beta1/httprule.go
@@ -19,15 +19,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
-	"time"
+	context "context"
 
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	scheme "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
-	rest "k8s.io/client-go/rest"
+	gentype "k8s.io/client-go/gentype"
 )
 
 // HTTPRulesGetter has a method to return a HTTPRuleInterface.
@@ -38,158 +37,34 @@ type HTTPRulesGetter interface {
 
 // HTTPRuleInterface has methods to work with HTTPRule resources.
 type HTTPRuleInterface interface {
-	Create(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.CreateOptions) (*v1beta1.HTTPRule, error)
-	Update(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (*v1beta1.HTTPRule, error)
-	UpdateStatus(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (*v1beta1.HTTPRule, error)
+	Create(ctx context.Context, hTTPRule *akov1beta1.HTTPRule, opts v1.CreateOptions) (*akov1beta1.HTTPRule, error)
+	Update(ctx context.Context, hTTPRule *akov1beta1.HTTPRule, opts v1.UpdateOptions) (*akov1beta1.HTTPRule, error)
+	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+	UpdateStatus(ctx context.Context, hTTPRule *akov1beta1.HTTPRule, opts v1.UpdateOptions) (*akov1beta1.HTTPRule, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
-	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1beta1.HTTPRule, error)
-	List(ctx context.Context, opts v1.ListOptions) (*v1beta1.HTTPRuleList, error)
+	Get(ctx context.Context, name string, opts v1.GetOptions) (*akov1beta1.HTTPRule, error)
+	List(ctx context.Context, opts v1.ListOptions) (*akov1beta1.HTTPRuleList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HTTPRule, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *akov1beta1.HTTPRule, err error)
 	HTTPRuleExpansion
 }
 
 // hTTPRules implements HTTPRuleInterface
 type hTTPRules struct {
-	client rest.Interface
-	ns     string
+	*gentype.ClientWithList[*akov1beta1.HTTPRule, *akov1beta1.HTTPRuleList]
 }
 
 // newHTTPRules returns a HTTPRules
 func newHTTPRules(c *AkoV1beta1Client, namespace string) *hTTPRules {
 	return &hTTPRules{
-		client: c.RESTClient(),
-		ns:     namespace,
+		gentype.NewClientWithList[*akov1beta1.HTTPRule, *akov1beta1.HTTPRuleList](
+			"httprules",
+			c.RESTClient(),
+			scheme.ParameterCodec,
+			namespace,
+			func() *akov1beta1.HTTPRule { return &akov1beta1.HTTPRule{} },
+			func() *akov1beta1.HTTPRuleList { return &akov1beta1.HTTPRuleList{} },
+		),
 	}
-}
-
-// Get takes name of the hTTPRule, and returns the corresponding hTTPRule object, and an error if there is any.
-func (c *hTTPRules) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.HTTPRule, err error) {
-	result = &v1beta1.HTTPRule{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("httprules").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HTTPRules that match those selectors.
-func (c *hTTPRules) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.HTTPRuleList, err error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	result = &v1beta1.HTTPRuleList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("httprules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested hTTPRules.
-func (c *hTTPRules) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
-	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
-	}
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("httprules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Watch(ctx)
-}
-
-// Create takes the representation of a hTTPRule and creates it.  Returns the server's representation of the hTTPRule, and an error, if there is any.
-func (c *hTTPRules) Create(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.CreateOptions) (result *v1beta1.HTTPRule, err error) {
-	result = &v1beta1.HTTPRule{}
-	err = c.client.Post().
-		Namespace(c.ns).
-		Resource("httprules").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hTTPRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Update takes the representation of a hTTPRule and updates it. Returns the server's representation of the hTTPRule, and an error, if there is any.
-func (c *hTTPRules) Update(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (result *v1beta1.HTTPRule, err error) {
-	result = &v1beta1.HTTPRule{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("httprules").
-		Name(hTTPRule.Name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hTTPRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *hTTPRules) UpdateStatus(ctx context.Context, hTTPRule *v1beta1.HTTPRule, opts v1.UpdateOptions) (result *v1beta1.HTTPRule, err error) {
-	result = &v1beta1.HTTPRule{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("httprules").
-		Name(hTTPRule.Name).
-		SubResource("status").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(hTTPRule).
-		Do(ctx).
-		Into(result)
-	return
-}
-
-// Delete takes name of the hTTPRule and deletes it. Returns an error if one occurs.
-func (c *hTTPRules) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("httprules").
-		Name(name).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *hTTPRules) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	var timeout time.Duration
-	if listOpts.TimeoutSeconds != nil {
-		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
-	}
-	return c.client.Delete().
-		Namespace(c.ns).
-		Resource("httprules").
-		VersionedParams(&listOpts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Body(&opts).
-		Do(ctx).
-		Error()
-}
-
-// Patch applies the patch and returns the patched hTTPRule.
-func (c *hTTPRules) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.HTTPRule, err error) {
-	result = &v1beta1.HTTPRule{}
-	err = c.client.Patch(pt).
-		Namespace(c.ns).
-		Resource("httprules").
-		Name(name).
-		SubResource(subresources...).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Body(data).
-		Do(ctx).
-		Into(result)
-	return
 }

--- a/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/aviinfrasetting.go
+++ b/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/aviinfrasetting.go
@@ -19,13 +19,13 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	apisakov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	versioned "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned"
 	internalinterfaces "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/informers/externalversions/internalinterfaces"
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -36,7 +36,7 @@ import (
 // AviInfraSettings.
 type AviInfraSettingInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta1.AviInfraSettingLister
+	Lister() akov1beta1.AviInfraSettingLister
 }
 
 type aviInfraSettingInformer struct {
@@ -70,7 +70,7 @@ func NewFilteredAviInfraSettingInformer(client versioned.Interface, resyncPeriod
 				return client.AkoV1beta1().AviInfraSettings().Watch(context.TODO(), options)
 			},
 		},
-		&akov1beta1.AviInfraSetting{},
+		&apisakov1beta1.AviInfraSetting{},
 		resyncPeriod,
 		indexers,
 	)
@@ -81,9 +81,9 @@ func (f *aviInfraSettingInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *aviInfraSettingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&akov1beta1.AviInfraSetting{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisakov1beta1.AviInfraSetting{}, f.defaultInformer)
 }
 
-func (f *aviInfraSettingInformer) Lister() v1beta1.AviInfraSettingLister {
-	return v1beta1.NewAviInfraSettingLister(f.Informer().GetIndexer())
+func (f *aviInfraSettingInformer) Lister() akov1beta1.AviInfraSettingLister {
+	return akov1beta1.NewAviInfraSettingLister(f.Informer().GetIndexer())
 }

--- a/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/hostrule.go
+++ b/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/hostrule.go
@@ -19,13 +19,13 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	apisakov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	versioned "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned"
 	internalinterfaces "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/informers/externalversions/internalinterfaces"
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -36,7 +36,7 @@ import (
 // HostRules.
 type HostRuleInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta1.HostRuleLister
+	Lister() akov1beta1.HostRuleLister
 }
 
 type hostRuleInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredHostRuleInformer(client versioned.Interface, namespace string, r
 				return client.AkoV1beta1().HostRules(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&akov1beta1.HostRule{},
+		&apisakov1beta1.HostRule{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *hostRuleInformer) defaultInformer(client versioned.Interface, resyncPer
 }
 
 func (f *hostRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&akov1beta1.HostRule{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisakov1beta1.HostRule{}, f.defaultInformer)
 }
 
-func (f *hostRuleInformer) Lister() v1beta1.HostRuleLister {
-	return v1beta1.NewHostRuleLister(f.Informer().GetIndexer())
+func (f *hostRuleInformer) Lister() akov1beta1.HostRuleLister {
+	return akov1beta1.NewHostRuleLister(f.Informer().GetIndexer())
 }

--- a/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/httprule.go
+++ b/pkg/client/v1beta1/informers/externalversions/ako/v1beta1/httprule.go
@@ -19,13 +19,13 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	apisakov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	versioned "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/clientset/versioned"
 	internalinterfaces "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/informers/externalversions/internalinterfaces"
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/client/v1beta1/listers/ako/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -36,7 +36,7 @@ import (
 // HTTPRules.
 type HTTPRuleInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1beta1.HTTPRuleLister
+	Lister() akov1beta1.HTTPRuleLister
 }
 
 type hTTPRuleInformer struct {
@@ -71,7 +71,7 @@ func NewFilteredHTTPRuleInformer(client versioned.Interface, namespace string, r
 				return client.AkoV1beta1().HTTPRules(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&akov1beta1.HTTPRule{},
+		&apisakov1beta1.HTTPRule{},
 		resyncPeriod,
 		indexers,
 	)
@@ -82,9 +82,9 @@ func (f *hTTPRuleInformer) defaultInformer(client versioned.Interface, resyncPer
 }
 
 func (f *hTTPRuleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&akov1beta1.HTTPRule{}, f.defaultInformer)
+	return f.factory.InformerFor(&apisakov1beta1.HTTPRule{}, f.defaultInformer)
 }
 
-func (f *hTTPRuleInformer) Lister() v1beta1.HTTPRuleLister {
-	return v1beta1.NewHTTPRuleLister(f.Informer().GetIndexer())
+func (f *hTTPRuleInformer) Lister() akov1beta1.HTTPRuleLister {
+	return akov1beta1.NewHTTPRuleLister(f.Informer().GetIndexer())
 }

--- a/pkg/client/v1beta1/informers/externalversions/factory.go
+++ b/pkg/client/v1beta1/informers/externalversions/factory.go
@@ -42,6 +42,7 @@ type sharedInformerFactory struct {
 	lock             sync.Mutex
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
+	transform        cache.TransformFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -76,6 +77,14 @@ func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFu
 func WithNamespace(namespace string) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
 		factory.namespace = namespace
+		return factory
+	}
+}
+
+// WithTransform sets a transform on all informers.
+func WithTransform(transform cache.TransformFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.transform = transform
 		return factory
 	}
 }
@@ -184,6 +193,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	}
 
 	informer = newFunc(f.client, resyncPeriod)
+	informer.SetTransform(f.transform)
 	f.informers[informerType] = informer
 
 	return informer
@@ -218,6 +228,7 @@ type SharedInformerFactory interface {
 
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
+	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	Start(stopCh <-chan struct{})
 
 	// Shutdown marks a factory as shutting down. At that point no new

--- a/pkg/client/v1beta1/informers/externalversions/generic.go
+++ b/pkg/client/v1beta1/informers/externalversions/generic.go
@@ -19,7 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
-	"fmt"
+	fmt "fmt"
 
 	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/v1beta1/listers/ako/v1beta1/aviinfrasetting.go
+++ b/pkg/client/v1beta1/listers/ako/v1beta1/aviinfrasetting.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
+	akov1beta1 "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/apis/ako/v1beta1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // AviInfraSettingLister helps list AviInfraSettings.
@@ -30,39 +30,19 @@ import (
 type AviInfraSettingLister interface {
 	// List lists all AviInfraSettings in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.AviInfraSetting, err error)
+	List(selector labels.Selector) (ret []*akov1beta1.AviInfraSetting, err error)
 	// Get retrieves the AviInfraSetting from the index for a given name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.AviInfraSetting, error)
+	Get(name string) (*akov1beta1.AviInfraSetting, error)
 	AviInfraSettingListerExpansion
 }
 
 // aviInfraSettingLister implements the AviInfraSettingLister interface.
 type aviInfraSettingLister struct {
-	indexer cache.Indexer
+	listers.ResourceIndexer[*akov1beta1.AviInfraSetting]
 }
 
 // NewAviInfraSettingLister returns a new AviInfraSettingLister.
 func NewAviInfraSettingLister(indexer cache.Indexer) AviInfraSettingLister {
-	return &aviInfraSettingLister{indexer: indexer}
-}
-
-// List lists all AviInfraSettings in the indexer.
-func (s *aviInfraSettingLister) List(selector labels.Selector) (ret []*v1beta1.AviInfraSetting, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.AviInfraSetting))
-	})
-	return ret, err
-}
-
-// Get retrieves the AviInfraSetting from the index for a given name.
-func (s *aviInfraSettingLister) Get(name string) (*v1beta1.AviInfraSetting, error) {
-	obj, exists, err := s.indexer.GetByKey(name)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.NewNotFound(v1beta1.Resource("aviinfrasetting"), name)
-	}
-	return obj.(*v1beta1.AviInfraSetting), nil
+	return &aviInfraSettingLister{listers.New[*akov1beta1.AviInfraSetting](indexer, akov1beta1.Resource("aviinfrasetting"))}
 }

--- a/tests/ingresstests/crd_test.go
+++ b/tests/ingresstests/crd_test.go
@@ -821,10 +821,14 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 		if len(nodes[0].SniNodes) == 1 && nodes[0].SniNodes[0].AnalyticsPolicy != nil &&
 			nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs != nil &&
 			nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Enabled != nil {
-			return *nodes[0].SniNodes[0].AnalyticsPolicy.AllHeaders && *nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Enabled
+			return *nodes[0].SniNodes[0].AnalyticsPolicy.AllHeaders &&
+				*nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Enabled
 		}
 		return false
 	}, 10*time.Second).Should(gomega.Equal(true))
+
+	// default Duration value should be set to 0 i.e infinite since field isn't present in hr
+	g.Expect(*nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Duration).To(gomega.Equal(uint32(0)))
 
 	// Update host rule with AnalyticsPolicy - with all fields
 	hrUpdate = integrationtest.FakeHostRule{
@@ -832,11 +836,14 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 		Namespace: "default",
 		Fqdn:      "foo.com",
 	}.HostRule()
+
 	enabled = true
+	duration := uint32(10)
 	analyticsPolicy = &v1beta1.HostRuleAnalyticsPolicy{
 		FullClientLogs: &v1beta1.FullClientLogs{
 			Enabled:  &enabled,
 			Throttle: "LOW",
+			Duration: &duration,
 		},
 		LogAllHeaders: &enabled,
 	}
@@ -864,6 +871,7 @@ func TestHostruleAnalyticsPolicyUpdate(t *testing.T) {
 
 	g.Expect(*nodes[0].SniNodes[0].AnalyticsPolicy.AllHeaders).To(gomega.BeTrue())
 	g.Expect(*nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Enabled).To(gomega.BeTrue())
+	g.Expect(*nodes[0].SniNodes[0].AnalyticsPolicy.FullClientLogs.Duration).To(gomega.Equal(uint32(10)))
 
 	// Remove the analyticPolicy and check whether values are removed from VS
 	hrUpdate.Spec.VirtualHost.AnalyticsPolicy = nil


### PR DESCRIPTION
Adds 'Duration' field to FullClientLogs under AnalyticsPolicy to allow customization of log collection duration which currently defaults to 0 (infinity).

Includes CRD changes, HostRule `AnalyticsPolicy` > 'FullClientLogs` spec change per CRD, and integration test `TestHostruleAnalyticsPolicyUpdate` change to verify default duration and hr specified duration modifications, as well as `hostrule.md` change to include duration field in sample and description of duration field under *Configure Analytics Policy*.