### PR TITLE
AV-252930 Remove duplicate vpc_mode env from sts

### DIFF
--- a/helm/ako/templates/statefulset.yaml
+++ b/helm/ako/templates/statefulset.yaml
@@ -363,11 +363,6 @@ spec:
               configMapKeyRef:
                 name: avi-k8s-config
                 key: dedicatedTenantMode
-          - name: VPC_MODE
-            valueFrom:
-              configMapKeyRef:
-                name: avi-k8s-config
-                key: vpcMode
           - name: CLUSTER_NAME
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
GatewayAPI STS has 2 entries for VPC_MODE causing - 

```
warning: spec.template.spec.containers[1].env[16]: hides previous definition of "VPC_MODE", which may be dropped when using apply
```