### PR TITLE
VKAL-32019 Add dedicated tenant mode flag for VKS Clusters

### DIFF
--- a/helm/ako/templates/configmap.yaml
+++ b/helm/ako/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
   vipPerNamespace: {{ .Values.AKOSettings.vipPerNamespace | quote }}
   tenantName: {{ .Values.ControllerSettings.tenantName | quote }}
   vrfName: {{ .Values.ControllerSettings.vrfName | quote }}
+  dedicatedTenantMode: {{ .Values.ControllerSettings.dedicatedTenantMode | quote }}
   {{ if .Values.NetworkSettings.defaultDomain }}
   defaultDomain: {{ .Values.NetworkSettings.defaultDomain | quote }}
   {{ else }}

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -133,6 +133,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: tenantName
+          - name: DEDICATED_TENANT_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: dedicatedTenantMode
           - name: VRF_NAME
             valueFrom:
               configMapKeyRef:
@@ -348,6 +353,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: tenantName
+          - name: DEDICATED_TENANT_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: dedicatedTenantMode
           - name: CLUSTER_NAME
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -358,6 +358,11 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: dedicatedTenantMode
+          - name: VPC_MODE
+            valueFrom:
+              configMapKeyRef:
+                name: avi-k8s-config
+                key: vpcMode
           - name: CLUSTER_NAME
             valueFrom:
               configMapKeyRef:

--- a/helm/ako/values.yaml
+++ b/helm/ako/values.yaml
@@ -117,6 +117,7 @@ ControllerSettings:
   controllerHost: "" # IP address or Hostname of Avi Controller
   tenantName: "admin" # Name of the tenant where all the AKO objects will be created in AVI.
   vrfName: "" # Name of the VRFContext. All Avi objects will be under this VRF. Applicable only in Vcenter Cloud.
+  dedicatedTenantMode: false # If true, AKO will only query objects from its specific tenant instead of all tenants.
 
 nodePortSelector: # Only applicable if serviceType is NodePort
   key: ""

--- a/internal/cache/controller_obj_cache.go
+++ b/internal/cache/controller_obj_cache.go
@@ -143,7 +143,7 @@ func (c *AviObjCache) AviObjCachePopulate(client []*clients.AviClient, version s
 	allVsKeys = c.VsCacheMeta.AviGetAllKeys()
 	err = func(client *clients.AviClient) error {
 		setDefaultTenant := session.SetTenant(lib.GetTenant())
-		setTenant := session.SetTenant("*")
+		setTenant := session.SetTenant(lib.GetQueryTenant())
 		setTenant(client.AviSession)
 		defer setDefaultTenant(client.AviSession)
 		return c.AviObjVSCachePopulate(client, cloud, &allVsKeys)
@@ -538,7 +538,7 @@ func (c *AviObjCache) AviPopulateAllPGs(client *clients.AviClient, cloud string,
 func (c *AviObjCache) PopulatePgDataToCache(client *clients.AviClient, cloud string) {
 	var pgData []AviPGCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllPGs(client, cloud, &pgData)
@@ -721,7 +721,7 @@ func (c *AviObjCache) AviPopulateAllPools(client *clients.AviClient, cloud strin
 func (c *AviObjCache) PopulatePkiProfilesToCache(client *clients.AviClient) {
 	var pkiProfData []AviPkiProfileCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllPkiPRofiles(client, &pkiProfData)
@@ -759,7 +759,7 @@ func (c *AviObjCache) PopulatePkiProfilesToCache(client *clients.AviClient) {
 func (c *AviObjCache) PopulatePoolsToCache(client *clients.AviClient, cloud string) {
 	var poolsData []AviPoolCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllPools(client, cloud, &poolsData)
@@ -895,7 +895,7 @@ func (c *AviObjCache) AviPopulateAllVSVips(client *clients.AviClient, cloud stri
 func (c *AviObjCache) PopulateVsVipDataToCache(client *clients.AviClient, cloud string) {
 	var vsVipData []AviVSVIPCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllVSVips(client, cloud, &vsVipData)
@@ -1005,7 +1005,7 @@ func (c *AviObjCache) AviPopulateAllDSs(client *clients.AviClient, cloud string,
 func (c *AviObjCache) PopulateDSDataToCache(client *clients.AviClient, cloud string) {
 	var DsData []AviDSCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllDSs(client, cloud, &DsData)
@@ -1725,7 +1725,7 @@ func (c *AviObjCache) AviPopulateOneVsL4PolCache(client *clients.AviClient,
 func (c *AviObjCache) PopulateSSLKeyToCache(client *clients.AviClient, cloud string) {
 	var SslKeyData []AviSSLCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllSSLKeys(client, cloud, &SslKeyData)
@@ -1914,7 +1914,7 @@ func (c *AviObjCache) AviPopulateHttpPolicySetbyUUID(client *clients.AviClient, 
 func (c *AviObjCache) PopulateHttpPolicySetToCache(client *clients.AviClient, cloud string) {
 	var HttPolData []AviHTTPPolicyCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	_, count, err := c.AviPopulateAllHttpPolicySets(client, cloud, &HttPolData)
@@ -2043,7 +2043,7 @@ func (c *AviObjCache) AviPopulateAllL4PolicySets(client *clients.AviClient, clou
 func (c *AviObjCache) PopulateL4PolicySetToCache(client *clients.AviClient, cloud string) {
 	var l4PolData []AviL4PolicyCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	_, count, err := c.AviPopulateAllL4PolicySets(client, cloud, &l4PolData)
@@ -2135,7 +2135,7 @@ func (c *AviObjCache) AviPopulateAllStringGroups(client *clients.AviClient, clou
 func (c *AviObjCache) PopulateStringGroupDataToCache(client *clients.AviClient, cloud string) {
 	var StringGroupData []AviStringGroupCache
 	setDefaultTenant := session.SetTenant(lib.GetTenant())
-	setTenant := session.SetTenant("*")
+	setTenant := session.SetTenant(lib.GetQueryTenant())
 	setTenant(client.AviSession)
 	defer setDefaultTenant(client.AviSession)
 	c.AviPopulateAllStringGroups(client, cloud, &StringGroupData)

--- a/internal/lib/lib.go
+++ b/internal/lib/lib.go
@@ -747,6 +747,23 @@ func GetTenant() string {
 	return utils.ADMIN_NS
 }
 
+func IsDedicatedTenantMode() bool {
+	if ok, _ := strconv.ParseBool(os.Getenv("DEDICATED_TENANT_MODE")); ok {
+		return true
+	}
+	return false
+}
+
+// GetQueryTenant returns the tenant to use for queries
+// If dedicatedTenantMode is enabled, returns the specific tenant
+// Otherwise, returns "*" for all tenants
+func GetQueryTenant() string {
+	if IsDedicatedTenantMode() {
+		return GetTenant()
+	}
+	return "*"
+}
+
 func IsIstioEnabled() bool {
 	if ok, _ := strconv.ParseBool(os.Getenv("ISTIO_ENABLED")); ok {
 		utils.AviLog.Debugf("Istio is enabled")


### PR DESCRIPTION
In VKS, roles are created with granular RBAC filters and are specific to their tenant. Consequently, a user with such a role is not allowed to populate the cache for all tenants. A generic mode is being introduced to control this behavior.

Additionally, the VPC mode has been added to the gateway container's env section.

