### PR TITLE
AV-251077 : AKO CRD Opertaor installation fails when Helm version 3.2.1 is used

### DIFF
--- a/ako-crd-operator/helm/ako-crd-operator/chart/templates/manager/manager.yaml
+++ b/ako-crd-operator/helm/ako-crd-operator/chart/templates/manager/manager.yaml
@@ -19,11 +19,6 @@ spec:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
-        {{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}
-        {{- range $key, $value := .Values.controllerManager.pod.labels }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
-        {{- end }}
     spec:
       containers:
         - name: ako-crd-operator

--- a/ako-crd-operator/helm/ako-crd-operator/chart/templates/rbac/service_account.yaml
+++ b/ako-crd-operator/helm/ako-crd-operator/chart/templates/rbac/service_account.yaml
@@ -3,11 +3,5 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
-  annotations:
-    {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
-  {{- end }}
   name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This PR removes certain jinja2 templates defined in the chart, that try to use fields, that are not defined in values.yaml. Using undefined fields results in nil pointer exception in older helm versions while same is ignored in newer helm versions.