### PR TITLE
AV-247848: Add TrafficEnabled flag for ParentVS in GatewayAPI and L4 VS

### DIFF
--- a/ako-gateway-api/k8s/gateway_controller.go
+++ b/ako-gateway-api/k8s/gateway_controller.go
@@ -735,11 +735,7 @@ func IsGatewayUpdated(oldGateway, newGateway *gatewayv1.Gateway) bool {
 	}
 	oldHash := utils.Hash(utils.Stringify(oldGateway.Spec))
 	newHash := utils.Hash(utils.Stringify(newGateway.Spec))
-	oldvipType := oldGateway.Annotations[akogatewayapilib.LBVipTypeAnnotation]
-	newvipType := newGateway.Annotations[akogatewayapilib.LBVipTypeAnnotation]
-	oldDedicatedMode := oldGateway.Annotations[akogatewayapilib.DedicatedGatewayModeAnnotation]
-	newDedicatedMode := newGateway.Annotations[akogatewayapilib.DedicatedGatewayModeAnnotation]
-	return oldHash != newHash || oldvipType != newvipType || oldDedicatedMode != newDedicatedMode
+	return oldHash != newHash || !reflect.DeepEqual(oldGateway.Annotations, newGateway.Annotations)
 }
 
 func IsHTTPRouteUpdated(oldHTTPRoute, newHTTPRoute *gatewayv1.HTTPRoute) bool {

--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -60,10 +60,9 @@ func (o *AviObjectGraph) BuildGatewayParent(gateway *gatewayv1.Gateway, key stri
 		oldTenant = lib.GetTenant()
 	}
 	// Default: Traffic is enabled
-	// Not using it in Shared VIP as we don't have use case for it.
 	trafficEnabled := proto.Bool(true)
 
-	if traffic_enabled, ok := gateway.Annotations[lib.VSTrafficEnabled]; ok && strings.ToLower(traffic_enabled) == "false" {
+	if traffic_disabled, ok := gateway.Annotations[lib.VSTrafficDisabled]; ok && strings.ToLower(traffic_disabled) == "true" {
 		trafficEnabled = proto.Bool(false)
 	}
 	// Cleanup resources in the old tenant in case of tenant change

--- a/ako-gateway-api/nodes/gateway_model.go
+++ b/ako-gateway-api/nodes/gateway_model.go
@@ -16,7 +16,9 @@ package nodes
 
 import (
 	"context"
+	"strings"
 
+	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
@@ -57,6 +59,13 @@ func (o *AviObjectGraph) BuildGatewayParent(gateway *gatewayv1.Gateway, key stri
 	if oldTenant == "" {
 		oldTenant = lib.GetTenant()
 	}
+	// Default: Traffic is enabled
+	// Not using it in Shared VIP as we don't have use case for it.
+	trafficEnabled := proto.Bool(true)
+
+	if traffic_enabled, ok := gateway.Annotations[lib.VSTrafficEnabled]; ok && strings.ToLower(traffic_enabled) == "false" {
+		trafficEnabled = proto.Bool(false)
+	}
 	// Cleanup resources in the old tenant in case of tenant change
 	if tenant != oldTenant {
 		oldModelName := lib.GetModelName(oldTenant, vsName)
@@ -79,7 +88,8 @@ func (o *AviObjectGraph) BuildGatewayParent(gateway *gatewayv1.Gateway, key stri
 		ServiceMetadata: lib.ServiceMetadataObj{
 			Gateway: gateway.Namespace + "/" + gateway.Name,
 		},
-		Caller: utils.GATEWAY_API, // Always Populate this field to recognise caller at rest layer
+		TrafficEnabled: trafficEnabled,
+		Caller:         utils.GATEWAY_API, // Always Populate this field to recognise caller at rest layer
 	}
 	infraSetting, err := lib.GetNamespacedAviInfraSetting(key, gateway.GetNamespace(), akogatewayapilib.AKOControlConfig().AviInfraSettingInformer())
 	if err != nil {

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -256,7 +256,7 @@ const (
 	AviIngressController             = "ako.vmware.com/avi-lb"
 	AKOConditionType                 = "ako.vmware.com/ObjectDeletionInProgress"
 	DefaultSecretEnabled             = "ako.vmware.com/enable-tls"
-	VSTrafficEnabled                 = "ako.vmware.com/enable-traffic"
+	VSTrafficDisabled                = "ako.vmware.com/disable-traffic"
 	GatewayNameLabelKey              = "service.route.lbapi.run.tanzu.vmware.com/gateway-name"
 	GatewayNamespaceLabelKey         = "service.route.lbapi.run.tanzu.vmware.com/gateway-namespace"
 	GatewayTypeLabelKey              = "service.route.lbapi.run.tanzu.vmware.com/type"

--- a/internal/lib/constants.go
+++ b/internal/lib/constants.go
@@ -256,6 +256,7 @@ const (
 	AviIngressController             = "ako.vmware.com/avi-lb"
 	AKOConditionType                 = "ako.vmware.com/ObjectDeletionInProgress"
 	DefaultSecretEnabled             = "ako.vmware.com/enable-tls"
+	VSTrafficEnabled                 = "ako.vmware.com/enable-traffic"
 	GatewayNameLabelKey              = "service.route.lbapi.run.tanzu.vmware.com/gateway-name"
 	GatewayNamespaceLabelKey         = "service.route.lbapi.run.tanzu.vmware.com/gateway-namespace"
 	GatewayTypeLabelKey              = "service.route.lbapi.run.tanzu.vmware.com/type"

--- a/internal/nodes/avi_model_evh_nodes.go
+++ b/internal/nodes/avi_model_evh_nodes.go
@@ -155,6 +155,7 @@ type AviEvhVsNode struct {
 	Secure              bool
 	Caller              string
 	StringGroupRefs     []*AviStringGroupNode
+	TrafficEnabled      *bool
 
 	AviVsNodeCommonFields
 
@@ -741,6 +742,10 @@ func (v *AviEvhVsNode) CalculateCheckSum() {
 
 	if v.Enabled != nil {
 		checksum += utils.Hash(utils.Stringify(v.Enabled))
+	}
+	// TrafficEnabled: For GatewayAPI VS always PUT request
+	if v.TrafficEnabled != nil {
+		checksum += utils.Hash(utils.Stringify(v.TrafficEnabled))
 	}
 
 	checksum += lib.GetMarkersChecksum(v.AviMarkers)

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -60,7 +60,13 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 			fqdns = append(fqdns, fqdn)
 		}
 	}
+	// Default: Traffic is enabled
+	// Not using it in Shared VIP as we don't have use case for it.
+	trafficEnabled := proto.Bool(true)
 
+	if traffic_enabled, ok := svcObj.Annotations[lib.VSTrafficEnabled]; ok && strings.ToLower(traffic_enabled) == "false" {
+		trafficEnabled = proto.Bool(false)
+	}
 	tenant := lib.GetTenantInNamespace(svcObj.GetNamespace())
 
 	DeleteStaleTenantModelData(svcObj.GetName(), svcObj.GetNamespace(), key, tenant, lib.L4VS)
@@ -82,6 +88,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 		},
 		ServiceEngineGroup: lib.GetSEGName(),
 		EnableRhi:          proto.Bool(lib.GetEnableRHI()),
+		TrafficEnabled:     trafficEnabled,
 	}
 
 	vrfcontext := lib.GetVrf()

--- a/internal/nodes/avi_model_l4_translator.go
+++ b/internal/nodes/avi_model_l4_translator.go
@@ -64,7 +64,7 @@ func (o *AviObjectGraph) ConstructAviL4VsNode(svcObj *corev1.Service, key string
 	// Not using it in Shared VIP as we don't have use case for it.
 	trafficEnabled := proto.Bool(true)
 
-	if traffic_enabled, ok := svcObj.Annotations[lib.VSTrafficEnabled]; ok && strings.ToLower(traffic_enabled) == "false" {
+	if traffic_disabled, ok := svcObj.Annotations[lib.VSTrafficDisabled]; ok && strings.ToLower(traffic_disabled) == "true" {
 		trafficEnabled = proto.Bool(false)
 	}
 	tenant := lib.GetTenantInNamespace(svcObj.GetNamespace())

--- a/internal/nodes/avi_model_nodes.go
+++ b/internal/nodes/avi_model_nodes.go
@@ -429,6 +429,7 @@ type AviVsNode struct {
 	IsL4VS                bool
 	Secure                bool
 	StringGroupRefs       []*AviStringGroupNode
+	TrafficEnabled        *bool
 
 	AviVsNodeCommonFields
 
@@ -1071,7 +1072,10 @@ func (v *AviVsNode) CalculateCheckSum() {
 	if v.Enabled != nil {
 		checksum += utils.Hash(utils.Stringify(v.Enabled))
 	}
-
+	// TrafficEnabled: This will cause PUT request on all L4 VS
+	if v.TrafficEnabled != nil {
+		checksum += utils.Hash(utils.Stringify(v.TrafficEnabled))
+	}
 	checksum += lib.GetMarkersChecksum(v.AviMarkers)
 
 	if v.EnableRhi != nil {

--- a/internal/rest/avi_evh_obj.go
+++ b/internal/rest/avi_evh_obj.go
@@ -346,6 +346,10 @@ func (rest *RestOperations) AviVsBuildForEvh(vs_meta *nodes.AviEvhVsNode, rest_m
 			vs.EnableRhi = &enableRhi
 		}
 
+		if vs_meta.TrafficEnabled != nil {
+			vs.TrafficEnabled = vs_meta.TrafficEnabled
+		}
+
 		if vs_meta.SharedVS {
 			vs.Markers = lib.GetMarkers()
 		} else {

--- a/internal/rest/avi_obj_vs.go
+++ b/internal/rest/avi_obj_vs.go
@@ -101,6 +101,9 @@ func (rest *RestOperations) AviVsBuild(vs_meta *nodes.AviVsNode, rest_method uti
 			RevokeVipRoute:        vs_meta.RevokeVipRoute,
 		}
 
+		if vs_meta.TrafficEnabled != nil {
+			vs.TrafficEnabled = vs_meta.TrafficEnabled
+		}
 		if vs_meta.ApplicationProfileRef != nil {
 			// hostrule ref overrides defaults
 			vs.ApplicationProfileRef = vs_meta.ApplicationProfileRef

--- a/tests/gatewayapitests/utils.go
+++ b/tests/gatewayapitests/utils.go
@@ -38,6 +38,7 @@ import (
 
 	akogatewayapilib "github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/ako-gateway-api/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/k8s"
+	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/internal/lib"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pkg/utils"
 	"github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/integrationtest"
 )
@@ -349,7 +350,23 @@ func UpdateGateway(t *testing.T, name, namespace, gatewayClass string, ipAddress
 	g.Gateway = g.GatewayV1(name, namespace, gatewayClass, ipAddress, listeners, vipType...)
 	g.Update(t)
 }
+func SetupGatewayWithAnnotation(t *testing.T, name, namespace, gatewayClass string, ipAddress []gatewayv1.GatewaySpecAddress, listeners []gatewayv1.Listener) {
+	g := &Gateway{}
+	g.Gateway = g.GatewayV1(name, namespace, gatewayClass, ipAddress, listeners)
+	g.Gateway.Annotations = map[string]string{lib.VSTrafficDisabled: "true"}
+	g.Create(t)
+}
 
+func UpdateGatewayWithAnnotation(t *testing.T, name, namespace, gatewayClass, annotation string, ipAddress []gatewayv1.GatewaySpecAddress, listeners []gatewayv1.Listener, vipType ...string) {
+	g := &Gateway{}
+	g.Gateway = g.GatewayV1(name, namespace, gatewayClass, ipAddress, listeners, vipType...)
+	if annotation == "nil" {
+		g.Gateway.Annotations = nil
+	} else {
+		g.Gateway.Annotations = map[string]string{lib.VSTrafficDisabled: annotation}
+	}
+	g.Update(t)
+}
 func TeardownGateway(t *testing.T, name, namespace string) {
 	g := &Gateway{}
 	g.Gateway = g.GatewayV1(name, namespace, "", nil, nil)


### PR DESCRIPTION
This is for VCD to VCF migration use case.


VCF handling of L4 annotation will be taken separately.