### PR TITLE
AV-238748 : AV-238748 : Fix Makefile to remove pre-build target that is no longer required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,16 +68,9 @@ endif
 .PHONY: all
 all: build docker
 
-.PHONY: sync-crd-files
-sync-crd-files:
-		cp ./helm/ako/crds/* ./ako-operator/helm/ako-operator/crds/
-
-.PHONY: pre-build
-pre-build: sync-crd-files
-
 # builds
 .PHONY: build
-build: pre-build glob-vars
+build: glob-vars
 		sudo docker run \
 		-w=/go/src/$(PACKAGE_PATH_AKO) \
 		-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
@@ -88,7 +81,7 @@ build: pre-build glob-vars
 		/go/src/$(REL_PATH_AKO)
 
 .PHONY: build-infra
-build-infra: pre-build glob-vars
+build-infra: glob-vars
 		sudo docker run \
 		-w=/go/src/$(PACKAGE_PATH_AKO) \
 		-v $(PWD):/go/src/$(PACKAGE_PATH_AKO) $(BUILD_GO_IMG) \
@@ -110,7 +103,7 @@ build-gateway-api: glob-vars
 		/go/src/$(REL_PATH_AKO_GATEWAY_API)
 
 .PHONY: build-local
-build-local: pre-build
+build-local:
 		$(GOBUILD) \
 		-o bin/$(BINARY_NAME_AKO) \
 		-ldflags $(AKO_LDFLAGS) \
@@ -118,7 +111,7 @@ build-local: pre-build
 		./cmd/ako-main
 
 .PHONY: build-local-infra
-build-local-infra: pre-build
+build-local-infra:
 		$(GOBUILD) \
 		-o bin/$(BINARY_NAME_AKO_INFRA) \
 		-ldflags $(AKO_LDFLAGS) \


### PR DESCRIPTION
There is a failure seen in the build pipeline https://prodjenkins.avilb.broadcom.net/job/ako_OS-release-1.13.2-ci-build/154/console#:~:text=12%3A33%3A33-,cp%20./helm/ako/crds/*%20./ako%2Doperator/helm/ako%2Doperator/crds/,-12%3A33%3A33 as the ako-operator/helm directory itself is now removed. Hence removed the pre-build target from Makefile.  