### PR TITLE
AV-239696: Add status condition on deletion failure 

### DIFF
--- a/ako-crd-operator/Dockerfile
+++ b/ako-crd-operator/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG golang_src_repo=golang:latest
 ARG photon_src_repo=photon:latest
-FROM ${golang_src_repo} as build
+FROM --platform=${BUILDPLATFORM} ${golang_src_repo} as build
 
 WORKDIR /workspace
 COPY . /workspace/

--- a/ako-crd-operator/internal/constants/constants.go
+++ b/ako-crd-operator/internal/constants/constants.go
@@ -1,9 +1,12 @@
 package constants
 
+import "time"
+
 const (
 	HealthMonitorFinalizer      = "healthmonitor.ako.vmware.com/finalizer"
 	HealthMonitorURL            = "/api/healthmonitor"
 	Sensitive                   = "<sensitive>"
 	ApplicationProfileFinalizer = "applicationprofile.ako.vmware.com/finalizer"
 	ApplicationProfileURL       = "/api/applicationprofile"
+	RequeueInterval             = 5 * time.Minute
 )

--- a/ako-crd-operator/internal/controller/applicationprofile_controller.go
+++ b/ako-crd-operator/internal/controller/applicationprofile_controller.go
@@ -100,10 +100,18 @@ func (r *ApplicationProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	} else {
 		// The object is being deleted
-		if err := r.DeleteObject(ctx, ap); err != nil {
+		removeFinalizer := false
+		if err, removeFinalizer = r.DeleteObject(ctx, ap); err != nil {
 			return ctrl.Result{}, err
 		}
-		controllerutil.RemoveFinalizer(ap, constants.ApplicationProfileFinalizer)
+		if removeFinalizer {
+			controllerutil.RemoveFinalizer(ap, constants.ApplicationProfileFinalizer)
+		} else {
+			if err := r.Status().Update(ctx, ap); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: constants.RequeueInterval}, nil
+		}
 		if err := r.Update(ctx, ap); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -133,26 +141,40 @@ func (r *ApplicationProfileReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Complete(r)
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *ApplicationProfileReconciler) DeleteObject(ctx context.Context, ap *akov1alpha1.ApplicationProfile) error {
+// DeleteObject deletes the ApplicationProfile from Avi Controller and returns (error, bool)
+// The boolean indicates whether the finalizer should be removed (true) or kept (false)
+func (r *ApplicationProfileReconciler) DeleteObject(ctx context.Context, ap *akov1alpha1.ApplicationProfile) (error, bool) {
 	log := utils.LoggerFromContext(ctx)
 	if ap.Status.UUID != "" {
 		if err := r.AviClient.AviSessionDelete(utils.GetUriEncoded(fmt.Sprintf("%s/%s", constants.ApplicationProfileURL, ap.Status.UUID)), nil, nil); err != nil {
-
 			// Handle 404 as success case - object doesn't exist, which is the desired state for delete
-			if aviError, ok := err.(session.AviError); ok && aviError.HttpStatusCode == 404 {
-				log.Info("ApplicationProfile not found on Avi Controller (404), treating as successful deletion")
-				return nil
+			if aviError, ok := err.(session.AviError); ok {
+				switch aviError.HttpStatusCode {
+				case 404:
+					log.Info("ApplicationProfile not found on Avi Controller (404), treating as successful deletion")
+					return nil, true
+				case 403:
+					log.Errorf("ApplicationProfile is being referred by other objects, cannot be deleted. %s", aviError.Error())
+					r.EventRecorder.Event(ap, corev1.EventTypeWarning, "DeletionSkipped", aviError.Error())
+					ap.Status.Conditions = controllerutils.SetCondition(ap.Status.Conditions, metav1.Condition{
+						Type:               "Delete",
+						Status:             metav1.ConditionFalse,
+						LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
+						Reason:             "DeletionSkipped",
+						Message:            controllerutils.ParseAviErrorMessage(*aviError.Message),
+					})
+					return nil, false
+				}
 			}
 			log.Errorf("error deleting application profile: %s", err.Error())
 			r.EventRecorder.Event(ap, corev1.EventTypeWarning, "DeletionFailed", fmt.Sprintf("Failed to delete ApplicationProfile from Avi Controller: %v", err))
-			return err
+			return err, false
 		}
 	} else {
 		r.EventRecorder.Event(ap, corev1.EventTypeWarning, "DeletionSkipped", "UUID not present, ApplicationProfile may not have been created on Avi Controller")
 		log.Warn("error deleting application profile. uuid not present. possibly avi application profile object not created")
 	}
-	return nil
+	return nil, true
 }
 
 // TODO: Make this function generic

--- a/ako-crd-operator/internal/controller/applicationprofile_controller.go
+++ b/ako-crd-operator/internal/controller/applicationprofile_controller.go
@@ -157,7 +157,7 @@ func (r *ApplicationProfileReconciler) DeleteObject(ctx context.Context, ap *ako
 					log.Errorf("ApplicationProfile is being referred by other objects, cannot be deleted. %s", aviError.Error())
 					r.EventRecorder.Event(ap, corev1.EventTypeWarning, "DeletionSkipped", aviError.Error())
 					ap.Status.Conditions = controllerutils.SetCondition(ap.Status.Conditions, metav1.Condition{
-						Type:               "Delete",
+						Type:               "Deleted",
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
 						Reason:             "DeletionSkipped",
@@ -246,7 +246,7 @@ func (r *ApplicationProfileReconciler) ReconcileIfRequired(ctx context.Context, 
 }
 
 // createApplicationProfile will attempt to create a application profile, if it already exists, it will return an object which contains the uuid
-func (r *ApplicationProfileReconciler) createApplicationProfile(ctx context.Context, apReq *ApplicationProfileRequest, ap *akov1alpha1.ApplicationProfile ) (map[string]interface{}, error) {
+func (r *ApplicationProfileReconciler) createApplicationProfile(ctx context.Context, apReq *ApplicationProfileRequest, ap *akov1alpha1.ApplicationProfile) (map[string]interface{}, error) {
 	log := utils.LoggerFromContext(ctx)
 	resp := map[string]interface{}{}
 	if err := r.AviClient.AviSessionPost(utils.GetUriEncoded(constants.ApplicationProfileURL), apReq, &resp); err != nil {

--- a/ako-crd-operator/internal/controller/healthmonitor_controller.go
+++ b/ako-crd-operator/internal/controller/healthmonitor_controller.go
@@ -153,7 +153,7 @@ func (r *HealthMonitorReconciler) DeleteObject(ctx context.Context, hm *akov1alp
 					log.Errorf("HealthMonitor is being reffered by other objects, cannot be deleted. %s", aviError.Error())
 					r.EventRecorder.Event(hm, corev1.EventTypeWarning, "DeletionSkipped", aviError.Error())
 					hm.Status.Conditions = controllerutils.SetCondition(hm.Status.Conditions, metav1.Condition{
-						Type:               "Delete",
+						Type:               "Deleted",
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
 						Reason:             "DeletionSkipped",

--- a/ako-crd-operator/internal/controller/healthmonitor_controller.go
+++ b/ako-crd-operator/internal/controller/healthmonitor_controller.go
@@ -110,7 +110,7 @@ func (r *HealthMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err := r.Status().Update(ctx, hm); err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+			return ctrl.Result{RequeueAfter: constants.RequeueInterval}, nil
 		}
 		if err := r.Update(ctx, hm); err != nil {
 			return ctrl.Result{}, err

--- a/ako-crd-operator/internal/controller/healthmonitor_controller_test.go
+++ b/ako-crd-operator/internal/controller/healthmonitor_controller_test.go
@@ -594,7 +594,7 @@ func TestHealthMonitorController(t *testing.T) {
 					UUID: "123",
 					Conditions: []metav1.Condition{
 						{
-							Type:               "Delete",
+							Type:               "Deleted",
 							Status:             metav1.ConditionFalse,
 							LastTransitionTime: metav1.Time{Time: time.Now().Truncate(time.Second)},
 							Reason:             "DeletionSkipped",

--- a/ako-crd-operator/internal/utils/utils.go
+++ b/ako-crd-operator/internal/utils/utils.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/vmware/alb-sdk/go/models"
@@ -168,4 +170,15 @@ func CreateMarkers(clusterName, namespace string) []*models.RoleFilterMatchLabel
 	}
 
 	return markers
+}
+
+// ParseAviErrorMessage parses the error message from ALB SDK
+// ALB SDK returns error message in string format: `map[... error: ...]`
+func ParseAviErrorMessage(input string) string {
+	re := regexp.MustCompile(`map\[.*error:([^]]*?)(?:\s+obj_name:.*?)?\]`)
+	match := re.FindStringSubmatch(input)
+	if len(match) >= 2 {
+		return strings.TrimSpace(match[1])
+	}
+	return input
 }

--- a/ako-crd-operator/internal/utils/utils.go
+++ b/ako-crd-operator/internal/utils/utils.go
@@ -175,10 +175,11 @@ func CreateMarkers(clusterName, namespace string) []*models.RoleFilterMatchLabel
 // ParseAviErrorMessage parses the error message from ALB SDK
 // ALB SDK returns error message in string format: `map[... error: ...]`
 func ParseAviErrorMessage(input string) string {
-	re := regexp.MustCompile(`map\[.*error:([^]]*?)(?:\s+obj_name:.*?)?\]`)
+	re := regexp.MustCompile(`map\[.*error:(.*?)(?:\s+obj_name:.*?)?\]$`)
 	match := re.FindStringSubmatch(input)
 	if len(match) >= 2 {
-		return strings.TrimSpace(match[1])
+		errorMsg := strings.TrimSpace(match[1])
+		return errorMsg
 	}
 	return input
 }

--- a/ako-crd-operator/internal/utils/utils_test.go
+++ b/ako-crd-operator/internal/utils/utils_test.go
@@ -602,3 +602,44 @@ func TestResourceWithStatusInterface(t *testing.T) {
 	ap.SetLastUpdated(now)
 	assert.Equal(t, now, ap.Status.LastUpdated)
 }
+
+func TestParseAviErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "error message with array and obj_name",
+			input:    `map[error:Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',    ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg''] obj_name:my-cluster2-default-example-ping-healthmonitor]`,
+			expected: "Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',    ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg''",
+		},
+		{
+			name:     "simple error message with obj_name",
+			input:    `map[error:Resource not found obj_name:test-resource]`,
+			expected: "Resource not found",
+		},
+		{
+			name:     "error message without obj_name",
+			input:    `map[error:Invalid configuration]`,
+			expected: "Invalid configuration",
+		},
+		{
+			name:     "non-map format returns original",
+			input:    `This is just a regular error message`,
+			expected: "This is just a regular error message",
+		},
+		{
+			name:     "map without error key returns original",
+			input:    `map[status:failed obj_name:test-object]`,
+			expected: "map[status:failed obj_name:test-object]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAviErrorMessage(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ako-crd-operator/internal/utils/utils_test.go
+++ b/ako-crd-operator/internal/utils/utils_test.go
@@ -612,7 +612,7 @@ func TestParseAviErrorMessage(t *testing.T) {
 		{
 			name:     "error message with array and obj_name",
 			input:    `map[error:Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',    ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg''] obj_name:my-cluster2-default-example-ping-healthmonitor]`,
-			expected: "Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',    ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg''",
+			expected: "Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',    ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg'']",
 		},
 		{
 			name:     "simple error message with obj_name",
@@ -628,11 +628,6 @@ func TestParseAviErrorMessage(t *testing.T) {
 			name:     "non-map format returns original",
 			input:    `This is just a regular error message`,
 			expected: "This is just a regular error message",
-		},
-		{
-			name:     "map without error key returns original",
-			input:    `map[status:failed obj_name:test-object]`,
-			expected: "map[status:failed obj_name:test-object]",
 		},
 	}
 


### PR DESCRIPTION
Sample object after deletion failure due to object being reffered to other objects:

```
apiVersion: ako.vmware.com/v1alpha1
kind: HealthMonitor
metadata:
  creationTimestamp: "2025-06-17T09:28:34Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2025-06-18T06:36:31Z"
  finalizers:
  - healthmonitor.ako.vmware.com/finalizer
  generation: 4
  name: example-ping-healthmonitor
  namespace: default
  resourceVersion: "11159506"
  uid: eae8bbd9-c390-4a31-812c-f021403ef2a4
spec:
  failed_checks: 4
  monitor_port: 80
  receive_timeout: 5
  send_interval: 10
  successful_checks: 2
  type: HEALTH_MONITOR_PING
status:
  backendObjectName: my-cluster2-default-example-ping-healthmonitor
  conditions:
  - lastTransitionTime: "2025-06-17T09:51:38Z"
    message: HealthMonitor updated successfully on Avi Controller
    reason: Updated
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-06-18T09:37:54Z"
    message: 'Cannot delete, object is referred by: [''IcapProfile custom-icap-profile'',
      ''Pool custom-icap-pool1'', ''PoolGroup custom-icap-pg'''
    reason: DeletionSkipped
    status: "False"
    type: Delete
  lastUpdated: "2025-06-17T09:51:38Z"
  observedGeneration: 2
  uuid: healthmonitor-911852f1-ed7b-4998-9896-a049d5df9cf0
```
App profile: 

```
apiVersion: ako.vmware.com/v1alpha1
kind: ApplicationProfile
metadata:
  creationTimestamp: "2025-06-17T09:30:20Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2025-06-18T10:16:23Z"
  finalizers:
  - applicationprofile.ako.vmware.com/finalizer
  generation: 4
  labels:
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: ako-crd-operator
  name: app-profile
  namespace: default
  resourceVersion: "11163968"
  uid: d94a1cc0-02d8-4ff4-b291-846b3ab7a9ca
spec:
  http_profile:
    client_body_timeout: 30001
    client_max_body_size: 14
    close_server_side_connection_on_error: true
    connection_multiplexing_enabled: true
    http_upstream_buffer_size: 13
    keepalive_header: true
    keepalive_timeout: 30001
    max_header_count: 257
    max_keepalive_requests: 1000
    reset_conn_http_on_ssl_port: true
    true_client_ip:
      direction: RIGHT
      headers:
      - X-Forwarded-For
      index_in_header: 3
    use_app_keepalive_timeout: true
    use_true_client_ip: true
    x_forwarded_proto_enabled: true
    xff_enabled: true
    xff_update: APPEND_TO_THE_XFF_HEADER
  type: APPLICATION_PROFILE_TYPE_HTTP
status:
  backendObjectName: my-cluster2-default-app-profile
  conditions:
  - lastTransitionTime: "2025-06-17T09:51:38Z"
    message: ApplicationProfile updated successfully on Avi Controller
    reason: Updated
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-06-18T10:27:44Z"
    message: 'Cannot delete, object is referred by: [''VirtualService childVS'']'
    reason: DeletionSkipped
    status: "False"
    type: Delete
  lastUpdated: "2025-06-17T09:51:38Z"
  observedGeneration: 3
  uuid: applicationprofile-0e10277f-0d87-4368-a377-b36d905f4251
```
