### PR TITLE
AV-245081 fix utf-8 order

### DIFF
--- a/hack/jenkins/promote_build.py
+++ b/hack/jenkins/promote_build.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2025 Broadcom Inc. and/or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# -*- coding: utf-8 -*-
 from argparse import ArgumentParser
 from datetime import datetime
 import os


### PR DESCRIPTION
```
08:58:13    File "promote_build.py", line 1
08:58:13  SyntaxError: Non-ASCII character '\xc2' in file promote_build.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
[Pipeline] }
```