### PR TITLE
AV-239773: Add validation for PING and TCP HMs

### DIFF
--- a/ako-crd-operator/api/v1alpha1/healthmonitor_types.go
+++ b/ako-crd-operator/api/v1alpha1/healthmonitor_types.go
@@ -42,7 +42,7 @@ const (
 )
 
 // HealthMonitorSpec defines the desired state of HealthMonitor
-// +kubebuilder:validation:XValidation:rule="(!has(self.http_monitor.auth_type) || has(self.authentication.username) && has(self.authentication.password))",message="If auth_type is set, both username and password must be set in authentication"
+// +kubebuilder:validation:XValidation:rule="(!has(self.http_monitor) || !has(self.http_monitor.auth_type) || has(self.authentication.username) && has(self.authentication.password))",message="If auth_type is set, both username and password must be set in authentication"
 type HealthMonitorSpec struct {
 	// SendInterval is the frequency, in seconds, that pings are sent.
 	// +kubebuilder:validation:Minimum=1
@@ -113,6 +113,7 @@ type HealthMonitorInfo struct {
 }
 
 // TCPMonitor defines the TCP monitor configuration.
+// +kubebuilder:validation:XValidation:rule="!has(self.tcp_half_open) || !self.tcp_half_open || (!has(self.tcp_request) && !has(self.tcp_response) && !has(self.maintenance_response))",message="If tcp_half_open is true, tcp_request, tcp_response, and maintenance_response must not be set"
 type TCPMonitor struct {
 	// TcpRequest is the request to send for the TCP health check.
 	// +optional

--- a/ako-crd-operator/config/crd/bases/ako.vmware.com_healthmonitors.yaml
+++ b/ako-crd-operator/config/crd/bases/ako.vmware.com_healthmonitors.yaml
@@ -200,6 +200,11 @@ spec:
                     maxLength: 512
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: If tcp_half_open is true, tcp_request, tcp_response, and
+                    maintenance_response must not be set
+                  rule: '!has(self.tcp_half_open) || !self.tcp_half_open || (!has(self.tcp_request)
+                    && !has(self.tcp_response) && !has(self.maintenance_response))'
               type:
                 description: Type is the type of health monitor.
                 enum:
@@ -217,8 +222,8 @@ spec:
             x-kubernetes-validations:
             - message: If auth_type is set, both username and password must be set
                 in authentication
-              rule: (!has(self.http_monitor.auth_type) || has(self.authentication.username)
-                && has(self.authentication.password))
+              rule: (!has(self.http_monitor) || !has(self.http_monitor.auth_type)
+                || has(self.authentication.username) && has(self.authentication.password))
           status:
             description: Status defines the observed state of HealthMonitor
             properties:

--- a/ako-crd-operator/docs/samples/healthmonitor/hm-http.yaml
+++ b/ako-crd-operator/docs/samples/healthmonitor/hm-http.yaml
@@ -1,0 +1,25 @@
+apiVersion: ako.vmware.com/v1alpha1
+kind: HealthMonitor
+metadata:
+  name: example-http-healthmonitor
+  namespace: default
+spec:
+  type: HEALTH_MONITOR_HTTP
+  failed_checks: 3
+  successful_checks: 2
+  receive_timeout: 5
+  send_interval: 15
+  monitor_port: 80
+  http_monitor:
+    http_request: GET /health HTTP/1.1
+    http_response_code:
+      - "HTTP_1XX"
+      - "HTTP_2XX"
+    http_response: "OK"
+    exact_http_request: true
+    maintenance_code:
+      - 503
+      - 500
+    maintenance_response: "Maintenance"
+    response_size: 2049
+  is_federated: false

--- a/ako-crd-operator/docs/samples/healthmonitor/hm-ping.yaml
+++ b/ako-crd-operator/docs/samples/healthmonitor/hm-ping.yaml
@@ -1,0 +1,13 @@
+apiVersion: ako.vmware.com/v1alpha1
+kind: HealthMonitor
+metadata:
+  name: example-ping-healthmonitor
+  namespace: default
+spec:
+  type: HEALTH_MONITOR_PING
+  failed_checks: 3
+  successful_checks: 2
+  receive_timeout: 5
+  send_interval: 10
+  monitor_port: 80
+  is_federated: false

--- a/ako-crd-operator/docs/samples/healthmonitor/hm-tcp.yaml
+++ b/ako-crd-operator/docs/samples/healthmonitor/hm-tcp.yaml
@@ -1,0 +1,18 @@
+apiVersion: ako.vmware.com/v1alpha1
+kind: HealthMonitor
+metadata:
+  name: example-tcp-healthmonitor
+  namespace: default
+spec:
+  type: HEALTH_MONITOR_TCP
+  failed_checks: 3
+  successful_checks: 2
+  receive_timeout: 5
+  send_interval: 15
+  monitor_port: 80
+  tcp_monitor:
+    tcp_request: GET /health HTTP/1.1
+    tcp_response: "OK"
+    maintenance_response: "Maintenance"
+    tcp_half
+  is_federated: false

--- a/ako-crd-operator/helm/ako-crd-operator/chart/templates/crd/ako.vmware.com_healthmonitors.yaml
+++ b/ako-crd-operator/helm/ako-crd-operator/chart/templates/crd/ako.vmware.com_healthmonitors.yaml
@@ -200,6 +200,11 @@ spec:
                     maxLength: 512
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: If tcp_half_open is true, tcp_request, tcp_response, and
+                    maintenance_response must not be set
+                  rule: '!has(self.tcp_half_open) || !self.tcp_half_open || (!has(self.tcp_request)
+                    && !has(self.tcp_response) && !has(self.maintenance_response))'
               type:
                 description: Type is the type of health monitor.
                 enum:
@@ -217,8 +222,8 @@ spec:
             x-kubernetes-validations:
             - message: If auth_type is set, both username and password must be set
                 in authentication
-              rule: (!has(self.http_monitor.auth_type) || has(self.authentication.username)
-                && has(self.authentication.password))
+              rule: (!has(self.http_monitor) || !has(self.http_monitor.auth_type)
+                || has(self.authentication.username) && has(self.authentication.password))
           status:
             description: Status defines the observed state of HealthMonitor
             properties:


### PR DESCRIPTION
Added validations for PING and TCP HMs.
Manual tests done: 
1. Created both PING and TCP HMs
2. Updated both PING and TCP HMs.
3. Validate TCP HM creation/updation fails if tcp_half_open is set to true and other tcp fields are set.

Also fixed an issue where auth_type validation was failing when complete http object was missing in case of TCP or PING HM