### PR TITLE
Update Kubernetes maxVersion to 1.34

### DIFF
--- a/buildsettings.json
+++ b/buildsettings.json
@@ -4,7 +4,7 @@
         "minVersion": "22.1.3"
     },
     "kubernetes": {
-        "maxVersion": "1.33",
+        "maxVersion": "1.34",
         "minVersion": "1.24"
     },
     "version": "1.13.3"


### PR DESCRIPTION
Update Kubernetes maxVersion to 1.34

This is required for VKS standard package release Oct 22

https://vmw-confluence.broadcom.net/spaces/WCP/pages/2218034077/Standard+Packages+v2025.10.22