### PR TITLE
AV-245746 Add vpc_mode to ako-gateway-api sts container template

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -407,6 +407,11 @@ spec:
                 name: avi-k8s-config
                 key: nsxtT1LR
           {{ end }}
+          - name: VPC_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: vpcMode
           {{ if .Values.persistentVolumeClaim }}
           - name: USE_PVC
             value: "true"

--- a/tests/helmtests/statefulset_test.yaml
+++ b/tests/helmtests/statefulset_test.yaml
@@ -84,3 +84,45 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+  - it: StatefulSet should contain VPC_MODE in ako statefulset when GatewayAPI is disabled
+    set:
+      featureGates:
+        GatewayAPI: false
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:      
+            name: VPC_MODE
+            valueFrom:
+              configMapKeyRef:
+                key: vpcMode
+                name: avi-k8s-config
+  - it: StatefulSet should contain VPC_MODE in both ako and ako-gateway-api statefulset when GatewayAPI is enabled
+    set:
+      featureGates:
+        GatewayAPI: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:      
+            name: VPC_MODE
+            valueFrom:
+              configMapKeyRef:
+                key: vpcMode
+                name: avi-k8s-config
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:      
+            name: VPC_MODE
+            valueFrom:
+              configMapKeyRef:
+                key: vpcMode
+                name: avi-k8s-config


### PR DESCRIPTION
GatewayAPI wasn't able to read `vpcMode` env variable due to missing env read (from configmap) set in Statefulsets' template. 