### PR TITLE
AV-250920 : Fix RBE CRD validations

### DIFF
--- a/ako-crd-operator/api/v1alpha1/routebackendextension_types.go
+++ b/ako-crd-operator/api/v1alpha1/routebackendextension_types.go
@@ -117,8 +117,8 @@ type BackendTLS struct {
 }
 
 // RouteBackendExtensionSpec defines the desired state of RouteBackendExtension
-// +kubebuilder:validation:XValidation:rule="(self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') && has(self.lbAlgorithmHash)",message="lbAlgorithmHash must be set if and only if lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH"
-// +kubebuilder:validation:XValidation:rule="!has(self.lbAlgorithmHash) || (self.lbAlgorithmHash == 'LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER') && has(self.lbAlgorithmConsistentHashHdr)",message="lbAlgorithmConsistentHashHdr must be set if and only if lbAlgorithmHash is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER"
+// +kubebuilder:validation:XValidation:rule="(self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') == has(self.lbAlgorithmHash)",message="lbAlgorithmHash must be set if and only if lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH"
+// +kubebuilder:validation:XValidation:rule="!has(self.lbAlgorithmHash) || (self.lbAlgorithmHash == 'LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER') == has(self.lbAlgorithmConsistentHashHdr)",message="lbAlgorithmConsistentHashHdr must be set if and only if lbAlgorithmHash is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER"
 type RouteBackendExtensionSpec struct {
 	// Defines LB algorithm on Pool
 	// +optional
@@ -130,7 +130,6 @@ type RouteBackendExtensionSpec struct {
 	LBAlgorithmConsistentHashHdr string `json:"lbAlgorithmConsistentHashHdr,omitempty"`
 	//Criteria used as a key for determining the hash between the client and server
 	// +optional
-	// +kubebuilder:default=LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS
 	LBAlgorithmHash LBAlgorithmHashType `json:"lbAlgorithmHash,omitempty"`
 	// Defines the persistence profile type on Pool
 	// +optional

--- a/ako-crd-operator/config/crd/bases/ako.vmware.com_routebackendextensions.yaml
+++ b/ako-crd-operator/config/crd/bases/ako.vmware.com_routebackendextensions.yaml
@@ -123,7 +123,6 @@ spec:
                   This field should be specified only when lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH and lbAlgorithmHash is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER.
                 type: string
               lbAlgorithmHash:
-                default: LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS
                 description: Criteria used as a key for determining the hash between
                   the client and server
                 enum:
@@ -145,11 +144,11 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: lbAlgorithmHash must be set if and only if lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH
-              rule: (self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') && has(self.lbAlgorithmHash)
+              rule: (self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') == has(self.lbAlgorithmHash)
             - message: lbAlgorithmConsistentHashHdr must be set if and only if lbAlgorithmHash
                 is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER
               rule: '!has(self.lbAlgorithmHash) || (self.lbAlgorithmHash == ''LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER'')
-                && has(self.lbAlgorithmConsistentHashHdr)'
+                == has(self.lbAlgorithmConsistentHashHdr)'
           status:
             description: RouteBackendExtensionStatus defines the observed state of
               RouteBackendExtension.

--- a/ako-crd-operator/helm/ako-crd-operator/chart/templates/crd/ako.vmware.com_routebackendextensions.yaml
+++ b/ako-crd-operator/helm/ako-crd-operator/chart/templates/crd/ako.vmware.com_routebackendextensions.yaml
@@ -123,7 +123,6 @@ spec:
                   This field should be specified only when lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH and lbAlgorithmHash is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER.
                 type: string
               lbAlgorithmHash:
-                default: LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS
                 description: Criteria used as a key for determining the hash between
                   the client and server
                 enum:
@@ -145,11 +144,11 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: lbAlgorithmHash must be set if and only if lbAlgorithm is LB_ALGORITHM_CONSISTENT_HASH
-              rule: (self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') && has(self.lbAlgorithmHash)
+              rule: (self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') == has(self.lbAlgorithmHash)
             - message: lbAlgorithmConsistentHashHdr must be set if and only if lbAlgorithmHash
                 is LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER
               rule: '!has(self.lbAlgorithmHash) || (self.lbAlgorithmHash == ''LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER'')
-                && has(self.lbAlgorithmConsistentHashHdr)'
+                == has(self.lbAlgorithmConsistentHashHdr)'
           status:
             description: RouteBackendExtensionStatus defines the observed state of
               RouteBackendExtension.

--- a/ako-crd-operator/internal/controller/routebackendextension_controller.go
+++ b/ako-crd-operator/internal/controller/routebackendextension_controller.go
@@ -135,7 +135,7 @@ func (r *RouteBackendExtensionReconciler) SetupWithManager(mgr ctrl.Manager) err
 	// Add indexer for RouteBackendExtension by PKIProfile reference
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &akov1alpha1.RouteBackendExtension{}, PKIProfileIndexKey, func(rawObj client.Object) []string {
 		rbe := rawObj.(*akov1alpha1.RouteBackendExtension)
-		if rbe.Spec.BackendTLS.PKIProfile != nil && rbe.Spec.BackendTLS.PKIProfile.Kind == akov1alpha1.ObjectKindCRD {
+		if rbe.Spec.BackendTLS != nil && rbe.Spec.BackendTLS.PKIProfile != nil && rbe.Spec.BackendTLS.PKIProfile.Kind == akov1alpha1.ObjectKindCRD {
 			return []string{rbe.Spec.BackendTLS.PKIProfile.Name}
 		}
 		return nil


### PR DESCRIPTION
This PR fixes validation issues for RBE CRD. The validation rules  in CRD now use **==** instead of **&&** as the rules should pass when both statements on left and right side of condition are false.
For example, in the below CR, the given validation **(self.lbAlgorithm == 'LB_ALGORITHM_CONSISTENT_HASH') == has(self.lbAlgorithmHash)** will have both statements evaluate to false and hence evaluation will pass for **==** and would have failed for **&&** : 

apiVersion: ako.vmware.com/v1alpha1
kind: RouteBackendExtension
metadata:
  name: rbe-cr
spec:
  lbAlgorithm : LB_ALGORITHM_ROUND_ROBIN
  healthMonitor:
  - kind: AVIREF
    name: custom-hm
    
    
This PR also fixes a nil pointer exception see for RBE controller if **BackendTLS** was not set.