### PR TITLE
Use standard labels in AKO Helm Chart

### DIFF
--- a/helm/ako/templates/clusterrole.yaml
+++ b/helm/ako/templates/clusterrole.yaml
@@ -3,6 +3,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ako-cr
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["*"]
@@ -66,7 +68,7 @@ rules:
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get","watch","list"]
-{{- end }} 
+{{- end }}
 {{- if .Values.rbac.pspEnable }}
   - apiGroups: ["policy", "extensions"]
     resources: ["podsecuritypolicies"]

--- a/helm/ako/templates/clusterrolebinding.yaml
+++ b/helm/ako/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ako-crb-{{ .Release.Namespace }}
   {{- end }}
   labels:
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{- include "ako.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: avi-k8s-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
 data:
   primaryInstance: {{ .Values.AKOSettings.primaryInstance | quote }}
   controllerIP: {{ .Values.ControllerSettings.controllerHost | quote }}
@@ -56,5 +58,5 @@ data:
   istioEnabled: {{ .Values.AKOSettings.istioEnabled | quote }}
   useDefaultSecretsOnly: {{ .Values.AKOSettings.useDefaultSecretsOnly | quote }}
   enablePrometheus: {{ default "false" .Values.featureGates.EnablePrometheus | quote }}
-  enableEndpointSlice: {{ default "false" .Values.featureGates.EnableEndpointSlice | quote }} 
+  enableEndpointSlice: {{ default "false" .Values.featureGates.EnableEndpointSlice | quote }}
   fqdnReusePolicy: {{ default "InterNamespaceAllowed" .Values.L7Settings.fqdnReusePolicy | quote}}

--- a/helm/ako/templates/gatewayclass.yaml
+++ b/helm/ako/templates/gatewayclass.yaml
@@ -3,6 +3,8 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: avi-lb
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
 spec:
   controllerName: "ako.vmware.com/avi-lb"
 {{- end }}

--- a/helm/ako/templates/ingressclass.yaml
+++ b/helm/ako/templates/ingressclass.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"
   {{ end }}
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
 spec:
   controller: ako.vmware.com/avi-lb
 {{ end }}

--- a/helm/ako/templates/psppolicy.yaml
+++ b/helm/ako/templates/psppolicy.yaml
@@ -12,9 +12,7 @@ metadata:
   name: {{ template "ako.name" . }}-{{ .Release.Namespace }}
   {{- end }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- include "ako.labels" . | nindent 4 }}
     {{- if .Values.isClusterService }}
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"

--- a/helm/ako/templates/secret.yaml
+++ b/helm/ako/templates/secret.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: avi-secret
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
 type: Opaque
 data:
   username: {{ .Values.avicredentials.username | b64enc }}

--- a/helm/ako/templates/serviceaccount.yaml
+++ b/helm/ako/templates/serviceaccount.yaml
@@ -3,3 +3,6 @@ kind: ServiceAccount
 metadata:
   name: ako-sa
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ako.labels" . | nindent 4 }}
+

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
         {{ end }}
       {{ end }}
       labels:
-        {{- include "ako.selectorLabels" . | nindent 8 }}
+        {{- include "ako.labels" . | nindent 8 }}
     spec:
       serviceAccountName: ako-sa
       securityContext:


### PR DESCRIPTION
Use recommanded labels as described in Helm official documentation
https://helm.sh/docs/chart_best_practices/labels/#standard-labels

This implementation fixes an issue on ClusterRoleBinding as the following
The following labels definition must be guarded by `| replace "+" "_" `

The following definition
```
  labels:
    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
```
must be replaced by
```
  labels:
    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}.
```

Then, as this notation already exists in the `_helpers.tpl`.file,  it can be changed to
```
  labels:
    {{- include "ako.labels" . | nindent 4 }}
```