### PR TITLE
VKAL-30110: Added support for TCP Half Open Health Monitor in WCP env

### DIFF
--- a/ako-clean/cleanup.go
+++ b/ako-clean/cleanup.go
@@ -406,7 +406,7 @@ func cleanupPools() error {
 func cleanupAppProfiles() error {
 	tenant := lib.GetAdminTenant()
 	aviClient := avicache.SharedAVIClients(tenant).AviClient[0]
-	err, appProfs := lib.ProxyEnabledAppProfileGet(aviClient)
+	appProfs, err := lib.ProxyEnabledAppProfileGet(aviClient)
 	if err != nil {
 		utils.AviLog.Warnf("Application profile Get returned err %v", err)
 		return err
@@ -421,7 +421,7 @@ func cleanupAppProfiles() error {
 func cleanupHealthMonitors() error {
 	tenant := lib.GetAdminTenant()
 	aviClient := avicache.SharedAVIClients(tenant).AviClient[0]
-	err, healthMons := lib.TcpHalfOpenHealthMonitorGet(aviClient)
+	healthMons, err := lib.TcpHalfOpenHealthMonitorGet(aviClient)
 	if err != nil {
 		utils.AviLog.Warnf("Health monitor GET returned err %v", err)
 		return err

--- a/internal/k8s/ako_init.go
+++ b/internal/k8s/ako_init.go
@@ -1272,6 +1272,12 @@ func (c *AviController) FullSyncK8s(sync bool) error {
 			utils.AviLog.Errorf("Proxy enabled application profile Get/Create/Update failed: %s", err)
 			return err
 		}
+		// TCP Half-Open Connection Health Monitor GET/CREATE/UPDATE
+		err = lib.TcpHalfOpenHealthMonitorCU(aviClientPool.AviClient[0])
+		if err != nil {
+			utils.AviLog.Errorf("TCP Half-Open connection health monitor Get/Create/Update failed: %s", err)
+			return err
+		}
 
 		//Ingress Section
 		if utils.GetInformers().IngressInformer != nil {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -172,6 +172,8 @@ const (
 	SSLKeyCert                                 = "SSLKeyandCertificate"
 	PKIProfile                                 = "PKI Profile"
 	ApplicationProfile                         = "ApplicationProfile"
+	HealthMonitor                              = "HealthMonitor"
+	AllowedTCPHealthMonitorType                = "HEALTH_MONITOR_TCP"
 	PassthroughPG                              = "Passthrough PG"
 	Passthroughpool                            = "Passthrough pool"
 	PassthroughVS                              = "Passthrough VirtualService"

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -722,6 +722,11 @@ func GetProxyEnabledApplicationProfileName() string {
 	return Encode(GetClusterName()+"-proxy-applicationprofile", ApplicationProfile)
 }
 
+// One TCP half Open connection HM per cluster
+func GetTcpHalfOpenHealthMonitorName() string {
+	return Encode(GetClusterName()+"-tcphalfopen-healthmonitor", HealthMonitor)
+}
+
 func GetVPCMode() bool {
 	if vpcMode, _ := strconv.ParseBool(os.Getenv(utils.VPC_MODE)); vpcMode {
 		return true

--- a/internal/lib/utils.go
+++ b/internal/lib/utils.go
@@ -624,32 +624,36 @@ func GetLockSet() *LockSet {
 	return &lockSet
 }
 
-func ProxyEnabledAppProfileGet(client *clients.AviClient) (error, []models.ApplicationProfile) {
+func ProxyEnabledAppProfileGet(client *clients.AviClient) ([]models.ApplicationProfile, error) {
 	var appProfs []models.ApplicationProfile
 	uri := fmt.Sprintf("/api/applicationprofile/?name=%s", GetProxyEnabledApplicationProfileName())
 	result, err := AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("Application profile Get uri %v returned err %v", uri, err)
-		return err, appProfs
+		return appProfs, err
 	}
 	elems := make([]json.RawMessage, result.Count)
 	err = json.Unmarshal(result.Results, &elems)
 	if err != nil {
 		utils.AviLog.Warnf("Failed to unmarshal application profile result, err: %v", err)
-		return err, appProfs
+		return appProfs, err
 	}
 	for i := 0; i < len(elems); i++ {
 		appProf := models.ApplicationProfile{}
 		if err = json.Unmarshal(elems[i], &appProf); err != nil {
 			utils.AviLog.Warnf("Failed to unmarshal application profile data, err: %v", err)
-			return err, appProfs
+			return appProfs, err
 		}
 		appProfs = append(appProfs, appProf)
 	}
-	return nil, appProfs
+	return appProfs, nil
 }
 
 func ProxyEnabledAppProfileCU(client *clients.AviClient) error {
+	appProfs, err := ProxyEnabledAppProfileGet(client)
+	if err != nil {
+		return err
+	}
 	name := GetProxyEnabledApplicationProfileName()
 	tenant := fmt.Sprintf("/api/tenant/?name=%s", GetAdminTenant())
 	tcpAppProfile := models.TCPApplicationProfile{
@@ -663,8 +667,7 @@ func ProxyEnabledAppProfileCU(client *clients.AviClient) error {
 		TCPAppProfile: &tcpAppProfile,
 	}
 	resp := models.ApplicationProfileAPIResponse{}
-	err, appProfs := ProxyEnabledAppProfileGet(client)
-	if err == nil && len(appProfs) == 1 {
+	if len(appProfs) == 1 {
 		appProf := appProfs[0]
 		if appProf.TCPAppProfile != nil &&
 			appProf.TCPAppProfile.ProxyProtocolEnabled != nil &&
@@ -673,50 +676,57 @@ func ProxyEnabledAppProfileCU(client *clients.AviClient) error {
 			return nil
 		}
 		uri := fmt.Sprintf("/api/applicationprofile/%s", *appProf.UUID)
-		err = AviPut(client, uri, appProfile, resp)
-	} else {
-		if len(appProfs) > 1 {
-			return fmt.Errorf("More than one app profile with name %s found", name)
+		err := AviPut(client, uri, appProfile, resp)
+		if err != nil {
+			return err
 		}
-		if len(appProfs) == 0 {
-			uri := "/api/applicationprofile"
-			err = AviPost(client, uri, appProfile, resp)
+		utils.AviLog.Infof("Proxy enabled application profile %s updated", name)
+		return nil
+	}
+	if len(appProfs) == 0 {
+		uri := "/api/applicationprofile"
+		err := AviPost(client, uri, appProfile, resp)
+		if err != nil {
+			return err
 		}
+		utils.AviLog.Infof("Proxy enabled application profile %s created", name)
+		return nil
 	}
-	if err != nil {
-		return err
-	}
-	utils.AviLog.Infof("Proxy enabled application profile %s created/updated", name)
-	return nil
+	return fmt.Errorf("More than one app profile with name %s found", name)
 }
 
-func TcpHalfOpenHealthMonitorGet(client *clients.AviClient) (error, []models.HealthMonitor) {
+func TcpHalfOpenHealthMonitorGet(client *clients.AviClient) ([]models.HealthMonitor, error) {
 	var tcpHalfOpenHMs []models.HealthMonitor
 	uri := fmt.Sprintf("/api/healthmonitor/?name=%s", GetTcpHalfOpenHealthMonitorName())
 	result, err := AviGetCollectionRaw(client, uri)
 	if err != nil {
 		utils.AviLog.Warnf("Health Monitor Get uri %v returned err %v", uri, err)
-		return err, tcpHalfOpenHMs
+		return tcpHalfOpenHMs, err
 	}
 	elems := make([]json.RawMessage, result.Count)
 	err = json.Unmarshal(result.Results, &elems)
 	if err != nil {
 		utils.AviLog.Warnf("Failed to unmarshal health monitor result, err: %v", err)
-		return err, tcpHalfOpenHMs
+		return tcpHalfOpenHMs, err
 	}
 	for i := 0; i < len(elems); i++ {
 		hMon := models.HealthMonitor{}
 		if err = json.Unmarshal(elems[i], &hMon); err != nil {
 			utils.AviLog.Warnf("Failed to unmarshal health monitor data, err: %v", err)
-			return err, tcpHalfOpenHMs
+			return tcpHalfOpenHMs, err
 		}
 		tcpHalfOpenHMs = append(tcpHalfOpenHMs, hMon)
 	}
-	return nil, tcpHalfOpenHMs
+	return tcpHalfOpenHMs, nil
 }
 
 func TcpHalfOpenHealthMonitorCU(client *clients.AviClient) error {
+	tcpHalfOpenHMs, err := TcpHalfOpenHealthMonitorGet(client)
+	if err != nil {
+		return err
+	}
 	name := GetTcpHalfOpenHealthMonitorName()
+	resp := models.HealthMonitorAPIResponse{}
 	tenant := fmt.Sprintf("/api/tenant/?name=%s", GetAdminTenant())
 	tcpHM := models.HealthMonitorTCP{
 		TCPHalfOpen: proto.Bool(true),
@@ -727,9 +737,16 @@ func TcpHalfOpenHealthMonitorCU(client *clients.AviClient) error {
 		Type:       proto.String(AllowedTCPHealthMonitorType),
 		TCPMonitor: &tcpHM,
 	}
-	resp := models.HealthMonitorAPIResponse{}
-	err, tcpHalfOpenHMs := TcpHalfOpenHealthMonitorGet(client)
-	if err == nil && len(tcpHalfOpenHMs) == 1 {
+	if len(tcpHalfOpenHMs) == 0 {
+		uri := "/api/healthmonitor"
+		err := AviPost(client, uri, hMon, resp)
+		if err != nil {
+			return err
+		}
+		utils.AviLog.Infof("TCP Half Open connection health monitor %s created", name)
+		return nil
+	}
+	if len(tcpHalfOpenHMs) == 1 {
 		hm := tcpHalfOpenHMs[0]
 		if hm.TCPMonitor != nil &&
 			hm.TCPMonitor.TCPHalfOpen != nil &&
@@ -738,21 +755,14 @@ func TcpHalfOpenHealthMonitorCU(client *clients.AviClient) error {
 			return nil
 		}
 		uri := fmt.Sprintf("/api/healthmonitor/%s", *hm.UUID)
-		err = AviPut(client, uri, hMon, resp)
-	} else {
-		if len(tcpHalfOpenHMs) > 1 {
-			return fmt.Errorf("More than one TcpHalfOpen connection health monitor with name %s found", name)
+		err := AviPut(client, uri, hMon, resp)
+		if err != nil {
+			return err
 		}
-		if len(tcpHalfOpenHMs) == 0 {
-			uri := "/api/healthmonitor"
-			err = AviPost(client, uri, hMon, resp)
-		}
+		utils.AviLog.Infof("TCP Half Open connection health monitor %s updated", name)
+		return nil
 	}
-	if err != nil {
-		return err
-	}
-	utils.AviLog.Infof("TCP Half Open connection health monitor %s created/updated", name)
-	return nil
+	return fmt.Errorf("More than one TcpHalfOpen connection health monitor with name %s found", name)
 }
 
 func Uuid4() string {

--- a/internal/nodes/avi_model_advl4_translator.go
+++ b/internal/nodes/avi_model_advl4_translator.go
@@ -321,7 +321,6 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 	// create a mapping of portProto to hostname
 	gwListenerHostNameMapping := make(map[string]string)
 	gwClassName := ""
-	hmRef := ""
 	if lib.UseServicesAPI() {
 		// enable fqdn for gateway services only for non-advancedl4 usecases.
 		gw, err := lib.AKOControlConfig().SvcAPIInformers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
@@ -335,18 +334,6 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			}
 		}
 		gwClassName = gw.Spec.GatewayClassName
-	} else {
-		gw, err := lib.AKOControlConfig().AdvL4Informers().GatewayInformer.Lister().Gateways(namespace).Get(gwName)
-		if err != nil {
-			utils.AviLog.Warnf("key: %s, msg: GatewayLister returned error for advancedL4 pool nodes: %s", err)
-			return
-		}
-		if proxyProtoEnb, ok := gw.GetAnnotations()[lib.GwProxyProtocolEnableAnnotation]; ok {
-			proxyProtocolEnabled, err := strconv.ParseBool(proxyProtoEnb)
-			if err == nil && proxyProtocolEnabled {
-				hmRef = fmt.Sprintf("/api/healthmonitor/?name=%s", lib.GetTcpHalfOpenHealthMonitorName())
-			}
-		}
 	}
 
 	infraSetting, err := getL4InfraSetting(key, namespace, nil, &gwClassName)
@@ -402,7 +389,8 @@ func (o *AviObjectGraph) ConstructAdvL4PolPoolNodes(vsNode *AviVsNode, gwName, n
 			poolNode.VrfContext = ""
 		}
 
-		if hmRef != "" {
+		if vsNode.ApplicationProfile == lib.GetProxyEnabledApplicationProfileName() {
+			hmRef := fmt.Sprintf("/api/healthmonitor/?name=%s", lib.GetTcpHalfOpenHealthMonitorName())
 			poolNode.HealthMonitorRefs = append(poolNode.HealthMonitorRefs, hmRef)
 		}
 

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -1173,7 +1173,7 @@ func TestAdvL4MultiTenancyWithTenantDeannotationInNS(t *testing.T) {
 	VerifyGatewayVSNodeDeletion(g, newModelName)
 }
 
-func TestAdvL4WithProxyEnabledAppProfile(t *testing.T) {
+func TestAdvL4WithProxyEnabledAnnotation(t *testing.T) {
 	// create a gw object with proxy-enabled annotation
 	// graph layer VS should come up with correct app profile
 	// graph layer Pool should have correct health monitor ref

--- a/tests/advl4tests/advl4_hostname_test.go
+++ b/tests/advl4tests/advl4_hostname_test.go
@@ -1176,6 +1176,7 @@ func TestAdvL4MultiTenancyWithTenantDeannotationInNS(t *testing.T) {
 func TestAdvL4WithProxyEnabledAppProfile(t *testing.T) {
 	// create a gw object with proxy-enabled annotation
 	// graph layer VS should come up with correct app profile
+	// graph layer Pool should have correct health monitor ref
 	// delete the gw object, graph layer object deletion
 	g := gomega.NewGomegaWithT(t)
 
@@ -1215,6 +1216,7 @@ func TestAdvL4WithProxyEnabledAppProfile(t *testing.T) {
 	g.Expect(nodes[0].ServiceMetadata.Gateway).To(gomega.Equal("default/my-gateway"))
 	g.Expect(nodes[0].PoolRefs[0].Servers).To(gomega.HaveLen(3))
 	g.Expect(nodes[0].ApplicationProfile).To(gomega.Equal(lib.GetProxyEnabledApplicationProfileName()))
+	g.Expect(nodes[0].PoolRefs[0].HealthMonitorRefs[0]).To(gomega.ContainSubstring(lib.GetTcpHalfOpenHealthMonitorName()))
 
 	TeardownGatewayClass(t, gwClassName)
 	g.Eventually(func() int {

--- a/tests/integrationtest/lib.go
+++ b/tests/integrationtest/lib.go
@@ -1506,7 +1506,14 @@ func NormalControllerServer(w http.ResponseWriter, r *http.Request, args ...stri
 		}
 		w.WriteHeader(http.StatusOK)
 		w.Write(data)
-
+	} else if r.Method == "GET" && strings.Contains(url, "/api/applicationprofile/") &&
+		strings.HasSuffix(r.URL.RawQuery, lib.GetProxyEnabledApplicationProfileName()) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": [], "count": 0}`))
+	} else if r.Method == "GET" && strings.Contains(url, "/api/healthmonitor/") &&
+		strings.HasSuffix(r.URL.RawQuery, lib.GetTcpHalfOpenHealthMonitorName()) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"results": [], "count": 0}`))
 	} else if r.Method == "GET" && inArray(FakeAviObjects, object) {
 		FeedMockCollectionData(w, r, mockFilePath)
 


### PR DESCRIPTION
Jira Id: https://vmw-jira.broadcom.net/browse/VKAL-30110

This change will create a TCP HalfOpen HM at the time of AKO boot-up. If a gateway gets created (against the lb service) with the "proxy enabled" annotation then AKO will use the TCP Half Open HM for the pools associated to the VS which gets realised against the gateway. Also, this HM gets deleted when supervisor gets disabled.